### PR TITLE
feat/rules search, sticky FilterBars, keyboard undo/redo, and UX polish

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from "./Sidebar";
 import { DraftPanel } from "./DraftPanel";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { usePreloadEntities } from "@/hooks/useAllEntities";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
 // useSyncExternalStore is the React-recommended way to detect client-side
 // hydration without calling setState inside useEffect.
@@ -32,6 +33,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // Prefetch all entity types in parallel so any page has data immediately.
   // Hooks are disabled when there is no active connection (enabled: !!connection).
   usePreloadEntities();
+  useKeyboardShortcuts();
 
   // Returns false on the server, true on the client — no setState needed.
   const hydrated = useIsHydrated();

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -336,7 +336,7 @@ export function AccountsTable() {
 
   return (
     <>
-      <div ref={containerRef} className="flex flex-col outline-none" onKeyDown={handleKeyDown} onPaste={handlePaste} tabIndex={-1}>
+      <div ref={containerRef} className="flex min-h-0 flex-1 flex-col overflow-hidden outline-none" onKeyDown={handleKeyDown} onPaste={handlePaste} tabIndex={-1}>
         <FilterBar
           search={search} onSearchChange={setSearch}
           statusFilter={statusFilter} onStatusChange={setStatusFilter}
@@ -350,6 +350,7 @@ export function AccountsTable() {
           onDeselect={() => clearSelection()}
         />
 
+        <div className="min-h-0 flex-1 overflow-auto">
         {rows.length === 0 ? (
           <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
             {search || statusFilter !== "all" || budgetFilter !== "all"
@@ -564,6 +565,7 @@ export function AccountsTable() {
               </tbody>
           </table>
         )}
+        </div>
 
         <BulkAddBar bulkCount={bulkCount} onBulkCountChange={setBulkCount} onAdd={(n) => addRows(n, true)} />
       </div>

--- a/src/features/accounts/components/AccountsView.tsx
+++ b/src/features/accounts/components/AccountsView.tsx
@@ -96,6 +96,7 @@ export function AccountsView() {
       isError={isError}
       error={error}
       onRetry={refetch}
+      scrollManaged
       actions={
         <>
           <input

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -675,7 +675,7 @@ export function CategoriesTable({
 
   return (
     <>
-      <div ref={containerRef} className="flex flex-col outline-none" onKeyDown={handleKeyDown} tabIndex={-1}>
+      <div ref={containerRef} className="flex min-h-0 flex-1 flex-col overflow-hidden outline-none" onKeyDown={handleKeyDown} tabIndex={-1}>
         <FilterBar
           search={search} onSearchChange={setSearch}
           visibilityFilter={visibilityFilter} onVisibilityChange={setVisibilityFilter}
@@ -686,6 +686,7 @@ export function CategoriesTable({
           onDeselect={() => clearSelection()}
         />
 
+        <div className="min-h-0 flex-1 overflow-auto">
         <table className="w-full border-collapse text-sm">
           <thead className="sticky top-0 z-10 bg-background">
               <tr className="border-b border-border">
@@ -804,6 +805,7 @@ export function CategoriesTable({
               )}
             </tbody>
         </table>
+        </div>
       </div>
 
       {/* Confirm dialog */}

--- a/src/features/categories/components/CategoriesView.tsx
+++ b/src/features/categories/components/CategoriesView.tsx
@@ -103,6 +103,7 @@ export function CategoriesView() {
       isError={isError}
       error={error}
       onRetry={refetch}
+      scrollManaged
       actions={
         <>
           <Button

--- a/src/features/payees/components/PayeesTable.tsx
+++ b/src/features/payees/components/PayeesTable.tsx
@@ -231,9 +231,12 @@ export function PayeesTable() {
   }
 
   function handleNameDone(rowId: string, value: string, action: DoneAction) {
-    if (action !== "cancel" && value !== staged[rowId]?.entity.name) {
-      pushUndo();
-      stageUpdate("payees", rowId, { name: value });
+    if (action !== "cancel") {
+      const trimmed = value.trim();
+      if (trimmed !== staged[rowId]?.entity.name) {
+        pushUndo();
+        stageUpdate("payees", rowId, { name: trimmed });
+      }
     }
     commitEdit({ rowId, colId: "name" });
     if (action === "down") moveFrom(rowId, "name", 1, 0);
@@ -376,7 +379,7 @@ export function PayeesTable() {
 
   return (
     <>
-      <div ref={containerRef} className="flex flex-col outline-none" onKeyDown={handleKeyDown} onPaste={handlePaste} tabIndex={-1}>
+      <div ref={containerRef} className="flex min-h-0 flex-1 flex-col overflow-hidden outline-none" onKeyDown={handleKeyDown} onPaste={handlePaste} tabIndex={-1}>
         <FilterBar
           search={search} onSearchChange={setSearch}
           typeFilter={typeFilter} onTypeChange={setTypeFilter}
@@ -388,6 +391,7 @@ export function PayeesTable() {
           onDeselect={() => clearSelection()}
         />
 
+        <div className="min-h-0 flex-1 overflow-auto">
         {rows.length === 0 ? (
           <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
             {search || typeFilter !== "all" || rulesFilter !== "all"
@@ -618,6 +622,7 @@ export function PayeesTable() {
               </tbody>
           </table>
         )}
+        </div>
 
         <BulkAddBar bulkCount={bulkCount} onBulkCountChange={setBulkCount} onAdd={(n) => addRows(n, true)} />
       </div>

--- a/src/features/payees/components/PayeesView.tsx
+++ b/src/features/payees/components/PayeesView.tsx
@@ -91,6 +91,7 @@ export function PayeesView() {
       isError={isError}
       error={error}
       onRetry={refetch}
+      scrollManaged
       actions={
         <>
           <input

--- a/src/features/rules/components/RuleChips.tsx
+++ b/src/features/rules/components/RuleChips.tsx
@@ -4,6 +4,14 @@ import { CONDITION_FIELDS, ACTION_FIELDS, ACTION_OPS } from "../utils/ruleFields
 import { valueToString } from "../utils/rulePreview";
 import type { EntityMaps } from "../utils/rulePreview";
 import type { ConditionOrAction } from "@/types/entities";
+import { cn } from "@/lib/utils";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** True when the field resolves to a named entity (payee, category, account, group). */
+function isEntityField(field: string, fieldDefs: typeof CONDITION_FIELDS | typeof ACTION_FIELDS): boolean {
+  return !!fieldDefs[field]?.entity;
+}
 
 // ─── Entity resolution ────────────────────────────────────────────────────────
 
@@ -59,6 +67,7 @@ export function ConditionChip({
   const field = condition.field ?? "";
   const fieldLabel = CONDITION_FIELDS[field]?.label ?? field;
   const valueLabels = resolveValues(field, condition.value, maps, CONDITION_FIELDS);
+  const isEntity = isEntityField(field, CONDITION_FIELDS);
 
   return (
     <div className="flex items-center gap-1 flex-wrap">
@@ -68,11 +77,16 @@ export function ConditionChip({
       </span>
       {/* Op — muted */}
       <span className="text-[11px] text-muted-foreground">{condition.op}</span>
-      {/* Values — each as its own emerald chip */}
+      {/* Values — sky for entity references, emerald for plain strings */}
       {valueLabels.map((label, i) => (
-        <span key={i} className="rounded px-1 py-0.5 text-[11px] font-medium bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+        <span key={i} className={cn(
+          "rounded px-1 py-0.5 text-[11px] font-medium",
+          isEntity
+            ? "bg-sky-50 text-sky-700 dark:bg-sky-950/30 dark:text-sky-400"
+            : "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400"
+        )}>
           {label}
-          {i < valueLabels.length - 1 && <span className="text-emerald-500 ml-0.5">,</span>}
+          {i < valueLabels.length - 1 && <span className={isEntity ? "text-sky-500 ml-0.5" : "text-emerald-500 ml-0.5"}>,</span>}
         </span>
       ))}
     </div>
@@ -148,6 +162,7 @@ export function ActionChip({
   } else {
     valueLabels = resolveValues(field, action.value, maps, ACTION_FIELDS);
   }
+  const isEntity = isEntityField(field, ACTION_FIELDS);
 
   return (
     <div className="flex items-center gap-1 flex-wrap">
@@ -159,9 +174,14 @@ export function ActionChip({
       </span>
       <span className="text-[11px] text-muted-foreground">→</span>
       {valueLabels.map((label, i) => (
-        <span key={i} className="rounded px-1 py-0.5 text-[11px] font-medium bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+        <span key={i} className={cn(
+          "rounded px-1 py-0.5 text-[11px] font-medium",
+          isEntity
+            ? "bg-sky-50 text-sky-700 dark:bg-sky-950/30 dark:text-sky-400"
+            : "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400"
+        )}>
           {label}
-          {i < valueLabels.length - 1 && <span className="text-emerald-500 ml-0.5">,</span>}
+          {i < valueLabels.length - 1 && <span className={isEntity ? "text-sky-500 ml-0.5" : "text-emerald-500 ml-0.5"}>,</span>}
         </span>
       ))}
     </div>

--- a/src/features/rules/utils/rulePreview.ts
+++ b/src/features/rules/utils/rulePreview.ts
@@ -35,6 +35,22 @@ function resolveValue(
   fieldDefs: Record<string, { entity?: string }>
 ): string {
   const def = fieldDefs[field];
+
+  // For array values with an entity field, resolve each ID individually before
+  // joining — valueToString() would join the raw UUIDs first, making map lookups fail.
+  if (Array.isArray(value) && def?.entity) {
+    return (value as string[])
+      .filter(Boolean)
+      .map((id) => {
+        if (def.entity === "payee")         return maps.payees[id]?.entity.name         ?? id;
+        if (def.entity === "category")      return maps.categories[id]?.entity.name     ?? id;
+        if (def.entity === "account")       return maps.accounts[id]?.entity.name       ?? id;
+        if (def.entity === "categoryGroup") return maps.categoryGroups[id]?.entity.name ?? id;
+        return id;
+      })
+      .join(", ");
+  }
+
   const val = valueToString(value);
 
   if (def?.entity === "payee") {
@@ -60,7 +76,9 @@ function summariseCondition(c: ConditionOrAction, maps: EntityMaps): string {
   const field = c.field ?? "";
   const fieldLabel = CONDITION_FIELDS[field]?.label ?? field;
   const valueLabel = resolveValue(field, c.value, maps, CONDITION_FIELDS);
-  return `${fieldLabel} ${c.op} "${valueLabel}"`;
+  // Array values (e.g. oneOf) are already joined — no surrounding quotes needed.
+  const wrapped = Array.isArray(c.value) ? valueLabel : `"${valueLabel}"`;
+  return `${fieldLabel} ${c.op} ${wrapped}`;
 }
 
 function summariseAction(a: ConditionOrAction, maps: EntityMaps): string {
@@ -79,7 +97,8 @@ function summariseAction(a: ConditionOrAction, maps: EntityMaps): string {
   }
 
   const valueLabel = resolveValue(field, a.value, maps, ACTION_FIELDS);
-  return `set ${fieldLabel} → "${valueLabel}"`;
+  const wrapped = Array.isArray(a.value) ? valueLabel : `"${valueLabel}"`;
+  return `set ${fieldLabel} → ${wrapped}`;
 }
 
 export function rulePreview(rule: Rule, maps: EntityMaps): string {

--- a/src/features/tags/components/FilterBar.tsx
+++ b/src/features/tags/components/FilterBar.tsx
@@ -6,7 +6,7 @@ import { PillGroup } from "@/components/ui/pill-group";
 
 export type ColorFilter = "all" | "has_color" | "no_color";
 
-export const COLOR_OPTIONS: { value: ColorFilter; label: string }[] = [
+const COLOR_OPTIONS: { value: ColorFilter; label: string }[] = [
   { value: "all",       label: "All" },
   { value: "has_color", label: "Has Color" },
   { value: "no_color",  label: "No Color" },
@@ -16,17 +16,22 @@ export function FilterBar({
   search, onSearchChange,
   colorFilter, onColorFilterChange,
   filteredCount, totalCount,
+  colorCounts,
   selectedCount,
   onBulkDelete, onDeselect,
 }: {
   search: string; onSearchChange: (v: string) => void;
   colorFilter: ColorFilter; onColorFilterChange: (v: ColorFilter) => void;
   filteredCount: number; totalCount: number;
+  colorCounts?: Record<ColorFilter, number>;
   selectedCount: number;
   onBulkDelete: () => void;
   onDeselect: () => void;
 }) {
   const hasFilters = search || colorFilter !== "all";
+  const pillOptions = COLOR_OPTIONS.map((opt) =>
+    colorCounts ? { ...opt, label: `${opt.label} (${colorCounts[opt.value]})` } : opt
+  );
 
   if (selectedCount > 0) {
     return (
@@ -60,7 +65,7 @@ export function FilterBar({
         )}
       </div>
 
-      <PillGroup options={COLOR_OPTIONS} value={colorFilter} onChange={onColorFilterChange} />
+      <PillGroup options={pillOptions} value={colorFilter} onChange={onColorFilterChange} />
 
       {hasFilters && (
         <button

--- a/src/features/tags/components/TagsTable.tsx
+++ b/src/features/tags/components/TagsTable.tsx
@@ -150,7 +150,7 @@ export function TagsTable() {
     const q = search.trim().toLowerCase();
     return Object.values(stagedTags)
       .filter((s) => {
-        if (q && !s.entity.name.toLowerCase().includes(q)) return false;
+        if (q && !s.entity.name.toLowerCase().includes(q) && !(s.entity.description?.toLowerCase().includes(q) ?? false)) return false;
         if (colorFilter === "has_color" && !s.entity.color) return false;
         if (colorFilter === "no_color"  &&  s.entity.color) return false;
         return true;
@@ -169,6 +169,16 @@ export function TagsTable() {
       if (n) counts.set(n, (counts.get(n) ?? 0) + 1);
     }
     return new Set([...counts.entries()].filter(([, c]) => c > 1).map(([n]) => n));
+  }, [stagedTags]);
+
+  // ── Color filter counts (all non-deleted, unaffected by search) ──────────
+  const colorCounts = useMemo(() => {
+    const all = Object.values(stagedTags).filter((s) => !s.isDeleted);
+    return {
+      all:       all.length,
+      has_color: all.filter((s) =>  !!s.entity.color).length,
+      no_color:  all.filter((s) => !s.entity.color).length,
+    };
   }, [stagedTags]);
 
   // ── Select-all helpers ────────────────────────────────────────────────────
@@ -348,7 +358,7 @@ export function TagsTable() {
     <>
       <div
         ref={containerRef}
-        className="flex flex-col outline-none"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden outline-none"
         onKeyDown={handleKeyDown}
         tabIndex={-1}
       >
@@ -357,11 +367,13 @@ export function TagsTable() {
           colorFilter={colorFilter} onColorFilterChange={setColorFilter}
           filteredCount={rows.filter((r) => !r.isDeleted).length}
           totalCount={totalCount}
+          colorCounts={colorCounts}
           selectedCount={activeSelected}
           onBulkDelete={handleBulkDelete}
           onDeselect={clearSelection}
         />
 
+        <div className="min-h-0 flex-1 overflow-auto">
         {rows.length === 0 ? (
           <div className="flex flex-1 items-center justify-center py-16 text-sm text-muted-foreground">
             {search || colorFilter !== "all"
@@ -583,6 +595,7 @@ export function TagsTable() {
             </tbody>
           </table>
         )}
+        </div>
 
         <BulkAddBar bulkCount={bulkCount} onBulkCountChange={setBulkCount} onAdd={(n) => addRows(n, true)} />
       </div>

--- a/src/features/tags/components/TagsView.tsx
+++ b/src/features/tags/components/TagsView.tsx
@@ -89,6 +89,7 @@ export function TagsView() {
       isError={isError}
       error={error}
       onRetry={refetch}
+      scrollManaged
       actions={
         <>
           <input

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { useStagedStore } from "@/store/staged";
+
+/**
+ * Wires global keyboard shortcuts for the staged store.
+ * Must be called once, inside a client component (AppShell).
+ *
+ * Ctrl/Cmd+Z        → undo
+ * Ctrl/Cmd+Shift+Z  → redo
+ * Ctrl/Cmd+Y        → redo (Windows convention)
+ *
+ * Shortcuts are suppressed when focus is inside an input, textarea, or
+ * contentEditable element so native browser text-undo is not broken.
+ */
+export function useKeyboardShortcuts() {
+  const undo = useStagedStore((s) => s.undo);
+  const redo = useStagedStore((s) => s.redo);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+
+      // Don't steal Ctrl+Z from text inputs — let the browser handle it.
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) return;
+
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      } else if ((e.key === "z" && e.shiftKey) || e.key === "y") {
+        e.preventDefault();
+        redo();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo]);
+}


### PR DESCRIPTION
  ## Summary

  - **Rules search now matches entity names in `oneOf` conditions** — searching "ASTER" correctly returns rules with `Payee oneOf ASTER, iHERB, Life Pharmacy`. The bug was in
  `rulePreview.resolveValue()` which joined raw UUIDs into a single string before map lookup, causing every array-value entity lookup to miss.
  - **Rule chips visually distinguish entity references from string values** — entity chips (payee, category, account, group) render in sky/blue; plain string values keep emerald green.
  - **FilterBar stays visible while scrolling** in Payees, Accounts, Categories, and Tags pages — matches the existing Rules page behaviour. BulkAddBar also remains pinned at the bottom.
  - **Ctrl/Cmd+Z / Ctrl/Cmd+Shift+Z** globally trigger undo/redo from the staged store. Suppressed when an input or textarea has focus so native browser text-undo is not affected.
  - **Tags search now matches descriptions** in addition to tag names.
  - **Payee names are trimmed** on commit, consistent with Tags and with the existing duplicate-detection logic.
  - **Tags color filter pills show live counts** — e.g. `All (10)  Has Color (6)  No Color (4)`.
  - **Rule preview no longer wraps multi-value results in quotes** — `Payee oneOf "ASTER, iHERB"` → `Payee oneOf ASTER, iHERB`.

  Closes #48

  ## Test plan

  - [x] Search Payee Name in Rules — rules with `Payee oneOf Payee Name` appear in results
  - [x] Condition chip with a payee/category field renders in blue; `Notes contains "string"` renders in green
  - [x] Scroll down on Payees, Accounts, Categories, Tags — FilterBar stays at top, table header stays sticky, BulkAddBar stays at bottom
  - [x] Press Ctrl+Z / Cmd+Z outside any input — last staged change is undone; Ctrl+Shift+Z redoes it
  - [x] Press Ctrl+Z while editing a payee name input — browser text-undo fires, not store undo
  - [x] Search "supermarket" in Tags when a tag has description "Weekly supermarket" — tag appears
  - [x] Edit a payee name with leading/trailing spaces — spaces are stripped on commit
  - [x] Tags color filter pills display counts matching the actual data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts for undo and redo (Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z, Ctrl/Cmd+Y)

* **Improvements**
  * Optimized table scrolling behavior across accounts, categories, payees, and tags views
  * Enhanced rule visualization with distinct styling for entity vs. non-entity fields
  * Tag filters now display color counts
  * Tag search now includes descriptions
  * Payee name inputs automatically trimmed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->