### PR TITLE
feat/implement entity usage inspection and delete safety foundation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -41,6 +41,8 @@
 - CSV import and export
 - Duplicate name detection with visual warning
 - Rules count displayed per account — click it to jump to the rules list filtered to that account
+- Every delete and close action (single and bulk) shows a confirmation dialog pre-populated with the account's outstanding balance, transaction count, and rule reference count before staging the mutation; accounts with non-zero balances receive an explicit warning about budget consistency
+- Info button on each row opens the Usage Inspector drawer (see below)
 
 ## Payees
 
@@ -52,6 +54,8 @@
 - Inline editing with keyboard navigation
 - CSV import and export
 - Duplicate name detection with visual warning
+- Every delete action (single and bulk) always confirms, showing the payee's transaction count and rule reference count — previously single deletes with no rule references skipped the confirmation entirely; transfer payees are excluded from bulk delete and counted separately in the dialog
+- Info button on each regular payee row opens the Usage Inspector drawer (see below)
 
 ## Categories
 
@@ -64,6 +68,8 @@
 - Sort by name
 - CSV import and export with full group hierarchy preserved
 - Duplicate group name prevention
+- Every delete action confirms with an impact dialog: single category shows transaction count and rule references; group delete additionally shows the child category count and aggregated transaction count across all children with a cascade warning; bulk delete computes effective group and category sets, deduplicates implicit deletions, and aggregates totals
+- Info button on each category and group row opens the Usage Inspector drawer (see below)
 
 ## Schedules
 
@@ -80,6 +86,8 @@
 - Filter schedules by name, payee, account, frequency, auto-add state, and completion status
 - Bulk select with bulk delete
 - CSV import and export
+- Every delete action confirms with an impact dialog showing the schedule's linked rule status, auto-post flag, and transaction count; bulk delete aggregates totals across all selected schedules
+- Info button on each row opens the Usage Inspector drawer (see below)
 
 ## Tags
 
@@ -91,6 +99,32 @@
 - Bulk select with bulk delete
 - Duplicate name detection with visual warning
 - CSV import and export
+- Info button on each row opens the Usage Inspector drawer; tags show the rules badge and a note that transaction data is not available for tags
+
+## Delete Safety & Usage Inspector
+
+### Confirmation dialogs
+
+Every destructive action across all entity tables — single delete, bulk delete, single close, and bulk close — is intercepted by a confirmation dialog before any staged mutation is applied. Dialog messages are context-aware and tiered based on the available impact data:
+
+- **Transaction count**: how many existing transactions reference the entity being deleted or closed; fetched on demand via a single ActualQL `$oneof` query per action and cached for 30 seconds to avoid redundant network calls on rapid re-opens
+- **Rule references**: how many non-deleted staged rules reference the entity via their conditions or actions; computed locally from the in-memory rule store
+- **Balance** (accounts): outstanding balance at the time the action is triggered; non-zero balances produce an explicit consistency warning
+- **Child count** (category groups): number of non-deleted child categories; group deletes always show a cascade warning
+
+Loading states are reflected in the dialog message in real time — if the transaction count query is still in flight when the dialog opens, the copy shows "Checking usage…" and updates once the count arrives.
+
+### Usage Inspector drawer
+
+An Info button on every entity row opens a right-side drawer that displays a complete usage profile for that entity without triggering a delete flow:
+
+- **Stats row**: Rules badge (always visible), Transactions badge (all types except tags; shows "…" during loading), Balance badge (accounts; amber when non-zero), Categories badge (category groups only)
+- **Impact section**: pre-built warning strings describing the consequences of deletion, shown only when there is meaningful content to surface
+- **Empty state**: "No known references found." when all counts are zero and no warnings apply — including category groups with no children
+- **Quick links**: "View rules →" navigation shortcut for accounts, payees, and categories that have rule references, filtered to that entity on the rules page
+- **Tags**: transaction data is not available for tags; the drawer shows the rules badge and an explanatory note
+
+Transaction counts are fetched lazily when the drawer opens, gated by the same `enabled` flag used in confirm dialogs. Category groups query by child category IDs and aggregate the counts. New (unsaved) entities are excluded from the query since no server transactions exist for them yet.
 
 ## Staged Editing
 

--- a/agents/future-roadmap.md
+++ b/agents/future-roadmap.md
@@ -69,16 +69,16 @@ Each feature follows the same structure: `components/XxxView.tsx` (page shell + 
 ## Dependency Graph
 
 ```
-RD-001 (Schedules)     — independent
-RD-002 (Tags)          — independent; fix Tag type in entities.ts first
-RD-003 (Balance col)   — independent; add getAccountBalance to accounts.ts
+RD-001 (Schedules)     — complete
+RD-002 (Tags)          — complete; fix Tag type in entities.ts first
+RD-003 (Balance col)   — complete; add getAccountBalance to accounts.ts
 RD-004 (Payee merge)   — complete; add mergePayees to payees.ts
-RD-005 (Rules-by-payee)— can be done with RD-016 (same code path)
+RD-005 (Rules-by-payee)— complete; can be done with RD-016 (same code path)
 RD-006 (Budget export) — requires proxy binary support patch
 RD-007 (ActualQL console + saved query packs) — independent; shares run-query util with RD-016
 RD-008 (Delete txn action) — complete
 RD-009 (Session token) — independent
-RD-010 (Version display) — independent
+RD-010 (Version display) — complete
 RD-011 (Notes display) — independent
 RD-012 (Currency symbol) — independent
 RD-013 (High contrast theme) — independent
@@ -320,7 +320,7 @@ src/features/tags/
 |---|---|
 | **Priority** | High |
 | **Effort** | S |
-| **Status** | pending |
+| **Status** | complete |
 | **Depends on** | nothing |
 
 **What:** Add a read-only current balance column to the Accounts table. Users currently have no visibility into account balances inside actual-bench.
@@ -381,7 +381,7 @@ Body: { payeeId: string, mergeWithIds: string[] }
 |---|---|
 | **Priority** | Medium |
 | **Effort** | XS |
-| **Status** | pending |
+| **Status** | complete |
 | **Depends on** | Best implemented as part of RD-016 |
 
 **What:** Currently `payeeRuleCount` is computed by scanning `stagedRules` on the client. If the rules page has never been visited, `stagedRules` is empty and the count shows 0 even when the server has rules referencing that payee. This causes the delete safety warning to silently not fire.
@@ -756,7 +756,7 @@ GET /budgets/{id}/settings  → { currencySymbol: string, ... }
 |---|---|
 | **Priority** | High |
 | **Effort** | L |
-| **Status** | pending |
+| **Status** | complete |
 | **Depends on** | RD-003 for account balance checks; may reuse `runQuery` from RD-007 |
 
 **What:** Build one shared foundation for safe delete / close flows and reusable usage inspection across existing entities. This combines:
@@ -848,7 +848,7 @@ export function countRuleReferences(stagedRules: StagedMap<Rule>, entityId: stri
 6. Keep the first version lightweight: counts + key relationships + warnings
 7. Do not fetch or display full transaction lists
 
-**ActualQL count queries (read-only impact metadata):**
+**ActualQL queries to count existing transactions by entity - single call for each entity (read-only impact metadata):**
 
 Payees:
 ```json
@@ -897,6 +897,25 @@ Accounts:
     "select": [
       "account",
       "account.name",
+      {
+        "transactionCount": {
+          "$count": "$id"
+        }
+      }
+    ]
+  }
+}
+```
+
+Schedules:
+```json
+{
+  "ActualQLquery": {
+    "table": "transactions",
+    "groupBy": ["schedule", "schedule.name"],
+    "select": [
+      "schedule",
+      "schedule.name",
       {
         "transactionCount": {
           "$count": "$id"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+// ─── Shared state type ────────────────────────────────────────────────────────
+
+/**
+ * Describes the content and callback for a single confirmation dialog instance.
+ * Used as the state type in table components:
+ *   const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
+ */
+export type ConfirmState = {
+  title: string;
+  /** Accepts ReactNode — supports plain strings and inline loading/count lines. */
+  message: React.ReactNode;
+  onConfirm: () => void;
+  /** Label for the destructive action button. Defaults to "Delete". */
+  destructiveLabel?: string;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The current dialog state. May be null while the dialog is animating closed. */
+  state: ConfirmState | null;
+};
+
+export function ConfirmDialog({ open, onOpenChange, state }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{state?.title}</DialogTitle>
+          <DialogDescription>{state?.message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              state?.onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {state?.destructiveLabel ?? "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -5,27 +5,49 @@ import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useInlineEdit } from "@/hooks/useInlineEdit";
 import { useTableSelection } from "@/hooks/useTableSelection";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
 import { NameInput } from "@/components/ui/editable-cell";
 import type { DoneAction } from "@/components/ui/editable-cell";
 import {
   Archive, ArchiveRestore, RotateCcw, Trash2, RefreshCw,
-  ArrowUpDown, ArrowUp, ArrowDown, AlertTriangle,
+  ArrowUpDown, ArrowUp, ArrowDown, AlertTriangle, Info,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog, DialogContent, DialogHeader, DialogTitle,
-  DialogDescription, DialogFooter,
-} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import type { ConfirmState } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { useAccountBalances } from "../hooks/useAccountBalances";
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import {
+  buildAccountCloseWarning,
+  buildAccountDeleteWarning,
+  buildAccountBulkCloseWarning,
+  buildAccountBulkDeleteWarning,
+} from "@/lib/usageWarnings";
+import { UsageInspectorDrawer } from "@/features/usage-inspector/components/UsageInspectorDrawer";
 import { FilterBar } from "./FilterBar";
 import { BulkAddBar } from "./BulkAddBar";
 import type { StatusFilter, BudgetFilter, RulesFilter } from "./FilterBar";
 import type { StagedEntity } from "@/types/staged";
 import type { Account } from "@/types/entities";
+
+// ─── Delete intent ────────────────────────────────────────────────────────────
+
+type DeleteIntent = {
+  /** Server-side IDs for $oneof tx-count query. */
+  ids: string[];
+  title: string;
+  destructiveLabel?: string;
+  onConfirm: () => void;
+} & (
+  | { kind: "close";      label: string; balance: number }
+  | { kind: "delete";     label: string; balance: number; ruleCount: number }
+  | { kind: "bulkClose";  count: number; nonZeroBalanceCount: number }
+  | { kind: "bulkDelete"; serverCount: number; newCount: number; nonZeroBalanceCount: number; ruleCount: number }
+);
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -35,7 +57,6 @@ type CellId = { rowId: string; colId: NavigableCol };
 type AccountRow = StagedEntity<Account>;
 type SortCol = "name" | "offBudget" | "closed";
 type SortDir = "asc" | "desc";
-type ConfirmState = { title: string; message: string; onConfirm: () => void };
 
 // ─── Sort helpers ──────────────────────────────────────────────────────────────
 
@@ -73,7 +94,8 @@ export function AccountsTable({
 
   // ── Multi-select state ───────────────────────────────────────────────────────
   const { selectedIds, toggleSelect: toggleSelectRow, toggleSelectAll: _toggleSelectAll, clearSelection } = useTableSelection();
-  const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
+  const [deleteIntent, setDeleteIntent] = useState<DeleteIntent | null>(null);
+  const [inspectId, setInspectId] = useState<string | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -106,22 +128,62 @@ export function AccountsTable({
   }, [staged]);
 
   // ── Account → rule count ─────────────────────────────────────────────────────
-  const accountRuleCount = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const s of Object.values(stagedRules)) {
-      if (s.isDeleted) continue;
-      for (const part of [...s.entity.conditions, ...s.entity.actions]) {
-        if (part.field === "account") {
-          const ids = Array.isArray(part.value) ? part.value : [part.value];
-          for (const id of ids) {
-            if (typeof id === "string" && id)
-              counts.set(id, (counts.get(id) ?? 0) + 1);
-          }
+  const accountRuleCount = useMemo(
+    () => buildRuleReferenceMap(stagedRules, ["account"]),
+    [stagedRules]
+  );
+
+  // ── Lazy tx counts for delete/close confirm dialogs ───────────────────────────
+  const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
+    "account",
+    deleteIntent?.ids ?? [],
+    { enabled: !!deleteIntent && deleteIntent.ids.length > 0 }
+  );
+
+  const txTotal = deleteIntent?.ids.length
+    ? (txCounts ? [...txCounts.values()].reduce((a, b) => a + b, 0) : undefined)
+    : 0;
+
+  const confirmState: ConfirmState | null = deleteIntent
+    ? (() => {
+        const loading = txLoading && deleteIntent.ids.length > 0;
+        switch (deleteIntent.kind) {
+          case "close":
+            return {
+              title: deleteIntent.title,
+              message: buildAccountCloseWarning(deleteIntent.label, deleteIntent.balance, txTotal, loading),
+              onConfirm: deleteIntent.onConfirm,
+              destructiveLabel: "Close",
+            };
+          case "delete":
+            return {
+              title: deleteIntent.title,
+              message: buildAccountDeleteWarning(deleteIntent.label, deleteIntent.balance, deleteIntent.ruleCount, txTotal, loading),
+              onConfirm: deleteIntent.onConfirm,
+            };
+          case "bulkClose":
+            return {
+              title: deleteIntent.title,
+              message: buildAccountBulkCloseWarning(deleteIntent.count, deleteIntent.nonZeroBalanceCount),
+              onConfirm: deleteIntent.onConfirm,
+              destructiveLabel: "Close All",
+            };
+          case "bulkDelete":
+            return {
+              title: deleteIntent.title,
+              message: buildAccountBulkDeleteWarning(
+                deleteIntent.serverCount,
+                deleteIntent.newCount,
+                deleteIntent.nonZeroBalanceCount,
+                deleteIntent.ruleCount,
+                txTotal,
+                loading
+              ),
+              onConfirm: deleteIntent.onConfirm,
+            };
         }
-      }
-    }
-    return counts;
-  }, [stagedRules]);
+      })()
+    : null;
 
   // ── Derived rows: filter → sort ──────────────────────────────────────────────
   const rows: AccountRow[] = useMemo(() => {
@@ -241,25 +303,47 @@ export function AccountsTable({
 
   // ── Bulk actions ─────────────────────────────────────────────────────────────
   function handleBulkDelete() {
-    const ids = [...selectedIds].filter((id) => staged[id] && !staged[id].isNew);
+    const serverIds = [...selectedIds].filter((id) => staged[id] && !staged[id].isNew);
     const newIds = [...selectedIds].filter((id) => staged[id]?.isNew);
+    const nonZeroBalanceCount = serverIds.filter((id) => Math.abs(balances?.get(id) ?? 0) > 0).length;
+    const totalRuleCount = [...selectedIds].reduce((sum, id) => sum + (accountRuleCount.get(id) ?? 0), 0);
     const count = selectedIds.size;
-    setConfirmDialog({
+    const capturedIds = [...selectedIds];
+    setDeleteIntent({
+      kind: "bulkDelete",
+      ids: serverIds,
       title: `Delete ${count} account${count !== 1 ? "s" : ""}?`,
-      message: `${ids.length} will be staged for deletion and removed on Save. ${newIds.length > 0 ? `${newIds.length} unsaved new row${newIds.length !== 1 ? "s" : ""} will be discarded immediately.` : ""}`.trim(),
+      serverCount: serverIds.length,
+      newCount: newIds.length,
+      nonZeroBalanceCount,
+      ruleCount: totalRuleCount,
       onConfirm: () => {
         pushUndo();
-        for (const id of selectedIds) stageDelete("accounts", id);
+        for (const id of capturedIds) stageDelete("accounts", id);
         clearSelection();
       },
     });
   }
 
   function handleBulkClose() {
-    pushUndo();
-    for (const id of selectedIds) {
-      if (staged[id] && !staged[id].isDeleted) stageUpdate("accounts", id, { closed: true });
-    }
+    const closeableIds = [...selectedIds].filter(
+      (id) => staged[id] && !staged[id].isDeleted && !staged[id].entity.closed
+    );
+    const count = closeableIds.length;
+    if (count === 0) return;
+    const nonZeroBalanceCount = closeableIds.filter((id) => Math.abs(balances?.get(id) ?? 0) > 0).length;
+    const capturedIds = [...closeableIds];
+    setDeleteIntent({
+      kind: "bulkClose",
+      ids: [],
+      title: `Close ${count} account${count !== 1 ? "s" : ""}?`,
+      count,
+      nonZeroBalanceCount,
+      onConfirm: () => {
+        pushUndo();
+        for (const id of capturedIds) stageUpdate("accounts", id, { closed: true });
+      },
+    });
   }
 
   function handleBulkReopen() {
@@ -613,13 +697,44 @@ export function AccountsTable({
                           ) : (
                             <>
                               <Button variant="ghost" size="icon-xs" title={entity.closed ? "Reopen" : "Close"}
-                                onClick={() => { pushUndo(); stageUpdate("accounts", entity.id, { closed: !entity.closed }); }}>
+                                onClick={() => {
+                                  if (entity.closed) {
+                                    pushUndo();
+                                    stageUpdate("accounts", entity.id, { closed: false });
+                                  } else {
+                                    const balance = balances?.get(entity.id) ?? 0;
+                                    setDeleteIntent({
+                                      kind: "close",
+                                      ids: isNew ? [] : [entity.id],
+                                      title: "Close account?",
+                                      label: entity.name || "Unnamed",
+                                      balance,
+                                      onConfirm: () => { pushUndo(); stageUpdate("accounts", entity.id, { closed: true }); },
+                                    });
+                                  }
+                                }}>
                                 {entity.closed ? <ArchiveRestore /> : <Archive />}
                               </Button>
                               <Button variant="ghost" size="icon-xs" title="Delete"
                                 className="text-destructive hover:text-destructive"
-                                onClick={() => { pushUndo(); stageDelete("accounts", entity.id); }}>
+                                onClick={() => {
+                                  const balance = balances?.get(entity.id) ?? 0;
+                                  const ruleCount = accountRuleCount.get(entity.id) ?? 0;
+                                  setDeleteIntent({
+                                    kind: "delete",
+                                    ids: isNew ? [] : [entity.id],
+                                    title: "Delete account?",
+                                    label: entity.name || "Unnamed",
+                                    balance,
+                                    ruleCount,
+                                    onConfirm: () => { pushUndo(); stageDelete("accounts", entity.id); },
+                                  });
+                                }}>
                                 <Trash2 />
+                              </Button>
+                              <Button variant="ghost" size="icon-xs" title="Inspect usage" aria-label="Inspect usage"
+                                onClick={() => setInspectId(entity.id)}>
+                                <Info />
                               </Button>
                               {(isNew || isUpdated) && (
                                 <Button variant="ghost" size="icon-xs" title="Revert" onClick={() => revertEntity("accounts", entity.id)}>
@@ -641,24 +756,18 @@ export function AccountsTable({
         <BulkAddBar bulkCount={bulkCount} onBulkCountChange={setBulkCount} onAdd={(n) => addRows(n, true)} />
       </div>
 
-      {/* Confirm dialog */}
-      <Dialog open={confirmDialog !== null} onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{confirmDialog?.title}</DialogTitle>
-            <DialogDescription>{confirmDialog?.message}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDialog(null)}>Cancel</Button>
-            <Button
-              variant="destructive"
-              onClick={() => { confirmDialog?.onConfirm(); setConfirmDialog(null); }}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={!!deleteIntent}
+        onOpenChange={(open) => { if (!open) setDeleteIntent(null); }}
+        state={confirmState}
+      />
+
+      <UsageInspectorDrawer
+        entityId={inspectId}
+        entityType="account"
+        open={!!inspectId}
+        onOpenChange={(open) => { if (!open) setInspectId(null); }}
+      />
     </>
   );
 }

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -303,15 +303,18 @@ export function AccountsTable({
 
   // ── Bulk actions ─────────────────────────────────────────────────────────────
   function handleBulkDelete() {
-    const serverIds = [...selectedIds].filter((id) => staged[id] && !staged[id].isNew);
-    const newIds = [...selectedIds].filter((id) => staged[id]?.isNew);
+    const activeSelection = [...selectedIds].filter(
+      (id) => !staged[id]?.isDeleted
+    );
+    const serverIds = activeSelection.filter((id) => staged[id] && !staged[id].isNew);
+    const newIds = activeSelection.filter((id) => staged[id]?.isNew);
     const nonZeroBalanceCount = serverIds.filter((id) => {
       const b = balances?.get(id);
       return b === undefined || Math.abs(b) > 0; // unknown balance treated conservatively as non-zero
     }).length;
-    const totalRuleCount = [...selectedIds].reduce((sum, id) => sum + (accountRuleCount.get(id) ?? 0), 0);
-    const count = selectedIds.size;
-    const capturedIds = [...selectedIds];
+    const totalRuleCount = activeSelection.reduce((sum, id) => sum + (accountRuleCount.get(id) ?? 0), 0);
+    const count = activeSelection.length;
+    const capturedIds = activeSelection;
     setDeleteIntent({
       kind: "bulkDelete",
       ids: serverIds,

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -305,7 +305,10 @@ export function AccountsTable({
   function handleBulkDelete() {
     const serverIds = [...selectedIds].filter((id) => staged[id] && !staged[id].isNew);
     const newIds = [...selectedIds].filter((id) => staged[id]?.isNew);
-    const nonZeroBalanceCount = serverIds.filter((id) => Math.abs(balances?.get(id) ?? 0) > 0).length;
+    const nonZeroBalanceCount = serverIds.filter((id) => {
+      const b = balances?.get(id);
+      return b === undefined || Math.abs(b) > 0; // unknown balance treated conservatively as non-zero
+    }).length;
     const totalRuleCount = [...selectedIds].reduce((sum, id) => sum + (accountRuleCount.get(id) ?? 0), 0);
     const count = selectedIds.size;
     const capturedIds = [...selectedIds];
@@ -331,7 +334,10 @@ export function AccountsTable({
     );
     const count = closeableIds.length;
     if (count === 0) return;
-    const nonZeroBalanceCount = closeableIds.filter((id) => Math.abs(balances?.get(id) ?? 0) > 0).length;
+    const nonZeroBalanceCount = closeableIds.filter((id) => {
+      const b = balances?.get(id);
+      return b === undefined || Math.abs(b) > 0; // unknown balance treated conservatively as non-zero
+    }).length;
     const capturedIds = [...closeableIds];
     setDeleteIntent({
       kind: "bulkClose",

--- a/src/features/accounts/hooks/useAccountsSave.ts
+++ b/src/features/accounts/hooks/useAccountsSave.ts
@@ -110,6 +110,7 @@ export function useAccountsSave() {
     }
 
     await queryClient.invalidateQueries({ queryKey: ["accounts", connection.id] });
+    await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "account", connection.id] });
 
     return { succeeded, failed, idMap };
   }

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -5,32 +5,58 @@ import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useInlineEdit } from "@/hooks/useInlineEdit";
 import { useTableSelection } from "@/hooks/useTableSelection";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
 import { NameInput } from "@/components/ui/editable-cell";
 import type { DoneAction } from "@/components/ui/editable-cell";
 import {
   RotateCcw, Trash2, RefreshCw, Eye, EyeOff,
   ArrowUpDown, ArrowUp, ArrowDown, AlertTriangle,
-  ChevronDown, ChevronRight,
+  ChevronDown, ChevronRight, Info,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog, DialogContent, DialogHeader, DialogTitle,
-  DialogDescription, DialogFooter,
-} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import type { ConfirmState } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import {
+  buildCategoryDeleteWarning,
+  buildCategoryGroupDeleteWarning,
+  buildCategoryBulkDeleteWarning,
+} from "@/lib/usageWarnings";
+import { UsageInspectorDrawer } from "@/features/usage-inspector/components/UsageInspectorDrawer";
+import type { EntityUsageData } from "@/features/usage-inspector/types";
 import type { StagedEntity } from "@/types/staged";
 import type { CategoryGroup, Category } from "@/types/entities";
 import { FilterBar } from "./FilterBar";
 import type { VisibilityFilter, TypeFilter, RulesFilter, SortDir } from "./FilterBar";
 
+// ─── Delete intent ────────────────────────────────────────────────────────────
+
+type DeleteIntent = {
+  /** Server-side category IDs for $oneof tx-count query. */
+  ids: string[];
+  title: string;
+  onConfirm: () => void;
+  // Category single delete
+  entityLabel?: string;
+  entityRuleCount?: number;
+  // Group single delete
+  groupName?: string;
+  childCount?: number;
+  groupRuleCount?: number;
+  // Bulk delete
+  bulkServerCount?: number;
+  bulkNewCount?: number;
+  bulkRuleCount?: number;
+};
+
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
 type GroupRow = StagedEntity<CategoryGroup>;
 type CategoryRow = StagedEntity<Category>;
-type ConfirmState = { title: string; message: string; onConfirm: () => void };
 type SelectionKind = "group" | "category";
 type CellId = { kind: SelectionKind; id: string };
 
@@ -69,7 +95,8 @@ export function CategoriesTable({
 
   // ── Multi-select ─────────────────────────────────────────────────────────────
   const { selectedIds, toggleSelect, clearSelection } = useTableSelection();
-  const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
+  const [deleteIntent, setDeleteIntent] = useState<DeleteIntent | null>(null);
+  const [inspectTarget, setInspectTarget] = useState<{ id: string; type: EntityUsageData["entityType"] } | null>(null);
 
   const containerRef  = useRef<HTMLDivElement>(null);
   const router        = useRouter();
@@ -119,22 +146,51 @@ export function CategoriesTable({
   }, [stagedCats]);
 
   // ── Category → rule count ─────────────────────────────────────────────────────
-  const categoryRuleCount = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const s of Object.values(stagedRules)) {
-      if (s.isDeleted) continue;
-      for (const part of [...s.entity.conditions, ...s.entity.actions]) {
-        if (part.field === "category") {
-          const ids = Array.isArray(part.value) ? part.value : [part.value];
-          for (const id of ids) {
-            if (typeof id === "string" && id)
-              counts.set(id, (counts.get(id) ?? 0) + 1);
-          }
-        }
+  const categoryRuleCount = useMemo(
+    () => buildRuleReferenceMap(stagedRules, ["category"]),
+    [stagedRules]
+  );
+
+  // ── Lazy tx counts for delete confirm dialogs ─────────────────────────────────
+  const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
+    "category",
+    deleteIntent?.ids ?? [],
+    { enabled: !!deleteIntent && deleteIntent.ids.length > 0 }
+  );
+
+  const txTotal = deleteIntent?.ids.length
+    ? (txCounts ? [...txCounts.values()].reduce((a, b) => a + b, 0) : undefined)
+    : 0;
+
+  const confirmState: ConfirmState | null = deleteIntent
+    ? {
+        title: deleteIntent.title,
+        message:
+          deleteIntent.bulkServerCount !== undefined
+            ? buildCategoryBulkDeleteWarning(
+                deleteIntent.bulkServerCount,
+                deleteIntent.bulkNewCount ?? 0,
+                deleteIntent.bulkRuleCount ?? 0,
+                txTotal,
+                txLoading && deleteIntent.ids.length > 0
+              )
+            : deleteIntent.groupName !== undefined
+              ? buildCategoryGroupDeleteWarning(
+                  deleteIntent.groupName,
+                  deleteIntent.childCount ?? 0,
+                  deleteIntent.groupRuleCount ?? 0,
+                  txTotal,
+                  txLoading && deleteIntent.ids.length > 0
+                )
+              : buildCategoryDeleteWarning(
+                  deleteIntent.entityLabel ?? "",
+                  deleteIntent.entityRuleCount ?? 0,
+                  txTotal,
+                  txLoading && deleteIntent.ids.length > 0
+                ),
+        onConfirm: deleteIntent.onConfirm,
       }
-    }
-    return counts;
-  }, [stagedRules]);
+    : null;
 
   // ── Index all categories by groupId (no filters) ─────────────────────────────
   // Used by allGroups for group-level hidden/search checks, and as the base for
@@ -300,31 +356,69 @@ export function CategoriesTable({
 
   // ── Bulk delete ───────────────────────────────────────────────────────────────
   function handleBulkDelete() {
-    const count = selectedIds.size;
-    setConfirmDialog({
-      title: `Delete ${count} item${count !== 1 ? "s" : ""}?`,
-      message: "Staged deletions will be removed on Save. Deleting a group will also delete its categories.",
+    const pendingIncomeDeletes = [...selectedIds].filter(
+      (id) => stagedGroups[id]?.entity.isIncome && !stagedGroups[id]?.isDeleted
+    ).length;
+    const remainingIncomeAfter = incomeGroupCount - pendingIncomeDeletes;
+
+    // Resolve what will actually be deleted (respecting last-income-group guard)
+    const effectiveGroupIds: string[] = [];
+    const directCatIds: string[] = [];
+    let incomeSkipped = 0;
+
+    for (const id of selectedIds) {
+      if (stagedGroups[id]) {
+        const g = stagedGroups[id];
+        if (g.entity.isIncome && remainingIncomeAfter < 1 && incomeSkipped === 0) {
+          incomeSkipped++;
+          continue;
+        }
+        effectiveGroupIds.push(id);
+      } else if (stagedCats[id]) {
+        directCatIds.push(id);
+      }
+    }
+
+    // All category IDs affected (children of selected groups + directly selected cats)
+    const implicitCatIds = effectiveGroupIds.flatMap((gid) =>
+      Object.values(stagedCats)
+        .filter((c) => c.entity.groupId === gid)
+        .map((c) => c.entity.id)
+    );
+    const allCatIds = [...directCatIds, ...implicitCatIds];
+    const serverCatIds = allCatIds.filter((id) => !stagedCats[id]?.isNew);
+
+    const serverCount =
+      effectiveGroupIds.filter((id) => !stagedGroups[id]?.isNew).length +
+      directCatIds.filter((id) => !stagedCats[id]?.isNew).length;
+    const newCount =
+      effectiveGroupIds.filter((id) => stagedGroups[id]?.isNew).length +
+      directCatIds.filter((id) => stagedCats[id]?.isNew).length;
+    const totalRuleCount = allCatIds.reduce(
+      (sum, id) => sum + (categoryRuleCount.get(id) ?? 0),
+      0
+    );
+    const totalItems = effectiveGroupIds.length + directCatIds.length;
+
+    // Capture refs for the confirm closure
+    const groupsToDelete = [...effectiveGroupIds];
+    const catsToDelete = [...directCatIds];
+
+    setDeleteIntent({
+      ids: serverCatIds,
+      title: `Delete ${totalItems} item${totalItems !== 1 ? "s" : ""}?`,
+      bulkServerCount: serverCount,
+      bulkNewCount: newCount,
+      bulkRuleCount: totalRuleCount,
       onConfirm: () => {
         pushUndo();
-        const pendingIncomeDeletes = [...selectedIds].filter((id) => stagedGroups[id]?.entity.isIncome && !stagedGroups[id]?.isDeleted).length;
-        const remainingIncomeAfter = incomeGroupCount - pendingIncomeDeletes;
-        let incomeSkipped = 0;
-        for (const id of selectedIds) {
-          if (stagedGroups[id]) {
-            const g = stagedGroups[id];
-            // Never delete the last income group
-            if (g.entity.isIncome && remainingIncomeAfter < 1 && incomeSkipped === 0) {
-              incomeSkipped++;
-              continue;
-            }
-            for (const cat of Object.values(stagedCats)) {
-              if (cat.entity.groupId === id) stageDelete("categories", cat.entity.id);
-            }
-            stageDelete("categoryGroups", id);
-          } else if (stagedCats[id]) {
-            stageDelete("categories", id);
+        for (const gid of groupsToDelete) {
+          for (const cat of Object.values(stagedCats)) {
+            if (cat.entity.groupId === gid) stageDelete("categories", cat.entity.id);
           }
+          stageDelete("categoryGroups", gid);
         }
+        for (const id of catsToDelete) stageDelete("categories", id);
         clearSelection();
       },
     });
@@ -475,17 +569,38 @@ export function CategoriesTable({
               </Button>
             ) : (
               <>
+                <Button variant="ghost" size="icon-xs" title="Inspect usage" aria-label="Inspect usage"
+                  onClick={() => setInspectTarget({ id: entity.id, type: "categoryGroup" })}>
+                  <Info />
+                </Button>
                 {!(entity.isIncome && incomeGroupCount <= 1) && (
                   <Button
                     variant="ghost" size="icon-xs" title="Delete group"
                     className="text-destructive hover:text-destructive"
                     onClick={() => {
-                      pushUndo();
-                      // Stage-delete all child categories too
-                      for (const cat of Object.values(stagedCats)) {
-                        if (cat.entity.groupId === entity.id) stageDelete("categories", cat.entity.id);
-                      }
-                      stageDelete("categoryGroups", entity.id);
+                      const children = Object.values(stagedCats).filter(
+                        (cat) => cat.entity.groupId === entity.id && !cat.isDeleted
+                      );
+                      const serverChildIds = children
+                        .filter((cat) => !cat.isNew)
+                        .map((cat) => cat.entity.id);
+                      const groupRuleCount = children.reduce(
+                        (sum, cat) => sum + (categoryRuleCount.get(cat.entity.id) ?? 0),
+                        0
+                      );
+                      const capturedChildren = [...children];
+                      setDeleteIntent({
+                        ids: serverChildIds,
+                        title: `Delete group "${entity.name || "Unnamed"}"?`,
+                        groupName: entity.name || "Unnamed",
+                        childCount: children.length,
+                        groupRuleCount,
+                        onConfirm: () => {
+                          pushUndo();
+                          for (const cat of capturedChildren) stageDelete("categories", cat.entity.id);
+                          stageDelete("categoryGroups", entity.id);
+                        },
+                      });
                     }}
                   >
                     <Trash2 />
@@ -672,10 +787,22 @@ export function CategoriesTable({
               </Button>
             ) : (
               <>
+                <Button variant="ghost" size="icon-xs" title="Inspect usage" aria-label="Inspect usage"
+                  onClick={() => setInspectTarget({ id: entity.id, type: "category" })}>
+                  <Info />
+                </Button>
                 <Button
                   variant="ghost" size="icon-xs" title="Delete category"
                   className="text-destructive hover:text-destructive"
-                  onClick={() => { pushUndo(); stageDelete("categories", entity.id); }}
+                  onClick={() => {
+                    setDeleteIntent({
+                      ids: isNew ? [] : [entity.id],
+                      title: "Delete category?",
+                      entityLabel: entity.name || "Unnamed",
+                      entityRuleCount: categoryRuleCount.get(entity.id) ?? 0,
+                      onConfirm: () => { pushUndo(); stageDelete("categories", entity.id); },
+                    });
+                  }}
                 >
                   <Trash2 />
                 </Button>
@@ -876,24 +1003,18 @@ export function CategoriesTable({
         </div>
       </div>
 
-      {/* Confirm dialog */}
-      <Dialog open={confirmDialog !== null} onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{confirmDialog?.title}</DialogTitle>
-            <DialogDescription>{confirmDialog?.message}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDialog(null)}>Cancel</Button>
-            <Button
-              variant="destructive"
-              onClick={() => { confirmDialog?.onConfirm(); setConfirmDialog(null); }}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={!!deleteIntent}
+        onOpenChange={(open) => { if (!open) setDeleteIntent(null); }}
+        state={confirmState}
+      />
+
+      <UsageInspectorDrawer
+        entityId={inspectTarget?.id ?? null}
+        entityType={inspectTarget?.type ?? null}
+        open={!!inspectTarget}
+        onOpenChange={(open) => { if (!open) setInspectTarget(null); }}
+      />
     </>
   );
 }

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -369,12 +369,14 @@ export function CategoriesTable({
     for (const id of selectedIds) {
       if (stagedGroups[id]) {
         const g = stagedGroups[id];
+        if (g.isDeleted) continue;
         if (g.entity.isIncome && remainingIncomeAfter < 1 && incomeSkipped === 0) {
           incomeSkipped++;
           continue;
         }
         effectiveGroupIds.push(id);
       } else if (stagedCats[id]) {
+        if (stagedCats[id].isDeleted) continue;
         directCatIds.push(id);
       }
     }

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -379,13 +379,15 @@ export function CategoriesTable({
       }
     }
 
-    // All category IDs affected (children of selected groups + directly selected cats)
+    // All category IDs affected (children of selected groups + directly selected cats).
+    // Use a Set to deduplicate: a category that is both directly selected AND a child
+    // of a selected group must only be counted once.
     const implicitCatIds = effectiveGroupIds.flatMap((gid) =>
       Object.values(stagedCats)
         .filter((c) => c.entity.groupId === gid)
         .map((c) => c.entity.id)
     );
-    const allCatIds = [...directCatIds, ...implicitCatIds];
+    const allCatIds = [...new Set([...directCatIds, ...implicitCatIds])];
     const serverCatIds = allCatIds.filter((id) => !stagedCats[id]?.isNew);
 
     const serverCount =

--- a/src/features/categories/hooks/useCategoriesSave.ts
+++ b/src/features/categories/hooks/useCategoriesSave.ts
@@ -109,6 +109,7 @@ export function useCategoriesSave() {
 
     // Both entity types share one query key since they're loaded together
     await queryClient.invalidateQueries({ queryKey: ["categoryGroups", connection.id] });
+    await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "category", connection.id] });
 
     return { succeeded, failed, idMap };
   }

--- a/src/features/categories/hooks/useCategoryGroupsSave.ts
+++ b/src/features/categories/hooks/useCategoryGroupsSave.ts
@@ -106,6 +106,7 @@ export function useCategoryGroupsSave() {
     }
 
     await queryClient.invalidateQueries({ queryKey: ["categoryGroups", connection.id] });
+    await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "category", connection.id] });
 
     return { succeeded, failed, idMap };
   }

--- a/src/features/payees/components/PayeesTable.tsx
+++ b/src/features/payees/components/PayeesTable.tsx
@@ -5,11 +5,12 @@ import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useInlineEdit } from "@/hooks/useInlineEdit";
 import { useTableSelection } from "@/hooks/useTableSelection";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
 import { NameInput } from "@/components/ui/editable-cell";
 import type { DoneAction } from "@/components/ui/editable-cell";
 import {
   RotateCcw, Trash2, RefreshCw,
-  ArrowUpDown, ArrowUp, ArrowDown, AlertTriangle,
+  ArrowUpDown, ArrowUp, ArrowDown, AlertTriangle, Info,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,13 +18,35 @@ import {
   Dialog, DialogContent, DialogHeader, DialogTitle,
   DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import type { ConfirmState } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import { buildPayeeDeleteWarning, buildPayeeBulkDeleteWarning } from "@/lib/usageWarnings";
+import { UsageInspectorDrawer } from "@/features/usage-inspector/components/UsageInspectorDrawer";
 import type { StagedEntity } from "@/types/staged";
 import type { Payee } from "@/types/entities";
 import { FilterBar } from "./FilterBar";
 import type { TypeFilter, RulesFilter, SortCol, SortDir } from "./FilterBar";
+
+// ─── Delete intent ────────────────────────────────────────────────────────────
+
+type DeleteIntent = {
+  /** Server-side IDs for $oneof tx-count query. Empty when entity is isNew. */
+  ids: string[];
+  title: string;
+  onConfirm: () => void;
+  // Single delete
+  entityLabel?: string;
+  entityRuleCount?: number;
+  // Bulk delete
+  bulkServerCount?: number;
+  bulkNewCount?: number;
+  bulkSkippedCount?: number;
+  bulkRuleCount?: number;
+};
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -31,7 +54,6 @@ const NAVIGABLE_COLS = ["name"] as const;
 type NavigableCol = (typeof NAVIGABLE_COLS)[number];
 type CellId = { rowId: string; colId: NavigableCol };
 type PayeeRow = StagedEntity<Payee>;
-type ConfirmState = { title: string; message: string; onConfirm: () => void };
 type MergeCandidate = { id: string; name: string };
 type MergeState = { candidates: MergeCandidate[]; targetId: string };
 
@@ -87,7 +109,8 @@ export function PayeesTable({ onCreateRule }: {
 
   // ── Multi-select state ───────────────────────────────────────────────────────
   const { selectedIds, toggleSelect: toggleSelectRow, toggleSelectAll: _toggleSelectAll, clearSelection } = useTableSelection();
-  const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
+  const [deleteIntent, setDeleteIntent] = useState<DeleteIntent | null>(null);
+  const [inspectId, setInspectId] = useState<string | null>(null);
 
   const [mergeDialog, setMergeDialog] = useState<MergeState | null>(null);
 
@@ -107,23 +130,44 @@ export function PayeesTable({ onCreateRule }: {
   const stagePayeeMerge = useStagedStore((s) => s.stagePayeeMerge);
 
   // ── Rules reference count per payee ──────────────────────────────────────────
-  const payeeRuleCount = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const s of Object.values(stagedRules)) {
-      if (s.isDeleted) continue;
-      for (const part of [...s.entity.conditions, ...s.entity.actions]) {
-        if (part.field === "payee" || part.field === "imported_payee") {
-          const ids = Array.isArray(part.value) ? part.value : [part.value];
-          for (const id of ids) {
-            if (typeof id === "string" && id) {
-              counts.set(id, (counts.get(id) ?? 0) + 1);
-            }
-          }
-        }
+  const payeeRuleCount = useMemo(
+    () => buildRuleReferenceMap(stagedRules, ["payee", "imported_payee"]),
+    [stagedRules]
+  );
+
+  // ── Lazy tx counts for delete confirm dialogs ─────────────────────────────────
+  const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
+    "payee",
+    deleteIntent?.ids ?? [],
+    { enabled: !!deleteIntent && deleteIntent.ids.length > 0 }
+  );
+
+  const txTotal = deleteIntent?.ids.length
+    ? (txCounts ? [...txCounts.values()].reduce((a, b) => a + b, 0) : undefined)
+    : 0;
+
+  const confirmState: ConfirmState | null = deleteIntent
+    ? {
+        title: deleteIntent.title,
+        message:
+          deleteIntent.bulkServerCount !== undefined
+            ? buildPayeeBulkDeleteWarning(
+                deleteIntent.bulkServerCount,
+                deleteIntent.bulkNewCount ?? 0,
+                deleteIntent.bulkSkippedCount ?? 0,
+                deleteIntent.bulkRuleCount ?? 0,
+                txTotal,
+                txLoading && deleteIntent.ids.length > 0
+              )
+            : buildPayeeDeleteWarning(
+                deleteIntent.entityLabel ?? "",
+                deleteIntent.entityRuleCount ?? 0,
+                txTotal,
+                txLoading && deleteIntent.ids.length > 0
+              ),
+        onConfirm: deleteIntent.onConfirm,
       }
-    }
-    return counts;
-  }, [stagedRules]);
+    : null;
 
   // ── Duplicate name detection ─────────────────────────────────────────────────
   const duplicateNames = useMemo(() => {
@@ -290,25 +334,19 @@ export function PayeesTable({ onCreateRule }: {
       return;
     }
 
-    const referencedRules = deletableIds.reduce((sum, id) => sum + (payeeRuleCount.get(id) ?? 0), 0);
+    const totalRuleCount = deletableIds.reduce((sum, id) => sum + (payeeRuleCount.get(id) ?? 0), 0);
+    const capturedIds = [...deletableIds];
 
-    let message = `${serverIds.length} will be staged for deletion and removed on Save.`;
-    if (newIds.length > 0) {
-      message += ` ${newIds.length} unsaved new row${newIds.length !== 1 ? "s" : ""} will be discarded immediately.`;
-    }
-    if (skipped > 0) {
-      message += ` ${skipped} transfer payee${skipped !== 1 ? "s" : ""} skipped (system-managed).`;
-    }
-    if (referencedRules > 0) {
-      message += ` Warning: ${referencedRules} rule reference${referencedRules !== 1 ? "s" : ""} will be affected.`;
-    }
-
-    setConfirmDialog({
+    setDeleteIntent({
+      ids: serverIds,
       title: `Delete ${count} payee${count !== 1 ? "s" : ""}?`,
-      message: message.trim(),
+      bulkServerCount: serverIds.length,
+      bulkNewCount: newIds.length,
+      bulkSkippedCount: skipped,
+      bulkRuleCount: totalRuleCount,
       onConfirm: () => {
         pushUndo();
-        for (const id of deletableIds) stageDelete("payees", id);
+        for (const id of capturedIds) stageDelete("payees", id);
         clearSelection();
       },
     });
@@ -633,20 +671,20 @@ export function PayeesTable({ onCreateRule }: {
                                 variant="ghost" size="icon-xs" title="Delete"
                                 className="text-destructive hover:text-destructive"
                                 onClick={() => {
-                                  const ruleCount = payeeRuleCount.get(entity.id) ?? 0;
-                                  if (ruleCount > 0) {
-                                    setConfirmDialog({
-                                      title: `Delete "${entity.name}"?`,
-                                      message: `This payee is referenced by ${ruleCount} rule${ruleCount !== 1 ? "s" : ""}. Deleting it may break those rules.`,
-                                      onConfirm: () => { pushUndo(); stageDelete("payees", entity.id); },
-                                    });
-                                  } else {
-                                    pushUndo();
-                                    stageDelete("payees", entity.id);
-                                  }
+                                  setDeleteIntent({
+                                    ids: isNew ? [] : [entity.id],
+                                    title: "Delete payee?",
+                                    entityLabel: entity.name || "Unnamed",
+                                    entityRuleCount: payeeRuleCount.get(entity.id) ?? 0,
+                                    onConfirm: () => { pushUndo(); stageDelete("payees", entity.id); },
+                                  });
                                 }}
                               >
                                 <Trash2 />
+                              </Button>
+                              <Button variant="ghost" size="icon-xs" title="Inspect usage" aria-label="Inspect usage"
+                                onClick={() => setInspectId(entity.id)}>
+                                <Info />
                               </Button>
                               {(isNew || isUpdated) && (
                                 <Button variant="ghost" size="icon-xs" title="Revert" onClick={() => revertEntity("payees", entity.id)}>
@@ -668,24 +706,18 @@ export function PayeesTable({ onCreateRule }: {
         <BulkAddBar bulkCount={bulkCount} onBulkCountChange={setBulkCount} onAdd={(n) => addRows(n, true)} />
       </div>
 
-      {/* Confirm dialog */}
-      <Dialog open={confirmDialog !== null} onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{confirmDialog?.title}</DialogTitle>
-            <DialogDescription>{confirmDialog?.message}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDialog(null)}>Cancel</Button>
-            <Button
-              variant="destructive"
-              onClick={() => { confirmDialog?.onConfirm(); setConfirmDialog(null); }}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={!!deleteIntent}
+        onOpenChange={(open) => { if (!open) setDeleteIntent(null); }}
+        state={confirmState}
+      />
+
+      <UsageInspectorDrawer
+        entityId={inspectId}
+        entityType="payee"
+        open={!!inspectId}
+        onOpenChange={(open) => { if (!open) setInspectId(null); }}
+      />
 
       {/* Merge dialog */}
       <Dialog open={mergeDialog !== null} onOpenChange={(open) => { if (!open) setMergeDialog(null); }}>

--- a/src/features/payees/components/PayeesTable.tsx
+++ b/src/features/payees/components/PayeesTable.tsx
@@ -321,10 +321,9 @@ export function PayeesTable({ onCreateRule }: {
   // ── Bulk actions ─────────────────────────────────────────────────────────────
   function handleBulkDelete() {
     // Only delete regular payees (transfer payees are system-managed)
-    const deletableIds = [...selectedIds].filter(
-      (id) => staged[id] && !staged[id].entity.transferAccountId
-    );
-    const skipped = selectedIds.size - deletableIds.length;
+    const activeIds = [...selectedIds].filter((id) => staged[id] && !staged[id].isDeleted);
+    const deletableIds = activeIds.filter((id) => !staged[id]!.entity.transferAccountId);
+    const skipped = activeIds.length - deletableIds.length;
     const newIds = deletableIds.filter((id) => staged[id]?.isNew);
     const serverIds = deletableIds.filter((id) => !staged[id]?.isNew);
     const count = deletableIds.length;

--- a/src/features/payees/hooks/usePayeesSave.ts
+++ b/src/features/payees/hooks/usePayeesSave.ts
@@ -147,6 +147,7 @@ export function usePayeesSave() {
     }
 
     await queryClient.invalidateQueries({ queryKey: ["payees", connection.id] });
+    await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "payee", connection.id] });
     if (pendingPayeeMerges.length > 0) {
       await queryClient.invalidateQueries({ queryKey: ["rules", connection.id] });
     }

--- a/src/features/rules/components/RulesTable.tsx
+++ b/src/features/rules/components/RulesTable.tsx
@@ -7,9 +7,12 @@ import { useTableSelection } from "@/hooks/useTableSelection";
 import { Pencil, Trash2, RotateCcw, Copy, AlertTriangle, CalendarDays } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import type { ConfirmState } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
+import { buildRuleDeleteWarning, buildRuleBulkDeleteWarning } from "@/lib/usageWarnings";
 import { rulePreview } from "../utils/rulePreview";
 import type { EntityMaps } from "../utils/rulePreview";
 import { STAGE_LABELS } from "../utils/ruleFields";
@@ -47,6 +50,8 @@ type Props = {
 };
 
 export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: Props) {
+  const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
+
   const stagedRules = useStagedStore((s) => s.rules);
   const payees = useStagedStore((s) => s.payees);
   const categories = useStagedStore((s) => s.categories);
@@ -126,8 +131,11 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
   }, [stagedRules, stageFilter, actionTypeFilter, payeeId, categoryId, accountId, search, rulePreviews]);
 
   function handleDelete(id: string) {
-    pushUndo();
-    stageDelete("rules", id);
+    setConfirmDialog({
+      title: "Delete rule?",
+      message: buildRuleDeleteWarning(),
+      onConfirm: () => { pushUndo(); stageDelete("rules", id); },
+    });
   }
 
   function handleDuplicate(rule: Rule) {
@@ -163,14 +171,22 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
   }
 
   function handleDeleteSelected() {
-    pushUndo();
-    for (const id of activeSelectedIds) stageDelete("rules", id);
-    clearSelection();
+    if (activeSelectedIds.length === 0) return;
+    setConfirmDialog({
+      title: `Delete ${activeSelectedIds.length} rule${activeSelectedIds.length !== 1 ? "s" : ""}?`,
+      message: buildRuleBulkDeleteWarning(activeSelectedIds.length),
+      onConfirm: () => {
+        pushUndo();
+        for (const id of activeSelectedIds) stageDelete("rules", id);
+        clearSelection();
+      },
+    });
   }
 
   const totalVisible = Object.values(stagedRules).filter((s) => !s.isDeleted).length;
 
   return (
+    <>
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <FilterBar
         search={search}
@@ -386,5 +402,12 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
         )}
       </div>
     </div>
+
+    <ConfirmDialog
+      open={confirmDialog !== null}
+      onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}
+      state={confirmDialog}
+    />
+    </>
   );
 }

--- a/src/features/rules/components/RulesTable.tsx
+++ b/src/features/rules/components/RulesTable.tsx
@@ -172,12 +172,22 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
 
   function handleDeleteSelected() {
     if (activeSelectedIds.length === 0) return;
+    // Schedule-linked rules are managed by the Schedules page and cannot be
+    // deleted directly — mirror the per-row disabled guard for bulk actions.
+    const deletableIds = activeSelectedIds.filter(
+      (id) => !stagedRules[id]?.entity.actions.some((a) => a.op === "link-schedule")
+    );
+    const skippedCount = activeSelectedIds.length - deletableIds.length;
+    if (deletableIds.length === 0) return;
+    const skippedNote = skippedCount > 0
+      ? ` ${skippedCount} schedule-linked rule${skippedCount !== 1 ? "s" : ""} skipped.`
+      : "";
     setConfirmDialog({
-      title: `Delete ${activeSelectedIds.length} rule${activeSelectedIds.length !== 1 ? "s" : ""}?`,
-      message: buildRuleBulkDeleteWarning(activeSelectedIds.length),
+      title: `Delete ${deletableIds.length} rule${deletableIds.length !== 1 ? "s" : ""}?`,
+      message: buildRuleBulkDeleteWarning(deletableIds.length) + skippedNote,
       onConfirm: () => {
         pushUndo();
-        for (const id of activeSelectedIds) stageDelete("rules", id);
+        for (const id of deletableIds) stageDelete("rules", id);
         clearSelection();
       },
     });

--- a/src/features/schedules/components/SchedulesTable.tsx
+++ b/src/features/schedules/components/SchedulesTable.tsx
@@ -3,17 +3,37 @@
 import { useState, useMemo } from "react";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useTableSelection } from "@/hooks/useTableSelection";
-import { Pencil, Trash2, RotateCcw, Copy, ExternalLink, AlertTriangle, Repeat2, CalendarDays } from "lucide-react";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
+import { Pencil, Trash2, RotateCcw, Copy, ExternalLink, AlertTriangle, Repeat2, CalendarDays, Info } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import type { ConfirmState } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
+import { buildScheduleDeleteWarning, buildScheduleBulkDeleteWarning } from "@/lib/usageWarnings";
+import { UsageInspectorDrawer } from "@/features/usage-inspector/components/UsageInspectorDrawer";
 import { recurSummary, frequencyLabel } from "../lib/recurSummary";
 import { FilterBar } from "./FilterBar";
 import type { StatusFilter, AutoAddFilter, FrequencyFilter, EntityOption } from "./FilterBar";
 import type { StagedEntity } from "@/types/staged";
 import type { Schedule, ScheduleAmountRange } from "@/types/entities";
+
+// ─── Delete intent ────────────────────────────────────────────────────────────
+
+type DeleteIntent = {
+  /** Server-side IDs for $oneof tx-count query. Empty when all selected are isNew. */
+  ids: string[];
+  title: string;
+  onConfirm: () => void;
+  // Single delete
+  entityLabel?: string;
+  ruleId?: string;
+  postsTransaction?: boolean;
+  // Bulk delete
+  bulkCount?: number;
+};
 
 // ─── Amount display helper ────────────────────────────────────────────────────
 
@@ -66,6 +86,41 @@ export function SchedulesTable({ onEdit, onEditAsRule }: Props) {
   const pushUndo        = useStagedStore((s) => s.pushUndo);
 
   const highlightedId = useHighlight();
+
+  const [deleteIntent, setDeleteIntent] = useState<DeleteIntent | null>(null);
+  const [inspectId, setInspectId] = useState<string | null>(null);
+
+  const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
+    "schedule",
+    deleteIntent?.ids ?? [],
+    { enabled: !!deleteIntent && (deleteIntent.ids.length > 0) }
+  );
+
+  // ── Confirm dialog state (computed from intent + live tx counts) ─────────────
+  const txTotal = deleteIntent?.ids.length
+    ? (txCounts ? [...txCounts.values()].reduce((a, b) => a + b, 0) : undefined)
+    : 0;
+
+  const confirmState: ConfirmState | null = deleteIntent
+    ? {
+        title: deleteIntent.title,
+        message:
+          deleteIntent.bulkCount !== undefined
+            ? buildScheduleBulkDeleteWarning(
+                deleteIntent.bulkCount,
+                txTotal,
+                txLoading && deleteIntent.ids.length > 0
+              )
+            : buildScheduleDeleteWarning(
+                deleteIntent.entityLabel ?? "",
+                deleteIntent.ruleId,
+                deleteIntent.postsTransaction ?? false,
+                txTotal,
+                txLoading && deleteIntent.ids.length > 0
+              ),
+        onConfirm: deleteIntent.onConfirm,
+      }
+    : null;
 
   const [search, setSearch]                       = useState("");
   const [statusFilter, setStatusFilter]           = useState<StatusFilter>("active");
@@ -139,7 +194,19 @@ export function SchedulesTable({ onEdit, onEditAsRule }: Props) {
 
   function toggleSelectAll() { _toggleSelectAll(selectableIds, allSelected); }
 
-  function handleDelete(id: string) { pushUndo(); stageDelete("schedules", id); }
+  function handleDelete(id: string) {
+    const s = staged[id];
+    if (!s) return;
+    const entity = s.entity;
+    setDeleteIntent({
+      ids: s.isNew ? [] : [entity.id],
+      title: "Delete schedule?",
+      entityLabel: entity.name ?? "Unnamed",
+      ruleId: entity.ruleId,
+      postsTransaction: entity.postsTransaction ?? false,
+      onConfirm: () => { pushUndo(); stageDelete("schedules", id); },
+    });
+  }
 
   function handleDuplicate(s: Schedule) {
     pushUndo();
@@ -154,12 +221,22 @@ export function SchedulesTable({ onEdit, onEditAsRule }: Props) {
   }
 
   function handleBulkDelete() {
-    pushUndo();
-    for (const id of activeSelectedIds) stageDelete("schedules", id);
-    clearSelection();
+    const count = activeSelectedIds.length;
+    const serverIds = activeSelectedIds.filter((id) => !staged[id]?.isNew);
+    setDeleteIntent({
+      ids: serverIds,
+      title: `Delete ${count} schedule${count === 1 ? "" : "s"}?`,
+      bulkCount: count,
+      onConfirm: () => {
+        pushUndo();
+        for (const id of activeSelectedIds) stageDelete("schedules", id);
+        clearSelection();
+      },
+    });
   }
 
   return (
+    <>
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <FilterBar
         search={search}              onSearchChange={setSearch}
@@ -335,6 +412,10 @@ export function SchedulesTable({ onEdit, onEditAsRule }: Props) {
                             <RotateCcw />
                           </Button>
                         )}
+                        <Button variant="ghost" size="icon-xs" title="Inspect usage" aria-label="Inspect usage"
+                          onClick={() => setInspectId(entity.id)}>
+                          <Info />
+                        </Button>
                         <Button
                           variant="ghost" size="icon-xs"
                           className="text-destructive hover:text-destructive"
@@ -353,5 +434,19 @@ export function SchedulesTable({ onEdit, onEditAsRule }: Props) {
         )}
       </div>
     </div>
+
+    <ConfirmDialog
+      open={!!deleteIntent}
+      onOpenChange={(open) => { if (!open) setDeleteIntent(null); }}
+      state={confirmState}
+    />
+
+    <UsageInspectorDrawer
+      entityId={inspectId}
+      entityType="schedule"
+      open={!!inspectId}
+      onOpenChange={(open) => { if (!open) setInspectId(null); }}
+    />
+    </>
   );
 }

--- a/src/features/schedules/hooks/useSchedulesSave.ts
+++ b/src/features/schedules/hooks/useSchedulesSave.ts
@@ -137,6 +137,7 @@ export function useSchedulesSave() {
 
     await queryClient.invalidateQueries({ queryKey: ["schedules", connection.id] });
     await queryClient.invalidateQueries({ queryKey: ["rules", connection.id] });
+    await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "schedule", connection.id] });
 
     return { succeeded, failed, idMap };
     } finally {

--- a/src/features/tags/components/TagsTable.tsx
+++ b/src/features/tags/components/TagsTable.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
-import { Trash2, RotateCcw, RefreshCw, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { Trash2, RotateCcw, RefreshCw, ArrowUpDown, ArrowUp, ArrowDown, Info } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import type { ConfirmState } from "@/components/ui/confirm-dialog";
+import { UsageInspectorDrawer } from "@/features/usage-inspector/components/UsageInspectorDrawer";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { useTableSelection } from "@/hooks/useTableSelection";
@@ -37,7 +39,6 @@ function contrastText(hex: string): string {
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type ConfirmState = { title: string; message: string; onConfirm: () => void };
 
 // ─── DescInput ────────────────────────────────────────────────────────────────
 
@@ -135,6 +136,7 @@ export function TagsTable() {
   // ── Selection state ───────────────────────────────────────────────────────
   const { selectedIds, toggleSelect, toggleSelectAll: _toggleSelectAll, clearSelection } = useTableSelection();
   const [confirmDialog, setConfirmDialog] = useState<ConfirmState | null>(null);
+  const [inspectId, setInspectId] = useState<string | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -585,6 +587,10 @@ export function TagsTable() {
                           </Button>
                         ) : (
                           <>
+                            <Button variant="ghost" size="icon-xs" title="Inspect usage" aria-label="Inspect usage"
+                              onClick={() => setInspectId(entity.id)}>
+                              <Info />
+                            </Button>
                             <Button
                               variant="ghost" size="icon-xs"
                               className="text-destructive hover:text-destructive"
@@ -613,24 +619,18 @@ export function TagsTable() {
         <BulkAddBar bulkCount={bulkCount} onBulkCountChange={setBulkCount} onAdd={(n) => addRows(n, true)} />
       </div>
 
-      {/* Confirm delete dialog */}
-      <Dialog open={confirmDialog !== null} onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{confirmDialog?.title}</DialogTitle>
-            <DialogDescription>{confirmDialog?.message}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDialog(null)}>Cancel</Button>
-            <Button
-              variant="destructive"
-              onClick={() => { confirmDialog?.onConfirm(); setConfirmDialog(null); }}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={confirmDialog !== null}
+        onOpenChange={(open) => { if (!open) setConfirmDialog(null); }}
+        state={confirmDialog}
+      />
+
+      <UsageInspectorDrawer
+        entityId={inspectId}
+        entityType="tag"
+        open={!!inspectId}
+        onOpenChange={(open) => { if (!open) setInspectId(null); }}
+      />
     </>
   );
 }

--- a/src/features/usage-inspector/components/UsageInspectorDrawer.tsx
+++ b/src/features/usage-inspector/components/UsageInspectorDrawer.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription,
+} from "@/components/ui/sheet";
+import { useEntityUsage } from "../hooks/useEntityUsage";
+import type { EntityUsageData } from "../types";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+type Props = {
+  entityId: string | null;
+  entityType: EntityUsageData["entityType"] | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const ENTITY_DISPLAY_NAME: Record<EntityUsageData["entityType"], string> = {
+  account:       "Account",
+  payee:         "Payee",
+  category:      "Category",
+  categoryGroup: "Category Group",
+  schedule:      "Schedule",
+  tag:           "Tag",
+};
+
+function rulesUrl(entityType: EntityUsageData["entityType"], entityId: string): string | null {
+  switch (entityType) {
+    case "account":  return `/rules?accountId=${entityId}`;
+    case "payee":    return `/rules?payeeId=${entityId}`;
+    case "category": return `/rules?categoryId=${entityId}`;
+    default:         return null;
+  }
+}
+
+// ─── UsageInspectorDrawer ─────────────────────────────────────────────────────
+
+export function UsageInspectorDrawer({ entityId, entityType, open, onOpenChange }: Props) {
+  const router = useRouter();
+  const usage = useEntityUsage(entityId, entityType, open);
+
+  const isEmpty =
+    usage &&
+    !usage.txLoading &&
+    usage.ruleCount === 0 &&
+    (usage.txCount === undefined || usage.txCount === 0) &&
+    (usage.balance === undefined || Math.abs(usage.balance) === 0) &&
+    usage.warnings.length === 0;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-[380px] flex-col gap-0 p-0 sm:w-[420px]">
+        <SheetHeader className="border-b border-border px-5 py-4">
+          <SheetTitle className="text-sm font-semibold">
+            {usage?.entityLabel || "Usage Inspector"}
+          </SheetTitle>
+          <SheetDescription className="text-xs text-muted-foreground">
+            {usage ? ENTITY_DISPLAY_NAME[usage.entityType] : ""}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {!usage ? (
+            <p className="text-xs text-muted-foreground">Loading...</p>
+          ) : (
+            <>
+              {/* ── Stats row ────────────────────────────────────────────── */}
+              <div className="flex flex-wrap gap-2">
+                {/* Rules badge — always shown */}
+                <StatBadge label="Rules" value={String(usage.ruleCount)} />
+
+                {/* Tx count badge — not for tags */}
+                {usage.entityType !== "tag" && (
+                  <StatBadge
+                    label="Transactions"
+                    value={usage.txLoading ? "…" : String(usage.txCount ?? 0)}
+                    loading={usage.txLoading}
+                  />
+                )}
+
+                {/* Balance badge — accounts only */}
+                {usage.entityType === "account" && usage.balance !== undefined && (
+                  <StatBadge
+                    label="Balance"
+                    value={usage.balance.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    variant={Math.abs(usage.balance) > 0 ? "warn" : "neutral"}
+                  />
+                )}
+
+                {/* Child count — category groups only */}
+                {usage.entityType === "categoryGroup" && usage.childCount !== undefined && (
+                  <StatBadge label="Categories" value={String(usage.childCount)} />
+                )}
+              </div>
+
+              {/* ── Tags note ────────────────────────────────────────────── */}
+              {usage.entityType === "tag" && (
+                <p className="text-xs text-muted-foreground italic">
+                  Transaction data is not available for tags.
+                </p>
+              )}
+
+              {/* ── Loading state ─────────────────────────────────────────── */}
+              {usage.txLoading && (
+                <p className="text-xs text-muted-foreground">Checking usage...</p>
+              )}
+
+              {/* ── Warnings ─────────────────────────────────────────────── */}
+              {usage.warnings.length > 0 && (
+                <section>
+                  <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Impact
+                  </h3>
+                  <ul className="space-y-1.5">
+                    {usage.warnings.map((w) => (
+                      <li key={String(w)} className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs leading-relaxed">
+                        {w}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {/* ── Empty state ───────────────────────────────────────────── */}
+              {isEmpty && (
+                <p className="text-xs text-muted-foreground italic">
+                  No known references found.
+                </p>
+              )}
+
+              {/* ── Quick links ───────────────────────────────────────────── */}
+              {usage.ruleCount > 0 && entityId && entityType && (
+                (() => {
+                  const url = rulesUrl(entityType, entityId);
+                  return url ? (
+                    <section>
+                      <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                        Quick Links
+                      </h3>
+                      <button
+                        className="text-xs text-primary underline hover:opacity-80"
+                        onClick={() => { router.push(url); onOpenChange(false); }}
+                      >
+                        View rules →
+                      </button>
+                    </section>
+                  ) : null;
+                })()
+              )}
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── StatBadge ────────────────────────────────────────────────────────────────
+
+function StatBadge({
+  label, value, loading = false, variant = "neutral",
+}: {
+  label: string;
+  value: string;
+  loading?: boolean;
+  variant?: "neutral" | "warn";
+}) {
+  return (
+    <div className="flex flex-col items-center rounded-md border border-border/60 bg-muted/20 px-3 py-2 min-w-[72px]">
+      <span className={`text-sm font-semibold tabular-nums ${loading ? "text-muted-foreground" : variant === "warn" ? "text-amber-600 dark:text-amber-400" : ""}`}>
+        {value}
+      </span>
+      <span className="text-[10px] text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/src/features/usage-inspector/hooks/useEntityUsage.ts
+++ b/src/features/usage-inspector/hooks/useEntityUsage.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo } from "react";
+import { useStagedStore } from "@/store/staged";
+import { useAccountBalances } from "@/features/accounts/hooks/useAccountBalances";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
+import type { TransactionCountGroupField } from "@/lib/api/query";
+import { buildEntityUsage } from "../lib/entityUsage";
+import type { EntityUsageData } from "../types";
+
+/**
+ * Resolves all usage data for a single entity.
+ * Fires the $oneof tx-count query only when the drawer is open.
+ * Returns null while entityId/entityType are null.
+ */
+export function useEntityUsage(
+  entityId: string | null,
+  entityType: EntityUsageData["entityType"] | null,
+  open: boolean
+): EntityUsageData | null {
+  const stagedRules          = useStagedStore((s) => s.rules);
+  const stagedAccounts       = useStagedStore((s) => s.accounts);
+  const stagedPayees         = useStagedStore((s) => s.payees);
+  const stagedCategories     = useStagedStore((s) => s.categories);
+  const stagedCategoryGroups = useStagedStore((s) => s.categoryGroups);
+  const stagedSchedules      = useStagedStore((s) => s.schedules);
+  const stagedTags           = useStagedStore((s) => s.tags);
+  const { data: balances }   = useAccountBalances();
+
+  // Determine the groupField for the $oneof query
+  const groupField = useMemo((): TransactionCountGroupField | null => {
+    if (!entityType || entityType === "tag") return null;
+    if (entityType === "categoryGroup") return "category"; // query by child category IDs
+    const map: Partial<Record<EntityUsageData["entityType"], TransactionCountGroupField>> = {
+      account: "account", payee: "payee", category: "category", schedule: "schedule",
+    };
+    return map[entityType] ?? null;
+  }, [entityType]);
+
+  // IDs to pass to the $oneof query
+  const queryIds = useMemo((): string[] => {
+    if (!entityId || !entityType || !open || !groupField) return [];
+    if (entityType === "categoryGroup") {
+      // Query by child category IDs (server-side only)
+      return Object.values(stagedCategories)
+        .filter((c) => c.entity.groupId === entityId && !c.isNew && !c.isDeleted)
+        .map((c) => c.entity.id);
+    }
+    // For other entity types, exclude isNew (no server transactions)
+    const isNewEntity = (() => {
+      switch (entityType) {
+        case "account":  return !!stagedAccounts[entityId]?.isNew;
+        case "payee":    return !!stagedPayees[entityId]?.isNew;
+        case "category": return !!stagedCategories[entityId]?.isNew;
+        case "schedule": return !!stagedSchedules[entityId]?.isNew;
+        default:         return false;
+      }
+    })();
+    return isNewEntity ? [] : [entityId];
+  }, [entityId, entityType, open, groupField, stagedCategories, stagedAccounts, stagedPayees, stagedSchedules]);
+
+  const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
+    groupField ?? "payee", // safe fallback — hook is disabled when groupField is null
+    queryIds,
+    { enabled: open && !!groupField && queryIds.length > 0 }
+  );
+
+  const entityLabel = useMemo((): string => {
+    if (!entityId || !entityType) return "";
+    switch (entityType) {
+      case "account":       return stagedAccounts[entityId]?.entity.name ?? "";
+      case "payee":         return stagedPayees[entityId]?.entity.name ?? "";
+      case "category":      return stagedCategories[entityId]?.entity.name ?? "";
+      case "categoryGroup": return stagedCategoryGroups[entityId]?.entity.name ?? "";
+      case "schedule":      return stagedSchedules[entityId]?.entity.name ?? "";
+      case "tag":           return stagedTags[entityId]?.entity.name ?? "";
+    }
+  }, [entityId, entityType, stagedAccounts, stagedPayees, stagedCategories, stagedCategoryGroups, stagedSchedules, stagedTags]);
+
+  return useMemo(() => {
+    if (!entityId || !entityType) return null;
+    const schedule = entityType === "schedule" ? stagedSchedules[entityId]?.entity : undefined;
+    return buildEntityUsage({
+      entityId,
+      entityType,
+      entityLabel,
+      stagedRules,
+      txCounts: open && groupField ? txCounts : undefined,
+      txLoading: open && !!groupField && queryIds.length > 0 && txLoading,
+      balanceMap: balances,
+      stagedCategories,
+      scheduleRuleId: schedule?.ruleId,
+      schedulePostsTransaction: schedule?.postsTransaction,
+    });
+  }, [
+    entityId, entityType, entityLabel, stagedRules, txCounts, txLoading,
+    open, groupField, queryIds.length, balances, stagedCategories, stagedSchedules,
+  ]);
+}

--- a/src/features/usage-inspector/lib/entityUsage.test.ts
+++ b/src/features/usage-inspector/lib/entityUsage.test.ts
@@ -1,0 +1,567 @@
+import { buildEntityUsage } from "./entityUsage";
+import type { StagedMap } from "@/types/staged";
+import type { Rule, Category } from "@/types/entities";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRule(id: string, overrides: Partial<Rule> = {}): Rule {
+  return {
+    id,
+    stage: "default",
+    conditionsOp: "and",
+    conditions: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function stagedRules(rules: Rule[]): StagedMap<Rule> {
+  const map: StagedMap<Rule> = {};
+  for (const r of rules) {
+    map[r.id] = {
+      entity: r,
+      original: r,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    };
+  }
+  return map;
+}
+
+function stagedCategories(
+  cats: Array<{ id: string; name: string; groupId: string; isNew?: boolean; isDeleted?: boolean }>
+): StagedMap<Category> {
+  const map: StagedMap<Category> = {};
+  for (const c of cats) {
+    const entity: Category = { id: c.id, name: c.name, groupId: c.groupId, isIncome: false, hidden: false };
+    map[c.id] = {
+      entity,
+      original: c.isNew ? null : entity,
+      isNew: c.isNew ?? false,
+      isUpdated: false,
+      isDeleted: c.isDeleted ?? false,
+      validationErrors: {},
+    };
+  }
+  return map;
+}
+
+const NO_RULES: StagedMap<Rule> = {};
+const NO_TX = new Map<string, number>();
+
+// ─── account ──────────────────────────────────────────────────────────────────
+
+describe("buildEntityUsage — account", () => {
+  it("returns ruleCount=0, txCount=0, balance=0, no warnings when entity has no refs", () => {
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+      balanceMap: new Map([["acc1", 0]]),
+    });
+
+    expect(result.ruleCount).toBe(0);
+    expect(result.txCount).toBe(0);
+    expect(result.balance).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("counts rules referencing the account", () => {
+    const rules = stagedRules([
+      makeRule("r1", { conditions: [{ field: "account", op: "is", value: "acc1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "account", op: "is", value: "acc1", type: "id" }] }),
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: rules,
+      txCounts: NO_TX,
+      txLoading: false,
+      balanceMap: new Map(),
+    });
+
+    expect(result.ruleCount).toBe(2);
+  });
+
+  it("reads balance from the balanceMap", () => {
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["acc1", 0]]),
+      txLoading: false,
+      balanceMap: new Map([["acc1", 500]]),
+    });
+
+    expect(result.balance).toBe(500);
+    expect(result.warnings.length).toBeGreaterThan(0); // non-zero balance triggers a warning
+  });
+
+  it("includes warning when balance is non-zero", () => {
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["acc1", 0]]),
+      txLoading: false,
+      balanceMap: new Map([["acc1", 100]]),
+    });
+
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(String(result.warnings[0])).toContain("100");
+  });
+
+  it("includes warning when txCount > 0", () => {
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["acc1", 5]]),
+      txLoading: false,
+      balanceMap: new Map([["acc1", 0]]),
+    });
+
+    expect(result.txCount).toBe(5);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("sets txCount=undefined when txCounts is undefined (not yet loaded / isNew entity)", () => {
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: NO_RULES,
+      txCounts: undefined,
+      txLoading: false,
+      balanceMap: new Map(),
+    });
+
+    expect(result.txCount).toBeUndefined();
+  });
+
+  it("sets txLoading=true and emits a warning when loading", () => {
+    const result = buildEntityUsage({
+      entityId: "acc1",
+      entityType: "account",
+      entityLabel: "Checking",
+      stagedRules: NO_RULES,
+      txCounts: undefined,
+      txLoading: true,
+      balanceMap: new Map(),
+    });
+
+    expect(result.txLoading).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(String(result.warnings[0])).toContain("Checking usage");
+  });
+});
+
+// ─── payee ────────────────────────────────────────────────────────────────────
+
+describe("buildEntityUsage — payee", () => {
+  it("returns no warnings for a payee with no refs", () => {
+    const result = buildEntityUsage({
+      entityId: "p1",
+      entityType: "payee",
+      entityLabel: "Amazon",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.ruleCount).toBe(0);
+    expect(result.txCount).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("counts payee and imported_payee rule references", () => {
+    const rules = stagedRules([
+      makeRule("r1", { conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "imported_payee", op: "is", value: "p1", type: "id" }] }),
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "p1",
+      entityType: "payee",
+      entityLabel: "Amazon",
+      stagedRules: rules,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.ruleCount).toBe(2);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("includes warning when txCount > 0", () => {
+    const result = buildEntityUsage({
+      entityId: "p1",
+      entityType: "payee",
+      entityLabel: "Amazon",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["p1", 8]]),
+      txLoading: false,
+    });
+
+    expect(result.txCount).toBe(8);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(String(result.warnings[0])).toContain("8 transaction");
+  });
+
+  it("balance and childCount are undefined for payees", () => {
+    const result = buildEntityUsage({
+      entityId: "p1",
+      entityType: "payee",
+      entityLabel: "Amazon",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.balance).toBeUndefined();
+    expect(result.childCount).toBeUndefined();
+  });
+});
+
+// ─── category ─────────────────────────────────────────────────────────────────
+
+describe("buildEntityUsage — category", () => {
+  it("returns no warnings for a category with no refs", () => {
+    const result = buildEntityUsage({
+      entityId: "cat1",
+      entityType: "category",
+      entityLabel: "Groceries",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.ruleCount).toBe(0);
+    expect(result.txCount).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("counts only 'category' field references (not account or payee)", () => {
+    const rules = stagedRules([
+      makeRule("r1", { conditions: [{ field: "category", op: "is", value: "cat1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "account",  op: "is", value: "cat1", type: "id" }] }),
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "cat1",
+      entityType: "category",
+      entityLabel: "Groceries",
+      stagedRules: rules,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.ruleCount).toBe(1); // only the category field rule counts
+  });
+
+  it("mentions 'uncategorized' in the warning when tx > 0", () => {
+    const result = buildEntityUsage({
+      entityId: "cat1",
+      entityType: "category",
+      entityLabel: "Groceries",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["cat1", 3]]),
+      txLoading: false,
+    });
+
+    expect(String(result.warnings[0])).toContain("uncategorized");
+  });
+});
+
+// ─── categoryGroup ────────────────────────────────────────────────────────────
+
+describe("buildEntityUsage — categoryGroup", () => {
+  it("counts children that belong to the group", () => {
+    const cats = stagedCategories([
+      { id: "c1", name: "Groceries", groupId: "g1" },
+      { id: "c2", name: "Dining",    groupId: "g1" },
+      { id: "c3", name: "Transport", groupId: "g2" }, // different group
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "g1",
+      entityType: "categoryGroup",
+      entityLabel: "Food",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["c1", 5], ["c2", 3]]),
+      txLoading: false,
+      stagedCategories: cats,
+    });
+
+    expect(result.childCount).toBe(2);
+    expect(result.txCount).toBe(8); // 5 + 3 aggregated
+  });
+
+  it("excludes deleted children from childCount", () => {
+    const cats = stagedCategories([
+      { id: "c1", name: "Groceries",  groupId: "g1" },
+      { id: "c2", name: "Dining",     groupId: "g1", isDeleted: true },
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "g1",
+      entityType: "categoryGroup",
+      entityLabel: "Food",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["c1", 2]]),
+      txLoading: false,
+      stagedCategories: cats,
+    });
+
+    expect(result.childCount).toBe(1);
+  });
+
+  it("sums rule references across all children", () => {
+    const cats = stagedCategories([
+      { id: "c1", name: "Groceries", groupId: "g1" },
+      { id: "c2", name: "Dining",    groupId: "g1" },
+    ]);
+    const rules = stagedRules([
+      makeRule("r1", { conditions: [{ field: "category", op: "is", value: "c1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "category", op: "is", value: "c2", type: "id" }] }),
+      makeRule("r3", { conditions: [{ field: "category", op: "is", value: "c2", type: "id" }] }),
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "g1",
+      entityType: "categoryGroup",
+      entityLabel: "Food",
+      stagedRules: rules,
+      txCounts: NO_TX,
+      txLoading: false,
+      stagedCategories: cats,
+    });
+
+    expect(result.ruleCount).toBe(3);
+  });
+
+  it("emits a warning when there are children or refs", () => {
+    const cats = stagedCategories([
+      { id: "c1", name: "Groceries", groupId: "g1" },
+    ]);
+
+    const result = buildEntityUsage({
+      entityId: "g1",
+      entityType: "categoryGroup",
+      entityLabel: "Food",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+      stagedCategories: cats,
+    });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(String(result.warnings[0])).toContain("Food");
+  });
+
+  it("emits NO warning and shows empty state for a group with 0 children, 0 rules, 0 tx", () => {
+    const result = buildEntityUsage({
+      entityId: "g1",
+      entityType: "categoryGroup",
+      entityLabel: "Empty Group",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+      stagedCategories: {},
+    });
+
+    expect(result.childCount).toBe(0);
+    expect(result.ruleCount).toBe(0);
+    expect(result.txCount).toBe(0);
+    expect(result.warnings).toHaveLength(0); // Fix 2: empty groups get no warning
+  });
+
+  it("returns txCount=undefined while loading", () => {
+    const cats = stagedCategories([{ id: "c1", name: "Groceries", groupId: "g1" }]);
+
+    const result = buildEntityUsage({
+      entityId: "g1",
+      entityType: "categoryGroup",
+      entityLabel: "Food",
+      stagedRules: NO_RULES,
+      txCounts: undefined,
+      txLoading: true,
+      stagedCategories: cats,
+    });
+
+    expect(result.txCount).toBeUndefined();
+    expect(result.txLoading).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0); // loading triggers warning
+  });
+});
+
+// ─── schedule ─────────────────────────────────────────────────────────────────
+
+describe("buildEntityUsage — schedule", () => {
+  it("returns ruleCount=0 (schedules have a linked rule, not rule references)", () => {
+    const result = buildEntityUsage({
+      entityId: "s1",
+      entityType: "schedule",
+      entityLabel: "Rent",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.ruleCount).toBe(0);
+  });
+
+  it("returns no warnings when no ruleId and no tx", () => {
+    const result = buildEntityUsage({
+      entityId: "s1",
+      entityType: "schedule",
+      entityLabel: "Rent",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("includes warning when linkedRuleId is present", () => {
+    const result = buildEntityUsage({
+      entityId: "s1",
+      entityType: "schedule",
+      entityLabel: "Rent",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+      scheduleRuleId: "rule-abc",
+      schedulePostsTransaction: false,
+    });
+
+    expect(result.linkedRuleId).toBe("rule-abc");
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(String(result.warnings[0])).toContain("unlinked");
+  });
+
+  it("mentions auto-post when postsTransaction=true", () => {
+    const result = buildEntityUsage({
+      entityId: "s1",
+      entityType: "schedule",
+      entityLabel: "Rent",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+      scheduleRuleId: "rule-abc",
+      schedulePostsTransaction: true,
+    });
+
+    expect(result.postsTransaction).toBe(true);
+    expect(String(result.warnings[0])).toContain("auto-post");
+  });
+
+  it("includes warning when txCount > 0", () => {
+    const result = buildEntityUsage({
+      entityId: "s1",
+      entityType: "schedule",
+      entityLabel: "Rent",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["s1", 12]]),
+      txLoading: false,
+    });
+
+    expect(result.txCount).toBe(12);
+    expect(String(result.warnings[0])).toContain("12 transaction");
+  });
+});
+
+// ─── tag ──────────────────────────────────────────────────────────────────────
+
+describe("buildEntityUsage — tag", () => {
+  it("has ruleCount=0, txCount=undefined, no warnings", () => {
+    const result = buildEntityUsage({
+      entityId: "tag1",
+      entityType: "tag",
+      entityLabel: "vacation",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.ruleCount).toBe(0);
+    expect(result.txCount).toBeUndefined();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("has no tx count even when txCounts is provided (tags opt out)", () => {
+    // The hook always passes txCounts=undefined for tags (enabled=false),
+    // but even if something passed a map, the tag case should ignore it.
+    const result = buildEntityUsage({
+      entityId: "tag1",
+      entityType: "tag",
+      entityLabel: "vacation",
+      stagedRules: NO_RULES,
+      txCounts: new Map([["tag1", 999]]),
+      txLoading: false,
+    });
+
+    // tag case always sets txCount = undefined regardless of txCounts input
+    expect(result.txCount).toBeUndefined();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("has balance=undefined, childCount=undefined, linkedRuleId=undefined", () => {
+    const result = buildEntityUsage({
+      entityId: "tag1",
+      entityType: "tag",
+      entityLabel: "vacation",
+      stagedRules: NO_RULES,
+      txCounts: undefined,
+      txLoading: false,
+    });
+
+    expect(result.balance).toBeUndefined();
+    expect(result.childCount).toBeUndefined();
+    expect(result.linkedRuleId).toBeUndefined();
+  });
+});
+
+// ─── Cross-cutting: return shape ──────────────────────────────────────────────
+
+describe("buildEntityUsage — return shape", () => {
+  it("always echoes back entityId, entityType, and entityLabel", () => {
+    const result = buildEntityUsage({
+      entityId: "x1",
+      entityType: "payee",
+      entityLabel: "Test Payee",
+      stagedRules: NO_RULES,
+      txCounts: NO_TX,
+      txLoading: false,
+    });
+
+    expect(result.entityId).toBe("x1");
+    expect(result.entityType).toBe("payee");
+    expect(result.entityLabel).toBe("Test Payee");
+  });
+
+  it("does not set txCount when txCounts is undefined (loading / isNew)", () => {
+    for (const type of ["account", "payee", "category", "schedule"] as const) {
+      const result = buildEntityUsage({
+        entityId: "e1",
+        entityType: type,
+        entityLabel: "Entity",
+        stagedRules: NO_RULES,
+        txCounts: undefined,
+        txLoading: false,
+      });
+      expect(result.txCount).toBeUndefined();
+    }
+  });
+});

--- a/src/features/usage-inspector/lib/entityUsage.ts
+++ b/src/features/usage-inspector/lib/entityUsage.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure function — no hooks. Accepts pre-resolved staged data + async results,
+ * returns a fully-populated EntityUsageData.
+ * Called from useEntityUsage once all data sources are available.
+ */
+
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import {
+  buildAccountDeleteWarning,
+  buildPayeeDeleteWarning,
+  buildCategoryDeleteWarning,
+  buildCategoryGroupDeleteWarning,
+  buildScheduleDeleteWarning,
+} from "@/lib/usageWarnings";
+import type { StagedMap } from "@/types/staged";
+import type { Rule, Category } from "@/types/entities";
+import type { EntityUsageData } from "../types";
+
+export function buildEntityUsage(params: {
+  entityId: string;
+  entityType: EntityUsageData["entityType"];
+  entityLabel: string;
+  stagedRules: StagedMap<Rule>;
+  /** undefined = not yet loaded; empty Map = loaded with no results */
+  txCounts: Map<string, number> | undefined;
+  txLoading: boolean;
+  balanceMap?: Map<string, number>;
+  stagedCategories?: StagedMap<Category>;
+  scheduleRuleId?: string;
+  schedulePostsTransaction?: boolean;
+}): EntityUsageData {
+  const {
+    entityId, entityType, entityLabel,
+    stagedRules, txCounts, txLoading,
+    balanceMap, stagedCategories,
+    scheduleRuleId, schedulePostsTransaction,
+  } = params;
+
+  let ruleCount = 0;
+  let txCount: number | undefined = undefined;
+  let balance: number | undefined = undefined;
+  let childCount: number | undefined = undefined;
+  const linkedRuleId = scheduleRuleId;
+  const postsTransaction = schedulePostsTransaction;
+  const warnings: string[] = [];
+
+  switch (entityType) {
+    case "account": {
+      ruleCount = buildRuleReferenceMap(stagedRules, ["account"]).get(entityId) ?? 0;
+      balance = balanceMap?.get(entityId);
+      if (!txLoading && txCounts !== undefined) txCount = txCounts.get(entityId) ?? 0;
+      const hasContent = Math.abs(balance ?? 0) > 0 || ruleCount > 0 || txLoading || (txCount !== undefined && txCount > 0);
+      if (hasContent) {
+        warnings.push(buildAccountDeleteWarning(entityLabel, balance ?? 0, ruleCount, txCount, txLoading));
+      }
+      break;
+    }
+    case "payee": {
+      ruleCount = buildRuleReferenceMap(stagedRules, ["payee", "imported_payee"]).get(entityId) ?? 0;
+      if (!txLoading && txCounts !== undefined) txCount = txCounts.get(entityId) ?? 0;
+      const hasContent = ruleCount > 0 || txLoading || (txCount !== undefined && txCount > 0);
+      if (hasContent) {
+        warnings.push(buildPayeeDeleteWarning(entityLabel, ruleCount, txCount, txLoading));
+      }
+      break;
+    }
+    case "category": {
+      ruleCount = buildRuleReferenceMap(stagedRules, ["category"]).get(entityId) ?? 0;
+      if (!txLoading && txCounts !== undefined) txCount = txCounts.get(entityId) ?? 0;
+      const hasContent = ruleCount > 0 || txLoading || (txCount !== undefined && txCount > 0);
+      if (hasContent) {
+        warnings.push(buildCategoryDeleteWarning(entityLabel, ruleCount, txCount, txLoading));
+      }
+      break;
+    }
+    case "categoryGroup": {
+      const children = stagedCategories
+        ? Object.values(stagedCategories).filter((c) => c.entity.groupId === entityId && !c.isDeleted)
+        : [];
+      childCount = children.length;
+      const catRuleMap = buildRuleReferenceMap(stagedRules, ["category"]);
+      ruleCount = children.reduce((sum, c) => sum + (catRuleMap.get(c.entity.id) ?? 0), 0);
+      if (!txLoading && txCounts !== undefined) {
+        txCount = [...txCounts.values()].reduce((a, b) => a + b, 0);
+      }
+      const hasContent = childCount > 0 || ruleCount > 0 || txLoading || (txCount !== undefined && txCount > 0);
+      if (hasContent) {
+        warnings.push(buildCategoryGroupDeleteWarning(entityLabel, childCount, ruleCount, txCount, txLoading));
+      }
+      break;
+    }
+    case "schedule": {
+      // Schedules are not referenced by rules — they have a linked rule, not the other way around
+      ruleCount = 0;
+      if (!txLoading && txCounts !== undefined) txCount = txCounts.get(entityId) ?? 0;
+      const hasContent = linkedRuleId || txLoading || (txCount !== undefined && txCount > 0);
+      if (hasContent) {
+        warnings.push(buildScheduleDeleteWarning(entityLabel, linkedRuleId, postsTransaction ?? false, txCount, txLoading));
+      }
+      break;
+    }
+    case "tag": {
+      // Tags have no rule references in the rule engine; no transaction count support
+      ruleCount = 0;
+      txCount = undefined;
+      break;
+    }
+  }
+
+  return {
+    entityId,
+    entityType,
+    entityLabel,
+    ruleCount,
+    txCount,
+    txLoading,
+    balance,
+    childCount,
+    linkedRuleId,
+    postsTransaction,
+    warnings,
+  };
+}

--- a/src/features/usage-inspector/types.ts
+++ b/src/features/usage-inspector/types.ts
@@ -1,0 +1,20 @@
+import type React from "react";
+
+export type EntityUsageData = {
+  entityId: string;
+  entityType: "account" | "payee" | "category" | "categoryGroup" | "tag" | "schedule";
+  entityLabel: string;
+  ruleCount: number;
+  /** undefined = not applicable (tags) or still loading */
+  txCount?: number;
+  txLoading: boolean;
+  /** Accounts only — from useAccountBalances */
+  balance?: number;
+  /** categoryGroups only */
+  childCount?: number;
+  /** schedules only */
+  linkedRuleId?: string;
+  /** schedules only */
+  postsTransaction?: boolean;
+  warnings: React.ReactNode[];
+};

--- a/src/hooks/useTransactionCountsForIds.ts
+++ b/src/hooks/useTransactionCountsForIds.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { getTransactionCountsForIds } from "@/lib/api/query";
+import type { TransactionCountGroupField } from "@/lib/api/query";
+
+/**
+ * Fetches transaction counts for a specific set of entity IDs via a single
+ * $oneof-filtered ActualQL query.
+ *
+ * Lazy by design — fires only when `options.enabled` is true.
+ * Use this exclusively for delete/close impact warnings and the inspector drawer.
+ * Never call on page mount. Never set a refetchInterval.
+ *
+ * Query key includes sorted IDs so different click-orders for the same selection
+ * hit the same cache entry.
+ *
+ * Cache is invalidated by each entity's save hook after successful mutations.
+ * staleTime: 30s — handles rapid re-opens of the same dialog without re-fetching.
+ * gcTime: 60s — no long-term retention.
+ */
+export function useTransactionCountsForIds(
+  groupField: TransactionCountGroupField,
+  ids: string[],
+  options: { enabled: boolean }
+): { data: Map<string, number> | undefined; isLoading: boolean } {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const sortedIds = [...ids].sort();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["transactionCounts", groupField, connection?.id, sortedIds],
+    queryFn: () => {
+      if (!connection) throw new Error("No active connection");
+      return getTransactionCountsForIds(connection, groupField, ids);
+    },
+    enabled: options.enabled && ids.length > 0 && !!connection,
+    staleTime: 30_000,
+    gcTime: 60_000,
+  });
+
+  return { data, isLoading };
+}

--- a/src/hooks/useTransactionCountsForIds.ts
+++ b/src/hooks/useTransactionCountsForIds.ts
@@ -33,7 +33,7 @@ export function useTransactionCountsForIds(
     queryKey: ["transactionCounts", groupField, connection?.id, sortedIds],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getTransactionCountsForIds(connection, groupField, ids);
+      return getTransactionCountsForIds(connection, groupField, sortedIds);
     },
     enabled: options.enabled && ids.length > 0 && !!connection,
     staleTime: 30_000,

--- a/src/lib/api/query.test.ts
+++ b/src/lib/api/query.test.ts
@@ -1,0 +1,133 @@
+import { getTransactionCountsForIds } from "./query";
+import type { ConnectionInstance } from "@/store/connection";
+
+// ─── Mock apiRequest ──────────────────────────────────────────────────────────
+
+jest.mock("./client", () => ({
+  apiRequest: jest.fn(),
+}));
+
+import { apiRequest } from "./client";
+const mockApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
+
+const connection: ConnectionInstance = {
+  id: "conn-1",
+  label: "Test",
+  baseUrl: "http://localhost:5006",
+  apiKey: "test-key",
+  budgetSyncId: "budget-1",
+};
+
+// ─── getTransactionCountsForIds ───────────────────────────────────────────────
+
+describe("getTransactionCountsForIds", () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset();
+  });
+
+  it("returns empty Map immediately when ids is empty — no network call", async () => {
+    const result = await getTransactionCountsForIds(connection, "payee", []);
+    expect(result.size).toBe(0);
+    expect(mockApiRequest).not.toHaveBeenCalled();
+  });
+
+  it("maps each row in the response to entityId → count", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      data: [
+        { payee: "p1", "payee.name": "Amazon", transactionCount: 10 },
+        { payee: "p2", "payee.name": "Netflix", transactionCount: 3 },
+      ],
+    });
+
+    const result = await getTransactionCountsForIds(connection, "payee", ["p1", "p2"]);
+    expect(result.get("p1")).toBe(10);
+    expect(result.get("p2")).toBe(3);
+    expect(result.size).toBe(2);
+  });
+
+  it("returns an empty Map when the server returns no matching rows", async () => {
+    mockApiRequest.mockResolvedValueOnce({ data: [] });
+
+    const result = await getTransactionCountsForIds(connection, "payee", ["p1"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles category groupField correctly", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      data: [
+        { category: "cat1", "category.name": "Groceries", transactionCount: 7 },
+      ],
+    });
+
+    const result = await getTransactionCountsForIds(connection, "category", ["cat1"]);
+    expect(result.get("cat1")).toBe(7);
+  });
+
+  it("handles schedule groupField correctly", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      data: [
+        { schedule: "sched1", "schedule.name": "Rent", transactionCount: 12 },
+      ],
+    });
+
+    const result = await getTransactionCountsForIds(connection, "schedule", ["sched1"]);
+    expect(result.get("sched1")).toBe(12);
+  });
+
+  it("handles account groupField correctly", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      data: [
+        { account: "acc1", "account.name": "Checking", transactionCount: 42 },
+      ],
+    });
+
+    const result = await getTransactionCountsForIds(connection, "account", ["acc1"]);
+    expect(result.get("acc1")).toBe(42);
+  });
+
+  it("skips rows where the groupField value is not a string", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      data: [
+        { payee: null, "payee.name": null, transactionCount: 5 },
+        { payee: "p1", "payee.name": "Amazon", transactionCount: 2 },
+      ],
+    });
+
+    const result = await getTransactionCountsForIds(connection, "payee", ["p1"]);
+    expect(result.size).toBe(1);
+    expect(result.get("p1")).toBe(2);
+  });
+
+  it("sends the correct ActualQL query body", async () => {
+    mockApiRequest.mockResolvedValueOnce({ data: [] });
+
+    await getTransactionCountsForIds(connection, "payee", ["p1", "p2"]);
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      connection,
+      "/run-query",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.objectContaining({
+          ActualQLquery: expect.objectContaining({
+            table: "transactions",
+            filter: { payee: { $oneof: ["p1", "p2"] } },
+            groupBy: ["payee", "payee.name"],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("includes $count transactionCount in the select", async () => {
+    mockApiRequest.mockResolvedValueOnce({ data: [] });
+
+    await getTransactionCountsForIds(connection, "account", ["acc1"]);
+
+    const callBody = mockApiRequest.mock.calls[0][2] as { method: string; body: { ActualQLquery: { select: unknown[] } } };
+    const selectField = callBody.body.ActualQLquery.select.find(
+      (s: unknown) => typeof s === "object" && s !== null && "transactionCount" in (s as object)
+    );
+    expect(selectField).toEqual({ transactionCount: { $count: "$id" } });
+  });
+});

--- a/src/lib/api/query.ts
+++ b/src/lib/api/query.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared ActualQL query helper.
+ *
+ * Scope: intentionally narrow — RD-016 impact warnings only.
+ * RD-007 (ActualQL console) will expand this file when it ships.
+ *
+ * All calls route through the proxy queue via apiRequest.
+ */
+
+import { apiRequest } from "./client";
+import type { ConnectionInstance } from "@/store/connection";
+
+// ─── Generic runner ───────────────────────────────────────────────────────────
+
+export async function runQuery<T>(
+  connection: ConnectionInstance,
+  body: object
+): Promise<T> {
+  return apiRequest<T>(connection, "/run-query", {
+    method: "POST",
+    body,
+  });
+}
+
+// ─── Transaction counts ───────────────────────────────────────────────────────
+
+export type TransactionCountGroupField =
+  | "payee"
+  | "category"
+  | "account"
+  | "schedule";
+
+type TransactionCountRow = Record<string, string | number> & {
+  transactionCount: number;
+};
+
+/**
+ * Fetches transaction counts for a specific set of entity IDs via a single
+ * $oneof-filtered ActualQL query. Returns Map<entityId, count>.
+ *
+ * Entities absent from the response have zero transactions — callers use
+ * `map.get(id) ?? 0`.
+ *
+ * Guard: ids.length === 0 → returns empty Map immediately, no network call.
+ */
+export async function getTransactionCountsForIds(
+  connection: ConnectionInstance,
+  groupField: TransactionCountGroupField,
+  ids: string[]
+): Promise<Map<string, number>> {
+  if (ids.length === 0) return new Map();
+
+  const response = await runQuery<{ data: TransactionCountRow[] }>(connection, {
+    ActualQLquery: {
+      table: "transactions",
+      filter: { [groupField]: { $oneof: ids } },
+      groupBy: [groupField, `${groupField}.name`],
+      select: [
+        groupField,
+        `${groupField}.name`,
+        { transactionCount: { $count: "$id" } },
+      ],
+    },
+  });
+
+  const map = new Map<string, number>();
+  for (const row of response.data) {
+    const id = row[groupField];
+    if (typeof id === "string") {
+      map.set(id, row.transactionCount);
+    }
+  }
+  return map;
+}

--- a/src/lib/referenceCheck.test.ts
+++ b/src/lib/referenceCheck.test.ts
@@ -1,0 +1,182 @@
+import { buildRuleReferenceMap } from "./referenceCheck";
+import type { StagedMap } from "@/types/staged";
+import type { Rule } from "@/types/entities";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRule(id: string, overrides: Partial<Rule> = {}): Rule {
+  return {
+    id,
+    stage: "default",
+    conditionsOp: "and",
+    conditions: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function staged(rules: Rule[]): StagedMap<Rule> {
+  const map: StagedMap<Rule> = {};
+  for (const r of rules) {
+    map[r.id] = {
+      entity: r,
+      original: r,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    };
+  }
+  return map;
+}
+
+function stagedDeleted(rule: Rule): StagedMap<Rule> {
+  return {
+    [rule.id]: {
+      entity: rule,
+      original: rule,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: true,
+      validationErrors: {},
+    },
+  };
+}
+
+// ─── buildRuleReferenceMap ────────────────────────────────────────────────────
+
+describe("buildRuleReferenceMap", () => {
+  it("returns empty map when there are no rules", () => {
+    const result = buildRuleReferenceMap({}, ["payee"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("counts a condition that references an entity", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.get("p1")).toBe(1);
+  });
+
+  it("counts an action that references an entity", () => {
+    const rules = staged([
+      makeRule("r1", {
+        actions: [{ field: "category", op: "set", value: "cat1", type: "id" }],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["category"]);
+    expect(result.get("cat1")).toBe(1);
+  });
+
+  it("accumulates counts when multiple rules reference the same entity", () => {
+    const rules = staged([
+      makeRule("r1", { conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }] }),
+      makeRule("r3", { conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }] }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.get("p1")).toBe(3);
+  });
+
+  it("counts each ID independently when entities differ", () => {
+    const rules = staged([
+      makeRule("r1", { conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "payee", op: "is", value: "p2", type: "id" }] }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.get("p1")).toBe(1);
+    expect(result.get("p2")).toBe(1);
+  });
+
+  it("handles array values — each element in the array counts as one reference", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [{ field: "payee", op: "oneof", value: ["p1", "p2", "p3"], type: "id" }],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.get("p1")).toBe(1);
+    expect(result.get("p2")).toBe(1);
+    expect(result.get("p3")).toBe(1);
+  });
+
+  it("skips deleted rules", () => {
+    const rule = makeRule("r1", {
+      conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }],
+    });
+    const result = buildRuleReferenceMap(stagedDeleted(rule), ["payee"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("does not count fields outside the provided set", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [
+          { field: "payee", op: "is", value: "p1", type: "id" },
+          { field: "category", op: "is", value: "cat1", type: "id" },
+        ],
+      }),
+    ]);
+    const payeeResult = buildRuleReferenceMap(rules, ["payee"]);
+    expect(payeeResult.get("p1")).toBe(1);
+    expect(payeeResult.get("cat1")).toBeUndefined();
+  });
+
+  it("matches multiple field names — payee and imported_payee both count", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [
+          { field: "payee", op: "is", value: "p1", type: "id" },
+          { field: "imported_payee", op: "is", value: "p1", type: "id" },
+        ],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee", "imported_payee"]);
+    expect(result.get("p1")).toBe(2);
+  });
+
+  it("ignores parts that have no field property", () => {
+    const rules = staged([
+      makeRule("r1", {
+        // delete-transaction action has no field — cast via unknown to satisfy ConditionOrAction
+        actions: [{ op: "delete-transaction", value: true, type: "boolean" } as unknown as import("@/types/entities").ConditionOrAction],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("ignores non-string values (numbers, booleans)", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [{ field: "payee", op: "is", value: 42, type: "number" }],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("ignores empty-string values", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [{ field: "payee", op: "is", value: "", type: "id" }],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("counts both conditions and actions together for the same entity", () => {
+    const rules = staged([
+      makeRule("r1", {
+        conditions: [{ field: "category", op: "is", value: "cat1", type: "id" }],
+        actions:    [{ field: "category", op: "set", value: "cat1", type: "id" }],
+      }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["category"]);
+    expect(result.get("cat1")).toBe(2);
+  });
+});

--- a/src/lib/referenceCheck.test.ts
+++ b/src/lib/referenceCheck.test.ts
@@ -125,7 +125,8 @@ describe("buildRuleReferenceMap", () => {
     expect(payeeResult.get("cat1")).toBeUndefined();
   });
 
-  it("matches multiple field names — payee and imported_payee both count", () => {
+  it("matches multiple field names — payee and imported_payee — counts the rule once even if both fields reference the same id", () => {
+    // One rule referencing "p1" via both payee and imported_payee still counts as 1 rule.
     const rules = staged([
       makeRule("r1", {
         conditions: [
@@ -133,6 +134,16 @@ describe("buildRuleReferenceMap", () => {
           { field: "imported_payee", op: "is", value: "p1", type: "id" },
         ],
       }),
+    ]);
+    const result = buildRuleReferenceMap(rules, ["payee", "imported_payee"]);
+    expect(result.get("p1")).toBe(1);
+  });
+
+  it("counts correctly when two different rules each match via different field names", () => {
+    // Two separate rules referencing the same id → count should be 2.
+    const rules = staged([
+      makeRule("r1", { conditions: [{ field: "payee", op: "is", value: "p1", type: "id" }] }),
+      makeRule("r2", { conditions: [{ field: "imported_payee", op: "is", value: "p1", type: "id" }] }),
     ]);
     const result = buildRuleReferenceMap(rules, ["payee", "imported_payee"]);
     expect(result.get("p1")).toBe(2);

--- a/src/lib/referenceCheck.test.ts
+++ b/src/lib/referenceCheck.test.ts
@@ -169,7 +169,8 @@ describe("buildRuleReferenceMap", () => {
     expect(result.size).toBe(0);
   });
 
-  it("counts both conditions and actions together for the same entity", () => {
+  it("counts a rule only once even when it references the same entity in both conditions and actions", () => {
+    // Semantics: "how many rules reference this entity", not "total occurrences".
     const rules = staged([
       makeRule("r1", {
         conditions: [{ field: "category", op: "is", value: "cat1", type: "id" }],
@@ -177,6 +178,6 @@ describe("buildRuleReferenceMap", () => {
       }),
     ]);
     const result = buildRuleReferenceMap(rules, ["category"]);
-    expect(result.get("cat1")).toBe(2);
+    expect(result.get("cat1")).toBe(1);
   });
 });

--- a/src/lib/referenceCheck.ts
+++ b/src/lib/referenceCheck.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure utilities for counting rule references to entities.
+ * No React, no hooks — safe to use in useMemo, plain functions, and tests.
+ */
+
+import type { StagedMap } from "@/types/staged";
+import type { Rule } from "@/types/entities";
+
+/**
+ * Builds a Map<entityId, referenceCount> by scanning all non-deleted staged
+ * rules for conditions and actions that reference entity IDs via the given
+ * field names.
+ *
+ * Use this in useMemo blocks where counts for all entities of a type are
+ * needed at once (table rendering, filter logic).
+ *
+ * Field arrays per entity type:
+ *   Accounts:   ["account"]
+ *   Categories: ["category"]
+ *   Payees:     ["payee", "imported_payee"]
+ */
+export function buildRuleReferenceMap(
+  stagedRules: StagedMap<Rule>,
+  fields: string[]
+): Map<string, number> {
+  const fieldSet = new Set(fields);
+  const counts = new Map<string, number>();
+
+  for (const s of Object.values(stagedRules)) {
+    if (s.isDeleted) continue;
+    for (const part of [...s.entity.conditions, ...s.entity.actions]) {
+      if (!part.field || !fieldSet.has(part.field)) continue;
+      const ids = Array.isArray(part.value) ? part.value : [part.value];
+      for (const id of ids) {
+        if (typeof id === "string" && id) {
+          counts.set(id, (counts.get(id) ?? 0) + 1);
+        }
+      }
+    }
+  }
+
+  return counts;
+}
+

--- a/src/lib/referenceCheck.ts
+++ b/src/lib/referenceCheck.ts
@@ -28,14 +28,20 @@ export function buildRuleReferenceMap(
 
   for (const s of Object.values(stagedRules)) {
     if (s.isDeleted) continue;
+    // Collect matched IDs into a per-rule Set so that a rule referencing the
+    // same entity in multiple conditions/actions counts as one reference, not many.
+    const matchedInRule = new Set<string>();
     for (const part of [...s.entity.conditions, ...s.entity.actions]) {
       if (!part.field || !fieldSet.has(part.field)) continue;
       const ids = Array.isArray(part.value) ? part.value : [part.value];
       for (const id of ids) {
         if (typeof id === "string" && id) {
-          counts.set(id, (counts.get(id) ?? 0) + 1);
+          matchedInRule.add(id);
         }
       }
+    }
+    for (const id of matchedInRule) {
+      counts.set(id, (counts.get(id) ?? 0) + 1);
     }
   }
 

--- a/src/lib/usageWarnings.test.ts
+++ b/src/lib/usageWarnings.test.ts
@@ -1,0 +1,433 @@
+import {
+  buildPayeeDeleteWarning,
+  buildPayeeBulkDeleteWarning,
+  buildCategoryDeleteWarning,
+  buildCategoryGroupDeleteWarning,
+  buildCategoryBulkDeleteWarning,
+  buildAccountCloseWarning,
+  buildAccountDeleteWarning,
+  buildAccountBulkCloseWarning,
+  buildAccountBulkDeleteWarning,
+  buildScheduleDeleteWarning,
+  buildScheduleBulkDeleteWarning,
+  buildRuleDeleteWarning,
+  buildRuleBulkDeleteWarning,
+} from "./usageWarnings";
+
+// ─── buildPayeeDeleteWarning ──────────────────────────────────────────────────
+
+describe("buildPayeeDeleteWarning", () => {
+  it("returns a generic delete message when there are no refs and not loading", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 0, 0, false);
+    expect(msg).toContain("Delete");
+    expect(msg).toContain("Amazon");
+  });
+
+  it("mentions rule count when rules > 0", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 2, 0, false);
+    expect(msg).toContain("2 rule");
+  });
+
+  it("mentions transaction count when tx > 0", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 0, 5, false);
+    expect(msg).toContain("5 transaction");
+    expect(msg).toContain("unlinked");
+  });
+
+  it("includes both rules and transactions when both > 0", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 3, 10, false);
+    expect(msg).toContain("3 rule");
+    expect(msg).toContain("10 transaction");
+  });
+
+  it("shows loading message when loading=true", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+
+  it("uses singular 'rule' for exactly 1", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 1, 0, false);
+    expect(msg).toMatch(/\b1 rule\b/);
+    expect(msg).not.toMatch(/\b1 rules\b/);
+  });
+
+  it("uses singular 'transaction' for exactly 1", () => {
+    const msg = buildPayeeDeleteWarning("Amazon", 0, 1, false);
+    expect(msg).toMatch(/\b1 transaction\b/);
+    expect(msg).not.toMatch(/\b1 transactions\b/);
+  });
+});
+
+// ─── buildPayeeBulkDeleteWarning ──────────────────────────────────────────────
+
+describe("buildPayeeBulkDeleteWarning", () => {
+  it("states staged-for-deletion count", () => {
+    const msg = buildPayeeBulkDeleteWarning(3, 0, 0, 0, 0, false);
+    expect(msg).toContain("3 payee");
+    expect(msg).toContain("Save");
+  });
+
+  it("includes new row count when > 0", () => {
+    const msg = buildPayeeBulkDeleteWarning(2, 1, 0, 0, 0, false);
+    expect(msg).toContain("1 unsaved new row");
+  });
+
+  it("includes skipped transfer payee count when > 0", () => {
+    const msg = buildPayeeBulkDeleteWarning(2, 0, 1, 0, 0, false);
+    expect(msg).toContain("1 transfer payee");
+    expect(msg).toContain("skipped");
+  });
+
+  it("includes rule reference warning when ruleCount > 0", () => {
+    const msg = buildPayeeBulkDeleteWarning(2, 0, 0, 4, 0, false);
+    expect(msg).toContain("4 rule reference");
+  });
+
+  it("includes tx count when > 0", () => {
+    const msg = buildPayeeBulkDeleteWarning(2, 0, 0, 0, 7, false);
+    expect(msg).toContain("7 transaction");
+    expect(msg).toContain("unlinked");
+  });
+
+  it("shows loading message instead of tx count when loading=true", () => {
+    const msg = buildPayeeBulkDeleteWarning(2, 0, 0, 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+    expect(msg).not.toContain("transaction");
+  });
+});
+
+// ─── buildCategoryDeleteWarning ───────────────────────────────────────────────
+
+describe("buildCategoryDeleteWarning", () => {
+  it("returns a generic delete message when there are no refs", () => {
+    const msg = buildCategoryDeleteWarning("Groceries", 0, 0, false);
+    expect(msg).toContain("Delete");
+    expect(msg).toContain("Groceries");
+  });
+
+  it("mentions rules when ruleCount > 0", () => {
+    const msg = buildCategoryDeleteWarning("Groceries", 2, 0, false);
+    expect(msg).toContain("2 rule");
+  });
+
+  it("mentions transactions and that they will be uncategorized", () => {
+    const msg = buildCategoryDeleteWarning("Groceries", 0, 3, false);
+    expect(msg).toContain("3 transaction");
+    expect(msg).toContain("uncategorized");
+  });
+
+  it("includes both refs when both > 0", () => {
+    const msg = buildCategoryDeleteWarning("Groceries", 1, 5, false);
+    expect(msg).toContain("1 rule");
+    expect(msg).toContain("5 transaction");
+  });
+
+  it("shows loading message when loading=true", () => {
+    const msg = buildCategoryDeleteWarning("Groceries", 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+});
+
+// ─── buildCategoryGroupDeleteWarning ─────────────────────────────────────────
+
+describe("buildCategoryGroupDeleteWarning", () => {
+  it("includes group name and child count", () => {
+    const msg = buildCategoryGroupDeleteWarning("Food", 3, 0, 0, false);
+    expect(msg).toContain("Food");
+    expect(msg).toContain("3 categor");
+  });
+
+  it("uses 'category' singular for exactly 1 child", () => {
+    const msg = buildCategoryGroupDeleteWarning("Food", 1, 0, 0, false);
+    expect(msg).toMatch(/\b1 category\b/);
+  });
+
+  it("uses 'categories' plural for more than 1", () => {
+    const msg = buildCategoryGroupDeleteWarning("Food", 2, 0, 0, false);
+    expect(msg).toContain("2 categories");
+  });
+
+  it("includes rule count when > 0", () => {
+    const msg = buildCategoryGroupDeleteWarning("Food", 2, 4, 0, false);
+    expect(msg).toContain("4 rule");
+  });
+
+  it("includes tx count when > 0", () => {
+    const msg = buildCategoryGroupDeleteWarning("Food", 2, 0, 6, false);
+    expect(msg).toContain("6 transaction");
+    expect(msg).toContain("uncategorized");
+  });
+
+  it("shows loading message when loading=true", () => {
+    const msg = buildCategoryGroupDeleteWarning("Food", 2, 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+});
+
+// ─── buildCategoryBulkDeleteWarning ──────────────────────────────────────────
+
+describe("buildCategoryBulkDeleteWarning", () => {
+  it("states staged-for-deletion item count", () => {
+    const msg = buildCategoryBulkDeleteWarning(4, 0, 0, 0, false);
+    expect(msg).toContain("4 item");
+    expect(msg).toContain("Save");
+  });
+
+  it("includes new row count when > 0", () => {
+    const msg = buildCategoryBulkDeleteWarning(3, 2, 0, 0, false);
+    expect(msg).toContain("2 unsaved new row");
+  });
+
+  it("always mentions group-child deletion cascade", () => {
+    const msg = buildCategoryBulkDeleteWarning(1, 0, 0, 0, false);
+    expect(msg).toContain("group");
+  });
+
+  it("includes rule count when > 0", () => {
+    const msg = buildCategoryBulkDeleteWarning(2, 0, 5, 0, false);
+    expect(msg).toContain("5 rule");
+  });
+
+  it("includes tx count when > 0", () => {
+    const msg = buildCategoryBulkDeleteWarning(2, 0, 0, 8, false);
+    expect(msg).toContain("8 transaction");
+    expect(msg).toContain("uncategorized");
+  });
+
+  it("shows loading when loading=true", () => {
+    const msg = buildCategoryBulkDeleteWarning(2, 0, 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+});
+
+// ─── buildAccountCloseWarning ─────────────────────────────────────────────────
+
+describe("buildAccountCloseWarning", () => {
+  it("warns about outstanding balance when balance !== 0", () => {
+    const msg = buildAccountCloseWarning("Checking", 100.50, 0, false);
+    expect(msg).toContain("100.50");
+    expect(msg).toContain("balance");
+  });
+
+  it("uses negative balance sign correctly", () => {
+    const msg = buildAccountCloseWarning("Checking", -50.25, 0, false);
+    expect(msg).toContain("-50.25");
+  });
+
+  it("mentions transaction count when balance is 0 and tx > 0", () => {
+    const msg = buildAccountCloseWarning("Checking", 0, 5, false);
+    expect(msg).toContain("5 transaction");
+    expect(msg).toContain("hide");
+  });
+
+  it("returns generic close message when balance=0 and no tx", () => {
+    const msg = buildAccountCloseWarning("Checking", 0, 0, false);
+    expect(msg).toContain("Close");
+    expect(msg).toContain("Checking");
+    expect(msg).toContain("hidden");
+  });
+
+  it("shows loading message when loading=true and balance=0", () => {
+    const msg = buildAccountCloseWarning("Checking", 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+
+  it("balance warning takes priority over loading state", () => {
+    // Non-zero balance always shown regardless of loading
+    const msg = buildAccountCloseWarning("Checking", 50, undefined, true);
+    expect(msg).toContain("50");
+    expect(msg).toContain("balance");
+  });
+});
+
+// ─── buildAccountDeleteWarning ────────────────────────────────────────────────
+
+describe("buildAccountDeleteWarning", () => {
+  it("returns generic delete message when all zero", () => {
+    const msg = buildAccountDeleteWarning("Savings", 0, 0, 0, false);
+    expect(msg).toContain("Delete");
+    expect(msg).toContain("Savings");
+  });
+
+  it("warns about non-zero balance", () => {
+    const msg = buildAccountDeleteWarning("Savings", 250, 0, 0, false);
+    expect(msg).toContain("250");
+    expect(msg).toContain("balance");
+  });
+
+  it("mentions rule count when > 0", () => {
+    const msg = buildAccountDeleteWarning("Savings", 0, 2, 0, false);
+    expect(msg).toContain("2 rule");
+  });
+
+  it("warns transactions will be permanently lost", () => {
+    const msg = buildAccountDeleteWarning("Savings", 0, 0, 10, false);
+    expect(msg).toContain("10 transaction");
+    expect(msg).toContain("lost");
+  });
+
+  it("combines all warnings when all are present", () => {
+    const msg = buildAccountDeleteWarning("Savings", 100, 3, 15, false);
+    expect(msg).toContain("100");
+    expect(msg).toContain("3 rule");
+    expect(msg).toContain("15 transaction");
+  });
+
+  it("shows loading message when loading=true", () => {
+    const msg = buildAccountDeleteWarning("Savings", 0, 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+});
+
+// ─── buildAccountBulkCloseWarning ─────────────────────────────────────────────
+
+describe("buildAccountBulkCloseWarning", () => {
+  it("includes account count", () => {
+    const msg = buildAccountBulkCloseWarning(3, 0);
+    expect(msg).toContain("3 account");
+  });
+
+  it("warns when some accounts have non-zero balance", () => {
+    const msg = buildAccountBulkCloseWarning(3, 2);
+    expect(msg).toContain("2 account");
+    expect(msg).toContain("non-zero balance");
+  });
+
+  it("returns simple message when no accounts have non-zero balance", () => {
+    const msg = buildAccountBulkCloseWarning(3, 0);
+    expect(msg).toContain("hidden");
+    expect(msg).not.toContain("non-zero");
+  });
+
+  it("uses singular 'has' for exactly 1 non-zero account", () => {
+    const msg = buildAccountBulkCloseWarning(3, 1);
+    expect(msg).toContain("1 account");
+    expect(msg).toMatch(/\bhas\b/);
+  });
+
+  it("uses plural 'have' for 2+ non-zero accounts", () => {
+    const msg = buildAccountBulkCloseWarning(3, 2);
+    expect(msg).toMatch(/\bhave\b/);
+  });
+});
+
+// ─── buildAccountBulkDeleteWarning ───────────────────────────────────────────
+
+describe("buildAccountBulkDeleteWarning", () => {
+  it("includes server account count", () => {
+    const msg = buildAccountBulkDeleteWarning(4, 0, 0, 0, 0, false);
+    expect(msg).toContain("4 account");
+    expect(msg).toContain("Save");
+  });
+
+  it("includes new row count when > 0", () => {
+    const msg = buildAccountBulkDeleteWarning(3, 1, 0, 0, 0, false);
+    expect(msg).toContain("1 unsaved new row");
+  });
+
+  it("warns about non-zero balance accounts", () => {
+    const msg = buildAccountBulkDeleteWarning(3, 0, 2, 0, 0, false);
+    expect(msg).toContain("2 account");
+    expect(msg).toContain("non-zero balance");
+  });
+
+  it("includes rule count when > 0", () => {
+    const msg = buildAccountBulkDeleteWarning(2, 0, 0, 5, 0, false);
+    expect(msg).toContain("5 rule");
+  });
+
+  it("warns transactions will be permanently lost", () => {
+    const msg = buildAccountBulkDeleteWarning(2, 0, 0, 0, 20, false);
+    expect(msg).toContain("20 transaction");
+    expect(msg).toContain("lost");
+  });
+
+  it("shows loading when loading=true", () => {
+    const msg = buildAccountBulkDeleteWarning(2, 0, 0, 0, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+});
+
+// ─── buildScheduleDeleteWarning ───────────────────────────────────────────────
+
+describe("buildScheduleDeleteWarning", () => {
+  it("returns simple delete message when no rule and no tx", () => {
+    const msg = buildScheduleDeleteWarning("Rent", undefined, false, 0, false);
+    expect(msg).toContain("Rent");
+    expect(msg).toContain("Delete");
+  });
+
+  it("mentions linked rule when ruleId is present (not postsTransaction)", () => {
+    const msg = buildScheduleDeleteWarning("Rent", "rule-1", false, 0, false);
+    expect(msg).toContain("linked to a rule");
+    expect(msg).toContain("unlinked");
+  });
+
+  it("warns about auto-post when ruleId + postsTransaction=true", () => {
+    const msg = buildScheduleDeleteWarning("Rent", "rule-1", true, 0, false);
+    expect(msg).toContain("auto-post");
+  });
+
+  it("mentions transactions that will be unlinked when tx > 0", () => {
+    const msg = buildScheduleDeleteWarning("Rent", undefined, false, 5, false);
+    expect(msg).toContain("5 transaction");
+    expect(msg).toContain("unlinked");
+  });
+
+  it("shows loading when loading=true", () => {
+    const msg = buildScheduleDeleteWarning("Rent", undefined, false, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+
+  it("falls back to 'This schedule' when name is empty", () => {
+    const msg = buildScheduleDeleteWarning("", "rule-1", false, 0, false);
+    expect(msg).toContain("This schedule");
+  });
+});
+
+// ─── buildScheduleBulkDeleteWarning ──────────────────────────────────────────
+
+describe("buildScheduleBulkDeleteWarning", () => {
+  it("includes schedule count", () => {
+    const msg = buildScheduleBulkDeleteWarning(3, 0, false);
+    expect(msg).toContain("3 schedule");
+  });
+
+  it("mentions linked rules becoming unlinked", () => {
+    const msg = buildScheduleBulkDeleteWarning(3, 0, false);
+    expect(msg).toContain("unlinked");
+  });
+
+  it("includes tx count when > 0", () => {
+    const msg = buildScheduleBulkDeleteWarning(3, 4, false);
+    expect(msg).toContain("4 transaction");
+  });
+
+  it("shows loading when loading=true", () => {
+    const msg = buildScheduleBulkDeleteWarning(3, undefined, true);
+    expect(msg).toContain("Checking usage");
+  });
+});
+
+// ─── buildRuleDeleteWarning / buildRuleBulkDeleteWarning ─────────────────────
+
+describe("buildRuleDeleteWarning", () => {
+  it("returns a non-empty delete message", () => {
+    const msg = buildRuleDeleteWarning();
+    expect(msg.length).toBeGreaterThan(0);
+    expect(msg.toLowerCase()).toContain("delete");
+  });
+});
+
+describe("buildRuleBulkDeleteWarning", () => {
+  it("includes the rule count", () => {
+    const msg = buildRuleBulkDeleteWarning(5);
+    expect(msg).toContain("5 rule");
+  });
+
+  it("uses singular for exactly 1", () => {
+    const msg = buildRuleBulkDeleteWarning(1);
+    expect(msg).toMatch(/\b1 rule\b/);
+    expect(msg).not.toMatch(/\b1 rules\b/);
+  });
+});

--- a/src/lib/usageWarnings.ts
+++ b/src/lib/usageWarnings.ts
@@ -1,0 +1,366 @@
+/**
+ * Pure warning-message builders for delete / close impact dialogs.
+ *
+ * All warning copy lives here — never inline in components.
+ * Used by both confirm dialogs (Steps B–G) and the UsageInspectorDrawer (Step H).
+ *
+ * Return type is string throughout — string satisfies React.ReactNode so these
+ * are drop-in values for the ConfirmDialog `message` prop.
+ */
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function plural(n: number, singular: string, pluralForm?: string): string {
+  return `${n} ${n === 1 ? singular : (pluralForm ?? `${singular}s`)}`;
+}
+
+function formatBalance(balance: number): string {
+  const abs = Math.abs(balance);
+  const sign = balance < 0 ? "-" : "";
+  return `${sign}${abs.toFixed(2)}`;
+}
+
+// ─── Single-entity warnings ───────────────────────────────────────────────────
+
+/**
+ * Payee single delete.
+ * Tiers: rules+tx → rules only → tx only → no refs.
+ */
+export function buildPayeeDeleteWarning(
+  name: string,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const txLine = loading
+    ? "Checking usage..."
+    : txCount && txCount > 0
+      ? `${plural(txCount, "transaction")} will be unlinked — their payee will be cleared.`
+      : null;
+
+  if (ruleCount > 0 && txLine && !loading) {
+    return `"${name}" is referenced by ${plural(ruleCount, "rule")} and used in ${plural(txCount!, "transaction")}. ${txLine}`;
+  }
+  if (ruleCount > 0) {
+    const suffix = loading ? ` ${txLine}` : "";
+    return `"${name}" is referenced by ${plural(ruleCount, "rule")}. Deleting it may break those rules.${suffix}`;
+  }
+  if (txLine) {
+    return `"${name}" is used in ${plural(txCount!, "transaction")}. ${txLine}`;
+  }
+  if (loading) {
+    return `Delete "${name}"? Checking usage...`;
+  }
+  return `Delete "${name}"? It will be removed on Save.`;
+}
+
+/**
+ * Payee bulk delete.
+ */
+export function buildPayeeBulkDeleteWarning(
+  serverCount: number,
+  newCount: number,
+  skippedCount: number,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const parts: string[] = [];
+
+  parts.push(`${plural(serverCount, "payee")} will be staged for deletion and removed on Save.`);
+
+  if (newCount > 0) {
+    parts.push(`${plural(newCount, "unsaved new row")} will be discarded immediately.`);
+  }
+  if (skippedCount > 0) {
+    parts.push(`${plural(skippedCount, "transfer payee")} skipped (system-managed).`);
+  }
+  if (ruleCount > 0) {
+    parts.push(`Warning: ${plural(ruleCount, "rule reference")} will be affected.`);
+  }
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`${plural(txCount, "transaction")} will be unlinked (not deleted) — their payee will be cleared.`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Category single delete.
+ * Tiers: rules+tx → rules only → tx only → no refs.
+ */
+export function buildCategoryDeleteWarning(
+  name: string,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const txLine = loading
+    ? "Checking usage..."
+    : txCount && txCount > 0
+      ? `${plural(txCount, "transaction")} will be uncategorized.`
+      : null;
+
+  if (ruleCount > 0 && txLine && !loading) {
+    return `"${name}" is referenced by ${plural(ruleCount, "rule")} and used in ${plural(txCount!, "transaction")}. ${txLine}`;
+  }
+  if (ruleCount > 0) {
+    const suffix = loading ? ` ${txLine}` : "";
+    return `"${name}" is referenced by ${plural(ruleCount, "rule")}. Deleting it may break those rules.${suffix}`;
+  }
+  if (txLine) {
+    return `"${name}" is used in ${plural(txCount!, "transaction")}. ${txLine}`;
+  }
+  if (loading) {
+    return `Delete "${name}"? Checking usage...`;
+  }
+  return `Delete "${name}"? It will be removed on Save.`;
+}
+
+/**
+ * Category group single delete.
+ * Always includes child count. Appends rule/tx lines when relevant.
+ */
+export function buildCategoryGroupDeleteWarning(
+  groupName: string,
+  childCount: number,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const header = `Delete group "${groupName}" and its ${plural(childCount, "category", "categories")}?`;
+  const parts: string[] = [header];
+
+  if (ruleCount > 0) {
+    parts.push(`${plural(ruleCount, "rule")} reference these categories.`);
+  }
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`${plural(txCount, "transaction")} will be uncategorized.`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Category bulk delete.
+ */
+export function buildCategoryBulkDeleteWarning(
+  serverCount: number,
+  newCount: number,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const parts: string[] = [];
+
+  parts.push(`${plural(serverCount, "item")} will be staged for deletion and removed on Save.`);
+  if (newCount > 0) {
+    parts.push(`${plural(newCount, "unsaved new row")} will be discarded immediately.`);
+  }
+  parts.push("Deleting a group also deletes its categories.");
+  if (ruleCount > 0) {
+    parts.push(`Warning: ${plural(ruleCount, "rule")} reference the selected categories.`);
+  }
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`${plural(txCount, "transaction")} will be uncategorized.`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Account single close.
+ * Three tiers based on balance and transaction count.
+ */
+export function buildAccountCloseWarning(
+  name: string,
+  balance: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  if (balance !== 0) {
+    return (
+      `"${name}" has an outstanding balance of ${formatBalance(balance)}. ` +
+      `In Actual Budget, accounts with transactions can only be closed after transferring the balance. ` +
+      `Staging this close may leave your budget inconsistent. Proceed only if you have handled the balance in Actual Budget directly.`
+    );
+  }
+
+  if (loading) {
+    return `Close "${name}"? Checking usage...`;
+  }
+
+  if (txCount && txCount > 0) {
+    return `"${name}" has ${plural(txCount, "transaction")}. Closing it will hide it from your budget views.`;
+  }
+
+  return `Close "${name}"? It will be hidden from your budget.`;
+}
+
+/**
+ * Account single delete.
+ * Leads with balance warning if non-zero, then appends rule/tx counts.
+ */
+export function buildAccountDeleteWarning(
+  name: string,
+  balance: number,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const parts: string[] = [];
+
+  if (balance !== 0) {
+    parts.push(
+      `Warning: "${name}" has an outstanding balance of ${formatBalance(balance)}. ` +
+      `Deleting it may cause inconsistencies — consider closing instead.`
+    );
+  }
+
+  if (ruleCount > 0) {
+    parts.push(`Referenced by ${plural(ruleCount, "rule")}.`);
+  }
+
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`Contains ${plural(txCount, "transaction")} — these will be permanently lost.`);
+  }
+
+  if (parts.length === 0) {
+    return `Delete "${name}"? It will be removed on Save.`;
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Account bulk close.
+ * No tx count needed — balance warning is sufficient for close flows.
+ */
+export function buildAccountBulkCloseWarning(
+  count: number,
+  nonZeroBalanceCount: number
+): string {
+  if (nonZeroBalanceCount > 0) {
+    return (
+      `Close ${plural(count, "account")}? ` +
+      `${plural(nonZeroBalanceCount, "account")} ${nonZeroBalanceCount === 1 ? "has" : "have"} a non-zero balance — ` +
+      `verify transfers are handled in Actual Budget before saving.`
+    );
+  }
+  return `Close ${plural(count, "account")}? ${count === 1 ? "It" : "They"} will be hidden from your budget.`;
+}
+
+/**
+ * Account bulk delete.
+ */
+export function buildAccountBulkDeleteWarning(
+  serverCount: number,
+  newCount: number,
+  nonZeroBalanceCount: number,
+  ruleCount: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const parts: string[] = [];
+
+  parts.push(`${plural(serverCount, "account")} will be staged for deletion and removed on Save.`);
+
+  if (newCount > 0) {
+    parts.push(`${plural(newCount, "unsaved new row")} will be discarded immediately.`);
+  }
+  if (nonZeroBalanceCount > 0) {
+    parts.push(
+      `Warning: ${plural(nonZeroBalanceCount, "account")} ${nonZeroBalanceCount === 1 ? "has" : "have"} a non-zero balance. ` +
+      `Deleting accounts with outstanding balances may cause inconsistencies.`
+    );
+  }
+  if (ruleCount > 0) {
+    parts.push(`${plural(ruleCount, "rule")} will be affected.`);
+  }
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`${plural(txCount, "transaction")} will be permanently lost.`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Schedule single delete.
+ */
+export function buildScheduleDeleteWarning(
+  name: string,
+  ruleId: string | undefined,
+  postsTransaction: boolean,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const parts: string[] = [];
+  const label = name || "This schedule";
+
+  if (ruleId && postsTransaction) {
+    parts.push(
+      `"${label}" is linked to a rule and set to auto-post transactions.`
+    );
+  } else if (ruleId) {
+    parts.push(`"${label}" is linked to a rule (the rule will not be deleted but will become unlinked).`);
+  } else {
+    parts.push(`Delete "${label}"?`);
+  }
+
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`${plural(txCount, "transaction")} will be unlinked.`);
+  }
+
+  if (parts.length === 1 && !ruleId) {
+    return `${parts[0]} It will be removed on Save.`;
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Schedule bulk delete.
+ */
+export function buildScheduleBulkDeleteWarning(
+  count: number,
+  txCount: number | undefined,
+  loading: boolean
+): string {
+  const parts: string[] = [
+    `Delete ${plural(count, "schedule")}? Linked rules will remain but become unlinked.`,
+  ];
+
+  if (loading) {
+    parts.push("Checking usage...");
+  } else if (txCount && txCount > 0) {
+    parts.push(`${plural(txCount, "transaction")} will be unlinked.`);
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Rule single delete (no tx counts — rules don't have transactions).
+ */
+export function buildRuleDeleteWarning(): string {
+  return "Delete this rule? It will be removed on Save.";
+}
+
+/**
+ * Rule bulk delete.
+ */
+export function buildRuleBulkDeleteWarning(count: number): string {
+  return `Delete ${plural(count, "rule")}? This cannot be undone after Save.`;
+}

--- a/src/lib/usageWarnings.ts
+++ b/src/lib/usageWarnings.ts
@@ -32,18 +32,16 @@ export function buildPayeeDeleteWarning(
   txCount: number | undefined,
   loading: boolean
 ): string {
-  const txLine = loading
-    ? "Checking usage..."
-    : txCount && txCount > 0
-      ? `${plural(txCount, "transaction")} will be unlinked — their payee will be cleared.`
-      : null;
+  // txLine is only set when we have a definite non-zero count; loading is handled separately.
+  const txLine = !loading && txCount && txCount > 0
+    ? `${plural(txCount, "transaction")} will be unlinked — their payee will be cleared.`
+    : null;
 
-  if (ruleCount > 0 && txLine && !loading) {
+  if (ruleCount > 0 && txLine) {
     return `"${name}" is referenced by ${plural(ruleCount, "rule")} and used in ${plural(txCount!, "transaction")}. ${txLine}`;
   }
   if (ruleCount > 0) {
-    const suffix = loading ? ` ${txLine}` : "";
-    return `"${name}" is referenced by ${plural(ruleCount, "rule")}. Deleting it may break those rules.${suffix}`;
+    return `"${name}" is referenced by ${plural(ruleCount, "rule")}. Deleting it may break those rules.${loading ? " Checking usage..." : ""}`;
   }
   if (txLine) {
     return `"${name}" is used in ${plural(txCount!, "transaction")}. ${txLine}`;
@@ -97,18 +95,16 @@ export function buildCategoryDeleteWarning(
   txCount: number | undefined,
   loading: boolean
 ): string {
-  const txLine = loading
-    ? "Checking usage..."
-    : txCount && txCount > 0
-      ? `${plural(txCount, "transaction")} will be uncategorized.`
-      : null;
+  // txLine is only set when we have a definite non-zero count; loading is handled separately.
+  const txLine = !loading && txCount && txCount > 0
+    ? `${plural(txCount, "transaction")} will be uncategorized.`
+    : null;
 
-  if (ruleCount > 0 && txLine && !loading) {
+  if (ruleCount > 0 && txLine) {
     return `"${name}" is referenced by ${plural(ruleCount, "rule")} and used in ${plural(txCount!, "transaction")}. ${txLine}`;
   }
   if (ruleCount > 0) {
-    const suffix = loading ? ` ${txLine}` : "";
-    return `"${name}" is referenced by ${plural(ruleCount, "rule")}. Deleting it may break those rules.${suffix}`;
+    return `"${name}" is referenced by ${plural(ruleCount, "rule")}. Deleting it may break those rules.${loading ? " Checking usage..." : ""}`;
   }
   if (txLine) {
     return `"${name}" is used in ${plural(txCount!, "transaction")}. ${txLine}`;
@@ -134,7 +130,7 @@ export function buildCategoryGroupDeleteWarning(
   const parts: string[] = [header];
 
   if (ruleCount > 0) {
-    parts.push(`${plural(ruleCount, "rule")} reference these categories.`);
+    parts.push(`${plural(ruleCount, "rule")} ${ruleCount === 1 ? "references" : "reference"} these categories.`);
   }
   if (loading) {
     parts.push("Checking usage...");


### PR DESCRIPTION
## Summary

Implements RD-016 by adding a shared entity-usage foundation for safer delete / close flows and a read-only Usage Inspector across the app.

This change adds impact-aware confirmation dialogs for destructive actions and a reusable inspector drawer for Accounts, Payees, Categories, Tags, Schedules, and Rules.

Closes #23
Closes #51 
Closes #52 

## What’s included

- Shared foundations
  - `referenceCheck.ts` for rule reference counting
  - `query.ts` + `useTransactionCountsForIds` for lazy `$oneof` transaction counts
  - `usageWarnings.ts` as the single source of warning copy
  - shared `ConfirmDialog`

- Safer entity flows
  - Rules: single + bulk delete confirmation
  - Payees: always-confirm delete, with rule / transaction impact
  - Categories: single, group, and bulk delete impact handling
  - Accounts: close + delete warnings using balance, rule refs, and transaction counts
  - Schedules: delete warnings with linked rule / auto-post context
  - Tags: inspector support; delete flow unchanged

- Usage Inspector
  - new read-only drawer with rules, transaction counts, balances, child counts, linked rule info, and warnings
  - available from row actions across supported entity tables

## Implementation approach

This feature is built in four layers:
1. pure usage data model
2. lazy count fetching
3. centralized warning generation
4. entity-specific flows + inspector UI

Transaction data is used only for counts / impact warnings.
Counts are fetched lazily on intent with `$oneof`.
No polling or page-level preloading was added.

## Unit Tests

Added 118 unit tests covering:
- rule reference counting
- warning generation
- ActualQL transaction count queries
- entity usage derivation across all supported entity types

## Why it matters

This makes destructive actions safer, keeps warning logic consistent, and adds a reusable usage model for future diagnostics without turning Actual Bench into a transaction browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global confirmation dialogs for all destructive actions with live usage impact; per-row Info opens a Usage Inspector drawer with stats, warnings, and quick links.

* **Improvements**
  * Single & bulk delete flows show aggregated impact, deduplicate implicit deletions, exclude transfer payees from bulk payee deletes, always require payee confirmation, and surface account balances/transaction counts where relevant.
  * Dialog copy updates in real time while usage data loads; tags explicitly note transaction data is unavailable.

* **Tests**
  * Added comprehensive tests for usage warnings, reference counting, and transaction-count queries.

* **Documentation**
  * Updated feature docs and roadmap; package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->