### PR TITLE
  feat: rules integration, UX polish, and table improvements across e…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useInlineEdit } from "@/hooks/useInlineEdit";
 import { useTableSelection } from "@/hooks/useTableSelection";
@@ -21,13 +22,13 @@ import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { FilterBar } from "./FilterBar";
 import { BulkAddBar } from "./BulkAddBar";
-import type { StatusFilter, BudgetFilter } from "./FilterBar";
+import type { StatusFilter, BudgetFilter, RulesFilter } from "./FilterBar";
 import type { StagedEntity } from "@/types/staged";
 import type { Account } from "@/types/entities";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
-const NAVIGABLE_COLS = ["name", "offBudget"] as const;
+const NAVIGABLE_COLS = ["name"] as const;
 type NavigableCol = (typeof NAVIGABLE_COLS)[number];
 type CellId = { rowId: string; colId: NavigableCol };
 type AccountRow = StagedEntity<Account>;
@@ -46,13 +47,19 @@ function SortIndicator({ col, sortCol, sortDir }: { col: SortCol; sortCol: SortC
 
 // ─── AccountsTable ─────────────────────────────────────────────────────────────
 
-export function AccountsTable() {
+export function AccountsTable({
+  onCreateRule,
+}: {
+  onCreateRule?: (accountId: string, accountName: string) => void;
+}) {
   const highlightedId = useHighlight();
+  const router = useRouter();
 
   // ── Filter / sort state ──────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [budgetFilter, setBudgetFilter] = useState<BudgetFilter>("all");
+  const [rulesFilter, setRulesFilter] = useState<RulesFilter>("all");
   const [sortCol, setSortCol] = useState<SortCol | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -71,6 +78,7 @@ export function AccountsTable() {
 
   // ── Store subscriptions ──────────────────────────────────────────────────────
   const staged = useStagedStore((s) => s.accounts);
+  const stagedRules = useStagedStore((s) => s.rules);
   const stageNew = useStagedStore((s) => s.stageNew);
   const stageUpdate = useStagedStore((s) => s.stageUpdate);
   const stageDelete = useStagedStore((s) => s.stageDelete);
@@ -93,6 +101,24 @@ export function AccountsTable() {
     return dupes;
   }, [staged]);
 
+  // ── Account → rule count ─────────────────────────────────────────────────────
+  const accountRuleCount = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of Object.values(stagedRules)) {
+      if (s.isDeleted) continue;
+      for (const part of [...s.entity.conditions, ...s.entity.actions]) {
+        if (part.field === "account") {
+          const ids = Array.isArray(part.value) ? part.value : [part.value];
+          for (const id of ids) {
+            if (typeof id === "string" && id)
+              counts.set(id, (counts.get(id) ?? 0) + 1);
+          }
+        }
+      }
+    }
+    return counts;
+  }, [stagedRules]);
+
   // ── Derived rows: filter → sort ──────────────────────────────────────────────
   const rows: AccountRow[] = useMemo(() => {
     const q = search.toLowerCase();
@@ -103,6 +129,8 @@ export function AccountsTable() {
       if (statusFilter === "closed" && !r.entity.closed)    continue;
       if (budgetFilter === "on"  && r.entity.offBudget)  continue;
       if (budgetFilter === "off" && !r.entity.offBudget) continue;
+      if (rulesFilter === "with_rules" && !(accountRuleCount.get(r.entity.id) ?? 0)) continue;
+      if (rulesFilter === "no_rules"   &&  (accountRuleCount.get(r.entity.id) ?? 0)) continue;
       result.push(r);
     }
 
@@ -118,7 +146,7 @@ export function AccountsTable() {
       });
     }
     return result;
-  }, [staged, search, statusFilter, budgetFilter, sortCol, sortDir]);
+  }, [staged, search, statusFilter, budgetFilter, rulesFilter, accountRuleCount, sortCol, sortDir]);
 
   function toggleSort(col: SortCol) {
     if (sortCol === col) {
@@ -235,20 +263,6 @@ export function AccountsTable() {
     }
   }
 
-  function handleFillDown() {
-    if (!selectedCell || selectedIds.size < 2) return;
-    const colId = selectedCell.colId;
-    const selectedInOrder = rows.filter((r) => selectedIds.has(r.entity.id));
-    if (selectedInOrder.length < 2) return;
-    const source = selectedInOrder[0];
-    pushUndo();
-    for (const row of selectedInOrder.slice(1)) {
-      if (row.isDeleted) continue;
-      if (colId === "name") stageUpdate("accounts", row.entity.id, { name: source.entity.name });
-      else if (colId === "offBudget") stageUpdate("accounts", row.entity.id, { offBudget: source.entity.offBudget });
-    }
-  }
-
   // ── Paste from Excel / Sheets ─────────────────────────────────────────────────
   function handlePaste(e: React.ClipboardEvent<HTMLDivElement>) {
     if (editingCell) return; // let the input field handle it
@@ -315,13 +329,6 @@ export function AccountsTable() {
         e.preventDefault();
         if (selectedCell.colId === "name" && !row.isDeleted) startEditing(selectedCell.rowId, "name");
         break;
-      case " ":
-        if (selectedCell.colId === "offBudget" && !row.isDeleted) {
-          e.preventDefault();
-          pushUndo();
-          stageUpdate("accounts", row.entity.id, { offBudget: !row.entity.offBudget });
-        }
-        break;
       default:
         if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && selectedCell.colId === "name" && !row.isDeleted) {
           startEditing(selectedCell.rowId, "name", e.key);
@@ -331,7 +338,6 @@ export function AccountsTable() {
 
   // ── Render ───────────────────────────────────────────────────────────────────
   const totalCount = Object.keys(staged).length;
-  const canFillDown = selectedIds.size >= 2 && selectedCell !== null;
   const activeSelectedCount = [...selectedIds].filter((id) => staged[id] && !staged[id].isDeleted).length;
 
   return (
@@ -341,9 +347,9 @@ export function AccountsTable() {
           search={search} onSearchChange={setSearch}
           statusFilter={statusFilter} onStatusChange={setStatusFilter}
           budgetFilter={budgetFilter} onBudgetChange={setBudgetFilter}
+          rulesFilter={rulesFilter} onRulesFilterChange={setRulesFilter}
           filteredCount={rows.length} totalCount={totalCount}
-          selectedCount={activeSelectedCount} canFillDown={canFillDown}
-          onFillDown={handleFillDown}
+          selectedCount={activeSelectedCount}
           onBulkClose={handleBulkClose}
           onBulkReopen={handleBulkReopen}
           onBulkDelete={handleBulkDelete}
@@ -352,10 +358,16 @@ export function AccountsTable() {
 
         <div className="min-h-0 flex-1 overflow-auto">
         {rows.length === 0 ? (
-          <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-            {search || statusFilter !== "all" || budgetFilter !== "all"
-              ? "No accounts match the current filters."
-              : "No accounts yet."}
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+            <span>{search || statusFilter !== "all" || budgetFilter !== "all" || rulesFilter !== "all" ? "No accounts match the current filters." : "No accounts yet."}</span>
+            {(search || statusFilter !== "all" || budgetFilter !== "all" || rulesFilter !== "all") && (
+              <button
+                className="text-xs underline hover:text-foreground"
+                onClick={() => { setSearch(""); setStatusFilter("all"); setBudgetFilter("all"); setRulesFilter("all"); }}
+              >
+                Clear filters
+              </button>
+            )}
           </div>
         ) : (
           <table className="w-full border-collapse text-sm">
@@ -394,13 +406,17 @@ export function AccountsTable() {
                   </th>
 
                   <th
-                    className="w-24 cursor-pointer select-none px-2 py-1.5 text-left hover:bg-muted/30"
+                    className="w-32 cursor-pointer select-none px-2 py-1.5 text-left hover:bg-muted/30"
                     onClick={() => toggleSort("closed")}
                   >
                     <span className="flex items-center text-xs font-medium text-muted-foreground">
                       Status
                       <SortIndicator col="closed" sortCol={sortCol} sortDir={sortDir} />
                     </span>
+                  </th>
+
+                  <th className="w-40 px-2 py-1.5 text-left">
+                    <span className="text-xs font-medium text-muted-foreground">Rules</span>
                   </th>
 
                   <th className="w-24 p-0" />
@@ -412,7 +428,6 @@ export function AccountsTable() {
                   const { entity, isNew, isUpdated, isDeleted, saveError } = row;
                   const isDuplicate = !isDeleted && duplicateNames.has(entity.name.trim().toLowerCase());
                   const nameSelected   = selectedCell?.rowId === entity.id && selectedCell?.colId === "name";
-                  const budgetSelected = selectedCell?.rowId === entity.id && selectedCell?.colId === "offBudget";
                   const nameEditing    = editingCell?.rowId  === entity.id && editingCell?.colId  === "name";
                   const isRowSelected  = selectedIds.has(entity.id);
 
@@ -495,33 +510,59 @@ export function AccountsTable() {
                       </td>
 
                       {/* Budget toggle */}
-                      <td
-                        data-cell={`${entity.id}:offBudget`}
-                        tabIndex={budgetSelected ? 0 : -1}
-                        className={cn(
-                          "w-32 cursor-default px-2 py-0.5 outline-none",
-                          budgetSelected && "bg-primary/10 ring-1 ring-inset ring-primary/50",
-                        )}
-                        onClick={() => {
-                          if (budgetSelected && !isDeleted) {
-                            pushUndo();
-                            stageUpdate("accounts", entity.id, { offBudget: !entity.offBudget });
-                          } else {
-                            selectCell(entity.id, "offBudget");
-                          }
-                        }}
-                        onFocus={() => { if (!editingCell) selectCell(entity.id, "offBudget"); }}
-                      >
-                        <Badge variant={entity.offBudget ? "secondary" : "default"} className="text-xs font-normal">
+                      <td className="w-40 px-2 py-0.5">
+                        <button
+                          disabled={isDeleted}
+                          onClick={() => { pushUndo(); stageUpdate("accounts", entity.id, { offBudget: !entity.offBudget }); }}
+                          className={cn(
+                            "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium transition-opacity",
+                            entity.offBudget
+                              ? "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800/60 dark:text-slate-400 dark:hover:bg-slate-800"
+                              : "bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/60",
+                            isDeleted && "cursor-default opacity-50",
+                          )}
+                        >
+                          <span className={cn(
+                            "relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors",
+                            entity.offBudget ? "bg-slate-300 dark:bg-slate-600" : "bg-emerald-500 dark:bg-emerald-600",
+                          )}>
+                            <span className={cn(
+                              "inline-block h-3 w-3 rounded-full bg-white shadow transition-transform",
+                              entity.offBudget ? "translate-x-0.5" : "translate-x-3.5",
+                            )} />
+                          </span>
                           {entity.offBudget ? "Off Budget" : "On Budget"}
-                        </Badge>
+                        </button>
                       </td>
 
                       {/* Status */}
-                      <td className="w-24 px-2 py-0.5">
+                      <td className="w-32 px-2 py-0.5">
                         <Badge variant={entity.closed ? "status-inactive" : "status-active"} className="text-xs font-normal">
                           {entity.closed ? "Closed" : "Open"}
                         </Badge>
+                      </td>
+
+                      {/* Rules */}
+                      <td className="w-40 px-2 py-0.5">
+                        {!isDeleted && (() => {
+                          const count = accountRuleCount.get(entity.id) ?? 0;
+                          const label = count === 0
+                            ? "create rule"
+                            : count === 1
+                              ? "1 associated rule"
+                              : `${count} associated rules`;
+                          return (
+                            <button
+                              className="inline-flex items-center rounded bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 hover:bg-purple-200 dark:bg-purple-900/40 dark:text-purple-300 dark:hover:bg-purple-900/60"
+                              onClick={() => count > 0
+                                ? router.push(`/rules?accountId=${entity.id}`)
+                                : onCreateRule ? onCreateRule(entity.id, entity.name) : router.push("/rules?new=1")}
+                              title={count > 0 ? "View rules for this account" : "Create a rule for this account"}
+                            >
+                              {label}
+                            </button>
+                          );
+                        })()}
                       </td>
 
                       {/* Row actions */}

--- a/src/features/accounts/components/AccountsView.tsx
+++ b/src/features/accounts/components/AccountsView.tsx
@@ -38,8 +38,8 @@ export function AccountsView() {
 
   function handleCreateRule(accountId: string, accountName: string) {
     setRuleSeed({
-      conditions: [{ field: "account", op: "is", value: accountId, type: "id" }],
-      actions:    [{ field: "notes",   op: "set", value: accountName, type: "string" }],
+      conditions: [{ field: "payee",   op: "contains", value: accountName, type: "string" }],
+      actions:    [{ field: "account", op: "set",      value: accountId,   type: "id"     }],
     });
     setRuleDrawerOpen(true);
   }

--- a/src/features/accounts/components/AccountsView.tsx
+++ b/src/features/accounts/components/AccountsView.tsx
@@ -10,13 +10,14 @@ import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { useAccounts } from "../hooks/useAccounts";
 import { AccountsTable } from "./AccountsTable";
-import { AccountFormDrawer } from "./AccountFormDrawer";
+import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { exportAccountsToCsv } from "../csv/accountsCsvExport";
 import { importAccountsFromCsv } from "../csv/accountsCsvImport";
-import type { AccountFormValues } from "../schemas/account.schema";
 
 export function AccountsView() {
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [ruleDrawerOpen, setRuleDrawerOpen] = useState(false);
+  const [ruleSeed, setRuleSeed] = useState<RuleSeed | undefined>(undefined);
   const importInputRef = useRef<HTMLInputElement>(null);
 
   const { isLoading, isError, error, refetch } = useAccounts();
@@ -25,14 +26,22 @@ export function AccountsView() {
   const stageNew = useStagedStore((s) => s.stageNew);
   const pushUndo = useStagedStore((s) => s.pushUndo);
 
-  function handleDrawerSubmit(values: AccountFormValues) {
+  function handleAddAccount() {
     pushUndo();
     stageNew("accounts", {
       id: generateId(),
-      name: values.name,
-      offBudget: values.offBudget,
+      name: "New Account",
+      offBudget: false,
       closed: false,
     });
+  }
+
+  function handleCreateRule(accountId: string, accountName: string) {
+    setRuleSeed({
+      conditions: [{ field: "account", op: "is", value: accountId, type: "id" }],
+      actions:    [{ field: "notes",   op: "set", value: accountName, type: "string" }],
+    });
+    setRuleDrawerOpen(true);
   }
 
   function handleExportCsv() {
@@ -114,19 +123,20 @@ export function AccountsView() {
             <Upload />
             Export
           </Button>
-          <Button size="sm" onClick={() => setDrawerOpen(true)}>
+          <Button size="sm" onClick={handleAddAccount}>
             <Plus />
             Add Account
           </Button>
         </>
       }
     >
-      <AccountsTable />
+      <AccountsTable onCreateRule={handleCreateRule} />
 
-      <AccountFormDrawer
-        open={drawerOpen}
-        onOpenChange={setDrawerOpen}
-        onSubmit={handleDrawerSubmit}
+      <RuleDrawer
+        open={ruleDrawerOpen}
+        onOpenChange={setRuleDrawerOpen}
+        ruleId={null}
+        seed={ruleSeed}
       />
     </PageLayout>
   );

--- a/src/features/accounts/components/FilterBar.tsx
+++ b/src/features/accounts/components/FilterBar.tsx
@@ -6,6 +6,7 @@ import { PillGroup } from "@/components/ui/pill-group";
 
 export type StatusFilter = "all" | "open" | "closed";
 export type BudgetFilter = "all" | "on" | "off";
+export type RulesFilter = "all" | "with_rules" | "no_rules";
 
 export const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: "all", label: "All" },
@@ -19,6 +20,12 @@ export const BUDGET_OPTIONS: { value: BudgetFilter; label: string }[] = [
   { value: "off", label: "Off Budget" },
 ];
 
+export const RULES_OPTIONS: { value: RulesFilter; label: string }[] = [
+  { value: "all",        label: "All" },
+  { value: "with_rules", label: "Has Rules" },
+  { value: "no_rules",   label: "No Rules" },
+];
+
 export function FilterBar({
   search,
   onSearchChange,
@@ -26,11 +33,11 @@ export function FilterBar({
   onStatusChange,
   budgetFilter,
   onBudgetChange,
+  rulesFilter,
+  onRulesFilterChange,
   filteredCount,
   totalCount,
   selectedCount,
-  canFillDown,
-  onFillDown,
   onBulkClose,
   onBulkReopen,
   onBulkDelete,
@@ -42,27 +49,22 @@ export function FilterBar({
   onStatusChange: (v: StatusFilter) => void;
   budgetFilter: BudgetFilter;
   onBudgetChange: (v: BudgetFilter) => void;
+  rulesFilter: RulesFilter;
+  onRulesFilterChange: (v: RulesFilter) => void;
   filteredCount: number;
   totalCount: number;
   selectedCount: number;
-  canFillDown: boolean;
-  onFillDown: () => void;
   onBulkClose: () => void;
   onBulkReopen: () => void;
   onBulkDelete: () => void;
   onDeselect: () => void;
 }) {
-  const hasFilters = search || statusFilter !== "all" || budgetFilter !== "all";
+  const hasFilters = search || statusFilter !== "all" || budgetFilter !== "all" || rulesFilter !== "all";
 
   if (selectedCount > 0) {
     return (
       <div className="flex flex-wrap items-center gap-2 border-b border-border/40 bg-primary/5 px-2 py-1.5">
         <span className="text-xs font-medium text-primary">{selectedCount} selected</span>
-        {canFillDown && (
-          <Button size="xs" variant="outline" onClick={onFillDown}>
-            Fill Down
-          </Button>
-        )}
         <Button size="xs" variant="outline" onClick={onBulkClose}>
           Close All
         </Button>
@@ -104,6 +106,7 @@ export function FilterBar({
 
       <PillGroup options={STATUS_OPTIONS} value={statusFilter} onChange={onStatusChange} />
       <PillGroup options={BUDGET_OPTIONS} value={budgetFilter} onChange={onBudgetChange} />
+      <PillGroup options={RULES_OPTIONS} value={rulesFilter} onChange={onRulesFilterChange} />
 
       {hasFilters && (
         <button
@@ -111,6 +114,7 @@ export function FilterBar({
             onSearchChange("");
             onStatusChange("all");
             onBudgetChange("all");
+            onRulesFilterChange("all");
           }}
           className="text-xs text-muted-foreground underline hover:text-foreground"
         >

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -24,7 +24,7 @@ import { generateId } from "@/lib/uuid";
 import type { StagedEntity } from "@/types/staged";
 import type { CategoryGroup, Category } from "@/types/entities";
 import { FilterBar } from "./FilterBar";
-import type { VisibilityFilter, TypeFilter, SortDir } from "./FilterBar";
+import type { VisibilityFilter, TypeFilter, RulesFilter, SortDir } from "./FilterBar";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -48,14 +48,17 @@ function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
 export function CategoriesTable({
   collapsedGroups,
   setCollapsedGroups,
+  onCreateRule,
 }: {
   collapsedGroups: Set<string>;
   setCollapsedGroups: React.Dispatch<React.SetStateAction<Set<string>>>;
+  onCreateRule?: (categoryId: string) => void;
 }) {
   // ── Filter / sort state ──────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>("all");
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [rulesFilter, setRulesFilter] = useState<RulesFilter>("all");
   const [sortNameDir, setSortNameDir] = useState<SortDir | null>(null);
 
   // ── Editing state ────────────────────────────────────────────────────────────
@@ -133,6 +136,60 @@ export function CategoriesTable({
     return counts;
   }, [stagedRules]);
 
+  // ── Index all categories by groupId (no filters) ─────────────────────────────
+  // Used by allGroups for group-level hidden/search checks, and as the base for
+  // filteredCatsByGroup. Recomputed only when stagedCats changes.
+  const allCatsByGroup = useMemo(() => {
+    const map = new Map<string, CategoryRow[]>();
+    for (const s of Object.values(stagedCats)) {
+      const cat = s as CategoryRow;
+      const list = map.get(cat.entity.groupId);
+      if (list) list.push(cat);
+      else map.set(cat.entity.groupId, [cat]);
+    }
+    return map;
+  }, [stagedCats]);
+
+  // ── Filtered + sorted categories per group ────────────────────────────────────
+  // Replaces the getCategoriesForGroup plain function. Each call site becomes O(1).
+  const filteredCatsByGroup = useMemo(() => {
+    const q = search.toLowerCase();
+    const map = new Map<string, CategoryRow[]>();
+    for (const [groupId, cats] of allCatsByGroup) {
+      let filtered: CategoryRow[] = cats;
+      if (q) filtered = filtered.filter((c) => c.entity.name.toLowerCase().includes(q));
+      if (visibilityFilter === "visible") filtered = filtered.filter((c) => !c.entity.hidden);
+      if (visibilityFilter === "hidden")  filtered = filtered.filter((c) =>  c.entity.hidden);
+      if (sortNameDir) {
+        filtered = [...filtered].sort((a, b) =>
+          sortNameDir === "asc"
+            ? a.entity.name.toLowerCase().localeCompare(b.entity.name.toLowerCase())
+            : b.entity.name.toLowerCase().localeCompare(a.entity.name.toLowerCase())
+        );
+      }
+      map.set(groupId, filtered);
+    }
+    return map;
+  }, [allCatsByGroup, search, visibilityFilter, sortNameDir]);
+
+  // ── Rules filter layer on top of filteredCatsByGroup ────────────────────────
+  const visibleCatsByGroup = useMemo(() => {
+    if (rulesFilter === "all") return filteredCatsByGroup;
+    const map = new Map<string, CategoryRow[]>();
+    for (const [groupId, cats] of filteredCatsByGroup) {
+      const filtered = cats.filter((c) => {
+        const count = categoryRuleCount.get(c.entity.id) ?? 0;
+        return rulesFilter === "with_rules" ? count > 0 : count === 0;
+      });
+      map.set(groupId, filtered);
+    }
+    return map;
+  }, [filteredCatsByGroup, rulesFilter, categoryRuleCount]);
+
+  function getCategoriesForGroup(groupId: string): CategoryRow[] {
+    return visibleCatsByGroup.get(groupId) ?? [];
+  }
+
   // ── Build flat ordered list of visible groups ─────────────────────────────────
   const allGroups: GroupRow[] = useMemo(() => {
     let gs = Object.values(stagedGroups) as GroupRow[];
@@ -142,17 +199,16 @@ export function CategoriesTable({
     if (visibilityFilter === "visible") gs = gs.filter((g) => !g.entity.hidden);
     if (visibilityFilter === "hidden") gs = gs.filter((g) =>
       g.entity.hidden ||
-      Object.values(stagedCats).some(
-        (c) => c.entity.groupId === g.entity.id && c.entity.hidden && !c.isDeleted
+      (allCatsByGroup.get(g.entity.id) ?? []).some(
+        (c) => c.entity.hidden && !c.isDeleted
       )
     );
     if (q) gs = gs.filter((g) => {
       if (g.entity.name.toLowerCase().includes(q)) return true;
       // Also show group if any child category matches
-      const children = Object.values(stagedCats).filter(
-        (c) => c.entity.groupId === g.entity.id && c.entity.name.toLowerCase().includes(q)
+      return (allCatsByGroup.get(g.entity.id) ?? []).some(
+        (c) => c.entity.name.toLowerCase().includes(q)
       );
-      return children.length > 0;
     });
     if (sortNameDir) {
       gs = [...gs].sort((a, b) => {
@@ -165,32 +221,13 @@ export function CategoriesTable({
       gs = [...gs].sort((a, b) => Number(b.entity.isIncome) - Number(a.entity.isIncome));
     }
     return gs;
-  }, [stagedGroups, stagedCats, search, typeFilter, visibilityFilter, sortNameDir]);
+  }, [stagedGroups, allCatsByGroup, search, typeFilter, visibilityFilter, sortNameDir]);
 
-  // Categories for a given group (filtered + sorted)
-  function getCategoriesForGroup(groupId: string): CategoryRow[] {
-    let cats = Object.values(stagedCats).filter(
-      (c) => c.entity.groupId === groupId
-    ) as CategoryRow[];
-
-    const q = search.toLowerCase();
-    if (q) cats = cats.filter((c) => c.entity.name.toLowerCase().includes(q));
-    if (visibilityFilter === "visible") cats = cats.filter((c) => !c.entity.hidden);
-    if (visibilityFilter === "hidden") cats = cats.filter((c) => c.entity.hidden);
-
-    if (sortNameDir) {
-      cats = [...cats].sort((a, b) =>
-        sortNameDir === "asc"
-          ? a.entity.name.toLowerCase().localeCompare(b.entity.name.toLowerCase())
-          : b.entity.name.toLowerCase().localeCompare(a.entity.name.toLowerCase())
-      );
-    }
-    return cats;
-  }
+  const incomeGroupCount = Object.values(stagedGroups).filter((g) => !g.isDeleted && g.entity.isIncome).length;
 
   const totalCount = Object.keys(stagedGroups).length + Object.keys(stagedCats).length;
   const filteredCount = allGroups.reduce(
-    (acc, g) => acc + 1 + getCategoriesForGroup(g.entity.id).length,
+    (acc, g) => acc + 1 + (visibleCatsByGroup.get(g.entity.id)?.length ?? 0),
     0
   );
 
@@ -269,9 +306,17 @@ export function CategoriesTable({
       message: "Staged deletions will be removed on Save. Deleting a group will also delete its categories.",
       onConfirm: () => {
         pushUndo();
+        const pendingIncomeDeletes = [...selectedIds].filter((id) => stagedGroups[id]?.entity.isIncome && !stagedGroups[id]?.isDeleted).length;
+        const remainingIncomeAfter = incomeGroupCount - pendingIncomeDeletes;
+        let incomeSkipped = 0;
         for (const id of selectedIds) {
           if (stagedGroups[id]) {
-            // Also delete all child categories of this group
+            const g = stagedGroups[id];
+            // Never delete the last income group
+            if (g.entity.isIncome && remainingIncomeAfter < 1 && incomeSkipped === 0) {
+              incomeSkipped++;
+              continue;
+            }
             for (const cat of Object.values(stagedCats)) {
               if (cat.entity.groupId === id) stageDelete("categories", cat.entity.id);
             }
@@ -373,6 +418,14 @@ export function CategoriesTable({
                 )}>
                   {entity.name || "empty name"}
                   {isDuplicate && <AlertTriangle className="h-3 w-3 shrink-0 text-amber-500" aria-label="Duplicate name" />}
+                  {!isDeleted && (() => {
+                    const total = (allCatsByGroup.get(entity.id) ?? []).filter((c) => !c.isDeleted).length;
+                    const visible = (visibleCatsByGroup.get(entity.id) ?? []).filter((c) => !c.isDeleted).length;
+                    const label = visible !== total ? `${visible}/${total}` : `${total}`;
+                    return (
+                      <span className="text-xs font-normal text-muted-foreground">({label})</span>
+                    );
+                  })()}
                 </span>
                 {saveError && (
                   <span className="text-xs text-destructive leading-tight pb-0.5">{saveError}</span>
@@ -422,20 +475,22 @@ export function CategoriesTable({
               </Button>
             ) : (
               <>
-                <Button
-                  variant="ghost" size="icon-xs" title="Delete group"
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => {
-                    pushUndo();
-                    // Stage-delete all child categories too
-                    for (const cat of Object.values(stagedCats)) {
-                      if (cat.entity.groupId === entity.id) stageDelete("categories", cat.entity.id);
-                    }
-                    stageDelete("categoryGroups", entity.id);
-                  }}
-                >
-                  <Trash2 />
-                </Button>
+                {!(entity.isIncome && incomeGroupCount <= 1) && (
+                  <Button
+                    variant="ghost" size="icon-xs" title="Delete group"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => {
+                      pushUndo();
+                      // Stage-delete all child categories too
+                      for (const cat of Object.values(stagedCats)) {
+                        if (cat.entity.groupId === entity.id) stageDelete("categories", cat.entity.id);
+                      }
+                      stageDelete("categoryGroups", entity.id);
+                    }}
+                  >
+                    <Trash2 />
+                  </Button>
+                )}
                 {(isNew || isUpdated) && (
                   <Button variant="ghost" size="icon-xs" title="Revert" onClick={() => revertEntity("categoryGroups", entity.id)}>
                     <RotateCcw />
@@ -593,8 +648,10 @@ export function CategoriesTable({
             return (
               <button
                 className="inline-flex items-center rounded bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 hover:bg-purple-200 dark:bg-purple-900/40 dark:text-purple-300 dark:hover:bg-purple-900/60"
-                onClick={() => router.push(count > 0 ? `/rules?categoryId=${entity.id}` : "/rules?new=1")}
-                title={count > 0 ? "View rules for this category" : "Go to rules to create a rule"}
+                onClick={() => count > 0
+                  ? router.push(`/rules?categoryId=${entity.id}`)
+                  : onCreateRule ? onCreateRule(entity.id) : router.push("/rules?new=1")}
+                title={count > 0 ? "View rules for this category" : "Create a rule for this category"}
               >
                 {label}
               </button>
@@ -680,6 +737,7 @@ export function CategoriesTable({
           search={search} onSearchChange={setSearch}
           visibilityFilter={visibilityFilter} onVisibilityChange={setVisibilityFilter}
           typeFilter={typeFilter} onTypeChange={setTypeFilter}
+          rulesFilter={rulesFilter} onRulesFilterChange={setRulesFilter}
           filteredCount={filteredCount} totalCount={totalCount}
           selectedCount={activeSelectedCount}
           onBulkDelete={handleBulkDelete}
@@ -724,7 +782,12 @@ export function CategoriesTable({
                   {incomeGroups.length === 0 && (
                     <tr>
                       <td colSpan={7} className="px-4 py-3 text-xs text-muted-foreground">
-                        No income groups{search ? " matching the search" : ""}.
+                        <span>No income groups{search || visibilityFilter !== "all" || rulesFilter !== "all" ? " matching the current filters" : ""}.</span>
+                        {(search || visibilityFilter !== "all" || rulesFilter !== "all") && (
+                          <button className="ml-2 underline hover:text-foreground" onClick={() => { setSearch(""); setVisibilityFilter("all"); setRulesFilter("all"); }}>
+                            Clear filters
+                          </button>
+                        )}
                       </td>
                     </tr>
                   )}
@@ -775,7 +838,12 @@ export function CategoriesTable({
                   {expenseGroups.length === 0 && (
                     <tr>
                       <td colSpan={7} className="px-4 py-3 text-xs text-muted-foreground">
-                        No expense groups{search ? " matching the search" : ""}.
+                        <span>No expense groups{search || visibilityFilter !== "all" || rulesFilter !== "all" ? " matching the current filters" : ""}.</span>
+                        {(search || visibilityFilter !== "all" || rulesFilter !== "all") && (
+                          <button className="ml-2 underline hover:text-foreground" onClick={() => { setSearch(""); setVisibilityFilter("all"); setRulesFilter("all"); }}>
+                            Clear filters
+                          </button>
+                        )}
                       </td>
                     </tr>
                   )}

--- a/src/features/categories/components/CategoriesView.tsx
+++ b/src/features/categories/components/CategoriesView.tsx
@@ -10,6 +10,8 @@ import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { useCategoryGroups } from "../hooks/useCategoryGroups";
 import { CategoriesTable } from "./CategoriesTable";
+import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { exportCategoriesToCsv } from "../csv/categoriesCsvExport";
 import { importCategoriesFromCsv } from "../csv/categoriesCsvImport";
 
@@ -19,6 +21,16 @@ export function CategoriesView() {
 
   // Collapse state lifted here so toolbar can control it
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [ruleDrawerOpen, setRuleDrawerOpen] = useState(false);
+  const [ruleSeed, setRuleSeed] = useState<RuleSeed | undefined>(undefined);
+
+  function handleCreateRule(categoryId: string) {
+    setRuleSeed({
+      conditions: [{ field: "payee",    op: "is",  value: "",         type: "id" }],
+      actions:    [{ field: "category", op: "set", value: categoryId, type: "id" }],
+    });
+    setRuleDrawerOpen(true);
+  }
 
   const stagedGroups = useStagedStore((s) => s.categoryGroups);
   const stagedCats = useStagedStore((s) => s.categories);
@@ -137,6 +149,14 @@ export function CategoriesView() {
       <CategoriesTable
         collapsedGroups={collapsedGroups}
         setCollapsedGroups={setCollapsedGroups}
+        onCreateRule={handleCreateRule}
+      />
+
+      <RuleDrawer
+        open={ruleDrawerOpen}
+        onOpenChange={setRuleDrawerOpen}
+        ruleId={null}
+        seed={ruleSeed}
       />
     </PageLayout>
   );

--- a/src/features/categories/components/FilterBar.tsx
+++ b/src/features/categories/components/FilterBar.tsx
@@ -6,6 +6,7 @@ import { PillGroup } from "@/components/ui/pill-group";
 
 export type VisibilityFilter = "all" | "visible" | "hidden";
 export type TypeFilter = "all" | "income" | "expense";
+export type RulesFilter = "all" | "with_rules" | "no_rules";
 export type SortDir = "asc" | "desc";
 
 export const VISIBILITY_OPTIONS: { value: VisibilityFilter; label: string }[] = [
@@ -20,10 +21,17 @@ export const TYPE_OPTIONS: { value: TypeFilter; label: string }[] = [
   { value: "expense", label: "Expense" },
 ];
 
+export const RULES_OPTIONS: { value: RulesFilter; label: string }[] = [
+  { value: "all",        label: "All" },
+  { value: "with_rules", label: "Has Rules" },
+  { value: "no_rules",   label: "No Rules" },
+];
+
 export function FilterBar({
   search, onSearchChange,
   visibilityFilter, onVisibilityChange,
   typeFilter, onTypeChange,
+  rulesFilter, onRulesFilterChange,
   filteredCount, totalCount,
   selectedCount,
   onBulkDelete, onDeselect,
@@ -31,12 +39,13 @@ export function FilterBar({
   search: string; onSearchChange: (v: string) => void;
   visibilityFilter: VisibilityFilter; onVisibilityChange: (v: VisibilityFilter) => void;
   typeFilter: TypeFilter; onTypeChange: (v: TypeFilter) => void;
+  rulesFilter: RulesFilter; onRulesFilterChange: (v: RulesFilter) => void;
   filteredCount: number; totalCount: number;
   selectedCount: number;
   onBulkDelete: () => void;
   onDeselect: () => void;
 }) {
-  const hasFilters = search || visibilityFilter !== "all" || typeFilter !== "all";
+  const hasFilters = search || visibilityFilter !== "all" || typeFilter !== "all" || rulesFilter !== "all";
 
   if (selectedCount > 0) {
     return (
@@ -69,10 +78,11 @@ export function FilterBar({
 
       <PillGroup options={VISIBILITY_OPTIONS} value={visibilityFilter} onChange={onVisibilityChange} />
       <PillGroup options={TYPE_OPTIONS} value={typeFilter} onChange={onTypeChange} />
+      <PillGroup options={RULES_OPTIONS} value={rulesFilter} onChange={onRulesFilterChange} />
 
       {hasFilters && (
         <button
-          onClick={() => { onSearchChange(""); onVisibilityChange("all"); onTypeChange("all"); }}
+          onClick={() => { onSearchChange(""); onVisibilityChange("all"); onTypeChange("all"); onRulesFilterChange("all"); }}
           className="text-xs text-muted-foreground underline hover:text-foreground"
         >
           Clear

--- a/src/features/payees/components/FilterBar.tsx
+++ b/src/features/payees/components/FilterBar.tsx
@@ -26,15 +26,14 @@ export function FilterBar({
   typeFilter, onTypeChange,
   rulesFilter, onRulesFilterChange,
   filteredCount, totalCount,
-  selectedCount, canFillDown, canMerge,
-  onFillDown, onBulkDelete, onMerge, onDeselect,
+  selectedCount, canMerge,
+  onBulkDelete, onMerge, onDeselect,
 }: {
   search: string; onSearchChange: (v: string) => void;
   typeFilter: TypeFilter; onTypeChange: (v: TypeFilter) => void;
   rulesFilter: RulesFilter; onRulesFilterChange: (v: RulesFilter) => void;
   filteredCount: number; totalCount: number;
-  selectedCount: number; canFillDown: boolean; canMerge: boolean;
-  onFillDown: () => void;
+  selectedCount: number; canMerge: boolean;
   onBulkDelete: () => void;
   onMerge: () => void;
   onDeselect: () => void;
@@ -45,9 +44,6 @@ export function FilterBar({
     return (
       <div className="flex flex-wrap items-center gap-2 border-b border-border/40 bg-primary/5 px-2 py-1.5">
         <span className="text-xs font-medium text-primary">{selectedCount} selected</span>
-        {canFillDown && (
-          <Button size="xs" variant="outline" onClick={onFillDown}>Fill Down</Button>
-        )}
         {canMerge && (
           <Button size="xs" variant="outline" onClick={onMerge}>Merge</Button>
         )}

--- a/src/features/payees/components/PayeesTable.tsx
+++ b/src/features/payees/components/PayeesTable.tsx
@@ -68,7 +68,9 @@ function BulkAddBar({ bulkCount, onBulkCountChange, onAdd }: {
 
 // ─── PayeesTable ───────────────────────────────────────────────────────────────
 
-export function PayeesTable() {
+export function PayeesTable({ onCreateRule }: {
+  onCreateRule?: (payeeId: string, payeeName: string) => void;
+}) {
   // ── Filter / sort state ──────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
@@ -139,16 +141,15 @@ export function PayeesTable() {
   }, [staged]);
 
   // ── Derived rows: filter → sort ──────────────────────────────────────────────
-  const rows: PayeeRow[] = useMemo(() => {
+  // baseRows excludes the rules filter so that rules mutations don't invalidate
+  // the sort/search/type-filter work when rulesFilter is "all" (the default).
+  const baseRows: PayeeRow[] = useMemo(() => {
     const q = search.toLowerCase();
     const result: PayeeRow[] = [];
     for (const r of Object.values(staged) as PayeeRow[]) {
       if (q && !r.entity.name.toLowerCase().includes(q)) continue;
       if (typeFilter === "regular"  && r.entity.transferAccountId)  continue;
       if (typeFilter === "transfer" && !r.entity.transferAccountId) continue;
-      const rc = payeeRuleCount.get(r.entity.id) ?? 0;
-      if (rulesFilter === "with_rules" && rc === 0) continue;
-      if (rulesFilter === "no_rules"   && rc  >  0) continue;
       result.push(r);
     }
     result.sort((a, b) => {
@@ -169,7 +170,19 @@ export function PayeesTable() {
       return 0;
     });
     return result;
-  }, [staged, search, typeFilter, rulesFilter, payeeRuleCount, sortCol, sortDir]);
+  }, [staged, search, typeFilter, sortCol, sortDir]);
+
+  // Apply the rules filter as a second step so it only invalidates when
+  // rulesFilter is active or payeeRuleCount changes.
+  const rows: PayeeRow[] = useMemo(() => {
+    if (rulesFilter === "all") return baseRows;
+    return baseRows.filter((r) => {
+      const rc = payeeRuleCount.get(r.entity.id) ?? 0;
+      if (rulesFilter === "with_rules" && rc === 0) return false;
+      if (rulesFilter === "no_rules"   && rc  >  0) return false;
+      return true;
+    });
+  }, [baseRows, rulesFilter, payeeRuleCount]);
 
   function toggleSort(col: SortCol) {
     if (sortCol === col) {
@@ -301,18 +314,6 @@ export function PayeesTable() {
     });
   }
 
-  function handleFillDown() {
-    if (!selectedCell || selectedIds.size < 2) return;
-    const selectedInOrder = rows.filter((r) => selectedIds.has(r.entity.id));
-    if (selectedInOrder.length < 2) return;
-    const source = selectedInOrder[0];
-    pushUndo();
-    for (const row of selectedInOrder.slice(1)) {
-      if (row.isDeleted || row.entity.transferAccountId) continue;
-      stageUpdate("payees", row.entity.id, { name: source.entity.name });
-    }
-  }
-
   function handleMerge() {
     // Iterate selectedIds in insertion order (click order) — first-clicked payee
     // is pre-selected as the target; the user can override in the dialog.
@@ -402,7 +403,6 @@ export function PayeesTable() {
 
   // ── Render ───────────────────────────────────────────────────────────────────
   const totalCount = Object.keys(staged).length;
-  const canFillDown = selectedIds.size >= 2 && selectedCell !== null;
   const activeSelectedCount = [...selectedIds].filter((id) => staged[id] && !staged[id].isDeleted).length;
   // Merge requires 2+ non-deleted regular (non-transfer) payees selected
   const mergeableCount = [...selectedIds].filter(
@@ -418,8 +418,7 @@ export function PayeesTable() {
           typeFilter={typeFilter} onTypeChange={setTypeFilter}
           rulesFilter={rulesFilter} onRulesFilterChange={setRulesFilter}
           filteredCount={rows.length} totalCount={totalCount}
-          selectedCount={activeSelectedCount} canFillDown={canFillDown} canMerge={canMerge}
-          onFillDown={handleFillDown}
+          selectedCount={activeSelectedCount} canMerge={canMerge}
           onMerge={handleMerge}
           onBulkDelete={handleBulkDelete}
           onDeselect={() => clearSelection()}
@@ -427,10 +426,16 @@ export function PayeesTable() {
 
         <div className="min-h-0 flex-1 overflow-auto">
         {rows.length === 0 ? (
-          <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-            {search || typeFilter !== "all" || rulesFilter !== "all"
-              ? "No payees match the current filters."
-              : "No payees yet."}
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+            <span>{search || typeFilter !== "all" || rulesFilter !== "all" ? "No payees match the current filters." : "No payees yet."}</span>
+            {(search || typeFilter !== "all" || rulesFilter !== "all") && (
+              <button
+                className="text-xs underline hover:text-foreground"
+                onClick={() => { setSearch(""); setTypeFilter("all"); setRulesFilter("all"); }}
+              >
+                Clear filters
+              </button>
+            )}
           </div>
         ) : (
           <table className="w-full border-collapse text-sm">
@@ -595,8 +600,10 @@ export function PayeesTable() {
                             ? (
                               <button
                                 className="inline-flex items-center rounded bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 hover:bg-purple-200 dark:bg-purple-900/40 dark:text-purple-300 dark:hover:bg-purple-900/60"
-                                onClick={() => router.push(count > 0 ? `/rules?payeeId=${entity.id}` : "/rules?new=1")}
-                                title={count > 0 ? "View rules for this payee" : "Go to rules to create a rule"}
+                                onClick={() => count > 0
+                                  ? router.push(`/rules?payeeId=${entity.id}`)
+                                  : onCreateRule ? onCreateRule(entity.id, entity.name) : router.push("/rules?new=1")}
+                                title={count > 0 ? "View rules for this payee" : "Create a rule for this payee"}
                               >
                                 {label}
                               </button>

--- a/src/features/payees/components/PayeesView.tsx
+++ b/src/features/payees/components/PayeesView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Plus, Download, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -10,17 +10,29 @@ import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { usePayees } from "../hooks/usePayees";
 import { PayeesTable } from "./PayeesTable";
+import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { exportPayeesToCsv } from "../csv/payeesCsvExport";
 import { importPayeesFromCsv } from "../csv/payeesCsvImport";
 
 export function PayeesView() {
   const importInputRef = useRef<HTMLInputElement>(null);
+  const [ruleDrawerOpen, setRuleDrawerOpen] = useState(false);
+  const [ruleSeed, setRuleSeed] = useState<RuleSeed | undefined>(undefined);
 
   const { isLoading, isError, error, refetch } = usePayees();
 
   const staged = useStagedStore((s) => s.payees);
   const stageNew = useStagedStore((s) => s.stageNew);
   const pushUndo = useStagedStore((s) => s.pushUndo);
+
+  function handleCreateRule(payeeId: string, payeeName: string) {
+    setRuleSeed({
+      conditions: [{ field: "notes", op: "contains", value: payeeName, type: "string" }],
+      actions:    [{ field: "payee", op: "set",      value: payeeId,   type: "id"     }],
+    });
+    setRuleDrawerOpen(true);
+  }
 
   function handleAddPayee() {
     pushUndo();
@@ -116,7 +128,14 @@ export function PayeesView() {
         </>
       }
     >
-      <PayeesTable />
+      <PayeesTable onCreateRule={handleCreateRule} />
+
+      <RuleDrawer
+        open={ruleDrawerOpen}
+        onOpenChange={setRuleDrawerOpen}
+        ruleId={null}
+        seed={ruleSeed}
+      />
     </PageLayout>
   );
 }

--- a/src/features/rules/components/FilterBar.tsx
+++ b/src/features/rules/components/FilterBar.tsx
@@ -2,27 +2,43 @@
 
 import { Search, X, Merge } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { PillGroup } from "@/components/ui/pill-group";
 import { cn } from "@/lib/utils";
 import { STAGE_LABELS } from "../utils/ruleFields";
 
 export type StageFilter = "all" | "pre" | "default" | "post";
+export type ActionTypeFilter = "all" | "category" | "payee" | "account" | "cleared" | "notes";
+
+export const ACTION_TYPE_OPTIONS: { value: ActionTypeFilter; label: string }[] = [
+  { value: "all",      label: "All" },
+  { value: "category", label: "Sets Category" },
+  { value: "payee",    label: "Sets Payee" },
+  { value: "account",  label: "Sets Account" },
+  { value: "cleared",  label: "Sets Cleared" },
+  { value: "notes",    label: "Sets Notes" },
+];
 
 export function FilterBar({
   search, onSearchChange,
   stageFilter, onStageFilterChange,
+  actionTypeFilter, onActionTypeFilterChange,
   payeeId, payeeName,
   categoryId, categoryName,
-  onClearPayee, onClearCategory,
+  accountId, accountName,
+  onClearPayee, onClearCategory, onClearAccount,
   rowCount, totalVisible,
   selectedCount,
   onDeleteSelected, onMerge, onDeselect,
 }: {
   search: string; onSearchChange: (v: string) => void;
   stageFilter: StageFilter; onStageFilterChange: (v: StageFilter) => void;
+  actionTypeFilter: ActionTypeFilter; onActionTypeFilterChange: (v: ActionTypeFilter) => void;
   payeeId?: string | null; payeeName?: string;
   categoryId?: string | null; categoryName?: string;
+  accountId?: string | null; accountName?: string;
   onClearPayee: () => void;
   onClearCategory: () => void;
+  onClearAccount: () => void;
   rowCount: number; totalVisible: number;
   selectedCount: number;
   onDeleteSelected: () => void;
@@ -61,7 +77,7 @@ export function FilterBar({
         <input
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search rules…"
+          placeholder="Search…"
           className="h-6 w-44 rounded border border-border bg-background pl-6 pr-6 text-xs outline-none focus:ring-1 focus:ring-ring"
         />
         {search && (
@@ -91,6 +107,8 @@ export function FilterBar({
         ))}
       </div>
 
+      <PillGroup options={ACTION_TYPE_OPTIONS} value={actionTypeFilter} onChange={onActionTypeFilterChange} />
+
       {payeeId && (
         <div className="flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2 py-0.5 text-xs text-primary">
           <span>
@@ -115,6 +133,21 @@ export function FilterBar({
             onClick={onClearCategory}
             className="text-primary/60 hover:text-primary"
             title="Clear category filter"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+
+      {accountId && (
+        <div className="flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2 py-0.5 text-xs text-primary">
+          <span>
+            Account: <span className="font-medium">{accountName ?? accountId}</span>
+          </span>
+          <button
+            onClick={onClearAccount}
+            className="text-primary/60 hover:text-primary"
+            title="Clear account filter"
           >
             <X className="h-3 w-3" />
           </button>

--- a/src/features/rules/components/RuleDrawer.tsx
+++ b/src/features/rules/components/RuleDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Plus, Code } from "lucide-react";
+import { Plus, Code, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -17,17 +17,25 @@ import { ActionRow } from "./ActionRow";
 import { STAGE_OPTIONS, CONDITIONS_OP_OPTIONS } from "../utils/ruleFields";
 import type { ConditionOrAction, RuleStage, ConditionsOp } from "@/types/entities";
 
+export type RuleSeed = {
+  conditions: ConditionOrAction[];
+  actions: ConditionOrAction[];
+};
+
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** ID of the rule to edit. Null = creating a new rule. */
   ruleId: string | null;
+  /** Pre-populated conditions/actions when creating a new rule from another entity. */
+  seed?: RuleSeed;
 };
 
-export function RuleDrawer({ open, onOpenChange, ruleId }: Props) {
+export function RuleDrawer({ open, onOpenChange, ruleId, seed }: Props) {
   const stagedRules = useStagedStore((s) => s.rules);
   const stageNew = useStagedStore((s) => s.stageNew);
   const stageUpdate = useStagedStore((s) => s.stageUpdate);
+  const stageDelete = useStagedStore((s) => s.stageDelete);
   const pushUndo = useStagedStore((s) => s.pushUndo);
 
   const existingRule = ruleId ? stagedRules[ruleId]?.entity : null;
@@ -50,8 +58,8 @@ export function RuleDrawer({ open, onOpenChange, ruleId }: Props) {
     } else {
       setStage("default");
       setConditionsOp("and");
-      setConditions([{ field: "payee", op: "is", value: "", type: "id" }]);
-      setActions([{ field: "category", op: "set", value: "", type: "id" }]);
+      setConditions(seed?.conditions ?? [{ field: "payee", op: "is", value: "", type: "id" }]);
+      setActions(seed?.actions ?? [{ field: "category", op: "set", value: "", type: "id" }]);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, ruleId]);
@@ -203,15 +211,28 @@ export function RuleDrawer({ open, onOpenChange, ruleId }: Props) {
         )}
 
         <SheetFooter className="shrink-0 flex-row items-center gap-2 border-t px-4 py-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="mr-auto text-xs text-muted-foreground"
-            onClick={() => setShowJson((v) => !v)}
-          >
-            <Code className="h-3 w-3 mr-1" />
-            {showJson ? "Hide JSON" : "JSON"}
-          </Button>
+          <div className="mr-auto flex items-center gap-2">
+            {!isNew && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs text-destructive hover:text-destructive"
+                onClick={() => { pushUndo(); stageDelete("rules", ruleId!); onOpenChange(false); }}
+              >
+                <Trash2 className="h-3 w-3 mr-1" />
+                Delete
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs text-muted-foreground"
+              onClick={() => setShowJson((v) => !v)}
+            >
+              <Code className="h-3 w-3 mr-1" />
+              {showJson ? "Hide JSON" : "JSON"}
+            </Button>
+          </div>
           <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>

--- a/src/features/rules/components/RulesTable.tsx
+++ b/src/features/rules/components/RulesTable.tsx
@@ -14,7 +14,7 @@ import { rulePreview } from "../utils/rulePreview";
 import type { EntityMaps } from "../utils/rulePreview";
 import { STAGE_LABELS } from "../utils/ruleFields";
 import { FilterBar } from "./FilterBar";
-import type { StageFilter } from "./FilterBar";
+import type { StageFilter, ActionTypeFilter } from "./FilterBar";
 import { ConditionChip, ActionChip } from "./RuleChips";
 import type { StagedEntity } from "@/types/staged";
 import type { Rule } from "@/types/entities";
@@ -42,9 +42,11 @@ type Props = {
   payeeId?: string | null;
   /** When set, only rules that reference this category ID in a condition or action are shown. */
   categoryId?: string | null;
+  /** When set, only rules that reference this account ID in a condition or action are shown. */
+  accountId?: string | null;
 };
 
-export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
+export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: Props) {
   const stagedRules = useStagedStore((s) => s.rules);
   const payees = useStagedStore((s) => s.payees);
   const categories = useStagedStore((s) => s.categories);
@@ -60,6 +62,7 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
   const highlightedId = useHighlight();
 
   const [stageFilter, setStageFilter] = useState<StageFilter>("all");
+  const [actionTypeFilter, setActionTypeFilter] = useState<ActionTypeFilter>("all");
   const [search, setSearch] = useState("");
   const { selectedIds, toggleSelect, toggleSelectAll: _toggleSelectAll, clearSelection } = useTableSelection();
 
@@ -85,6 +88,10 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
     return Object.values(stagedRules).filter((s) => {
       if (s.isDeleted) return false;
       if (stageFilter !== "all" && normalizeStage(s.entity.stage) !== stageFilter) return false;
+      if (actionTypeFilter !== "all") {
+        const hasAction = s.entity.actions.some((a) => a.field === actionTypeFilter);
+        if (!hasAction) return false;
+      }
       if (payeeId) {
         const parts = [...s.entity.conditions, ...s.entity.actions];
         const hasPayee = parts.some((part) => {
@@ -103,10 +110,19 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
         });
         if (!hasCategory) return false;
       }
+      if (accountId) {
+        const parts = [...s.entity.conditions, ...s.entity.actions];
+        const hasAccount = parts.some((part) => {
+          if (part.field !== "account") return false;
+          const ids = Array.isArray(part.value) ? part.value : [part.value];
+          return ids.includes(accountId);
+        });
+        if (!hasAccount) return false;
+      }
       if (q && !(rulePreviews.get(s.entity.id) ?? "").includes(q)) return false;
       return true;
     });
-  }, [stagedRules, stageFilter, payeeId, categoryId, search, rulePreviews]);
+  }, [stagedRules, stageFilter, actionTypeFilter, payeeId, categoryId, accountId, search, rulePreviews]);
 
   function handleDelete(id: string) {
     pushUndo();
@@ -160,12 +176,17 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
         onSearchChange={setSearch}
         stageFilter={stageFilter}
         onStageFilterChange={setStageFilter}
+        actionTypeFilter={actionTypeFilter}
+        onActionTypeFilterChange={setActionTypeFilter}
         payeeId={payeeId}
         payeeName={payeeId ? payees[payeeId]?.entity.name : undefined}
         categoryId={categoryId}
         categoryName={categoryId ? categories[categoryId]?.entity.name : undefined}
+        accountId={accountId}
+        accountName={accountId ? accounts[accountId]?.entity.name : undefined}
         onClearPayee={() => router.push("/rules")}
         onClearCategory={() => router.push("/rules")}
+        onClearAccount={() => router.push("/rules")}
         rowCount={rows.length}
         totalVisible={totalVisible}
         selectedCount={activeSelectedIds.length}
@@ -177,8 +198,21 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
       {/* Table */}
       <div className="min-h-0 flex-1 overflow-auto">
         {rows.length === 0 ? (
-          <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
-            No rules found.
+          <div className="flex flex-col items-center justify-center gap-2 py-20 text-sm text-muted-foreground">
+            <span>No rules found.</span>
+            {(search || stageFilter !== "all" || actionTypeFilter !== "all" || payeeId || categoryId || accountId) && (
+              <button
+                className="text-xs underline hover:text-foreground"
+                onClick={() => {
+                  setSearch("");
+                  setStageFilter("all");
+                  setActionTypeFilter("all");
+                  if (payeeId || categoryId || accountId) router.push("/rules");
+                }}
+              >
+                Clear filters
+              </button>
+            )}
           </div>
         ) : (
           <table className="w-full text-xs">
@@ -212,16 +246,17 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
                     key={rule.id}
                     data-row-id={rule.id}
                     className={cn(
-                      "group border-b border-border border-l-2 border-l-transparent hover:bg-muted/20 transition-colors align-top",
+                      "group cursor-pointer border-b border-border border-l-2 border-l-transparent hover:bg-muted/20 transition-colors align-top",
                       highlightedId === rule.id && "bg-primary/20 ring-2 ring-inset ring-primary/40",
                       highlightedId !== rule.id && selectedIds.has(rule.id) && "bg-primary/10",
                       highlightedId !== rule.id && !selectedIds.has(rule.id) && hasError && "bg-destructive/5 border-l-destructive",
                       highlightedId !== rule.id && !selectedIds.has(rule.id) && !hasError && s.isNew && "bg-green-50/40 dark:bg-green-950/10 border-l-green-500",
                       highlightedId !== rule.id && !selectedIds.has(rule.id) && !hasError && !s.isNew && s.isUpdated && "bg-amber-50/40 dark:bg-amber-950/10 border-l-amber-400",
                     )}
+                    onClick={() => onEdit(rule.id)}
                   >
                     {/* Checkbox */}
-                    <td className="px-3 py-2.5">
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
                       <input
                         type="checkbox"
                         checked={selectedIds.has(rule.id)}
@@ -261,7 +296,10 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
                     {/* Conditions — one chip per line */}
                     <td className="px-3 py-2.5">
                       {rule.conditions.length === 0 ? (
-                        <span className="text-[11px] italic text-muted-foreground">No conditions</span>
+                        <span className="flex items-center gap-1.5">
+                          <span className="text-[11px] italic text-muted-foreground">No conditions</span>
+                          <Badge variant="status-warning" className="text-[10px] font-normal">catch-all</Badge>
+                        </span>
                       ) : (
                         <div className="flex flex-col gap-1">
                           {rule.conditions.map((c, i) => (
@@ -288,7 +326,7 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId }: Props) {
                     </td>
 
                     {/* Row buttons */}
-                    <td className="px-3 py-2.5">
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
                       <div className="flex items-center justify-end gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
                         <Button
                           variant="ghost"

--- a/src/features/rules/components/RulesView.tsx
+++ b/src/features/rules/components/RulesView.tsx
@@ -24,6 +24,7 @@ export function RulesView() {
   const searchParams = useSearchParams();
   const payeeIdFilter    = searchParams.get("payeeId");
   const categoryIdFilter = searchParams.get("categoryId");
+  const accountIdFilter  = searchParams.get("accountId");
 
   const importInputRef = useRef<HTMLInputElement>(null);
 
@@ -166,6 +167,7 @@ export function RulesView() {
         onMerge={(ids) => setMergeRuleIds(ids)}
         payeeId={payeeIdFilter}
         categoryId={categoryIdFilter}
+        accountId={accountIdFilter}
       />
 
       <RuleDrawer

--- a/src/features/tags/components/FilterBar.tsx
+++ b/src/features/tags/components/FilterBar.tsx
@@ -16,22 +16,17 @@ export function FilterBar({
   search, onSearchChange,
   colorFilter, onColorFilterChange,
   filteredCount, totalCount,
-  colorCounts,
   selectedCount,
   onBulkDelete, onDeselect,
 }: {
   search: string; onSearchChange: (v: string) => void;
   colorFilter: ColorFilter; onColorFilterChange: (v: ColorFilter) => void;
   filteredCount: number; totalCount: number;
-  colorCounts?: Record<ColorFilter, number>;
   selectedCount: number;
   onBulkDelete: () => void;
   onDeselect: () => void;
 }) {
   const hasFilters = search || colorFilter !== "all";
-  const pillOptions = COLOR_OPTIONS.map((opt) =>
-    colorCounts ? { ...opt, label: `${opt.label} (${colorCounts[opt.value]})` } : opt
-  );
 
   if (selectedCount > 0) {
     return (
@@ -65,7 +60,7 @@ export function FilterBar({
         )}
       </div>
 
-      <PillGroup options={pillOptions} value={colorFilter} onChange={onColorFilterChange} />
+      <PillGroup options={COLOR_OPTIONS} value={colorFilter} onChange={onColorFilterChange} />
 
       {hasFilters && (
         <button

--- a/src/features/tags/components/TagsTable.tsx
+++ b/src/features/tags/components/TagsTable.tsx
@@ -167,14 +167,14 @@ export function TagsTable() {
       });
   }, [stagedTags, search, colorFilter, sortNameDir]);
 
-  const duplicateNames = useMemo(() => {
+  const nameCountMap = useMemo(() => {
     const counts = new Map<string, number>();
     for (const s of Object.values(stagedTags)) {
       if (s.isDeleted) continue;
       const n = s.entity.name.trim().toLowerCase();
       if (n) counts.set(n, (counts.get(n) ?? 0) + 1);
     }
-    return new Set([...counts.entries()].filter(([, c]) => c > 1).map(([n]) => n));
+    return counts;
   }, [stagedTags]);
 
   // ── Select-all helpers ────────────────────────────────────────────────────
@@ -226,8 +226,12 @@ export function TagsTable() {
       const trimmed = value.trim().replace(/ /g, "");
       const current = stagedTags[rowId]?.entity;
       if (trimmed && current) {
-        const isDuplicate = duplicateNames.has(trimmed.toLowerCase());
-        if (isDuplicate) {
+        const candidateKey = trimmed.toLowerCase();
+        const currentKey   = current.name.trim().toLowerCase();
+        // Build a count that excludes this row's current name so renaming to
+        // the same value doesn't trigger a false collision.
+        const countWithoutSelf = (nameCountMap.get(candidateKey) ?? 0) - (candidateKey === currentKey ? 1 : 0);
+        if (countWithoutSelf >= 1) {
           toast.error(`A tag named "${trimmed}" already exists.`);
           commitEdit({ rowId, colId: "name" });
           return;
@@ -389,17 +393,21 @@ export function TagsTable() {
                 <th className="w-1 p-0" />
                 <th className="w-10 px-2 py-1.5 text-left text-xs font-medium">Color</th>
                 <th
-                  className="w-[300px] cursor-pointer select-none px-2 py-1.5 text-left hover:bg-muted/30"
-                  onClick={() => setSortNameDir((d) => d === null ? "asc" : d === "asc" ? "desc" : null)}
+                  className="w-[300px] px-2 py-1.5 text-left"
+                  aria-sort={sortNameDir === "asc" ? "ascending" : sortNameDir === "desc" ? "descending" : "none"}
                 >
-                  <span className="flex items-center text-xs font-medium text-muted-foreground">
+                  <button
+                    className="flex select-none items-center text-xs font-medium text-muted-foreground hover:text-foreground"
+                    onClick={() => setSortNameDir((d) => d === null ? "asc" : d === "asc" ? "desc" : null)}
+                    aria-label={`Sort by name${sortNameDir === "asc" ? ", ascending" : sortNameDir === "desc" ? ", descending" : ""}`}
+                  >
                     Name
                     {sortNameDir === null
                       ? <ArrowUpDown className="ml-1 inline h-3 w-3 opacity-30" />
                       : sortNameDir === "asc"
                         ? <ArrowUp className="ml-1 inline h-3 w-3" />
                         : <ArrowDown className="ml-1 inline h-3 w-3" />}
-                  </span>
+                  </button>
                 </th>
                 <th className="px-2 py-1.5 text-left text-xs font-medium">Description</th>
                 <th className="w-16 p-0" />
@@ -407,7 +415,7 @@ export function TagsTable() {
             </thead>
             <tbody>
               {rows.map(({ entity, isNew, isUpdated, isDeleted, saveError }) => {
-                const isDuplicate   = !isDeleted && duplicateNames.has(entity.name.trim().toLowerCase());
+                const isDuplicate   = !isDeleted && (nameCountMap.get(entity.name.trim().toLowerCase()) ?? 0) > 1;
                 const nameSelected  = selectedCell?.rowId === entity.id && selectedCell?.colId === "name";
                 const nameEditing   = editingCell?.rowId  === entity.id && editingCell?.colId  === "name";
                 const descSelected  = selectedCell?.rowId === entity.id && selectedCell?.colId === "description";

--- a/src/features/tags/components/TagsTable.tsx
+++ b/src/features/tags/components/TagsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
-import { Trash2, RotateCcw, RefreshCw } from "lucide-react";
+import { Trash2, RotateCcw, RefreshCw, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -123,6 +123,7 @@ export function TagsTable() {
   // ── Filter + bulk-add state ───────────────────────────────────────────────
   const [search, setSearch]           = useState("");
   const [colorFilter, setColorFilter] = useState<ColorFilter>("all");
+  const [sortNameDir, setSortNameDir] = useState<"asc" | "desc" | null>(null);
   const [bulkCount, setBulkCount]     = useState(5);
 
   // ── Inline-edit state ─────────────────────────────────────────────────────
@@ -156,10 +157,15 @@ export function TagsTable() {
         return true;
       })
       .sort((a, b) => {
+        if (sortNameDir) {
+          return sortNameDir === "asc"
+            ? a.entity.name.toLowerCase().localeCompare(b.entity.name.toLowerCase())
+            : b.entity.name.toLowerCase().localeCompare(a.entity.name.toLowerCase());
+        }
         if (a.isNew !== b.isNew) return a.isNew ? -1 : 1;
         return a.entity.name.localeCompare(b.entity.name);
       });
-  }, [stagedTags, search, colorFilter]);
+  }, [stagedTags, search, colorFilter, sortNameDir]);
 
   const duplicateNames = useMemo(() => {
     const counts = new Map<string, number>();
@@ -169,16 +175,6 @@ export function TagsTable() {
       if (n) counts.set(n, (counts.get(n) ?? 0) + 1);
     }
     return new Set([...counts.entries()].filter(([, c]) => c > 1).map(([n]) => n));
-  }, [stagedTags]);
-
-  // ── Color filter counts (all non-deleted, unaffected by search) ──────────
-  const colorCounts = useMemo(() => {
-    const all = Object.values(stagedTags).filter((s) => !s.isDeleted);
-    return {
-      all:       all.length,
-      has_color: all.filter((s) =>  !!s.entity.color).length,
-      no_color:  all.filter((s) => !s.entity.color).length,
-    };
   }, [stagedTags]);
 
   // ── Select-all helpers ────────────────────────────────────────────────────
@@ -230,9 +226,7 @@ export function TagsTable() {
       const trimmed = value.trim().replace(/ /g, "");
       const current = stagedTags[rowId]?.entity;
       if (trimmed && current) {
-        const isDuplicate = Object.values(stagedTags).some(
-          (s) => !s.isDeleted && s.entity.id !== rowId && s.entity.name.trim().toLowerCase() === trimmed.toLowerCase()
-        );
+        const isDuplicate = duplicateNames.has(trimmed.toLowerCase());
         if (isDuplicate) {
           toast.error(`A tag named "${trimmed}" already exists.`);
           commitEdit({ rowId, colId: "name" });
@@ -367,7 +361,6 @@ export function TagsTable() {
           colorFilter={colorFilter} onColorFilterChange={setColorFilter}
           filteredCount={rows.filter((r) => !r.isDeleted).length}
           totalCount={totalCount}
-          colorCounts={colorCounts}
           selectedCount={activeSelected}
           onBulkDelete={handleBulkDelete}
           onDeselect={clearSelection}
@@ -395,7 +388,19 @@ export function TagsTable() {
                 </th>
                 <th className="w-1 p-0" />
                 <th className="w-10 px-2 py-1.5 text-left text-xs font-medium">Color</th>
-                <th className="w-[300px] px-2 py-1.5 text-left text-xs font-medium">Name</th>
+                <th
+                  className="w-[300px] cursor-pointer select-none px-2 py-1.5 text-left hover:bg-muted/30"
+                  onClick={() => setSortNameDir((d) => d === null ? "asc" : d === "asc" ? "desc" : null)}
+                >
+                  <span className="flex items-center text-xs font-medium text-muted-foreground">
+                    Name
+                    {sortNameDir === null
+                      ? <ArrowUpDown className="ml-1 inline h-3 w-3 opacity-30" />
+                      : sortNameDir === "asc"
+                        ? <ArrowUp className="ml-1 inline h-3 w-3" />
+                        : <ArrowDown className="ml-1 inline h-3 w-3" />}
+                  </span>
+                </th>
                 <th className="px-2 py-1.5 text-left text-xs font-medium">Description</th>
                 <th className="w-16 p-0" />
               </tr>


### PR DESCRIPTION
  ## Summary

  This PR improves the admin table workflows across Accounts, Payees, Categories, Rules, and Tags, while also reducing some avoidable precomputation in the heaviest views.

  ## What changed

  ### Rules workflows

  - Add account-linked rule navigation and filtering in the Rules page
  - Add action-type filtering in the Rules list
  - Allow opening a rule by clicking its row
  - Show a catch-all badge for rules with no conditions
  - Add delete support directly inside the rule drawer
  - Support seeded rule creation from other entities via RuleDrawer

  ### Accounts, Payees, and Categories

  - Add “associated rules” actions from Accounts, Payees, and Categories rows
  - When no rule exists yet, open the rule drawer pre-seeded from the selected entity
  - Add rules-based filters to Accounts and Categories
  - Add clearer empty states with “Clear filters” actions
  - Simplify Accounts creation to stage a new row directly instead of opening the account form drawer
  - Prevent deleting the last income category group

  ### Performance improvements

  - Optimize Categories table lookups by indexing categories by group and reusing filtered/sorted group mappings instead of repeatedly rescanning all categories
  - Split Payees table filtering into a base row pass plus an optional rules-filter pass so rules changes do not invalidate unrelated search/sort work when the rules filter is inactive
  - Reuse duplicate-name state in Tags instead of rescanning the full staged set during inline edits

  ### Tags and table UI

  - Add sortable tag names
  - Remove color-count pill labels from the Tags filter bar
  - Remove fill-down actions from Accounts and Payees bulk toolbars
  - Tidy several table empty states and filter reset flows

  ### Version

  - Bump app version from 1.0.6 to 1.0.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule creation and seeded rule drawer across accounts, categories, and payees
  * Action-type and account-scoped filtering in Rules
  * Name sort control for tags

* **Improvements**
  * Clear-filters controls in empty states
  * Faster rule-seeding workflows
  * More accurate duplicate-name detection for tags

* **Removed**
  * Fill-down bulk action for accounts and payees

* **Version**
  * Updated to v1.0.7
<!-- end of auto-generated comment: release notes by coderabbit.ai -->