### PR TITLE
fix/updated connection flow and server validation flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -26,9 +26,8 @@ export function ConnectForm() {
     budgets,
     validatedUrl,
     validatedApiVersion,
-    serverVersionMap,
-    selectedCloudFileId,
-    setSelectedCloudFileId,
+    selectedGroupId,
+    setSelectedGroupId,
     encryptionPassword,
     setEncryptionPassword,
     connectStatus,
@@ -192,15 +191,15 @@ export function ConnectForm() {
 
       <div className="flex flex-col gap-2 max-h-70 overflow-y-auto pr-1">
         {budgets.map((budget) => {
-          const selected = selectedCloudFileId === budget.cloudFileId;
+          const selected = selectedGroupId === budget.groupId;
           const alreadyConnected = connectedSyncIds.has(budget.groupId ?? "");
           return (
             <button
-              key={budget.cloudFileId}
+              key={budget.groupId}
               type="button"
               disabled={connectBusy || !!reconnectBusyId}
               onClick={() => {
-                setSelectedCloudFileId(budget.cloudFileId);
+                setSelectedGroupId(budget.groupId ?? null);
                 if (connectStatus.kind === "error") setConnectStatus({ kind: "idle" });
               }}
               className={cn(
@@ -232,11 +231,6 @@ export function ConnectForm() {
                 <span className="text-xs text-muted-foreground font-mono truncate">
                   Sync ID: {budget.groupId}
                 </span>
-                {serverVersionMap[budget.cloudFileId] && (
-                  <span className="text-xs text-muted-foreground font-mono truncate">
-                    Server version: v{serverVersionMap[budget.cloudFileId]}
-                  </span>
-                )}
               </span>
             </button>
           );
@@ -271,7 +265,7 @@ export function ConnectForm() {
 
       <button
         type="button"
-        disabled={connectBusy || !!reconnectBusyId || !selectedCloudFileId}
+        disabled={connectBusy || !!reconnectBusyId || !selectedGroupId}
         onClick={handleConnect}
         className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
       >
@@ -307,7 +301,7 @@ export function ConnectForm() {
                   instance={instance}
                   isActive={activeInstance?.id === instance.id}
                   onConnect={handleReconnect}
-                  onRemove={(id) => removeInstance(id)}
+                  onRemove={removeInstance}
                   connectBusyId={reconnectBusyId}
                 />
               ))}

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -51,8 +51,7 @@ export function useConnectForm() {
   const [validatedUrl, setValidatedUrl] = useState("");
   const [validatedKey, setValidatedKey] = useState("");
   const [validatedApiVersion, setValidatedApiVersion] = useState<string | null>(null);
-  const [serverVersionMap, setServerVersionMap] = useState<Record<string, string | null>>({});
-  const [selectedCloudFileId, setSelectedCloudFileId] = useState<string | null>(null);
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [encryptionPassword, setEncryptionPassword] = useState("");
   const [connectStatus, setConnectStatus] = useState<ConnectStatus>({ kind: "idle" });
 
@@ -78,13 +77,12 @@ export function useConnectForm() {
 
   function resetStep2() {
     setBudgets(null);
-    setSelectedCloudFileId(null);
+    setSelectedGroupId(null);
     setEncryptionPassword("");
     setConnectStatus({ kind: "idle" });
     setValidatedUrl("");
     setValidatedKey("");
     setValidatedApiVersion(null);
-    setServerVersionMap({});
   }
 
   function handleCredentialChange() {
@@ -165,7 +163,7 @@ export function useConnectForm() {
 
     setValidateStatus({ kind: "busy" });
     setBudgets(null);
-    setSelectedCloudFileId(null);
+    setSelectedGroupId(null);
     setEncryptionPassword("");
     setConnectStatus({ kind: "idle" });
 
@@ -186,30 +184,11 @@ export function useConnectForm() {
         return;
       }
 
-      const versionEntries = await Promise.all(
-        fetched.map(async (budget) => {
-          if (!budget.groupId) return [budget.cloudFileId, null] as const;
-          try {
-            const version = await getServerVersion(url, key, budget.groupId);
-            return [budget.cloudFileId, version] as const;
-          } catch (err) {
-            // Rethrow auth errors so the caller can surface them as step-1 failures.
-            const status =
-              err && typeof err === "object" && "status" in err
-                ? (err as { status: number }).status
-                : -1;
-            if (status === 401 || status === 403) throw err;
-            return [budget.cloudFileId, null] as const;
-          }
-        })
-      );
-
       setValidatedUrl(url);
       setValidatedKey(key);
       setValidatedApiVersion(apiVersion);
-      setServerVersionMap(Object.fromEntries(versionEntries));
       setBudgets(fetched);
-      setSelectedCloudFileId(fetched[0].cloudFileId);
+      setSelectedGroupId(fetched[0].groupId!);
       setValidateStatus({ kind: "idle" });
 
       // Persist the server, then select its chip so the manual form collapses.
@@ -233,9 +212,9 @@ export function useConnectForm() {
   // ── Connect to selected budget ──────────────────────────────────────────────
 
   async function connect() {
-    if (!budgets || !selectedCloudFileId) return;
+    if (!budgets || !selectedGroupId) return;
 
-    const selected = budgets.find((b) => b.cloudFileId === selectedCloudFileId);
+    const selected = budgets.find((b) => b.groupId === selectedGroupId);
     if (!selected) return;
 
     // If this budget is already saved, reconnect to the existing instance
@@ -255,6 +234,7 @@ export function useConnectForm() {
       setConnectStatus({ kind: "busy" });
       try {
         await reconnect(freshInstance);
+        setConnectStatus({ kind: "idle" });
       } catch (err) {
         const status =
           err && typeof err === "object" && "status" in err
@@ -284,10 +264,20 @@ export function useConnectForm() {
     setConnectStatus({ kind: "busy" });
     try {
       await testConnection(instance);
+      const [apiVersionResult, serverVersionResult] = await Promise.allSettled([
+        getApiVersion(validatedUrl, validatedKey),
+        getServerVersion(validatedUrl, validatedKey, selected.groupId!),
+      ]);
       const finalInstance: ConnectionInstance = {
         ...instance,
-        apiVersion: validatedApiVersion ?? undefined,
-        serverVersion: serverVersionMap[selected.cloudFileId] ?? undefined,
+        apiVersion:
+          apiVersionResult.status === "fulfilled"
+            ? apiVersionResult.value
+            : validatedApiVersion ?? undefined,
+        serverVersion:
+          serverVersionResult.status === "fulfilled"
+            ? serverVersionResult.value
+            : undefined,
       };
       discardAll();
       queryClient.clear();
@@ -337,9 +327,8 @@ export function useConnectForm() {
     budgets,
     validatedUrl,
     validatedApiVersion,
-    serverVersionMap,
-    selectedCloudFileId,
-    setSelectedCloudFileId,
+    selectedGroupId,
+    setSelectedGroupId,
     encryptionPassword,
     setEncryptionPassword,
     connectStatus,

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -10,6 +10,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -34,17 +42,22 @@ import { useCategoriesSave } from "@/features/categories/hooks/useCategoriesSave
 import { useRulesSave } from "@/features/rules/hooks/useRulesSave";
 import { useTagsSave } from "@/features/tags/hooks/useTagsSave";
 
+type PendingAction =
+  | { kind: "switch"; id: string }
+  | { kind: "addConnection" }
+  | { kind: "disconnect" };
+
 export function TopBar() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
 
   const activeInstance = useConnectionStore(selectActiveInstance);
   const instances = useConnectionStore((s) => s.instances);
   const setActive = useConnectionStore((s) => s.setActiveInstance);
   const clearAll = useConnectionStore((s) => s.clearAll);
   const clearServers = useSavedServersStore((s) => s.clearServers);
-
 
   const hasChanges = useStagedStore(selectHasChanges);
   const canUndo = useStagedStore(selectCanUndo);
@@ -62,23 +75,53 @@ export function TopBar() {
   const { save: saveTags, isSaving: isSavingTags } = useTagsSave();
   const isSaving = isSavingAccounts || isSavingPayees || isSavingGroups || isSavingCategories || isSavingRules || isSavingTags;
 
+  // ── Guarded action helpers ────────────────────────────────────────────────────
+
+  function requestAction(action: PendingAction) {
+    if (hasChanges) {
+      setPendingAction(action);
+    } else {
+      void executeAction(action);
+    }
+  }
+
+  async function executeAction(action: PendingAction) {
+    if (action.kind === "switch") {
+      discardAll();
+      queryClient.clear();
+      setActive(action.id);
+    } else if (action.kind === "addConnection") {
+      discardAll();
+      await queryClient.cancelQueries();
+      queryClient.clear();
+      setActive(null);
+      router.push("/connect");
+    } else if (action.kind === "disconnect") {
+      discardAll();
+      queryClient.clear();
+      clearAll();
+      clearServers();
+      router.push("/connect");
+    }
+  }
+
+  async function handleConfirmDiscard() {
+    const action = pendingAction;
+    setPendingAction(null);
+    if (action) await executeAction(action);
+  }
+
+  // ── Handlers ──────────────────────────────────────────────────────────────────
+
   async function handleSave() {
     try {
-      // Step 1: Save accounts, payees, category groups, and tags in parallel.
-      // These are independent and their server IDs are needed by later steps.
       const [accountsResult, payeesResult, groupsResult, tagsResult] = await Promise.all([
         saveAccounts(),
         savePayees(),
         saveCategoryGroups(),
         saveTags(),
       ]);
-
-      // Step 2: Save categories after groups. Pass the group idMap so that new
-      // categories whose groupId is a client UUID get the real server group ID.
       const categoriesResult = await saveCategories(groupsResult.idMap);
-
-      // Step 3: Save rules last, substituting any client UUIDs that appear in
-      // conditions/actions with the server-assigned IDs from steps 1–2.
       const entityIdMap = {
         ...payeesResult.idMap,
         ...accountsResult.idMap,
@@ -118,9 +161,7 @@ export function TopBar() {
 
   function handleSwitchConnection(id: string) {
     if (id === activeInstance?.id) return;
-    discardAll();
-    queryClient.clear();
-    setActive(id);
+    requestAction({ kind: "switch", id });
   }
 
   function handleRefresh() {
@@ -142,135 +183,147 @@ export function TopBar() {
     queryClient.invalidateQueries().then(() => setIsRefreshing(false));
   }
 
-  function handleDisconnect() {
-    discardAll();
-    queryClient.clear();
-    clearAll();
-    clearServers();
-    router.push("/connect");
-  }
-
   return (
-    <header className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4">
-      {/* Left: branding */}
-      <div className="flex items-center gap-2">
-        <Image src="/icon.png" alt="Actual Bench" height={24} width={24} className="object-contain" />        
-        <span className="text-sm font-semibold tracking-tight">
-          Actual Bench
-        </span>
+    <>
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4">
+        {/* Left: branding */}
+        <div className="flex items-center gap-2">
+          <Image src="/icon.png" alt="Actual Bench" height={24} width={24} className="object-contain" />
+          <span className="text-sm font-semibold tracking-tight">
+            Actual Bench
+          </span>
 
-        {activeInstance && (
-          <DropdownMenu>
-            <DropdownMenuTrigger className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground">
-              <span className="max-w-40 truncate text-muted-foreground">
-                {activeInstance.label}
-              </span>
-              <ChevronDown className="h-3 w-3 text-muted-foreground" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-80">
-              {instances.map((instance) => (
-                <DropdownMenuItem
-                  key={instance.id}
-                  onClick={() => handleSwitchConnection(instance.id)}
-                  className="flex items-center justify-between"
-                >
-                  <span className="truncate">{instance.label}</span>
-                  {instance.id === activeInstance.id && (
-                    <Badge variant="secondary" className="ml-2 text-xs">
-                      active
-                    </Badge>
-                  )}
+          {activeInstance && (
+            <DropdownMenu>
+              <DropdownMenuTrigger className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground">
+                <span className="max-w-40 truncate text-muted-foreground">
+                  {activeInstance.label}
+                </span>
+                <ChevronDown className="h-3 w-3 text-muted-foreground" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-80">
+                {instances.map((instance) => (
+                  <DropdownMenuItem
+                    key={instance.id}
+                    onClick={() => handleSwitchConnection(instance.id)}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="truncate">{instance.label}</span>
+                    {instance.id === activeInstance.id && (
+                      <Badge variant="secondary" className="ml-2 text-xs">
+                        active
+                      </Badge>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => requestAction({ kind: "addConnection" })}>
+                  Add connection…
                 </DropdownMenuItem>
-              ))}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => router.push("/connect")}>
-                Add connection…
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={handleDisconnect}
-                className="text-destructive"
-              >
-                Disconnect
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-
-        {activeInstance && (activeInstance.apiVersion ?? activeInstance.serverVersion) && (
-          <div className="flex items-center gap-2 text-xs select-none">
-            {activeInstance.apiVersion && (
-              <span className="px-3 py-1.5 rounded-md bg-muted text-muted-foreground">
-              actual-http-api v{activeInstance.apiVersion}
-              </span>
-            )}
-            {activeInstance.serverVersion && (
-              <span className="px-3 py-1.5 rounded-md bg-muted text-muted-foreground">
-              actual budget v{activeInstance.serverVersion}
-              </span>
-            )}
-          </div>
-        )}
-
-      </div>
-
-      {/* Right: undo/redo + unsaved indicator + save/discard */}
-      <div className="flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          disabled={!canUndo}
-          onClick={undo}
-          title="Undo"
-        >
-          <Undo2 className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          disabled={!canRedo}
-          onClick={redo}
-          title="Redo"
-        >
-          <Redo2 className="h-3.5 w-3.5" />
-        </Button>
-
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          disabled={isRefreshing}
-          onClick={handleRefresh}
-          title="Refresh data from server"
-        >
-          <RefreshCw className={`h-3.5 w-3.5${isRefreshing ? " animate-spin" : ""}`} />
-        </Button>
-
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 text-xs"
-          disabled={!hasChanges}
-          onClick={() => { discardAll(); queryClient.resetQueries(); }}
-        >
-          <X className="mr-1 h-3.5 w-3.5" />
-          Discard
-        </Button>
-
-        <Button
-          size="sm"
-          className={cn(
-            "h-7 text-xs bg-action text-action-foreground hover:bg-action-hover",
-            hasChanges && !isSaving && "ring-2 ring-offset-1 ring-action/50"
+                <DropdownMenuItem
+                  onClick={() => requestAction({ kind: "disconnect" })}
+                  className="text-destructive"
+                >
+                  Disconnect
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
-          disabled={!hasChanges || isSaving}
-          onClick={handleSave}
-        >
-          <Save className="mr-1 h-3.5 w-3.5" />
-          {isSaving ? "Saving…" : "Save"}
-        </Button>
-      </div>
-    </header>
+
+          {activeInstance && (activeInstance.apiVersion ?? activeInstance.serverVersion) && (
+            <div className="flex items-center gap-2 text-xs select-none">
+              {activeInstance.apiVersion && (
+                <span className="px-3 py-1.5 rounded-md bg-muted text-muted-foreground">
+                  actual-http-api v{activeInstance.apiVersion}
+                </span>
+              )}
+              {activeInstance.serverVersion && (
+                <span className="px-3 py-1.5 rounded-md bg-muted text-muted-foreground">
+                  actual budget v{activeInstance.serverVersion}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Right: undo/redo + unsaved indicator + save/discard */}
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            disabled={!canUndo}
+            onClick={undo}
+            title="Undo"
+          >
+            <Undo2 className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            disabled={!canRedo}
+            onClick={redo}
+            title="Redo"
+          >
+            <Redo2 className="h-3.5 w-3.5" />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            disabled={isRefreshing}
+            onClick={handleRefresh}
+            title="Refresh data from server"
+          >
+            <RefreshCw className={`h-3.5 w-3.5${isRefreshing ? " animate-spin" : ""}`} />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            disabled={!hasChanges}
+            onClick={() => { discardAll(); queryClient.resetQueries(); }}
+          >
+            <X className="mr-1 h-3.5 w-3.5" />
+            Discard
+          </Button>
+
+          <Button
+            size="sm"
+            className={cn(
+              "h-7 text-xs bg-action text-action-foreground hover:bg-action-hover",
+              hasChanges && !isSaving && "ring-2 ring-offset-1 ring-action/50"
+            )}
+            disabled={!hasChanges || isSaving}
+            onClick={handleSave}
+          >
+            <Save className="mr-1 h-3.5 w-3.5" />
+            {isSaving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </header>
+
+      <Dialog open={pendingAction !== null} onOpenChange={(open) => { if (!open) setPendingAction(null); }}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved staged edits. This action will discard them permanently.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingAction(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDiscard}>
+              Discard & Continue
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -159,7 +159,7 @@ export type BudgetFile = {
  * Lists remote budget files available on the server.
  * Uses GET /v1/budgets/ — a server-level endpoint that doesn't require a
  * budgetSyncId, so no budget is opened on the actual-http-api side.
- * Filters to state === "remote" and deduplicates by cloudFileId.
+ * Filters to state === "remote" and deduplicates by groupId (Sync ID).
  */
 export async function listBudgets(
   baseUrl: string,
@@ -188,13 +188,15 @@ export async function listBudgets(
   const payload = (await response.json()) as { data: BudgetFile[] } | BudgetFile[];
   const all: BudgetFile[] = Array.isArray(payload) ? payload : (payload.data ?? []);
 
-  // Keep only remote budgets that have a groupId, deduplicate by cloudFileId.
+  // Keep only remote budgets that have a groupId, deduplicate by groupId (Sync ID).
+  // groupId is the server-assigned unique identifier and is guaranteed unique
+  // among state === "remote" entries. cloudFileId is NOT guaranteed unique.
   const seen = new Set<string>();
   return all.filter((b) => {
     if (b.state !== "remote") return false;
     if (!b.groupId) return false;
-    if (seen.has(b.cloudFileId)) return false;
-    seen.add(b.cloudFileId);
+    if (seen.has(b.groupId)) return false;
+    seen.add(b.groupId);
     return true;
   });
 }

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -25,7 +25,7 @@ type ConnectionState = {
 type ConnectionActions = {
   addInstance: (instance: ConnectionInstance) => void;
   removeInstance: (id: string) => void;
-  setActiveInstance: (id: string) => void;
+  setActiveInstance: (id: string | null) => void;
   updateInstance: (id: string, patch: Partial<Omit<ConnectionInstance, "id">>) => void;
   clearAll: () => void;
 };


### PR DESCRIPTION
## Summary

Fix the connection and validation flow in Actual Bench so that:

1. **Server validation stays server-only**
2. **Add Connection disconnects the active budget immediately**
3. **Budget-scoped work happens only during explicit connect/reconnect**
4. **Reconnecting to the same budget after Add Connection works as a clean reconnect**

  useConnectForm.ts
  - Removed serverVersionMap state (useState, setServerVersionMap({}) in resetStep2(), return value) — it has been {} since the validation fix and was never read for anything meaningful
  - Fixed connect() existing-instance path: setConnectStatus({ kind: "idle" }) is now called on successful reconnect. Previously connectStatus was left at busy when navigating away on success, which was technically harmless but incorrect state

  ConnectForm.tsx
  - Removed serverVersionMap from destructuring and the dead JSX block (Server version: v{...}) that rendered nothing
  - Simplified onRemove={(id) => removeInstance(id)} → onRemove={removeInstance}


## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser

## Notes

<!-- Anything reviewers should pay attention to: edge cases, breaking changes, follow-up work. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog that prompts users to confirm before disconnecting or switching connections when unsaved changes exist.

* **Bug Fixes**
  * Improved connection selection and switching logic to properly preserve user changes.

* **Refactor**
  * Streamlined connection state management and removed redundant server version displays from connection lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->