### PR TITLE
feat/add ActualQL query workspace

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -101,6 +101,32 @@
 - CSV import and export
 - Info button on each row opens the Usage Inspector drawer; tags show the rules badge and a note that transaction data is not available for tags
 
+## ActualQL Queries
+
+- Dedicated query workspace for running arbitrary ActualQL JSON queries against the open budget
+- Resizable editor / results split — drag the divider to adjust the balance; position persists across reloads via session storage
+- Syntax-highlighted JSON editor with line numbers, current-line highlight, and JetBrains Mono font; edit raw JSON directly with no normalization or auto-correction
+- Action bar: Run (or Ctrl/Cmd+Enter), Format JSON, Save, Explain, and ActualQL Reference buttons
+- Parse errors shown inline beneath the editor before any network request is made
+- Lint warnings for risky query shapes — broad `transactions` queries with no `limit`, `groupBy`, or `calculate`; empty `$oneof`; `groupBy` with no aggregate; and more
+- Four result views selectable via tabs:
+  - **Table** — columns derived from the union of keys across all rows; nested values JSON-stringified; capped at 500 rows with a warning banner
+  - **Raw JSON** — syntax-highlighted with line numbers; full returned payload
+  - **Scalar** — large value card for `calculate` aggregate results
+  - **Tree** — collapsible recursive JSON tree; auto-selected for plain-object results; nodes with more than 5 children start collapsed
+- Smart cell formatting in the table view: ISO date strings displayed as human-readable dates (e.g. `Jan 15, 2024`); `amount` and `balance` integer columns formatted as decimal values (cents ÷ 100); raw value always accessible via hover tooltip
+- Execution metadata bar: OK / Error status chip, elapsed time, row count, and payload size shown inline with the result actions
+- Result actions: Copy result JSON, Copy query JSON, Copy sanitized cURL (secrets replaced with placeholders), and Copy full cURL (opt-in, clearly marked as containing real credentials)
+- cURL is always generated from the last successfully executed request, not the current editor state
+- **Explain this query** — one-click plain-English summary of what the current query does: target table, filters, grouping, aggregation, ordering, and whether the result is tabular or scalar
+- **ActualQL Reference** dialog — six-section quick reference covering basics, filter operators, joined fields, aggregates, transactions-specific options, and copyable snippets
+- Built-in example packs in four groups (Data inspection, Cleanup & validation, Aggregation, Targeted subset) — one-click insert into the editor
+- Saved queries — name and save any query locally per budget; load, rerun, duplicate, rename, delete, and pin as favorite
+- Query history — last 10 executed queries stored per budget in session storage; one-click reload into the editor; deduplicated (re-running the same query bumps it to the top rather than adding a duplicate)
+- Favorites — pin saved queries for fast access; shown at the top of the saved queries panel
+- Banner warns when unsaved staged changes exist — query results reflect saved server state, not pending local edits
+- Results bypass the staged store entirely; no mutations are introduced by running a query
+
 ## Delete Safety & Usage Inspector
 
 ### Confirmation dialogs

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Useful for power users who want more control over their budget data, and for tes
 - **Staged editing with undo/redo** - review every change locally before anything touches the server
 - **Multi-server, multi-budget** - save and switch between connections without leaking data between sessions
 - **Schedules management** - create and edit one-time and recurring schedules with full recurrence controls, amount modes, and weekend adjustment
-- **ActualQL console** *(coming soon)* - run ad-hoc queries against your budget directly from the browser
+- **ActualQL query workspace** - run ad-hoc ActualQL queries against your budget, inspect results as table / raw JSON / scalar / collapsible tree, save and replay named query packs, and copy a cURL command for any executed query
 - **SQLite budget diagnostic** *(coming soon)* - inspect a `.sqlite` budget file client-side: table overview, row counts, and a read-only table browser
 
 ## Architecture
@@ -58,6 +58,7 @@ All browser requests route through an internal Next.js proxy - no direct browser
 - **Rules** - view, filter by stage, create, edit, and merge rules with a full condition/action builder; CSV import/export
 - **Schedules** - create and manage one-time and recurring schedules with amount modes, weekend adjustment, and end conditions; overdue dates are highlighted; CSV import/export
 - **Tags** - create, rename, and color-code tags (requires Actual Budget v26.3.0+); CSV import/export
+- **ActualQL Queries** - syntax-highlighted query editor with run / format / save / explain actions; four result views (table, raw JSON, scalar, collapsible tree); built-in example packs; saved queries with favorites; query history; cURL copy; lint warnings; and an inline quick reference dialog
 
 → See [FEATURES.md](FEATURES.md) for the full feature reference.
 
@@ -168,10 +169,8 @@ Ready-to-use sample CSV files are included in [`public/samples csv/`](public/sam
 
 ## Coming Soon
 
-- **ActualQL console** - run ad-hoc queries against your budget from the browser; save and replay query packs
 - **Rule diagnostics** - detect conflicting, shadowed, or redundant rules across stages
 - **SQLite budget diagnostic** - drop a `.sqlite` file to inspect tables, row counts, and schema version without uploading anything to a server
-- **Entity usage & delete safety** - see which rules reference a payee or category before deleting it
 
 ## Known Limitations
 

--- a/agents/future-roadmap.md
+++ b/agents/future-roadmap.md
@@ -75,7 +75,7 @@ RD-003 (Balance col)   — complete; add getAccountBalance to accounts.ts
 RD-004 (Payee merge)   — complete; add mergePayees to payees.ts
 RD-005 (Rules-by-payee)— complete; can be done with RD-016 (same code path)
 RD-006 (Budget export) — requires proxy binary support patch
-RD-007 (ActualQL console + saved query packs) — independent; shares run-query util with RD-016
+RD-007 (ActualQL console + saved query packs) — complete
 RD-008 (Delete txn action) — complete
 RD-009 (Session token) — independent
 RD-010 (Version display) — complete
@@ -84,13 +84,13 @@ RD-012 (Currency symbol) — independent
 RD-013 (High contrast theme) — independent
 RD-014 (Regex in rules) — complete
 RD-015 (Rule templates) — complete
-RD-016 (Entity usage & delete safety) — combines former RD-017 and RD-021;
+RD-016 (Entity usage & delete safety) — complete combines former RD-017 and RD-021;
                                         RD-005 is a sub-task; depends on RD-003 for account balance checks;
                                         may reuse run-query util from RD-007
 RD-018 (Saved servers)       — complete
 RD-019 (Grouped categories)  — complete
 RD-020 (Rule editing improvements) — complete
-RD-023 (Rule diagnostics)    — depends on RD-007; enhanced by RD-016 if available
+RD-023 (Rule diagnostics)    — depends on RD-007 (now complete); enhanced by RD-016 if available; unblocked
 RD-024 (SQLite diagnostic)   — independent; fully client-side (WASM SQLite)
 ```
 
@@ -454,7 +454,7 @@ if (contentType.includes("zip") || contentType.includes("octet-stream")) {
 |---|---|
 | **Priority** | Medium |
 | **Effort** | M |
-| **Status** | pending |
+| **Status** | complete |
 | **Depends on** | Shared `runQuery` utility (also used by RD-016) |
 
 **What:** A developer / power-user page where users can run arbitrary ActualQL queries against the open budget, inspect results in a generic table or raw JSON view, and save useful queries locally for quick reuse.

--- a/src/app/(app)/query/page.tsx
+++ b/src/app/(app)/query/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { QueryWorkspace } from "@/features/query/components/QueryWorkspace";
+
+export const metadata: Metadata = {
+  title: "ActualQL Queries — Actual Bench",
+};
+
+export default function QueryPage() {
+  return <QueryWorkspace />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,11 +13,18 @@
   --color-staged-new: var(--staged-new);
   --color-staged-updated: var(--staged-updated);
   --color-staged-deleted: var(--staged-deleted);
+  /* ── JSON syntax token colors ─────────────────────────────────────────────── */
+  --color-json-key:     var(--json-key);
+  --color-json-string:  var(--json-string);
+  --color-json-number:  var(--json-number);
+  --color-json-boolean: var(--json-boolean);
+  --color-json-null:    var(--json-null);
+  --color-json-punct:   var(--json-punct);
   /* ─────────────────────────────────────────────────────────────────────────── */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-jetbrains-mono);
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -96,6 +103,15 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  /* ── JSON syntax token colors (light) ──────────────────────────────────── */
+  --json-key:     oklch(0.50 0.18 15);
+  --json-string:  oklch(0.45 0.15 250);
+  --json-number:  oklch(0.52 0.14 55);
+  --json-boolean: oklch(0.52 0.14 55);
+  --json-null:    oklch(0.50 0.08 250);
+  --json-punct:   oklch(0.55 0.02 250);
+  /* ── Editor overlay ──────────────────────────────────────────────────────── */
+  --editor-line-highlight: oklch(0.92 0.005 250 / 0.7);
 }
 
 .dark {
@@ -136,6 +152,15 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  /* ── JSON syntax token colors (dark) ───────────────────────────────────── */
+  --json-key:     oklch(0.72 0.18 15);
+  --json-string:  oklch(0.72 0.13 250);
+  --json-number:  oklch(0.78 0.15 55);
+  --json-boolean: oklch(0.78 0.15 55);
+  --json-null:    oklch(0.65 0.08 250);
+  --json-punct:   oklch(0.55 0.02 250);
+  /* ── Editor overlay ──────────────────────────────────────────────────────── */
+  --editor-line-highlight: oklch(0.25 0.005 250 / 0.6);
 }
 
 @layer base {
@@ -148,4 +173,12 @@
   html {
     @apply font-sans;
   }
+}
+
+/* JsonEditor: placeholder must be styled explicitly because the textarea's
+   text color is set to transparent (overlay renders the colored text).
+   Without this rule, ::placeholder inherits color: transparent. */
+.json-editor-textarea::placeholder {
+  color: var(--muted-foreground);
+  opacity: 0.35;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, Geist_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import { Providers } from "@/components/providers";
 import "./globals.css";
 
@@ -8,8 +8,8 @@ const inter = Inter({
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
 });
 
@@ -26,7 +26,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
     >
       <body className="h-full overflow-hidden font-sans">
         <Providers>{children}</Providers>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -93,7 +93,7 @@ export function Sidebar() {
     >
       <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2 pt-3">
         {NAV_ITEMS.map(({ label, href, icon: Icon, badge }) => {
-          const active = pathname.startsWith(href);
+          const active = pathname === href || pathname.startsWith(href + "/");
           return (
             <Link
               key={href}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   ScrollText,
   Calendar,
   Tag,
+  Terminal,
   PanelLeftClose,
   PanelLeftOpen,
   Trash2,
@@ -35,14 +36,22 @@ const GITHUB_URL = "https://github.com/x-rous/actual-bench";
 
 const LS_KEY = "sidebar-collapsed";
 
-const NAV_ITEMS = [
+type NavItem = {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  badge?: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
   { label: "Rules", href: "/rules", icon: ScrollText },
   { label: "Accounts", href: "/accounts", icon: Landmark },
   { label: "Payees", href: "/payees", icon: Users },
   { label: "Categories", href: "/categories", icon: LayoutList },
   { label: "Schedules", href: "/schedules", icon: Calendar },
   { label: "Tags", href: "/tags", icon: Tag },
-] as const;
+  { label: "ActualQL", href: "/query", icon: Terminal, badge: "dev" },
+];
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -83,7 +92,7 @@ export function Sidebar() {
       )}
     >
       <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2 pt-3">
-        {NAV_ITEMS.map(({ label, href, icon: Icon }) => {
+        {NAV_ITEMS.map(({ label, href, icon: Icon, badge }) => {
           const active = pathname.startsWith(href);
           return (
             <Link
@@ -99,7 +108,16 @@ export function Sidebar() {
               )}
             >
               <Icon className="h-4 w-4 shrink-0" />
-              {!collapsed && label}
+              {!collapsed && (
+                <>
+                  {label}
+                  {badge && (
+                    <span className="ml-auto rounded-sm bg-muted px-1 py-0.5 text-[9px] font-medium text-muted-foreground/60">
+                      {badge}
+                    </span>
+                  )}
+                </>
+              )}
             </Link>
           );
         })}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import * as React from "react"
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cn } from "@/lib/utils"
+
+function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "flex shrink-0 items-center border-b border-border",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors",
+        "hover:text-foreground",
+        "data-[active]:text-foreground",
+        // sliding bottom-border indicator
+        "after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:origin-left",
+        "after:scale-x-0 after:bg-foreground after:transition-transform",
+        "data-[active]:after:scale-x-100",
+        "outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("min-h-0 flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/features/query/components/CopyCurlButton.tsx
+++ b/src/features/query/components/CopyCurlButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Terminal, ShieldAlert } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { buildSanitizedCurl, buildFullCurl } from "../lib/queryCurl";
+import type { LastExecutedRequest } from "../types";
+
+interface CopyCurlButtonProps {
+  lastRequest: LastExecutedRequest;
+}
+
+export function CopyCurlButton({ lastRequest }: CopyCurlButtonProps) {
+  function copyDefaultCurl() {
+    const curl = buildSanitizedCurl(lastRequest);
+    navigator.clipboard
+      .writeText(curl)
+      .then(() => toast.success("Sanitized cURL copied — secrets replaced with placeholders"))
+      .catch(() => toast.error("Failed to copy"));
+  }
+
+  function copyFullCurl() {
+    const curl = buildFullCurl(lastRequest);
+    navigator.clipboard
+      .writeText(curl)
+      .then(() => toast.warning("Full cURL copied — includes real API key and credentials"))
+      .catch(() => toast.error("Failed to copy"));
+  }
+
+  return (
+    <>
+      {/* Safe version — prominent, always the first */}
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={copyDefaultCurl}
+        title="Copy a cURL command with secrets replaced by placeholders — safe to share"
+        className="gap-1.5 text-xs text-muted-foreground"
+      >
+        <Terminal className="h-3 w-3" />
+        Copy cURL
+      </Button>
+
+      {/* Dangerous version — amber styling signals risk */}
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={copyFullCurl}
+        title="Copy a cURL command with real API key and credentials — do not share publicly"
+        className="gap-1.5 text-xs text-amber-600 hover:bg-amber-50 hover:text-amber-700 dark:text-amber-500 dark:hover:bg-amber-950/40 dark:hover:text-amber-400"
+      >
+        <ShieldAlert className="h-3 w-3" />
+        cURL + secrets
+      </Button>
+    </>
+  );
+}

--- a/src/features/query/components/JsonEditor.tsx
+++ b/src/features/query/components/JsonEditor.tsx
@@ -55,7 +55,8 @@ interface JsonEditorProps {
   value: string;
   onChange: (value: string) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-  onUndo?: () => void;
+  /** Return true if custom undo was applied; false lets the browser handle it natively. */
+  onUndo?: () => boolean;
   height: number;
   placeholder?: string;
 }
@@ -112,9 +113,10 @@ export function JsonEditor({
     // This only fires when onUndo is provided, meaning a programmatic load just
     // replaced the editor value. Normal browser undo for typed text is unaffected.
     if ((e.ctrlKey || e.metaKey) && e.key === "z" && onUndo) {
-      e.preventDefault();
-      onUndo();
-      return;
+      if (onUndo()) {
+        e.preventDefault();
+        return;
+      }
     }
 
     // Intercept Tab to insert 2 spaces instead of moving browser focus.

--- a/src/features/query/components/JsonEditor.tsx
+++ b/src/features/query/components/JsonEditor.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+/**
+ * JsonEditor — textarea + syntax-highlight overlay + line numbers + line highlight.
+ *
+ * Architecture: three layers stacked in a position:relative container.
+ *
+ *   z-index 1  <pre>   — colorized mirror of textarea content (pointer-events: none)
+ *   z-index 2  gutter  — line numbers (pointer-events: none, scrolls via translateY)
+ *   z-index 3  <textarea> — captures all input; color: transparent so the pre shows through
+ *
+ * Font metrics MUST match between the textarea and the pre. Both use the same
+ * CSS custom properties (--font-mono, size, line-height, padding) so they stay
+ * in sync. A font change will automatically propagate to both layers.
+ *
+ * Scroll sync: textarea onScroll → pre.scrollTop/scrollLeft + gutter translateY.
+ *
+ * Active line: computed from selectionStart on click / keydown / select events.
+ * The active line span in the pre gets a subtle background highlight.
+ */
+
+import { useRef, useState, useCallback } from "react";
+import { colorizeJson } from "../lib/jsonColorize";
+
+// ─── Layout constants ─────────────────────────────────────────────────────────
+// These must match the textarea's rendered metrics exactly.
+
+const GUTTER_W   = 40;    // px — wide enough for 4-digit line numbers
+const PAD_X      = 16;    // px — horizontal content padding (matches px-4)
+const PAD_Y      = 12;    // px — vertical content padding (matches py-3)
+const FONT_SIZE  = 12;    // px — text-xs
+const LINE_H_R   = 1.625; // leading-relaxed
+const LINE_H_PX  = FONT_SIZE * LINE_H_R; // 19.5 px
+
+// Styles shared by both the <pre> overlay and the <textarea>.
+// They must be identical to keep lines visually aligned.
+const SHARED: React.CSSProperties = {
+  fontFamily:      "var(--font-mono)",
+  fontSize:        `${FONT_SIZE}px`,
+  lineHeight:      LINE_H_R,
+  paddingTop:      PAD_Y,
+  paddingBottom:   PAD_Y,
+  paddingLeft:     GUTTER_W + PAD_X,
+  paddingRight:    PAD_X,
+  tabSize:         2,
+  whiteSpace:      "pre",
+  wordBreak:       "normal",
+  overflowWrap:    "normal",
+  letterSpacing:   "normal",
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface JsonEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onUndo?: () => void;
+  height: number;
+  placeholder?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function JsonEditor({
+  value,
+  onChange,
+  onKeyDown,
+  onUndo,
+  height,
+  placeholder,
+}: JsonEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const preRef      = useRef<HTMLPreElement>(null);
+
+  const [activeLine,   setActiveLine]   = useState(0);
+  const [gutterOffset, setGutterOffset] = useState(0);
+
+  const lines = value.split("\n");
+
+  // ─── Active line tracking ────────────────────────────────────────────────────
+
+  const computeActiveLine = useCallback((el: HTMLTextAreaElement) => {
+    const pos  = el.selectionStart ?? 0;
+    const line = el.value.slice(0, pos).split("\n").length - 1;
+    setActiveLine(line);
+  }, []);
+
+  // ─── Scroll sync ─────────────────────────────────────────────────────────────
+
+  function handleScroll(e: React.UIEvent<HTMLTextAreaElement>) {
+    const { scrollTop, scrollLeft } = e.currentTarget;
+    setGutterOffset(scrollTop);
+    if (preRef.current) {
+      preRef.current.scrollTop  = scrollTop;
+      preRef.current.scrollLeft = scrollLeft;
+    }
+  }
+
+  // ─── Input event handlers ────────────────────────────────────────────────────
+
+  function handleClick(e: React.MouseEvent<HTMLTextAreaElement>) {
+    computeActiveLine(e.currentTarget);
+  }
+
+  function handleSelect(e: React.SyntheticEvent<HTMLTextAreaElement>) {
+    computeActiveLine(e.currentTarget);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Intercept Ctrl+Z / Cmd+Z to restore the pre-load snapshot (if one exists).
+    // This only fires when onUndo is provided, meaning a programmatic load just
+    // replaced the editor value. Normal browser undo for typed text is unaffected.
+    if ((e.ctrlKey || e.metaKey) && e.key === "z" && onUndo) {
+      e.preventDefault();
+      onUndo();
+      return;
+    }
+
+    // Intercept Tab to insert 2 spaces instead of moving browser focus.
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const el = e.currentTarget;
+      const start = el.selectionStart ?? 0;
+      const end = el.selectionEnd ?? 0;
+      const next = el.value.slice(0, start) + "  " + el.value.slice(end);
+      onChange(next);
+      // Restore cursor after React re-renders the controlled value.
+      requestAnimationFrame(() => {
+        if (textareaRef.current) {
+          textareaRef.current.selectionStart = start + 2;
+          textareaRef.current.selectionEnd = start + 2;
+          computeActiveLine(textareaRef.current);
+        }
+      });
+      return;
+    }
+    onKeyDown?.(e);
+    // Defer so selectionStart reflects the position after the key is applied.
+    requestAnimationFrame(() => {
+      if (textareaRef.current) computeActiveLine(textareaRef.current);
+    });
+  }
+
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      style={{ position: "relative", height, overflow: "hidden" }}
+      className="bg-background"
+    >
+      {/* ── Gutter: line numbers ─────────────────────────────────────────── */}
+      <div
+        aria-hidden="true"
+        style={{
+          position:        "absolute",
+          left:            0,
+          top:             0,
+          bottom:          0,
+          width:           GUTTER_W,
+          overflow:        "hidden",
+          zIndex:          2,
+          backgroundColor: "var(--background)",
+          borderRight:     "1px solid color-mix(in oklch, var(--border) 60%, transparent)",
+        }}
+      >
+        {/* Translate to match textarea scroll position */}
+        <div style={{ transform: `translateY(${-gutterOffset}px)`, paddingTop: PAD_Y }}>
+          {lines.map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height:      LINE_H_PX,
+                lineHeight:  `${LINE_H_PX}px`,
+                textAlign:   "right",
+                paddingRight: 8,
+                fontSize:    FONT_SIZE,
+                fontFamily:  "var(--font-mono)",
+                color:       "var(--muted-foreground)",
+                opacity:     i === activeLine ? 0.65 : 0.3,
+                userSelect:  "none",
+              }}
+            >
+              {i + 1}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Syntax highlight overlay ─────────────────────────────────────── */}
+      <pre
+        ref={preRef}
+        aria-hidden="true"
+        style={{
+          ...SHARED,
+          position:      "absolute",
+          inset:         0,
+          margin:        0,
+          zIndex:        1,
+          pointerEvents: "none",
+          overflow:      "hidden",
+          color:         "var(--foreground)",
+          background:    "transparent",
+        }}
+      >
+        {lines.map((line, i) => (
+          <span
+            key={i}
+            style={{
+              display:    "block",
+              background: i === activeLine
+                ? "var(--editor-line-highlight)"
+                : "transparent",
+            }}
+            // Empty lines must still occupy full line height; \u00A0 prevents collapse.
+            dangerouslySetInnerHTML={{ __html: colorizeJson(line) || "\u00A0" }}
+          />
+        ))}
+      </pre>
+
+      {/* ── Textarea ─────────────────────────────────────────────────────── */}
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={handleScroll}
+        onSelect={handleSelect}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        // Class only for the ::placeholder CSS rule in globals.css.
+        className="json-editor-textarea"
+        style={{
+          ...SHARED,
+          position:   "absolute",
+          inset:      0,
+          width:      "100%",
+          height:     "100%",
+          zIndex:     3,
+          color:      "transparent",
+          caretColor: "var(--foreground)",
+          background: "transparent",
+          resize:     "none",
+          outline:    "none",
+          overflow:   "auto",
+          border:     "none",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/features/query/components/JsonTreeView.tsx
+++ b/src/features/query/components/JsonTreeView.tsx
@@ -18,6 +18,16 @@
 
 import { useState } from "react";
 
+// ─── Path helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Encodes an object key into a JSON Pointer segment (RFC 6901).
+ * '~' → '~0', '/' → '~1' — prevents key collisions like "a.b" vs {a:{b:…}}.
+ */
+function encodePointerKey(key: string): string {
+  return key.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
 // ─── Collapse state ───────────────────────────────────────────────────────────
 
 type CollapseMap = Map<string, boolean>;
@@ -229,7 +239,7 @@ function JsonTreeNode({
           <JsonTreeNode
             key={i}
             value={item}
-            path={`${path}[${i}]`}
+            path={`${path}/${i}`}
             depth={depth + 1}
             label={<IndexLabel i={i} />}
             collapsed={collapsed}
@@ -271,7 +281,7 @@ function JsonTreeNode({
           <JsonTreeNode
             key={k}
             value={(value as Record<string, unknown>)[k]}
-            path={`${path}.${k}`}
+            path={`${path}/${encodePointerKey(k)}`}
             depth={depth + 1}
             label={<KeyLabel k={k} />}
             collapsed={collapsed}

--- a/src/features/query/components/JsonTreeView.tsx
+++ b/src/features/query/components/JsonTreeView.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+/**
+ * JsonTreeView — collapsible recursive JSON tree renderer.
+ *
+ * Renders as a fourth "Tree" tab in QueryResults. Shown when the result is
+ * a plain object or array (not a scalar). Auto-selected as the default view
+ * for plain objects (the scalar-like result shape from some calculate queries).
+ *
+ * Collapse state is a Map<path, boolean> keyed by node path (e.g. "root",
+ * "root.items[3]", "root.items[3].name"). Nodes not in the map use a default:
+ *   - arrays / objects with more than 5 children → collapsed
+ *   - everything else → expanded
+ *
+ * Token colors reuse the --json-* CSS variables from globals.css so coloring
+ * is consistent with the editor overlay and the RawView.
+ */
+
+import { useState } from "react";
+
+// ─── Collapse state ───────────────────────────────────────────────────────────
+
+type CollapseMap = Map<string, boolean>;
+
+function defaultCollapsed(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 5;
+  if (value !== null && typeof value === "object") {
+    return Object.keys(value as object).length > 5;
+  }
+  return false;
+}
+
+function nodeCollapsed(path: string, value: unknown, map: CollapseMap): boolean {
+  const stored = map.get(path);
+  return stored !== undefined ? stored : defaultCollapsed(value);
+}
+
+// ─── Value renderers ──────────────────────────────────────────────────────────
+
+function StrVal({ v }: { v: string }) {
+  const MAX = 120;
+  const truncated = v.length > MAX;
+  const display = truncated ? `${v.slice(0, MAX)}…` : v;
+  return (
+    <span
+      style={{ color: "var(--json-string)" }}
+      title={truncated ? v : undefined}
+    >
+      &quot;{display}&quot;
+    </span>
+  );
+}
+
+function NumVal({ v }: { v: number }) {
+  return <span style={{ color: "var(--json-number)" }}>{v}</span>;
+}
+
+function BoolVal({ v }: { v: boolean }) {
+  return <span style={{ color: "var(--json-boolean)" }}>{String(v)}</span>;
+}
+
+function NullVal() {
+  return <span style={{ color: "var(--json-null)" }}>null</span>;
+}
+
+function Punct({ children }: { children: React.ReactNode }) {
+  return <span style={{ color: "var(--json-punct)" }}>{children}</span>;
+}
+
+function KeyLabel({ k }: { k: string }) {
+  return (
+    <span className="shrink-0">
+      <span style={{ color: "var(--json-key)" }}>&quot;{k}&quot;</span>
+      <Punct>{": "}</Punct>
+    </span>
+  );
+}
+
+function IndexLabel({ i }: { i: number }) {
+  return (
+    <span
+      className="mr-1.5 shrink-0 text-[10px]"
+      style={{ color: "var(--json-punct)" }}
+    >
+      [{i}]
+    </span>
+  );
+}
+
+function CollapsedSummary({
+  count,
+  kind,
+}: {
+  count: number;
+  kind: "key" | "item";
+}) {
+  return (
+    <span className="mx-1 text-[10px] text-muted-foreground/50">
+      {count} {kind}
+      {count !== 1 ? "s" : ""}
+    </span>
+  );
+}
+
+function ToggleBtn({
+  collapsed,
+  onClick,
+}: {
+  collapsed: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      className="mr-1 shrink-0 text-muted-foreground/35 transition-colors hover:text-muted-foreground"
+      style={{ fontSize: 9, width: 10, lineHeight: 1 }}
+    >
+      {collapsed ? "▶" : "▼"}
+    </button>
+  );
+}
+
+// ─── Row wrapper ──────────────────────────────────────────────────────────────
+
+function Row({
+  depth,
+  children,
+}: {
+  depth: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="flex min-w-0 items-center rounded px-1 py-px transition-colors hover:bg-accent/30"
+      style={{ paddingLeft: 4 + depth * 14 }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ─── Tree node ────────────────────────────────────────────────────────────────
+
+interface NodeProps {
+  value: unknown;
+  path: string;
+  depth: number;
+  label?: React.ReactNode;
+  collapsed: CollapseMap;
+  onToggle: (path: string, currentlyCollapsed: boolean) => void;
+}
+
+function JsonTreeNode({
+  value,
+  path,
+  depth,
+  label,
+  collapsed,
+  onToggle,
+}: NodeProps) {
+  // ── null ────────────────────────────────────────────────────────────────────
+  if (value === null) {
+    return (
+      <Row depth={depth}>
+        {label}
+        <NullVal />
+      </Row>
+    );
+  }
+
+  // ── boolean ─────────────────────────────────────────────────────────────────
+  if (typeof value === "boolean") {
+    return (
+      <Row depth={depth}>
+        {label}
+        <BoolVal v={value} />
+      </Row>
+    );
+  }
+
+  // ── number ──────────────────────────────────────────────────────────────────
+  if (typeof value === "number") {
+    return (
+      <Row depth={depth}>
+        {label}
+        <NumVal v={value} />
+      </Row>
+    );
+  }
+
+  // ── string ──────────────────────────────────────────────────────────────────
+  if (typeof value === "string") {
+    return (
+      <Row depth={depth}>
+        {label}
+        <StrVal v={value} />
+      </Row>
+    );
+  }
+
+  // ── array ───────────────────────────────────────────────────────────────────
+  if (Array.isArray(value)) {
+    const coll = nodeCollapsed(path, value, collapsed);
+
+    if (coll) {
+      return (
+        <Row depth={depth}>
+          {label}
+          <ToggleBtn collapsed onClick={() => onToggle(path, coll)} />
+          <Punct>[</Punct>
+          <CollapsedSummary count={value.length} kind="item" />
+          <Punct>]</Punct>
+        </Row>
+      );
+    }
+
+    return (
+      <>
+        <Row depth={depth}>
+          {label}
+          <ToggleBtn collapsed={false} onClick={() => onToggle(path, coll)} />
+          <Punct>[</Punct>
+        </Row>
+        {value.map((item, i) => (
+          <JsonTreeNode
+            key={i}
+            value={item}
+            path={`${path}[${i}]`}
+            depth={depth + 1}
+            label={<IndexLabel i={i} />}
+            collapsed={collapsed}
+            onToggle={onToggle}
+          />
+        ))}
+        <Row depth={depth}>
+          <Punct>]</Punct>
+        </Row>
+      </>
+    );
+  }
+
+  // ── object ──────────────────────────────────────────────────────────────────
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>);
+    const coll = nodeCollapsed(path, value, collapsed);
+
+    if (coll) {
+      return (
+        <Row depth={depth}>
+          {label}
+          <ToggleBtn collapsed onClick={() => onToggle(path, coll)} />
+          <Punct>{"{"}</Punct>
+          <CollapsedSummary count={keys.length} kind="key" />
+          <Punct>{"}"}</Punct>
+        </Row>
+      );
+    }
+
+    return (
+      <>
+        <Row depth={depth}>
+          {label}
+          <ToggleBtn collapsed={false} onClick={() => onToggle(path, coll)} />
+          <Punct>{"{"}</Punct>
+        </Row>
+        {keys.map((k) => (
+          <JsonTreeNode
+            key={k}
+            value={(value as Record<string, unknown>)[k]}
+            path={`${path}.${k}`}
+            depth={depth + 1}
+            label={<KeyLabel k={k} />}
+            collapsed={collapsed}
+            onToggle={onToggle}
+          />
+        ))}
+        <Row depth={depth}>
+          <Punct>{"}"}</Punct>
+        </Row>
+      </>
+    );
+  }
+
+  // ── undefined / other ────────────────────────────────────────────────────────
+  return (
+    <Row depth={depth}>
+      {label}
+      <span className="text-muted-foreground/40">undefined</span>
+    </Row>
+  );
+}
+
+// ─── JsonTreeView ─────────────────────────────────────────────────────────────
+
+interface JsonTreeViewProps {
+  data: unknown;
+}
+
+export function JsonTreeView({ data }: JsonTreeViewProps) {
+  const [collapsed, setCollapsed] = useState<CollapseMap>(new Map());
+
+  function handleToggle(path: string, currentlyCollapsed: boolean) {
+    setCollapsed((prev) => {
+      const next = new Map(prev);
+      next.set(path, !currentlyCollapsed);
+      return next;
+    });
+  }
+
+  return (
+    <div className="h-full overflow-auto p-4 font-mono text-xs leading-relaxed">
+      <JsonTreeNode
+        value={data}
+        path="root"
+        depth={0}
+        collapsed={collapsed}
+        onToggle={handleToggle}
+      />
+    </div>
+  );
+}

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -21,7 +21,7 @@ interface QueryEditorProps {
   onExplain: () => void;
   onCopyQuery: () => void;
   onOpenReference: () => void;
-  onUndo?: () => void;
+  onUndo?: () => boolean;
   isRunning: boolean;
   parseError: string | null;
   editorHeight: number;

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Play, WrapText, Save, Lightbulb, BookOpen, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { JsonEditor } from "./JsonEditor";
+
+const DEFAULT_PLACEHOLDER = `{
+  "ActualQLquery": {
+    "table": "transactions",
+    "select": "*",
+    "limit": 10
+  }
+}`;
+
+interface QueryEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onRun: () => void;
+  onFormat: () => void;
+  onSave: () => void;
+  onExplain: () => void;
+  onCopyQuery: () => void;
+  onOpenReference: () => void;
+  onUndo?: () => void;
+  isRunning: boolean;
+  parseError: string | null;
+  editorHeight: number;
+}
+
+export function QueryEditor({
+  value,
+  onChange,
+  onRun,
+  onFormat,
+  onSave,
+  onExplain,
+  onCopyQuery,
+  onOpenReference,
+  onUndo,
+  isRunning,
+  parseError,
+  editorHeight,
+}: QueryEditorProps) {
+  const shortcutHint =
+    typeof navigator !== "undefined" &&
+    /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+      ? "⌘↵ to run"
+      : "Ctrl+↵ to run";
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      onRun();
+    }
+  }
+
+  return (
+    <div className="flex shrink-0 flex-col border-b border-border">
+      {/* Action bar */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <Button size="sm" onClick={onRun} disabled={isRunning} className="gap-1.5">
+          <Play className="h-3.5 w-3.5" />
+          {isRunning ? "Running…" : "Run"}
+        </Button>
+        <Button size="sm" variant="outline" onClick={onFormat} className="gap-1.5">
+          <WrapText className="h-3.5 w-3.5" />
+          Format
+        </Button>
+        <Button size="sm" variant="outline" onClick={onSave} className="gap-1.5">
+          <Save className="h-3.5 w-3.5" />
+          Save
+        </Button>
+        <Button size="sm" variant="outline" onClick={onExplain} className="gap-1.5">
+          <Lightbulb className="h-3.5 w-3.5" />
+          Explain
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onCopyQuery}
+          title="Copy the current query to clipboard"
+          className="gap-1.5"
+        >
+          <Copy className="h-3.5 w-3.5" />
+          Copy Query
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onOpenReference} className="gap-1.5">
+          <BookOpen className="h-3.5 w-3.5" />
+          Reference
+        </Button>
+        <span className="ml-auto text-xs text-muted-foreground/60">
+          {shortcutHint}
+        </span>
+      </div>
+
+      {/* Syntax-highlighted editor */}
+      <JsonEditor
+        value={value}
+        onChange={onChange}
+        onKeyDown={handleKeyDown}
+        onUndo={onUndo}
+        height={editorHeight}
+        placeholder={DEFAULT_PLACEHOLDER}
+      />
+
+      {/* Inline parse error */}
+      {parseError && (
+        <div className="shrink-0 border-t border-destructive/30 bg-destructive/5 px-3 py-1.5 text-xs text-destructive">
+          {parseError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/query/components/QueryExamplesPanel.tsx
+++ b/src/features/query/components/QueryExamplesPanel.tsx
@@ -13,7 +13,7 @@ interface QueryExamplesPanelProps {
 
 function GroupHeader({ label }: { label: string }) {
   return (
-    <div className="mx-3 mb-1 mt-4 border-b border-border pb-1 first:mt-2">
+    <div className="mx-3 mb-1 border-b border-border pb-1">
       <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
         {label}
       </span>
@@ -63,13 +63,13 @@ export function QueryExamplesPanel({ onInsert }: QueryExamplesPanelProps) {
   return (
     <div className="flex flex-col pb-3">
       {QUERY_PACK_GROUPS.map((group) => (
-        <div key={group.id}>
+        <div key={group.id} className="mt-4 first:mt-2">
           <GroupHeader label={group.label} />
           {group.packs.map((pack) => (
             <ExampleItem
               key={pack.id}
               pack={pack}
-              onInsert={() => onInsert(pack.query)}
+              onInsert={() => onInsert(typeof pack.query === "function" ? pack.query() : pack.query)}
             />
           ))}
         </div>

--- a/src/features/query/components/QueryExamplesPanel.tsx
+++ b/src/features/query/components/QueryExamplesPanel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { QUERY_PACK_GROUPS } from "../lib/queryPacks";
+import type { QueryPack } from "../lib/queryPacks";
+
+interface QueryExamplesPanelProps {
+  onInsert: (query: string) => void;
+}
+
+// ─── Group header ─────────────────────────────────────────────────────────────
+
+function GroupHeader({ label }: { label: string }) {
+  return (
+    <div className="mx-3 mb-1 mt-4 border-b border-border pb-1 first:mt-2">
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+// ─── Example item ─────────────────────────────────────────────────────────────
+
+function ExampleItem({
+  pack,
+  onInsert,
+}: {
+  pack: QueryPack;
+  onInsert: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onInsert}
+      className={cn(
+        "group flex w-full items-start gap-2 border-l-2 border-transparent px-3 py-2 text-left transition-colors",
+        "hover:border-primary/40 hover:bg-accent/60"
+      )}
+    >
+      {/* Text block */}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[11px] font-medium leading-snug text-foreground/90 group-hover:text-foreground">
+          {pack.name}
+        </div>
+        {pack.description && (
+          <div className="mt-0.5 line-clamp-2 text-[10px] leading-relaxed text-muted-foreground/70">
+            {pack.description}
+          </div>
+        )}
+      </div>
+
+      {/* Insert affordance — always visible, signals the action */}
+      <ArrowUpRight className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-primary/70" />
+    </button>
+  );
+}
+
+// ─── QueryExamplesPanel ───────────────────────────────────────────────────────
+
+export function QueryExamplesPanel({ onInsert }: QueryExamplesPanelProps) {
+  return (
+    <div className="flex flex-col pb-3">
+      {QUERY_PACK_GROUPS.map((group) => (
+        <div key={group.id}>
+          <GroupHeader label={group.label} />
+          {group.packs.map((pack) => (
+            <ExampleItem
+              key={pack.id}
+              pack={pack}
+              onInsert={() => onInsert(pack.query)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/query/components/QueryExplanationPanel.tsx
+++ b/src/features/query/components/QueryExplanationPanel.tsx
@@ -2,6 +2,27 @@
 
 import { X, Lightbulb } from "lucide-react";
 
+/** Renders a line string, converting `backtick` spans to safe <code> elements. */
+function ExplainLine({ line }: { line: string }) {
+  const parts = line.split(/`([^`]+)`/);
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 0 ? (
+          part
+        ) : (
+          <code
+            key={i}
+            className="rounded bg-blue-100/80 px-1 font-mono text-[10px] dark:bg-blue-900/40"
+          >
+            {part}
+          </code>
+        )
+      )}
+    </>
+  );
+}
+
 interface QueryExplanationPanelProps {
   lines: string[];
   onClose: () => void;
@@ -34,14 +55,7 @@ export function QueryExplanationPanel({
             className="flex items-start gap-1.5 text-xs text-blue-800 dark:text-blue-300"
           >
             <span className="mt-px shrink-0 text-blue-400">–</span>
-            <span
-              dangerouslySetInnerHTML={{
-                __html: line.replace(
-                  /`([^`]+)`/g,
-                  '<code class="rounded bg-blue-100/80 px-1 font-mono text-[10px] dark:bg-blue-900/40">$1</code>'
-                ),
-              }}
-            />
+            <span><ExplainLine line={line} /></span>
           </li>
         ))}
       </ul>

--- a/src/features/query/components/QueryExplanationPanel.tsx
+++ b/src/features/query/components/QueryExplanationPanel.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { X, Lightbulb } from "lucide-react";
+
+interface QueryExplanationPanelProps {
+  lines: string[];
+  onClose: () => void;
+}
+
+export function QueryExplanationPanel({
+  lines,
+  onClose,
+}: QueryExplanationPanelProps) {
+  return (
+    <div className="flex shrink-0 flex-col border-b border-border bg-blue-50/60 dark:bg-blue-950/20">
+      <div className="flex items-center gap-1.5 px-3 pt-2 pb-1">
+        <Lightbulb className="h-3.5 w-3.5 shrink-0 text-blue-600 dark:text-blue-400" />
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-blue-700/70 dark:text-blue-400/70">
+          Query explanation
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close explanation"
+          className="ml-auto rounded p-0.5 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <ul className="flex flex-col gap-0.5 px-4 pb-2">
+        {lines.map((line, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-1.5 text-xs text-blue-800 dark:text-blue-300"
+          >
+            <span className="mt-px shrink-0 text-blue-400">–</span>
+            <span
+              dangerouslySetInnerHTML={{
+                __html: line.replace(
+                  /`([^`]+)`/g,
+                  '<code class="rounded bg-blue-100/80 px-1 font-mono text-[10px] dark:bg-blue-900/40">$1</code>'
+                ),
+              }}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/query/components/QueryLintPanel.tsx
+++ b/src/features/query/components/QueryLintPanel.tsx
@@ -11,16 +11,21 @@ export function QueryLintPanel({ warnings }: QueryLintPanelProps) {
   if (warnings.length === 0) return null;
 
   return (
-    <div className="flex shrink-0 flex-col gap-0.5 border-b border-border bg-amber-50/60 px-3 py-1.5 dark:bg-amber-950/20">
+    <ul
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="flex shrink-0 flex-col gap-0.5 border-b border-border bg-amber-50/60 px-3 py-1.5 dark:bg-amber-950/20"
+    >
       {warnings.map((w) => (
-        <div
+        <li
           key={w.id}
           className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400"
         >
           <AlertTriangle className="mt-px h-3 w-3 shrink-0" />
           {w.message}
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/src/features/query/components/QueryLintPanel.tsx
+++ b/src/features/query/components/QueryLintPanel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import type { LintWarning } from "../types";
+
+interface QueryLintPanelProps {
+  warnings: LintWarning[];
+}
+
+export function QueryLintPanel({ warnings }: QueryLintPanelProps) {
+  if (warnings.length === 0) return null;
+
+  return (
+    <div className="flex shrink-0 flex-col gap-0.5 border-b border-border bg-amber-50/60 px-3 py-1.5 dark:bg-amber-950/20">
+      {warnings.map((w) => (
+        <div
+          key={w.id}
+          className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400"
+        >
+          <AlertTriangle className="mt-px h-3 w-3 shrink-0" />
+          {w.message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/query/components/QueryReferenceDialog.tsx
+++ b/src/features/query/components/QueryReferenceDialog.tsx
@@ -34,7 +34,7 @@ function Snippet({ code }: { code: string }) {
         type="button"
         onClick={copy}
         title="Copy snippet"
-        className="absolute right-1.5 top-1.5 hidden rounded p-0.5 text-muted-foreground hover:text-foreground group-hover:flex"
+        className="absolute right-1.5 top-1.5 flex rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
       >
         <Copy className="h-3 w-3" />
       </button>

--- a/src/features/query/components/QueryReferenceDialog.tsx
+++ b/src/features/query/components/QueryReferenceDialog.tsx
@@ -1,0 +1,616 @@
+"use client";
+
+import { useState } from "react";
+import { Copy } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface QueryReferenceDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// ─── Snippet copy helper ──────────────────────────────────────────────────────
+
+function Snippet({ code }: { code: string }) {
+  function copy() {
+    navigator.clipboard
+      .writeText(code)
+      .then(() => toast.success("Snippet copied"))
+      .catch(() => toast.error("Failed to copy"));
+  }
+
+  return (
+    <div className="group relative">
+      <pre className="overflow-x-auto rounded-md bg-muted/60 px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground">
+        {code}
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        title="Copy snippet"
+        className="absolute right-1.5 top-1.5 hidden rounded p-0.5 text-muted-foreground hover:text-foreground group-hover:flex"
+      >
+        <Copy className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+function Heading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </h3>
+  );
+}
+
+function Para({ children }: { children: React.ReactNode }) {
+  return <p className="mb-3 text-xs leading-relaxed text-foreground/80">{children}</p>;
+}
+
+function Kv({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 flex gap-2 text-xs">
+      <code className="shrink-0 rounded bg-muted/60 px-1 font-mono text-[11px] text-foreground">
+        {label}
+      </code>
+      <span className="text-foreground/70">{children}</span>
+    </div>
+  );
+}
+
+// ─── QueryReferenceDialog ─────────────────────────────────────────────────────
+
+export function QueryReferenceDialog({
+  open,
+  onClose,
+}: QueryReferenceDialogProps) {
+  const [section, setSection] = useState<
+    "basics" | "filters" | "joins" | "aggregates" | "transactions" | "snippets" | "datamodel"
+  >("basics");
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="flex h-[80vh] sm:max-w-4xl flex-col gap-0 p-0">
+        <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
+          <DialogTitle className="text-sm">ActualQL quick reference</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {/* Section nav */}
+          <nav className="flex w-36 shrink-0 flex-col gap-0.5 border-r border-border p-2 pt-3">
+            {(
+              [
+                ["basics", "Basics"],
+                ["filters", "Filters"],
+                ["joins", "Joins"],
+                ["aggregates", "Aggregates"],
+                ["transactions", "Transactions"],
+                ["snippets", "Snippets"],
+                ["datamodel", "Data model"],
+              ] as const
+            ).map(([id, label]) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setSection(id)}
+                className={`rounded px-2 py-1.5 text-left text-xs transition-colors ${
+                  section === id
+                    ? "bg-accent text-accent-foreground font-medium"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Content */}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {section === "basics" && <BasicsSection />}
+            {section === "filters" && <FiltersSection />}
+            {section === "joins" && <JoinsSection />}
+            {section === "aggregates" && <AggregatesSection />}
+            {section === "transactions" && <TransactionsSection />}
+            {section === "snippets" && <SnippetsSection />}
+            {section === "datamodel" && <DataModelSection />}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Sections ─────────────────────────────────────────────────────────────────
+
+function BasicsSection() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Para>
+        ActualQL is a JSON-based query language for reading data from an Actual Budget.
+        All queries must be wrapped in <code className="font-mono text-[11px]">{"{ \"ActualQLquery\": { ... } }"}</code>.
+      </Para>
+
+      <div>
+        <Heading>Required field</Heading>
+        <Kv label="table">Target table name — e.g. <code className="font-mono text-[11px]">transactions</code>, <code className="font-mono text-[11px]">payees</code>, <code className="font-mono text-[11px]">categories</code>, <code className="font-mono text-[11px]">schedules</code>, <code className="font-mono text-[11px]">rules</code></Kv>
+      </div>
+
+      <div>
+        <Heading>Optional fields</Heading>
+        <Kv label="filter">Filter conditions — see Filters section</Kv>
+        <Kv label="select">Fields to return — array of field names or aggregate objects</Kv>
+        <Kv label="groupBy">Array of fields to group by — pair with aggregates in select</Kv>
+        <Kv label="calculate">Scalar aggregate — returns a single value instead of rows</Kv>
+        <Kv label="orderBy">Array of field names or <code className="font-mono text-[11px]">{"{ field: \"asc\" | \"desc\" }"}</code></Kv>
+        <Kv label="limit">Maximum number of rows to return</Kv>
+        <Kv label="offset">Number of rows to skip (for pagination)</Kv>
+      </div>
+
+      <div>
+        <Heading>Minimal example</Heading>
+        <Snippet
+          code={`{\n  "ActualQLquery": {\n    "table": "payees",\n    "limit": 10\n  }\n}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FiltersSection() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Para>Filters go inside the <code className="font-mono text-[11px]">filter</code> object.</Para>
+
+      <div>
+        <Heading>Equality</Heading>
+        <Snippet code={`"filter": { "payee": "abc-id-123" }`} />
+      </div>
+
+      <div>
+        <Heading>Null check</Heading>
+        <Snippet code={`"filter": { "category": null }`} />
+      </div>
+
+      <div>
+        <Heading>Comparison — $gte, $lte</Heading>
+        <Snippet
+          code={`"filter": {\n  "date": { "$gte": "2025-01-01", "$lte": "2025-01-31" }\n}`}
+        />
+      </div>
+
+      <div>
+        <Heading>$oneof — match any in a list</Heading>
+        <Snippet
+          code={`"filter": { "payee": { "$oneof": ["id-1", "id-2", "id-3"] } }`}
+        />
+      </div>
+
+      <div>
+        <Heading>$and — all conditions must match</Heading>
+        <Snippet
+          code={`"filter": {\n  "$and": [\n    { "date": { "$gte": "2025-01-01" } },\n    { "category": null }\n  ]\n}`}
+        />
+      </div>
+
+      <div>
+        <Heading>$or — any condition must match</Heading>
+        <Snippet
+          code={`"filter": {\n  "$or": [\n    { "payee": "id-1" },\n    { "payee": "id-2" }\n  ]\n}`}
+        />
+      </div>
+
+      <div>
+        <Heading>$like — pattern match</Heading>
+        <Snippet code={`"filter": { "notes": { "$like": "%refund%" } }`} />
+      </div>
+    </div>
+  );
+}
+
+function JoinsSection() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Para>
+        ActualQL supports dotted paths to traverse relationships. This lets you
+        select and filter on fields from linked tables without writing explicit
+        joins.
+      </Para>
+
+      <div>
+        <Heading>Common dotted paths</Heading>
+        <Kv label="payee.name">Name of the transaction payee</Kv>
+        <Kv label="category.name">Name of the transaction category</Kv>
+        <Kv label="category.group.name">Name of the category group</Kv>
+        <Kv label="account.name">Name of the account</Kv>
+      </div>
+
+      <div>
+        <Heading>Using dotted paths in select</Heading>
+        <Snippet
+          code={`"select": [\n  "date",\n  "amount",\n  "payee.name",\n  "category.name",\n  "category.group.name"\n]`}
+        />
+      </div>
+
+      <div>
+        <Heading>Using dotted paths in groupBy</Heading>
+        <Snippet
+          code={`"groupBy": ["payee", "payee.name"],\n"select": [\n  "payee",\n  "payee.name",\n  { "count": { "$count": "$id" } }\n]`}
+        />
+      </div>
+
+      <div>
+        <Heading>Using dotted paths in filter</Heading>
+        <Snippet
+          code={`"filter": { "payee.name": { "$like": "%Amazon%" } }`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AggregatesSection() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Para>
+        Aggregates compute values across grouped rows. Use them in{" "}
+        <code className="font-mono text-[11px]">select</code> (per group) or{" "}
+        <code className="font-mono text-[11px]">calculate</code> (single scalar).
+      </Para>
+
+      <div>
+        <Heading>Functions</Heading>
+        <Kv label="$count">Count rows — typically <code className="font-mono text-[11px]">{"{ \"$count\": \"$id\" }"}</code></Kv>
+        <Kv label="$sum">Sum a numeric field — typically amount</Kv>
+        <Kv label="$avg">Average a numeric field</Kv>
+        <Kv label="$min">Minimum value</Kv>
+        <Kv label="$max">Maximum value</Kv>
+      </div>
+
+      <div>
+        <Heading>Grouped count in select</Heading>
+        <Snippet
+          code={`"groupBy": ["payee", "payee.name"],\n"select": [\n  "payee",\n  "payee.name",\n  { "count": { "$count": "$id" } }\n],\n"orderBy": [{ "count": "desc" }]`}
+        />
+      </div>
+
+      <div>
+        <Heading>Grouped sum in select</Heading>
+        <Snippet
+          code={`"groupBy": ["category", "category.name"],\n"select": [\n  "category",\n  "category.name",\n  { "total": { "$sum": "$amount" } }\n]`}
+        />
+      </div>
+
+      <div>
+        <Heading>Scalar result with calculate</Heading>
+        <Para>
+          Returns a single number, not a list of rows. Useful for totals and counts.
+        </Para>
+        <Snippet
+          code={`"table": "transactions",\n"calculate": { "$count": "$id" }`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TransactionsSection() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Para>
+        The <code className="font-mono text-[11px]">transactions</code> table is the most common query target.
+        Keep these notes in mind.
+      </Para>
+
+      <div>
+        <Heading>Amounts</Heading>
+        <Para>
+          Amounts are stored in cents (integer). Divide by 100 to get the value
+          in your budget&apos;s currency unit (e.g. <code className="font-mono text-[11px]">1200</code> = $12.00).
+          Negative values are expenses.
+        </Para>
+      </div>
+
+      <div>
+        <Heading>Dates</Heading>
+        <Para>
+          Dates are ISO strings like <code className="font-mono text-[11px]">2025-01-15</code>.
+          Use <code className="font-mono text-[11px]">$gte</code> and <code className="font-mono text-[11px]">$lte</code> to filter by date range.
+        </Para>
+      </div>
+
+      <div>
+        <Heading>options.splits</Heading>
+        <Kv label="inline">Sub-transactions appear as individual rows (default)</Kv>
+        <Kv label="grouped">Sub-transactions are grouped under their parent</Kv>
+        <Kv label="all">Returns both parent and child transactions</Kv>
+        <Snippet
+          code={`"table": "transactions",\n"options": { "splits": "grouped" },\n"limit": 20`}
+        />
+      </div>
+
+      <div>
+        <Heading>Unbounded scan warning</Heading>
+        <Para>
+          Querying <code className="font-mono text-[11px]">transactions</code> without a <code className="font-mono text-[11px]">limit</code>,
+          <code className="font-mono text-[11px]">groupBy</code>, or <code className="font-mono text-[11px]">calculate</code> can return
+          thousands of rows and may time out (proxy enforces a 15-second limit).
+        </Para>
+      </div>
+    </div>
+  );
+}
+
+function SnippetsSection() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Para>Copyable starter snippets. Paste into the editor and edit as needed.</Para>
+
+      <div>
+        <Heading>Month filter (January 2025)</Heading>
+        <Snippet
+          code={`"filter": {\n  "date": { "$gte": "2025-01-01", "$lte": "2025-01-31" }\n}`}
+        />
+      </div>
+
+      <div>
+        <Heading>Date range filter</Heading>
+        <Snippet
+          code={`"filter": {\n  "date": { "$gte": "2025-01-01", "$lte": "2025-03-31" }\n}`}
+        />
+      </div>
+
+      <div>
+        <Heading>Selected IDs with $oneof</Heading>
+        <Snippet
+          code={`"filter": {\n  "payee": { "$oneof": ["id-1", "id-2", "id-3"] }\n}`}
+        />
+      </div>
+
+      <div>
+        <Heading>Grouped count</Heading>
+        <Snippet
+          code={`"groupBy": ["payee", "payee.name"],\n"select": [\n  "payee",\n  "payee.name",\n  { "count": { "$count": "$id" } }\n],\n"orderBy": [{ "count": "desc" }]`}
+        />
+      </div>
+
+      <div>
+        <Heading>Grouped sum</Heading>
+        <Snippet
+          code={`"groupBy": ["category", "category.name"],\n"select": [\n  "category",\n  "category.name",\n  { "total": { "$sum": "$amount" } }\n],\n"orderBy": [{ "total": "asc" }]`}
+        />
+      </div>
+
+      <div>
+        <Heading>Scalar row count</Heading>
+        <Snippet
+          code={`{\n  "ActualQLquery": {\n    "table": "transactions",\n    "calculate": { "$count": "$id" }\n  }\n}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DataModelSection() {
+  return (
+    <div className="flex flex-col gap-5">
+      <Para>
+        ActualQL exposes the following tables. Use dotted paths to traverse relationships —
+        e.g. <code className="font-mono text-[11px]">payee.name</code> on a{" "}
+        <code className="font-mono text-[11px]">transactions</code> query resolves the linked payee&apos;s name.
+      </Para>
+
+      {/* ── transactions ──────────────────────────────────────────────────── */}
+      <div>
+        <Heading>transactions</Heading>
+        <Para>The core table. Each row is one transaction (or split sub-transaction).</Para>
+        <div className="overflow-x-auto rounded-md border border-border text-[11px]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Field</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Type</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {[
+                ["id", "string", "UUID — primary key"],
+                ["date", "string", "ISO date, e.g. 2025-01-15"],
+                ["amount", "integer", "Cents (÷ 100 for dollar value). Negative = expense"],
+                ["notes", "string | null", "Free-text memo"],
+                ["imported_id", "string | null", "Bank-provided transaction ID"],
+                ["transfer_id", "string | null", "Non-null for transfer legs"],
+                ["payee", "string | null", "Foreign key → payees.id"],
+                ["category", "string | null", "Foreign key → categories.id"],
+                ["account", "string", "Foreign key → accounts.id"],
+              ].map(([f, t, n]) => (
+                <tr key={f} className="border-b border-border/40">
+                  <td className="px-3 py-1 text-foreground">{f}</td>
+                  <td className="px-3 py-1 text-muted-foreground">{t}</td>
+                  <td className="px-3 py-1 font-sans text-muted-foreground/80">{n}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ── payees ────────────────────────────────────────────────────────── */}
+      <div>
+        <Heading>payees</Heading>
+        <Para>All payees (merchants, transfer accounts, starting balances).</Para>
+        <div className="overflow-x-auto rounded-md border border-border text-[11px]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Field</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Type</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {[
+                ["id", "string", "UUID"],
+                ["name", "string", "Human-readable payee name"],
+                ["transfer_acct", "string | null", "Non-null for transfer payees"],
+              ].map(([f, t, n]) => (
+                <tr key={f} className="border-b border-border/40">
+                  <td className="px-3 py-1 text-foreground">{f}</td>
+                  <td className="px-3 py-1 text-muted-foreground">{t}</td>
+                  <td className="px-3 py-1 font-sans text-muted-foreground/80">{n}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ── categories ────────────────────────────────────────────────────── */}
+      <div>
+        <Heading>categories</Heading>
+        <Para>Budget categories. Each belongs to one category group.</Para>
+        <div className="overflow-x-auto rounded-md border border-border text-[11px]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Field</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Type</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {[
+                ["id", "string", "UUID"],
+                ["name", "string", "Category name"],
+                ["group", "string", "Foreign key → category_groups.id"],
+                ["hidden", "boolean", "Hidden from budget view"],
+              ].map(([f, t, n]) => (
+                <tr key={f} className="border-b border-border/40">
+                  <td className="px-3 py-1 text-foreground">{f}</td>
+                  <td className="px-3 py-1 text-muted-foreground">{t}</td>
+                  <td className="px-3 py-1 font-sans text-muted-foreground/80">{n}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ── accounts ──────────────────────────────────────────────────────── */}
+      <div>
+        <Heading>accounts</Heading>
+        <Para>Bank accounts and tracking accounts.</Para>
+        <div className="overflow-x-auto rounded-md border border-border text-[11px]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Field</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Type</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {[
+                ["id", "string", "UUID"],
+                ["name", "string", "Account name"],
+                ["offbudget", "boolean", "true = tracking account, excluded from budget"],
+                ["closed", "boolean", "true = closed account"],
+              ].map(([f, t, n]) => (
+                <tr key={f} className="border-b border-border/40">
+                  <td className="px-3 py-1 text-foreground">{f}</td>
+                  <td className="px-3 py-1 text-muted-foreground">{t}</td>
+                  <td className="px-3 py-1 font-sans text-muted-foreground/80">{n}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ── schedules / rules ─────────────────────────────────────────────── */}
+      <div>
+        <Heading>schedules &amp; rules</Heading>
+        <Para>
+          <code className="font-mono text-[11px]">schedules</code> stores recurring transaction templates.
+          Each schedule can link to a <code className="font-mono text-[11px]">rules</code> row which controls
+          auto-matching of imported transactions.
+        </Para>
+        <div className="mb-2 overflow-x-auto rounded-md border border-border text-[11px]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Field (schedules)</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {[
+                ["id", "UUID"],
+                ["name", "Human-readable name"],
+                ["next_date", "ISO date of next occurrence"],
+                ["posts_transaction", "boolean — auto-post when due"],
+                ["rule", "Foreign key → rules.id (nullable)"],
+              ].map(([f, n]) => (
+                <tr key={f} className="border-b border-border/40">
+                  <td className="px-3 py-1 text-foreground">{f}</td>
+                  <td className="px-3 py-1 font-sans text-muted-foreground/80">{n}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* ── Relationship map ──────────────────────────────────────────────── */}
+      <div>
+        <Heading>Dotted-path relationship map</Heading>
+        <Para>
+          These are the most useful dotted paths when querying{" "}
+          <code className="font-mono text-[11px]">transactions</code>:
+        </Para>
+        <div className="overflow-x-auto rounded-md border border-border text-[11px]">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40">
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Dotted path</th>
+                <th className="px-3 py-1.5 text-left font-semibold text-muted-foreground">Resolves to</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {[
+                ["payee.name", "Payee display name"],
+                ["payee.transfer_acct", "Linked account ID for transfer payees"],
+                ["category.name", "Category display name"],
+                ["category.group", "Category group ID"],
+                ["category.group.name", "Category group display name"],
+                ["account.name", "Account display name"],
+                ["account.offbudget", "boolean — off-budget / tracking account"],
+                ["account.closed", "boolean — account is closed"],
+              ].map(([p, r]) => (
+                <tr key={p} className="border-b border-border/40">
+                  <td className="px-3 py-1 text-foreground">{p}</td>
+                  <td className="px-3 py-1 font-sans text-muted-foreground/80">{r}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <Para>
+          Dotted paths work in <code className="font-mono text-[11px]">select</code>,{" "}
+          <code className="font-mono text-[11px]">filter</code>,{" "}
+          <code className="font-mono text-[11px]">groupBy</code>, and{" "}
+          <code className="font-mono text-[11px]">orderBy</code>. When used in{" "}
+          <code className="font-mono text-[11px]">groupBy</code>, always include both the ID field and the
+          name path so the result set is unambiguous.
+        </Para>
+      </div>
+    </div>
+  );
+}

--- a/src/features/query/components/QueryResults.tsx
+++ b/src/features/query/components/QueryResults.tsx
@@ -123,11 +123,7 @@ function formatCellDisplay(col: string, value: unknown, centCols: Set<string>): 
   if (typeof value === "string") {
     return formatIsoDate(value) ?? value;
   }
-  if (
-    typeof value === "number" &&
-    Number.isInteger(value) &&
-    centCols.has(col)
-  ) {
+  if (typeof value === "number" && centCols.has(col)) {
     return formatCents(value);
   }
   if (typeof value === "object") return JSON.stringify(value);
@@ -169,6 +165,17 @@ function deriveRowCount(data: unknown): string | null {
  * Values are formatted the same way as in the Table view (dates localised,
  * cent columns divided by 100). The BOM ensures Excel opens the file correctly.
  */
+/**
+ * Neutralises CSV formula injection by prepending a tab to any cell value
+ * that starts with a spreadsheet formula trigger character (=, +, -, @).
+ * The tab is invisible in most spreadsheet apps but prevents formula execution.
+ */
+const FORMULA_TRIGGERS = new Set(["=", "+", "-", "@"]);
+
+function neutraliseFormula(v: string): string {
+  return FORMULA_TRIGGERS.has(v[0]) ? `\t${v}` : v;
+}
+
 function buildCsv(
   rows: Record<string, unknown>[],
   columns: string[],
@@ -176,11 +183,12 @@ function buildCsv(
 ): string {
   const BOM = "\uFEFF";
   const escape = (v: string) => `"${v.replace(/"/g, '""')}"`;
+  const cell = (v: string) => escape(neutraliseFormula(v));
 
   const header = columns.map(escape).join(",");
   const csvRows = rows.map((row) =>
     columns
-      .map((col) => escape(formatCellDisplay(col, row[col], centCols)))
+      .map((col) => cell(formatCellDisplay(col, row[col], centCols)))
       .join(",")
   );
 
@@ -437,9 +445,9 @@ export function QueryResults({
   function handleExportCsv() {
     if (!isArrayOfObjects(result)) return;
     const rows = result as Record<string, unknown>[];
-    const capped = rows.slice(0, TABLE_ROW_CAP);
-    const columns = getColumns(capped);
-    const csv = buildCsv(capped, columns, centCols);
+    // Export the full result set — TABLE_ROW_CAP only caps the preview render.
+    const columns = getColumns(rows);
+    const csv = buildCsv(rows, columns, centCols);
     downloadCsv(csv, "query-results.csv");
     toast.success("CSV downloaded");
   }

--- a/src/features/query/components/QueryResults.tsx
+++ b/src/features/query/components/QueryResults.tsx
@@ -405,6 +405,9 @@ export function QueryResults({
     [lastRequest]
   );
 
+  // Derived state: auto-select the appropriate view mode when the result changes.
+  // This is the React-documented getDerivedStateFromProps pattern for hooks —
+  // React re-renders immediately with the updated mode, preventing any flicker.
   const [prevResult, setPrevResult] = useState<unknown | null>(null);
   if (result !== prevResult) {
     setPrevResult(result);

--- a/src/features/query/components/QueryResults.tsx
+++ b/src/features/query/components/QueryResults.tsx
@@ -300,13 +300,23 @@ function TableView({ data, centCols }: { data: unknown; centCols: Set<string> })
               {columns.map((col) => (
                 <th
                   key={col}
-                  onClick={() => handleSortClick(col)}
-                  className="whitespace-nowrap px-3 py-1.5 text-left font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground hover:bg-muted/80 transition-colors"
+                  aria-sort={
+                    sortCol !== col
+                      ? "none"
+                      : sortDir === "asc"
+                        ? "ascending"
+                        : "descending"
+                  }
+                  className="whitespace-nowrap px-0 py-0 text-left font-medium text-muted-foreground"
                 >
-                  <span className="inline-flex items-center">
+                  <button
+                    type="button"
+                    onClick={() => handleSortClick(col)}
+                    className="inline-flex w-full items-center px-3 py-1.5 select-none cursor-pointer transition-colors hover:text-foreground hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                  >
                     {col}
                     <SortIcon col={col} sortCol={sortCol} sortDir={sortDir} />
-                  </span>
+                  </button>
                 </th>
               ))}
             </tr>

--- a/src/features/query/components/QueryResults.tsx
+++ b/src/features/query/components/QueryResults.tsx
@@ -1,0 +1,624 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Copy, ChevronUp, ChevronDown, ChevronsUpDown, Download } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { CopyCurlButton } from "./CopyCurlButton";
+import { JsonTreeView } from "./JsonTreeView";
+import { colorizeJson } from "../lib/jsonColorize";
+import { formatIsoDate, formatCents } from "../lib/queryFormatting";
+import type { QueryResultMode, LastExecutedRequest, ActualQLQuery } from "../types";
+
+const TABLE_ROW_CAP = 500;
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+function formatTime(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1048576) return `${(n / 1024).toFixed(1)} kB`;
+  return `${(n / 1048576).toFixed(1)} MB`;
+}
+
+// ─── Type guards ──────────────────────────────────────────────────────────────
+
+function isArrayOfObjects(value: unknown): value is Record<string, unknown>[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    typeof value[0] === "object" &&
+    value[0] !== null &&
+    !Array.isArray(value[0])
+  );
+}
+
+/** Returns the union of all keys across the first N rows. */
+function getColumns(rows: Record<string, unknown>[]): string[] {
+  const keys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      keys.add(key);
+    }
+  }
+  return Array.from(keys);
+}
+
+/** Raw cell value used for the title/tooltip — never transformed. */
+function rawCellValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Hard-coded column names that are always stored in cents (÷ 100 = dollar value).
+ * Aggregate aliases are handled separately via deriveCentColumns().
+ */
+const BASE_CENT_COLS = new Set(["amount", "balance"]);
+
+/**
+ * Aggregate operators that, when applied to a cent field, produce a cent result.
+ * $count is deliberately excluded — it counts rows, not amounts.
+ */
+const CENT_AGG_OPS = new Set(["$sum", "$avg", "$min", "$max"]);
+
+/**
+ * The $ -prefixed field references that represent cent-valued columns in
+ * aggregate expressions (e.g. { "$sum": "$amount" }).
+ */
+const CENT_SOURCE_REFS = new Set(["$amount", "$balance"]);
+
+/**
+ * Derives the full set of cent-valued column names from a query's select array.
+ *
+ * Starts from BASE_CENT_COLS, then inspects each aggregate entry in select:
+ *   { alias: { "$sum" | "$avg" | "$min" | "$max": "$amount" | "$balance" } }
+ * Any alias matching this pattern is added to the returned set.
+ *
+ * $count is excluded — it produces row counts, not monetary values.
+ * Non-array select (raw object or undefined) falls back to BASE_CENT_COLS only.
+ */
+function deriveCentColumns(query: ActualQLQuery | undefined): Set<string> {
+  const cols = new Set(BASE_CENT_COLS);
+  if (!query) return cols;
+
+  const select = query.select;
+  if (!Array.isArray(select)) return cols;
+
+  for (const item of select) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+    // Each aggregate entry: { alias: { op: sourceField } }
+    for (const [alias, aggExpr] of Object.entries(item as Record<string, unknown>)) {
+      if (typeof aggExpr !== "object" || aggExpr === null || Array.isArray(aggExpr)) continue;
+      for (const [op, sourceRef] of Object.entries(aggExpr as Record<string, unknown>)) {
+        if (
+          CENT_AGG_OPS.has(op) &&
+          typeof sourceRef === "string" &&
+          CENT_SOURCE_REFS.has(sourceRef)
+        ) {
+          cols.add(alias);
+        }
+      }
+    }
+  }
+
+  return cols;
+}
+
+/**
+ * Smart display formatter. Applies:
+ *   - ISO date strings → locale-aware date (e.g. "Jan 15, 2024")
+ *   - Cent columns → ÷ 100 decimal (e.g. "12.00"). The set of cent columns
+ *     includes hard-coded names (amount, balance) PLUS any aliases detected
+ *     as aggregates on cent fields by deriveCentColumns().
+ * Raw value is always preserved in the cell title tooltip.
+ */
+function formatCellDisplay(col: string, value: unknown, centCols: Set<string>): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") {
+    return formatIsoDate(value) ?? value;
+  }
+  if (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    centCols.has(col)
+  ) {
+    return formatCents(value);
+  }
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function isTreeable(data: unknown): boolean {
+  return Array.isArray(data) || (data !== null && typeof data === "object");
+}
+
+function detectMode(data: unknown): QueryResultMode {
+  if (Array.isArray(data)) return "table";
+  if (
+    typeof data === "number" ||
+    typeof data === "string" ||
+    typeof data === "boolean"
+  ) {
+    return "scalar";
+  }
+  // Plain objects default to Tree view
+  if (data !== null && typeof data === "object") return "tree";
+  return "raw";
+}
+
+function deriveRowCount(data: unknown): string | null {
+  if (data === null || data === undefined) return null;
+  if (Array.isArray(data)) return `${data.length} row${data.length !== 1 ? "s" : ""}`;
+  if (typeof data === "number" || typeof data === "string" || typeof data === "boolean") {
+    return "1 value";
+  }
+  if (typeof data === "object") return "1 object";
+  return null;
+}
+
+// ─── CSV export ───────────────────────────────────────────────────────────────
+
+/**
+ * Builds a UTF-8 BOM-prefixed CSV string from an array of row objects.
+ * Values are formatted the same way as in the Table view (dates localised,
+ * cent columns divided by 100). The BOM ensures Excel opens the file correctly.
+ */
+function buildCsv(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  centCols: Set<string>
+): string {
+  const BOM = "\uFEFF";
+  const escape = (v: string) => `"${v.replace(/"/g, '""')}"`;
+
+  const header = columns.map(escape).join(",");
+  const csvRows = rows.map((row) =>
+    columns
+      .map((col) => escape(formatCellDisplay(col, row[col], centCols)))
+      .join(",")
+  );
+
+  return BOM + [header, ...csvRows].join("\r\n");
+}
+
+function downloadCsv(content: string, filename: string) {
+  const blob = new Blob([content], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ─── Sub-views ────────────────────────────────────────────────────────────────
+
+type SortDir = "asc" | "desc";
+
+function sortRows(
+  rows: Record<string, unknown>[],
+  col: string,
+  dir: SortDir
+): Record<string, unknown>[] {
+  return [...rows].sort((a, b) => {
+    const av = a[col];
+    const bv = b[col];
+    if (av === null || av === undefined) return 1;
+    if (bv === null || bv === undefined) return -1;
+    const cmp =
+      typeof av === "number" && typeof bv === "number"
+        ? av - bv
+        : String(av).localeCompare(String(bv), undefined, { numeric: true });
+    return dir === "asc" ? cmp : -cmp;
+  });
+}
+
+function SortIcon({ col, sortCol, sortDir }: { col: string; sortCol: string | null; sortDir: SortDir | null }) {
+  if (col !== sortCol) return <ChevronsUpDown className="ml-1 h-3 w-3 opacity-30" />;
+  return sortDir === "asc"
+    ? <ChevronUp className="ml-1 h-3 w-3 text-foreground" />
+    : <ChevronDown className="ml-1 h-3 w-3 text-foreground" />;
+}
+
+function TableView({ data, centCols }: { data: unknown; centCols: Set<string> }) {
+  const [sortCol, setSortCol] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir | null>(null);
+
+  const rows = useMemo(
+    () => (isArrayOfObjects(data) ? data : []),
+    [data]
+  );
+  const capped = rows.slice(0, TABLE_ROW_CAP);
+  const columns = useMemo(() => getColumns(capped), [capped]);
+  const isCapped = rows.length > TABLE_ROW_CAP;
+
+  const sortedRows = useMemo(() => {
+    if (!sortCol || !sortDir) return capped;
+    return sortRows(capped, sortCol, sortDir);
+  }, [capped, sortCol, sortDir]);
+
+  function handleSortClick(col: string) {
+    if (sortCol !== col) {
+      setSortCol(col);
+      setSortDir("asc");
+    } else if (sortDir === "asc") {
+      setSortDir("desc");
+    } else {
+      // third click — clear sort
+      setSortCol(null);
+      setSortDir(null);
+    }
+  }
+
+  if (Array.isArray(data) && data.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        No rows matched this query.
+      </div>
+    );
+  }
+
+  if (!isArrayOfObjects(data)) {
+    return (
+      <pre className="overflow-auto p-4 font-mono text-xs leading-relaxed text-foreground">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center gap-3 border-b border-border px-3 py-1.5 text-xs text-muted-foreground">
+        <span>
+          {rows.length} row{rows.length !== 1 ? "s" : ""}
+        </span>
+        {isCapped && (
+          <span className="text-amber-600 dark:text-amber-500">
+            Showing first {TABLE_ROW_CAP} — add{" "}
+            <code className="font-mono">&quot;limit&quot;</code> to control
+            result size.
+          </span>
+        )}
+        {sortCol && (
+          <span className="text-muted-foreground/60">
+            Sorted by <span className="font-mono">{sortCol}</span> {sortDir}
+          </span>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full text-xs">
+          <thead className="sticky top-0 z-10">
+            <tr className="border-b border-border bg-muted">
+              {columns.map((col) => (
+                <th
+                  key={col}
+                  onClick={() => handleSortClick(col)}
+                  className="whitespace-nowrap px-3 py-1.5 text-left font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground hover:bg-muted/80 transition-colors"
+                >
+                  <span className="inline-flex items-center">
+                    {col}
+                    <SortIcon col={col} sortCol={sortCol} sortDir={sortDir} />
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows.map((row, i) => (
+              <tr key={i} className="border-b border-border/40 hover:bg-muted/20">
+                {columns.map((col) => (
+                  <td
+                    key={col}
+                    title={rawCellValue(row[col])}
+                    className="max-w-48 truncate px-3 py-1.5 font-mono text-foreground"
+                  >
+                    {formatCellDisplay(col, row[col], centCols)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function RawView({ data }: { data: unknown }) {
+  const lines = useMemo(
+    () => JSON.stringify(data, null, 2).split("\n"),
+    [data]
+  );
+
+  return (
+    <div className="h-full overflow-auto p-4 font-mono text-xs leading-relaxed">
+      <table className="border-separate border-spacing-0">
+        <tbody>
+          {lines.map((line, i) => (
+            <tr key={i}>
+              <td className="select-none pr-4 text-right align-top text-muted-foreground/30 w-10">
+                {i + 1}
+              </td>
+              <td
+                className="whitespace-pre align-top text-foreground"
+                dangerouslySetInnerHTML={{ __html: colorizeJson(line) }}
+              />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ScalarView({ data }: { data: unknown }) {
+  const display =
+    typeof data === "object"
+      ? JSON.stringify(data, null, 2)
+      : String(data);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-12">
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Calculated result
+      </span>
+      <div className="rounded-lg border border-border bg-muted/30 px-6 py-4 font-mono text-2xl font-semibold text-foreground">
+        {display}
+      </div>
+    </div>
+  );
+}
+
+// ─── QueryResults ─────────────────────────────────────────────────────────────
+
+interface QueryResultsProps {
+  result: unknown | null;
+  isRunning: boolean;
+  error: string | null;
+  lastRequest?: LastExecutedRequest | null;
+  execTime?: number | null;
+  payloadBytes?: number | null;
+}
+
+export function QueryResults({
+  result,
+  isRunning,
+  error,
+  lastRequest,
+  execTime,
+  payloadBytes,
+}: QueryResultsProps) {
+  const [mode, setMode] = useState<QueryResultMode>("table");
+
+  // Derive the full set of cent-valued column names from the executed query.
+  // Re-derived whenever the request changes (i.e. after each successful run).
+  const centCols = useMemo(
+    () => deriveCentColumns(lastRequest?.query),
+    [lastRequest]
+  );
+
+  const [prevResult, setPrevResult] = useState<unknown | null>(null);
+  if (result !== prevResult) {
+    setPrevResult(result);
+    if (result !== null) {
+      setMode(detectMode(result));
+    }
+  }
+
+  function handleCopyResult() {
+    if (result === null) return;
+    navigator.clipboard
+      .writeText(JSON.stringify(result, null, 2))
+      .then(() => toast.success("Result JSON copied"))
+      .catch(() => toast.error("Failed to copy"));
+  }
+
+  function handleExportCsv() {
+    if (!isArrayOfObjects(result)) return;
+    const rows = result as Record<string, unknown>[];
+    const capped = rows.slice(0, TABLE_ROW_CAP);
+    const columns = getColumns(capped);
+    const csv = buildCsv(capped, columns, centCols);
+    downloadCsv(csv, "query-results.csv");
+    toast.success("CSV downloaded");
+  }
+
+  if (isRunning) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Running query…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Status bar — shown on error too */}
+        {execTime !== null && execTime !== undefined && (
+          <ResultsActionBar
+            hasResult={false}
+            isTableResult={false}
+            isError
+            execTime={execTime}
+            rowCount={null}
+            payloadBytes={payloadBytes ?? null}
+            onCopyResult={handleCopyResult}
+            onExportCsv={handleExportCsv}
+            lastRequest={lastRequest ?? null}
+          />
+        )}
+        <div className="flex flex-1 flex-col items-center justify-center gap-1 px-4 py-12 text-sm">
+          <span className="text-destructive">{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (result === null) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Run a query to see results here.
+      </div>
+    );
+  }
+
+  const rowCount = deriveRowCount(result);
+
+  return (
+    <Tabs
+      value={mode}
+      onValueChange={(v) => setMode(v as QueryResultMode)}
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <ResultsActionBar
+        hasResult
+        isTableResult={isArrayOfObjects(result)}
+        isError={false}
+        execTime={execTime ?? null}
+        rowCount={rowCount}
+        payloadBytes={payloadBytes ?? null}
+        onCopyResult={handleCopyResult}
+        onExportCsv={handleExportCsv}
+        lastRequest={lastRequest ?? null}
+        tabsList={
+          <TabsList className="border-b-0">
+            <TabsTrigger value="table">Table</TabsTrigger>
+            <TabsTrigger value="raw">Raw JSON</TabsTrigger>
+            <TabsTrigger value="scalar">Scalar</TabsTrigger>
+            {isTreeable(result) && (
+              <TabsTrigger value="tree">Tree</TabsTrigger>
+            )}
+          </TabsList>
+        }
+      />
+
+      <TabsContent value="table" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <TableView data={result} centCols={centCols} />
+      </TabsContent>
+      <TabsContent value="raw" className="overflow-hidden">
+        <RawView data={result} />
+      </TabsContent>
+      <TabsContent value="scalar" className="overflow-hidden">
+        <ScalarView data={result} />
+      </TabsContent>
+      <TabsContent value="tree" className="overflow-hidden">
+        <JsonTreeView data={result} />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+// ─── ResultsActionBar ─────────────────────────────────────────────────────────
+
+interface ResultsActionBarProps {
+  hasResult: boolean;
+  isTableResult: boolean;
+  isError: boolean;
+  execTime: number | null;
+  rowCount: string | null;
+  payloadBytes: number | null;
+  onCopyResult: () => void;
+  onExportCsv: () => void;
+  lastRequest: LastExecutedRequest | null;
+  tabsList?: React.ReactNode;
+}
+
+function ResultsActionBar({
+  hasResult,
+  isTableResult,
+  isError,
+  execTime,
+  rowCount,
+  payloadBytes,
+  onCopyResult,
+  onExportCsv,
+  lastRequest,
+  tabsList,
+}: ResultsActionBarProps) {
+  const showMeta = execTime !== null;
+
+  return (
+    <div className="flex shrink-0 items-center justify-between border-b border-border">
+      {/* Left: tabs (when present) */}
+      <div className="flex items-center">
+        {tabsList ?? <div className="h-9" />}
+      </div>
+
+      {/* Right: metadata + actions */}
+      <div className="flex items-center gap-1 pr-2">
+        {showMeta && (
+          <>
+            {/* Status chip */}
+            {isError ? (
+              <span className="rounded px-1.5 py-0.5 text-[10px] font-medium bg-destructive/15 text-destructive">
+                Error
+              </span>
+            ) : (
+              <span className="rounded px-1.5 py-0.5 text-[10px] font-medium bg-green-500/15 text-green-700 dark:text-green-400">
+                OK
+              </span>
+            )}
+            {/* Execution time */}
+            <span className="text-[11px] text-muted-foreground">
+              {formatTime(execTime!)}
+            </span>
+            {/* Row count */}
+            {rowCount && (
+              <span className="text-[11px] text-muted-foreground">
+                {rowCount}
+              </span>
+            )}
+            {/* Payload size */}
+            {payloadBytes !== null && (
+              <span className="text-[11px] text-muted-foreground">
+                {formatBytes(payloadBytes)}
+              </span>
+            )}
+            {/* Divider */}
+            <div className="mx-1 h-4 w-px bg-border" />
+          </>
+        )}
+
+        {/* Export CSV — only for array-of-objects results */}
+        {hasResult && isTableResult && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onExportCsv}
+            title="Download table as a UTF-8 CSV file"
+            className="gap-1.5 text-xs text-muted-foreground"
+          >
+            <Download className="h-3 w-3" />
+            Export CSV
+          </Button>
+        )}
+
+        {/* Copy JSON result */}
+        {hasResult && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onCopyResult}
+            title="Copy full result as JSON to clipboard"
+            className="gap-1.5 text-xs text-muted-foreground"
+          >
+            <Copy className="h-3 w-3" />
+            Copy JSON
+          </Button>
+        )}
+
+        {/* cURL buttons — safe first, secrets second (amber) */}
+        {lastRequest && <CopyCurlButton lastRequest={lastRequest} />}
+      </div>
+    </div>
+  );
+}

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -209,7 +209,12 @@ export function QueryWorkspace() {
   const editorHeightRef = useRef(editorHeight);
   // Snapshot of editor content before a programmatic load — enables toast + Ctrl+Z undo.
   const prevEditorValueRef = useRef<string>("");
+  // Guards against overlapping concurrent query executions.
+  const isRunningRef = useRef(false);
+  // Mirrors the active connection so in-flight callbacks can detect stale responses.
+  const connectionRef = useRef(connection);
   useEffect(() => { editorHeightRef.current = editorHeight; }, [editorHeight]);
+  useEffect(() => { connectionRef.current = connection; }, [connection]);
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -244,13 +249,15 @@ export function QueryWorkspace() {
     setSavedQueries(getSavedQueries(connection.budgetSyncId));
   }, [connection]);
 
-  // Lint as the user types — parse errors suppress lint warnings
+  // Lint as the user types; also keeps the inline parse-error banner in sync.
   useEffect(() => {
     const parsed = parseQuery(editorValue);
     if (parsed instanceof Error) {
+      setParseError(parsed.message);
       setLintWarnings([]);
       return;
     }
+    setParseError(null);
     setLintWarnings(lintQuery(parsed.inner));
   }, [editorValue]);
 
@@ -262,15 +269,23 @@ export function QueryWorkspace() {
         toast.error("No active connection.");
         return;
       }
+      // Prevent overlapping concurrent executions.
+      if (isRunningRef.current) return;
+
       const parsed = parseQuery(queryString);
       if (parsed instanceof Error) {
         setParseError(parsed.message);
         return;
       }
       setParseError(null);
+      isRunningRef.current = true;
       setIsRunning(true);
       setRunError(null);
       setShowExplanation(false);
+
+      // Snapshot the budget ID before the async gap so we can detect connection
+      // changes that occur while the request is in flight.
+      const capturedBudgetId = connection.budgetSyncId;
 
       const start = Date.now();
       try {
@@ -278,6 +293,9 @@ export function QueryWorkspace() {
           connection,
           parsed.body
         );
+        // Discard the response if the active connection changed mid-flight.
+        if (connectionRef.current?.budgetSyncId !== capturedBudgetId) return;
+
         const elapsed = Date.now() - start;
         setResult(response.data);
         setExecTime(elapsed);
@@ -298,6 +316,7 @@ export function QueryWorkspace() {
         });
         setHistory(getHistory(connection.budgetSyncId));
       } catch (err) {
+        if (connectionRef.current?.budgetSyncId !== capturedBudgetId) return;
         setExecTime(Date.now() - start);
         setPayloadBytes(null);
         const msg =
@@ -309,6 +328,7 @@ export function QueryWorkspace() {
         setRunError(msg);
         setResult(null);
       } finally {
+        isRunningRef.current = false;
         setIsRunning(false);
       }
     },
@@ -353,13 +373,14 @@ export function QueryWorkspace() {
 
   // Restores the editor to the state it was in before the last programmatic load.
   // Called either by the toast Undo button or the Ctrl+Z intercept in JsonEditor.
-  const handleUndo = useCallback(() => {
+  const handleUndo = useCallback((): boolean => {
     const prev = prevEditorValueRef.current;
-    if (!prev) return;
+    if (!prev) return false;
     prevEditorValueRef.current = "";
     setEditorValue(prev);
     setParseError(null);
     toast.dismiss();
+    return true;
   }, []);
 
   function handleSaveConfirm(name: string) {
@@ -483,7 +504,7 @@ export function QueryWorkspace() {
             onExplain={handleExplain}
             onCopyQuery={handleCopyQuery}
             onOpenReference={() => setReferenceOpen(true)}
-            onUndo={prevEditorValueRef.current ? handleUndo : undefined}
+            onUndo={handleUndo}
             isRunning={isRunning}
             parseError={parseError}
             editorHeight={editorHeight}

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -198,10 +198,14 @@ export function QueryWorkspace() {
 
   const [editorHeight, setEditorHeight] = useState<number>(() => {
     if (typeof window === "undefined") return DEFAULT_HEIGHT;
-    const stored = sessionStorage.getItem(EDITOR_HEIGHT_KEY);
-    if (!stored) return DEFAULT_HEIGHT;
-    const parsed = parseInt(stored, 10);
-    return isNaN(parsed) ? DEFAULT_HEIGHT : Math.max(MIN_HEIGHT, parsed);
+    try {
+      const stored = sessionStorage.getItem(EDITOR_HEIGHT_KEY);
+      if (!stored) return DEFAULT_HEIGHT;
+      const parsed = parseInt(stored, 10);
+      return isNaN(parsed) ? DEFAULT_HEIGHT : Math.max(MIN_HEIGHT, parsed);
+    } catch {
+      return DEFAULT_HEIGHT;
+    }
   });
 
   const mainAreaRef = useRef<HTMLDivElement>(null);
@@ -231,7 +235,11 @@ export function QueryWorkspace() {
     }
 
     function onUp() {
-      sessionStorage.setItem(EDITOR_HEIGHT_KEY, String(editorHeightRef.current));
+      try {
+        sessionStorage.setItem(EDITOR_HEIGHT_KEY, String(editorHeightRef.current));
+      } catch {
+        // Storage unavailable — height is already correct in state, just don't persist.
+      }
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
     }
@@ -242,8 +250,14 @@ export function QueryWorkspace() {
 
   // ─── Init ─────────────────────────────────────────────────────────────────────
 
-  // Load persisted data once the connection is known
+  // When the connection changes, clear any result/error state that belongs to
+  // the previous budget, then load the new budget's history and saved queries.
   useEffect(() => {
+    setResult(null);
+    setRunError(null);
+    setLastExecutedRequest(null);
+    setExecTime(null);
+    setPayloadBytes(null);
     if (!connection) return;
     setHistory(getHistory(connection.budgetSyncId));
     setSavedQueries(getSavedQueries(connection.budgetSyncId));
@@ -287,6 +301,17 @@ export function QueryWorkspace() {
       // changes that occur while the request is in flight.
       const capturedBudgetId = connection.budgetSyncId;
 
+      // Snapshot the current request before the async gap so it is available
+      // for cURL generation on both the success and the error path.
+      setLastExecutedRequest({
+        query: parsed.inner,
+        rawQuery: queryString,
+        baseUrl: connection.baseUrl,
+        budgetSyncId: connection.budgetSyncId,
+        apiKey: connection.apiKey,
+        encryptionPassword: connection.encryptionPassword,
+      });
+
       const start = Date.now();
       try {
         const response = await runQuery<{ data: unknown }>(
@@ -302,14 +327,6 @@ export function QueryWorkspace() {
         setPayloadBytes(
           new TextEncoder().encode(JSON.stringify(response.data)).length
         );
-        setLastExecutedRequest({
-          query: parsed.inner,
-          rawQuery: queryString,
-          baseUrl: connection.baseUrl,
-          budgetSyncId: connection.budgetSyncId,
-          apiKey: connection.apiKey,
-          encryptionPassword: connection.encryptionPassword,
-        });
         addToHistory(connection.budgetSyncId, queryString, {
           execTime: elapsed,
           rowCount: Array.isArray(response.data) ? response.data.length : undefined,

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { toast } from "sonner";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { useStagedStore, selectHasChanges } from "@/store/staged";
+import { runQuery } from "@/lib/api/query";
+import { cn } from "@/lib/utils";
+import { QueryEditor } from "./QueryEditor";
+import { QueryResults } from "./QueryResults";
+import { HistoryPanel, SavedPanel } from "./SavedQueryList";
+import { SaveQueryDialog } from "./SaveQueryDialog";
+import { QueryExamplesPanel } from "./QueryExamplesPanel";
+import { QueryExplanationPanel } from "./QueryExplanationPanel";
+import { QueryLintPanel } from "./QueryLintPanel";
+import { QueryReferenceDialog } from "./QueryReferenceDialog";
+import { parseQuery, lintQuery } from "../lib/queryValidation";
+import { formatJson } from "../lib/queryFormatting";
+import { explainQuery } from "../lib/queryExplain";
+import {
+  getHistory,
+  addToHistory,
+  clearHistory,
+  getSavedQueries,
+  saveQuery,
+  updateSavedQuery,
+  deleteSavedQuery,
+  duplicateSavedQuery,
+} from "../lib/queryStorage";
+import type { SavedQuery, QueryHistoryEntry, LintWarning, LastExecutedRequest } from "../types";
+
+const DEFAULT_QUERY =
+  '{\n  "ActualQLquery": {\n    "table": "transactions",\n    "limit": 10\n  }\n}';
+
+// ─── Left panel tab layout ────────────────────────────────────────────────────
+
+type LeftTab = "examples" | "history" | "saved";
+
+interface LeftPanelProps {
+  history: QueryHistoryEntry[];
+  savedQueries: SavedQuery[];
+  onLoad: (query: string) => void;
+  onLoadAndRun: (query: string) => void;
+  onDelete: (id: string) => void;
+  onToggleFavorite: (id: string) => void;
+  onRename: (id: string, name: string) => void;
+  onDuplicate: (id: string) => void;
+  onClearHistory: () => void;
+}
+
+function LeftPanel({
+  history,
+  savedQueries,
+  onLoad,
+  onLoadAndRun,
+  onDelete,
+  onToggleFavorite,
+  onRename,
+  onDuplicate,
+  onClearHistory,
+}: LeftPanelProps) {
+  const [activeTab, setActiveTab] = useState<LeftTab>("examples");
+
+  const tabs: { id: LeftTab; label: string; count?: number }[] = [
+    { id: "examples", label: "Examples" },
+    { id: "history", label: "History", count: history.length || undefined },
+    {
+      id: "saved",
+      label: "Saved",
+      count: savedQueries.length || undefined,
+    },
+  ];
+
+  return (
+    <aside className="flex w-96 shrink-0 flex-col overflow-hidden border-r border-border">
+      {/* Tab bar */}
+      <div className="flex shrink-0 border-b border-border">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "flex flex-1 items-center justify-center gap-1 px-2 py-2 text-[11px] font-medium transition-colors",
+              activeTab === tab.id
+                ? "border-b-2 border-primary text-foreground"
+                : "border-b-2 border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span
+                className={cn(
+                  "rounded-full px-1 py-px text-[10px] leading-none tabular-nums",
+                  activeTab === tab.id
+                    ? "bg-primary/15 text-primary"
+                    : "bg-muted text-muted-foreground"
+                )}
+              >
+                {tab.count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab header (for panels that need an action bar) */}
+      {activeTab === "history" && history.length > 0 && (
+        <div className="flex shrink-0 items-center justify-between border-b border-border/60 px-3 py-1.5">
+          <span className="text-[10px] text-muted-foreground/60">
+            {history.length} entr{history.length !== 1 ? "ies" : "y"}
+          </span>
+          <button
+            type="button"
+            title="Clear history"
+            onClick={onClearHistory}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground/60 transition-colors hover:text-destructive"
+          >
+            <X className="h-3 w-3" />
+            Clear
+          </button>
+        </div>
+      )}
+
+      {activeTab === "saved" && savedQueries.length > 0 && (
+        <div className="flex shrink-0 items-center border-b border-border/60 px-3 py-1.5">
+          <span className="text-[10px] text-muted-foreground/60">
+            {savedQueries.length} saved · local to this browser
+          </span>
+        </div>
+      )}
+
+      {/* Tab content */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {activeTab === "examples" && (
+          <QueryExamplesPanel onInsert={onLoad} />
+        )}
+        {activeTab === "history" && (
+          <HistoryPanel
+            history={history}
+            onLoad={onLoad}
+            onLoadAndRun={onLoadAndRun}
+          />
+        )}
+        {activeTab === "saved" && (
+          <SavedPanel
+            savedQueries={savedQueries}
+            onLoad={onLoad}
+            onLoadAndRun={onLoadAndRun}
+            onDelete={onDelete}
+            onToggleFavorite={onToggleFavorite}
+            onRename={onRename}
+            onDuplicate={onDuplicate}
+          />
+        )}
+      </div>
+
+      {/* Footer — only shown on Examples tab */}
+      {activeTab === "examples" && (
+        <div className="shrink-0 border-t border-border px-3 py-2 text-[10px] text-muted-foreground/50">
+          Click an example to load it into the editor.
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export function QueryWorkspace() {
+  const connection = useConnectionStore(selectActiveInstance);
+  const hasChanges = useStagedStore(selectHasChanges);
+
+  // ─── Core state ───────────────────────────────────────────────────────────────
+  const [editorValue, setEditorValue] = useState(DEFAULT_QUERY);
+  const [result, setResult] = useState<unknown | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [lintWarnings, setLintWarnings] = useState<LintWarning[]>([]);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveDefaultName, setSaveDefaultName] = useState("");
+  const [history, setHistory] = useState<QueryHistoryEntry[]>([]);
+  const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
+
+  // ─── Phase 2 state ────────────────────────────────────────────────────────────
+  const [lastExecutedRequest, setLastExecutedRequest] =
+    useState<LastExecutedRequest | null>(null);
+  const [execTime, setExecTime] = useState<number | null>(null);
+  const [payloadBytes, setPayloadBytes] = useState<number | null>(null);
+  const [explainLines, setExplainLines] = useState<string[]>([]);
+  const [showExplanation, setShowExplanation] = useState(false);
+  const [referenceOpen, setReferenceOpen] = useState(false);
+
+  // ─── Resizable split ──────────────────────────────────────────────────────────
+  const EDITOR_HEIGHT_KEY = "actualql-editor-height";
+  const MIN_HEIGHT = 120;
+  const DEFAULT_HEIGHT = 220;
+
+  const [editorHeight, setEditorHeight] = useState<number>(() => {
+    if (typeof window === "undefined") return DEFAULT_HEIGHT;
+    const stored = sessionStorage.getItem(EDITOR_HEIGHT_KEY);
+    if (!stored) return DEFAULT_HEIGHT;
+    const parsed = parseInt(stored, 10);
+    return isNaN(parsed) ? DEFAULT_HEIGHT : Math.max(MIN_HEIGHT, parsed);
+  });
+
+  const mainAreaRef = useRef<HTMLDivElement>(null);
+  // Mirror editorHeight in a ref so the drag closure always reads the latest value.
+  const editorHeightRef = useRef(editorHeight);
+  // Snapshot of editor content before a programmatic load — enables toast + Ctrl+Z undo.
+  const prevEditorValueRef = useRef<string>("");
+  useEffect(() => { editorHeightRef.current = editorHeight; }, [editorHeight]);
+
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const startY = e.clientY;
+    const startHeight = editorHeightRef.current;
+
+    function onMove(ev: MouseEvent) {
+      const containerH = mainAreaRef.current?.clientHeight ?? 600;
+      const next = Math.max(
+        MIN_HEIGHT,
+        Math.min(startHeight + (ev.clientY - startY), containerH - MIN_HEIGHT)
+      );
+      setEditorHeight(next);
+    }
+
+    function onUp() {
+      sessionStorage.setItem(EDITOR_HEIGHT_KEY, String(editorHeightRef.current));
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    }
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, []);
+
+  // ─── Init ─────────────────────────────────────────────────────────────────────
+
+  // Load persisted data once the connection is known
+  useEffect(() => {
+    if (!connection) return;
+    setHistory(getHistory(connection.budgetSyncId));
+    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+  }, [connection]);
+
+  // Lint as the user types — parse errors suppress lint warnings
+  useEffect(() => {
+    const parsed = parseQuery(editorValue);
+    if (parsed instanceof Error) {
+      setLintWarnings([]);
+      return;
+    }
+    setLintWarnings(lintQuery(parsed.inner));
+  }, [editorValue]);
+
+  // ─── Core execution ──────────────────────────────────────────────────────────
+
+  const executeQuery = useCallback(
+    async (queryString: string) => {
+      if (!connection) {
+        toast.error("No active connection.");
+        return;
+      }
+      const parsed = parseQuery(queryString);
+      if (parsed instanceof Error) {
+        setParseError(parsed.message);
+        return;
+      }
+      setParseError(null);
+      setIsRunning(true);
+      setRunError(null);
+      setShowExplanation(false);
+
+      const start = Date.now();
+      try {
+        const response = await runQuery<{ data: unknown }>(
+          connection,
+          parsed.body
+        );
+        const elapsed = Date.now() - start;
+        setResult(response.data);
+        setExecTime(elapsed);
+        setPayloadBytes(
+          new TextEncoder().encode(JSON.stringify(response.data)).length
+        );
+        setLastExecutedRequest({
+          query: parsed.inner,
+          rawQuery: queryString,
+          baseUrl: connection.baseUrl,
+          budgetSyncId: connection.budgetSyncId,
+          apiKey: connection.apiKey,
+          encryptionPassword: connection.encryptionPassword,
+        });
+        addToHistory(connection.budgetSyncId, queryString, {
+          execTime: elapsed,
+          rowCount: Array.isArray(response.data) ? response.data.length : undefined,
+        });
+        setHistory(getHistory(connection.budgetSyncId));
+      } catch (err) {
+        setExecTime(Date.now() - start);
+        setPayloadBytes(null);
+        const msg =
+          err instanceof Error
+            ? err.message
+            : typeof err === "object" && err !== null && "message" in err
+              ? String((err as { message: unknown }).message)
+              : "Query failed.";
+        setRunError(msg);
+        setResult(null);
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [connection]
+  );
+
+  // ─── Editor actions ──────────────────────────────────────────────────────────
+
+  const handleRun = useCallback(
+    () => executeQuery(editorValue),
+    [executeQuery, editorValue]
+  );
+
+  const handleFormat = useCallback(() => {
+    setEditorValue((prev) => formatJson(prev));
+  }, []);
+
+  const handleSave = useCallback(() => {
+    const parsed = parseQuery(editorValue);
+    setSaveDefaultName(
+      parsed instanceof Error ? "" : `${parsed.inner.table} query`
+    );
+    setSaveDialogOpen(true);
+  }, [editorValue]);
+
+  const handleExplain = useCallback(() => {
+    const parsed = parseQuery(editorValue);
+    if (parsed instanceof Error) {
+      toast.error("Fix the query error before explaining.");
+      return;
+    }
+    setExplainLines(explainQuery(parsed.inner));
+    setShowExplanation(true);
+  }, [editorValue]);
+
+  const handleCopyQuery = useCallback(() => {
+    navigator.clipboard
+      .writeText(editorValue)
+      .then(() => toast.success("Query copied to clipboard"))
+      .catch(() => toast.error("Failed to copy"));
+  }, [editorValue]);
+
+  // Restores the editor to the state it was in before the last programmatic load.
+  // Called either by the toast Undo button or the Ctrl+Z intercept in JsonEditor.
+  const handleUndo = useCallback(() => {
+    const prev = prevEditorValueRef.current;
+    if (!prev) return;
+    prevEditorValueRef.current = "";
+    setEditorValue(prev);
+    setParseError(null);
+    toast.dismiss();
+  }, []);
+
+  function handleSaveConfirm(name: string) {
+    if (!connection) return;
+    saveQuery(connection.budgetSyncId, name, editorValue);
+    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+    toast.success(`Saved "${name}"`);
+  }
+
+  // ─── Sidebar actions ─────────────────────────────────────────────────────────
+
+  function handleLoad(query: string) {
+    prevEditorValueRef.current = editorValue;
+    setEditorValue(query);
+    setParseError(null);
+    setShowExplanation(false);
+    toast("Query loaded", {
+      action: { label: "Undo", onClick: handleUndo },
+      duration: 6000,
+    });
+  }
+
+  function handleLoadAndRun(query: string) {
+    prevEditorValueRef.current = editorValue;
+    setEditorValue(query);
+    setParseError(null);
+    setShowExplanation(false);
+    toast("Query loaded", {
+      action: { label: "Undo", onClick: handleUndo },
+      duration: 6000,
+    });
+    void executeQuery(query);
+  }
+
+  function handleDeleteSaved(id: string) {
+    if (!connection) return;
+    deleteSavedQuery(connection.budgetSyncId, id);
+    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+  }
+
+  function handleToggleFavorite(id: string) {
+    if (!connection) return;
+    const q = savedQueries.find((s) => s.id === id);
+    if (!q) return;
+    updateSavedQuery(connection.budgetSyncId, id, { isFavorite: !q.isFavorite });
+    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+  }
+
+  function handleRenameSaved(id: string, name: string) {
+    if (!connection) return;
+    updateSavedQuery(connection.budgetSyncId, id, { name });
+    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+  }
+
+  function handleDuplicateSaved(id: string) {
+    if (!connection) return;
+    duplicateSavedQuery(connection.budgetSyncId, id);
+    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+  }
+
+  function handleClearHistory() {
+    if (!connection) return;
+    clearHistory(connection.budgetSyncId);
+    setHistory([]);
+  }
+
+  // ─── Guard ───────────────────────────────────────────────────────────────────
+
+  if (!connection) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        No active connection. Connect to a budget first.
+      </div>
+    );
+  }
+
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      {/* ── Left panel: tabbed (Examples / History / Saved) ─────────────── */}
+      <LeftPanel
+        history={history}
+        savedQueries={savedQueries}
+        onLoad={handleLoad}
+        onLoadAndRun={handleLoadAndRun}
+        onDelete={handleDeleteSaved}
+        onToggleFavorite={handleToggleFavorite}
+        onRename={handleRenameSaved}
+        onDuplicate={handleDuplicateSaved}
+        onClearHistory={handleClearHistory}
+      />
+
+      {/* ── Main area ────────────────────────────────────────────────────── */}
+      <div ref={mainAreaRef} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* Page toolbar */}
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
+          <h1 className="text-sm font-semibold">ActualQL Queries</h1>
+          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground/70">
+            dev
+          </span>
+        </div>
+
+        {/* Staged-changes banner */}
+        {hasChanges && (
+          <div className="flex shrink-0 items-center gap-2 border-b border-amber-400/30 bg-amber-50/80 px-4 py-2 text-xs text-amber-800 dark:border-amber-600/30 dark:bg-amber-950/30 dark:text-amber-300">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            You have unsaved staged changes. Query results reflect saved server
+            state, not your staged edits.
+          </div>
+        )}
+
+        {/* ── Editor section (shrink-0, height controlled by drag) ───────── */}
+        <div className="flex shrink-0 flex-col">
+          <QueryEditor
+            value={editorValue}
+            onChange={setEditorValue}
+            onRun={handleRun}
+            onFormat={handleFormat}
+            onSave={handleSave}
+            onExplain={handleExplain}
+            onCopyQuery={handleCopyQuery}
+            onOpenReference={() => setReferenceOpen(true)}
+            onUndo={prevEditorValueRef.current ? handleUndo : undefined}
+            isRunning={isRunning}
+            parseError={parseError}
+            editorHeight={editorHeight}
+          />
+
+          {/* Lint warnings */}
+          <QueryLintPanel warnings={lintWarnings} />
+
+          {/* Explanation panel */}
+          {showExplanation && explainLines.length > 0 && (
+            <QueryExplanationPanel
+              lines={explainLines}
+              onClose={() => setShowExplanation(false)}
+            />
+          )}
+        </div>
+
+        {/* ── Drag handle ──────────────────────────────────────────────────── */}
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize editor"
+          onMouseDown={handleDragStart}
+          className="group flex shrink-0 cursor-ns-resize items-center justify-center border-b border-border py-px transition-colors hover:bg-accent/40 select-none"
+        >
+          <div className="h-px w-8 rounded-full bg-border transition-colors group-hover:bg-muted-foreground/40" />
+        </div>
+
+        {/* ── Results (takes remaining space) ──────────────────────────────── */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <QueryResults
+            result={result}
+            isRunning={isRunning}
+            error={runError}
+            lastRequest={lastExecutedRequest}
+            execTime={execTime}
+            payloadBytes={payloadBytes}
+          />
+        </div>
+      </div>
+
+      {/* Save dialog */}
+      <SaveQueryDialog
+        open={saveDialogOpen}
+        onClose={() => setSaveDialogOpen(false)}
+        onSave={handleSaveConfirm}
+        defaultName={saveDefaultName}
+      />
+
+      {/* Quick reference dialog */}
+      <QueryReferenceDialog
+        open={referenceOpen}
+        onClose={() => setReferenceOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/features/query/components/SaveQueryDialog.tsx
+++ b/src/features/query/components/SaveQueryDialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface SaveQueryDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (name: string) => void;
+  defaultName?: string;
+}
+
+export function SaveQueryDialog({
+  open,
+  onClose,
+  onSave,
+  defaultName = "",
+}: SaveQueryDialogProps) {
+  const [name, setName] = useState(defaultName);
+
+  // Reset name when the dialog transitions from closed → open.
+  // Uses React's "setState during render on prop change" pattern to avoid
+  // setState inside useEffect (react-hooks/set-state-in-effect).
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setName(defaultName);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSave(trimmed);
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Save query</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="query-name">Name</Label>
+            <Input
+              id="query-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Uncategorized transactions"
+              autoFocus
+            />
+          </div>
+          <DialogFooter showCloseButton>
+            <Button type="submit" size="sm" disabled={!name.trim()}>
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/query/components/SavedQueryList.tsx
+++ b/src/features/query/components/SavedQueryList.tsx
@@ -44,7 +44,8 @@ function formatExecTime(ms: number): string {
 function deriveOperationLabel(query: string): string {
   try {
     const parsed = JSON.parse(query) as Record<string, unknown>;
-    const inner = parsed.ActualQLquery as Record<string, unknown> | undefined;
+    // Accept both the wrapped { ActualQLquery: {...} } format and bare query objects.
+    const inner = (parsed.ActualQLquery ?? parsed) as Record<string, unknown>;
     if (!inner || typeof inner.table !== "string") return "query";
 
     const table = inner.table;
@@ -131,7 +132,6 @@ function HistoryItem({
   onLoad: () => void;
   onRun: () => void;
 }) {
-  const [hovered, setHovered] = useState(false);
   const label = deriveOperationLabel(entry.query);
 
   // Build the metadata line: "47 rows · 142ms" (only fields that exist)
@@ -150,8 +150,6 @@ function HistoryItem({
         "group flex items-start gap-1 border-l-2 border-transparent px-2 py-1.5 transition-colors",
         "hover:border-primary/40 hover:bg-accent/60"
       )}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
     >
       <button
         type="button"
@@ -175,16 +173,14 @@ function HistoryItem({
           </div>
         )}
       </button>
-      {hovered && (
-        <div className="flex shrink-0 items-center">
-          <ActionButton title="Load and run" onClick={onRun}>
-            <Play className="h-3 w-3" />
-          </ActionButton>
-          <ActionButton title="Copy query JSON" onClick={() => copyQuery(entry.query)}>
-            <Copy className="h-3 w-3" />
-          </ActionButton>
-        </div>
-      )}
+      <div className="flex shrink-0 items-center opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto">
+        <ActionButton title="Load and run" onClick={onRun}>
+          <Play className="h-3 w-3" />
+        </ActionButton>
+        <ActionButton title="Copy query JSON" onClick={() => copyQuery(entry.query)}>
+          <Copy className="h-3 w-3" />
+        </ActionButton>
+      </div>
     </div>
   );
 }
@@ -208,7 +204,6 @@ function SavedItem({
   onRename: (name: string) => void;
   onDuplicate: () => void;
 }) {
-  const [hovered, setHovered] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(query.name);
 
@@ -234,9 +229,7 @@ function SavedItem({
         "group flex items-center gap-1 border-l-2 border-transparent px-2 py-1.5 transition-colors",
         "hover:border-primary/40 hover:bg-accent/60"
       )}
-      onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => {
-        setHovered(false);
         if (isRenaming) submitRename();
       }}
     >
@@ -266,8 +259,8 @@ function SavedItem({
         </button>
       )}
 
-      {hovered && !isRenaming && (
-        <div className="flex shrink-0 items-center">
+      {!isRenaming && (
+        <div className="flex shrink-0 items-center opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto">
           <ActionButton title="Load and run" onClick={onRun}>
             <Play className="h-3 w-3" />
           </ActionButton>

--- a/src/features/query/components/SavedQueryList.tsx
+++ b/src/features/query/components/SavedQueryList.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useState } from "react";
+import { Star, Trash2, Copy, Play, Pencil, CopyPlus } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import type { SavedQuery, QueryHistoryEntry } from "../types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+function copyQuery(query: string) {
+  navigator.clipboard
+    .writeText(query)
+    .then(() => toast.success("Query JSON copied"))
+    .catch(() => toast.error("Failed to copy"));
+}
+
+function formatExecTime(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(2)}s`;
+}
+
+/**
+ * Derives a short human-readable operation label from a raw ActualQL JSON string.
+ * Priority: calculate > groupBy > filter > limit > table name only.
+ *
+ * Examples:
+ *   "transactions · calculate"
+ *   "transactions · grouped by payee"
+ *   "transactions · filtered"
+ *   "transactions · limit 20"
+ *   "payees"
+ */
+function deriveOperationLabel(query: string): string {
+  try {
+    const parsed = JSON.parse(query) as Record<string, unknown>;
+    const inner = parsed.ActualQLquery as Record<string, unknown> | undefined;
+    if (!inner || typeof inner.table !== "string") return "query";
+
+    const table = inner.table;
+
+    if (inner.calculate) {
+      return `${table} · calculate`;
+    }
+
+    if (Array.isArray(inner.groupBy) && inner.groupBy.length > 0) {
+      // Take the first entry that has no dot (the ID field, not the name path).
+      const field =
+        (inner.groupBy as string[]).find((f) => !f.includes(".")) ??
+        String(inner.groupBy[0]).split(".")[0];
+      return `${table} · grouped by ${field}`;
+    }
+
+    if (
+      inner.filter &&
+      typeof inner.filter === "object" &&
+      Object.keys(inner.filter).length > 0
+    ) {
+      return `${table} · filtered`;
+    }
+
+    if (typeof inner.limit === "number") {
+      return `${table} · limit ${inner.limit}`;
+    }
+
+    return table;
+  } catch {
+    return "query";
+  }
+}
+
+// ─── Shared icon button ───────────────────────────────────────────────────────
+
+export function ActionButton({
+  title,
+  onClick,
+  children,
+  className,
+}: {
+  title: string;
+  onClick: (e: React.MouseEvent) => void;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick(e);
+      }}
+      className={cn(
+        "rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-foreground",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ─── Sub-section label (used within Saved tab for Favorites vs. All) ──────────
+
+function SubLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-3 mb-0.5 mt-3 border-t border-border pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 first:mt-1 first:border-0 first:pt-0">
+      {children}
+    </div>
+  );
+}
+
+// ─── History item ─────────────────────────────────────────────────────────────
+
+function HistoryItem({
+  entry,
+  onLoad,
+  onRun,
+}: {
+  entry: QueryHistoryEntry;
+  onLoad: () => void;
+  onRun: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const label = deriveOperationLabel(entry.query);
+
+  // Build the metadata line: "47 rows · 142ms" (only fields that exist)
+  const metaParts: string[] = [];
+  if (entry.rowCount !== undefined) {
+    metaParts.push(`${entry.rowCount} row${entry.rowCount !== 1 ? "s" : ""}`);
+  }
+  if (entry.execTime !== undefined) {
+    metaParts.push(formatExecTime(entry.execTime));
+  }
+  const metaLine = metaParts.join(" · ");
+
+  return (
+    <div
+      className={cn(
+        "group flex items-start gap-1 border-l-2 border-transparent px-2 py-1.5 transition-colors",
+        "hover:border-primary/40 hover:bg-accent/60"
+      )}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <button
+        type="button"
+        onClick={onLoad}
+        title={entry.query}
+        className="min-w-0 flex-1 text-left"
+      >
+        {/* Primary line: operation label + timestamp */}
+        <div className="flex items-baseline gap-1.5">
+          <span className="truncate font-mono text-[11px] leading-snug text-foreground/90">
+            {label}
+          </span>
+          <span className="shrink-0 font-sans text-[10px] text-muted-foreground/50">
+            {formatTime(entry.executedAt)}
+          </span>
+        </div>
+        {/* Secondary line: row count + exec time */}
+        {metaLine && (
+          <div className="mt-0.5 text-[10px] leading-relaxed text-muted-foreground/60">
+            {metaLine}
+          </div>
+        )}
+      </button>
+      {hovered && (
+        <div className="flex shrink-0 items-center">
+          <ActionButton title="Load and run" onClick={onRun}>
+            <Play className="h-3 w-3" />
+          </ActionButton>
+          <ActionButton title="Copy query JSON" onClick={() => copyQuery(entry.query)}>
+            <Copy className="h-3 w-3" />
+          </ActionButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Saved query item ─────────────────────────────────────────────────────────
+
+function SavedItem({
+  query,
+  onLoad,
+  onRun,
+  onDelete,
+  onToggleFavorite,
+  onRename,
+  onDuplicate,
+}: {
+  query: SavedQuery;
+  onLoad: () => void;
+  onRun: () => void;
+  onDelete: () => void;
+  onToggleFavorite: () => void;
+  onRename: (name: string) => void;
+  onDuplicate: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(query.name);
+
+  function submitRename() {
+    const trimmed = renameValue.trim();
+    if (trimmed && trimmed !== query.name) {
+      onRename(trimmed);
+    } else {
+      setRenameValue(query.name);
+    }
+    setIsRenaming(false);
+  }
+
+  function startRename(e: React.MouseEvent) {
+    e.stopPropagation();
+    setRenameValue(query.name);
+    setIsRenaming(true);
+  }
+
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-1 border-l-2 border-transparent px-2 py-1.5 transition-colors",
+        "hover:border-primary/40 hover:bg-accent/60"
+      )}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => {
+        setHovered(false);
+        if (isRenaming) submitRename();
+      }}
+    >
+      {isRenaming ? (
+        <input
+          autoFocus
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          onBlur={submitRename}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") { e.preventDefault(); submitRename(); }
+            if (e.key === "Escape") {
+              setRenameValue(query.name);
+              setIsRenaming(false);
+            }
+          }}
+          className="flex-1 min-w-0 rounded border border-input bg-transparent px-1 py-px font-sans text-[11px] text-foreground outline-none focus:border-ring"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={onLoad}
+          title={query.name}
+          className="flex-1 truncate text-left text-[11px] leading-relaxed text-foreground/90"
+        >
+          {query.name}
+        </button>
+      )}
+
+      {hovered && !isRenaming && (
+        <div className="flex shrink-0 items-center">
+          <ActionButton title="Load and run" onClick={onRun}>
+            <Play className="h-3 w-3" />
+          </ActionButton>
+          <ActionButton
+            title={query.isFavorite ? "Unpin favorite" : "Pin as favorite"}
+            onClick={onToggleFavorite}
+            className={query.isFavorite ? "text-amber-500" : undefined}
+          >
+            <Star
+              className="h-3 w-3"
+              fill={query.isFavorite ? "currentColor" : "none"}
+            />
+          </ActionButton>
+          <ActionButton title="Rename" onClick={startRename}>
+            <Pencil className="h-3 w-3" />
+          </ActionButton>
+          <ActionButton title="Duplicate" onClick={onDuplicate}>
+            <CopyPlus className="h-3 w-3" />
+          </ActionButton>
+          <ActionButton title="Copy query JSON" onClick={() => copyQuery(query.query)}>
+            <Copy className="h-3 w-3" />
+          </ActionButton>
+          <ActionButton
+            title="Delete"
+            onClick={onDelete}
+            className="hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </ActionButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── HistoryPanel ─────────────────────────────────────────────────────────────
+
+interface HistoryPanelProps {
+  history: QueryHistoryEntry[];
+  onLoad: (query: string) => void;
+  onLoadAndRun: (query: string) => void;
+}
+
+export function HistoryPanel({ history, onLoad, onLoadAndRun }: HistoryPanelProps) {
+  if (history.length === 0) {
+    return (
+      <div className="px-3 py-6 text-center text-[11px] text-muted-foreground/60">
+        No history yet. Run a query to see it here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col text-xs">
+      {history.map((entry) => (
+        <HistoryItem
+          key={entry.id}
+          entry={entry}
+          onLoad={() => onLoad(entry.query)}
+          onRun={() => onLoadAndRun(entry.query)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ─── SavedPanel ───────────────────────────────────────────────────────────────
+
+interface SavedPanelProps {
+  savedQueries: SavedQuery[];
+  onLoad: (query: string) => void;
+  onLoadAndRun: (query: string) => void;
+  onDelete: (id: string) => void;
+  onToggleFavorite: (id: string) => void;
+  onRename: (id: string, name: string) => void;
+  onDuplicate: (id: string) => void;
+}
+
+export function SavedPanel({
+  savedQueries,
+  onLoad,
+  onLoadAndRun,
+  onDelete,
+  onToggleFavorite,
+  onRename,
+  onDuplicate,
+}: SavedPanelProps) {
+  const favorites = savedQueries.filter((q) => q.isFavorite);
+  const regular = savedQueries.filter((q) => !q.isFavorite);
+
+  if (savedQueries.length === 0) {
+    return (
+      <div className="px-3 py-6 text-center text-[11px] text-muted-foreground/60">
+        No saved queries yet. Run a query and click Save.
+      </div>
+    );
+  }
+
+  function renderItem(q: SavedQuery) {
+    return (
+      <SavedItem
+        key={q.id}
+        query={q}
+        onLoad={() => onLoad(q.query)}
+        onRun={() => onLoadAndRun(q.query)}
+        onDelete={() => onDelete(q.id)}
+        onToggleFavorite={() => onToggleFavorite(q.id)}
+        onRename={(name) => onRename(q.id, name)}
+        onDuplicate={() => onDuplicate(q.id)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col text-xs">
+      {favorites.length > 0 && (
+        <>
+          <SubLabel>Favorites</SubLabel>
+          {favorites.map(renderItem)}
+        </>
+      )}
+      {regular.length > 0 && (
+        <>
+          {favorites.length > 0 && <SubLabel>All saved</SubLabel>}
+          {regular.map(renderItem)}
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/src/features/query/lib/jsonColorize.ts
+++ b/src/features/query/lib/jsonColorize.ts
@@ -1,0 +1,86 @@
+/**
+ * Lightweight JSON syntax colorizer.
+ *
+ * Accepts a single line of pretty-printed JSON and returns an HTML string
+ * with <span> wrappers that apply CSS custom property colors per token type.
+ *
+ * Used by:
+ *   - RawView in QueryResults (results raw view)
+ *   - JsonEditor overlay in Batch 3 (editor syntax coloring)
+ *
+ * Token colors are driven by CSS custom properties defined in globals.css
+ * (--json-key, --json-string, --json-number, --json-boolean, --json-null,
+ * --json-punct) so they respond to the dark-mode variant automatically.
+ *
+ * XSS safety: all token content is HTML-escaped before being placed inside
+ * <span> tags. The HTML is only used via dangerouslySetInnerHTML in controlled
+ * display components, never in user-facing input fields.
+ */
+
+// Matches JSON tokens in order of specificity.
+// Group 1: string token
+// Group 2: optional whitespace + colon following a string (marks it as a key)
+// Group 3: boolean / null literal
+// Group 4: number
+// Group 5: punctuation character
+// Group 6: whitespace (passed through uncolored)
+const TOKEN_RE =
+  /("(?:\\u[a-fA-F0-9]{4}|\\[^u]|[^"\\])*")(\s*:)?|(true|false|null)|(-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)|([{}[\],:])|(\s+)/g;
+
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function span(cssVar: string, content: string): string {
+  return `<span style="color:var(--${cssVar})">${escapeHtml(content)}</span>`;
+}
+
+export function colorizeJson(line: string): string {
+  let result = "";
+  let lastIndex = 0;
+
+  TOKEN_RE.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = TOKEN_RE.exec(line)) !== null) {
+    // Pass through any gap between matches as escaped plain text
+    if (match.index > lastIndex) {
+      result += escapeHtml(line.slice(lastIndex, match.index));
+    }
+    lastIndex = TOKEN_RE.lastIndex;
+
+    const [, strToken, colonSuffix, literal, number, punct, whitespace] = match;
+
+    if (strToken !== undefined) {
+      if (colonSuffix !== undefined) {
+        // Object key — strToken is "key", colonSuffix may be " :" or ":"
+        result += span("json-key", strToken);
+        // Preserve any whitespace between the string and the colon
+        const ws = colonSuffix.slice(0, colonSuffix.indexOf(":"));
+        if (ws) result += escapeHtml(ws);
+        result += span("json-punct", ":");
+      } else {
+        result += span("json-string", strToken);
+      }
+    } else if (literal !== undefined) {
+      result += span(literal === "null" ? "json-null" : "json-boolean", literal);
+    } else if (number !== undefined) {
+      result += span("json-number", number);
+    } else if (punct !== undefined) {
+      result += span("json-punct", punct);
+    } else if (whitespace !== undefined) {
+      result += escapeHtml(whitespace);
+    }
+  }
+
+  // Any remaining unmatched text
+  if (lastIndex < line.length) {
+    result += escapeHtml(line.slice(lastIndex));
+  }
+
+  return result;
+}

--- a/src/features/query/lib/queryCurl.ts
+++ b/src/features/query/lib/queryCurl.ts
@@ -41,12 +41,12 @@ function buildCurl(
     `  -H "x-api-key: ${apiKey}" \\`,
   ];
 
-  if (req.encryptionPassword !== undefined) {
-    const password = sanitize
-      ? "{{BUDGET_ENCRYPTION_PASSWORD}}"
-      : shellEscapeDoubleQuote(req.encryptionPassword);
-    lines.push(`  -H "budget-encryption-password: ${password}" \\`);
-  }
+  // The proxy always sends budget-encryption-password (empty string when unset),
+  // so the cURL output must always include the header to match actual behaviour.
+  const password = sanitize
+    ? "{{BUDGET_ENCRYPTION_PASSWORD}}"
+    : shellEscapeDoubleQuote(req.encryptionPassword ?? "");
+  lines.push(`  -H "budget-encryption-password: ${password}" \\`);
 
   lines.push(`  -d '${body.replace(/'/g, "'\\''")}'`);
 

--- a/src/features/query/lib/queryCurl.ts
+++ b/src/features/query/lib/queryCurl.ts
@@ -11,6 +11,19 @@
 
 import type { LastExecutedRequest } from "../types";
 
+/**
+ * Escapes a value for safe interpolation inside a double-quoted shell string.
+ * Handles: backslash, double-quote, dollar sign, backtick, and newline.
+ */
+function shellEscapeDoubleQuote(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/\n/g, "\\n");
+}
+
 const ENDPOINT_PATH = (budgetSyncId: string) =>
   `/v1/budgets/${budgetSyncId}/run-query`;
 
@@ -20,7 +33,7 @@ function buildCurl(
 ): string {
   const url = `${req.baseUrl.replace(/\/$/, "")}${ENDPOINT_PATH(req.budgetSyncId)}`;
   const body = JSON.stringify({ ActualQLquery: req.query }, null, 2);
-  const apiKey = sanitize ? "{{API_KEY}}" : req.apiKey;
+  const apiKey = sanitize ? "{{API_KEY}}" : shellEscapeDoubleQuote(req.apiKey);
 
   const lines: string[] = [
     `curl -X POST "${url}" \\`,
@@ -31,7 +44,7 @@ function buildCurl(
   if (req.encryptionPassword !== undefined) {
     const password = sanitize
       ? "{{BUDGET_ENCRYPTION_PASSWORD}}"
-      : req.encryptionPassword;
+      : shellEscapeDoubleQuote(req.encryptionPassword);
     lines.push(`  -H "budget-encryption-password: ${password}" \\`);
   }
 

--- a/src/features/query/lib/queryCurl.ts
+++ b/src/features/query/lib/queryCurl.ts
@@ -1,0 +1,49 @@
+/**
+ * cURL command generation for the last successfully executed ActualQL request.
+ *
+ * buildSanitizedCurl — default. Replaces secrets with named placeholders.
+ * buildFullCurl      — includes real credentials. Must only be shown on
+ *                      explicit opt-in with a warning about sensitive data.
+ *
+ * Always generated from the last successful request snapshot, not from the
+ * current editor state (which may have changed since execution).
+ */
+
+import type { LastExecutedRequest } from "../types";
+
+const ENDPOINT_PATH = (budgetSyncId: string) =>
+  `/v1/budgets/${budgetSyncId}/run-query`;
+
+function buildCurl(
+  req: LastExecutedRequest,
+  sanitize: boolean
+): string {
+  const url = `${req.baseUrl.replace(/\/$/, "")}${ENDPOINT_PATH(req.budgetSyncId)}`;
+  const body = JSON.stringify({ ActualQLquery: req.query }, null, 2);
+  const apiKey = sanitize ? "{{API_KEY}}" : req.apiKey;
+
+  const lines: string[] = [
+    `curl -X POST "${url}" \\`,
+    `  -H "Content-Type: application/json" \\`,
+    `  -H "x-api-key: ${apiKey}" \\`,
+  ];
+
+  if (req.encryptionPassword !== undefined) {
+    const password = sanitize
+      ? "{{BUDGET_ENCRYPTION_PASSWORD}}"
+      : req.encryptionPassword;
+    lines.push(`  -H "budget-encryption-password: ${password}" \\`);
+  }
+
+  lines.push(`  -d '${body.replace(/'/g, "'\\''")}'`);
+
+  return lines.join("\n");
+}
+
+export function buildSanitizedCurl(req: LastExecutedRequest): string {
+  return buildCurl(req, true);
+}
+
+export function buildFullCurl(req: LastExecutedRequest): string {
+  return buildCurl(req, false);
+}

--- a/src/features/query/lib/queryExplain.ts
+++ b/src/features/query/lib/queryExplain.ts
@@ -1,0 +1,186 @@
+/**
+ * Deterministic plain-English explanation of an ActualQL inner query.
+ *
+ * No AI or network dependency — pure structural analysis of the query shape.
+ * Returns an ordered list of sentences that describe what the query does.
+ */
+
+import type { ActualQLQuery } from "../types";
+
+export function explainQuery(query: ActualQLQuery): string[] {
+  const lines: string[] = [];
+
+  // Table
+  lines.push(`Reads from the \`${query.table}\` table.`);
+
+  // Filter
+  if (query.filter && Object.keys(query.filter).length > 0) {
+    lines.push(describeFilter(query.filter));
+  }
+
+  // Select
+  if (query.select) {
+    lines.push(describeSelect(query.select));
+  }
+
+  // groupBy
+  if (query.groupBy && query.groupBy.length > 0) {
+    const fields = query.groupBy.map((f) => `\`${f}\``).join(", ");
+    lines.push(`Groups rows by ${fields}.`);
+  }
+
+  // calculate (scalar)
+  if (query.calculate) {
+    lines.push(describeCalculate(query.calculate));
+  }
+
+  // orderBy
+  if (query.orderBy && query.orderBy.length > 0) {
+    lines.push(describeOrderBy(query.orderBy));
+  }
+
+  // limit / offset
+  if (typeof query.limit === "number") {
+    lines.push(`Returns at most ${query.limit} row${query.limit !== 1 ? "s" : ""}.`);
+  }
+  if (typeof query.offset === "number" && query.offset > 0) {
+    lines.push(`Skips the first ${query.offset} row${query.offset !== 1 ? "s" : ""} (offset).`);
+  }
+
+  // options.splits
+  if (query.options?.splits) {
+    const splitDesc: Record<string, string> = {
+      inline: "shows sub-transactions individually",
+      grouped: "groups sub-transactions under their parent",
+      all: "returns both parent and sub-transactions",
+    };
+    const desc = splitDesc[query.options.splits] ?? query.options.splits;
+    lines.push(`Split behavior is set to \`${query.options.splits}\` — ${desc}.`);
+  }
+
+  // Result type summary
+  if (query.calculate) {
+    lines.push("Returns a single calculated value, not a list of rows.");
+  } else if (query.groupBy?.length) {
+    lines.push("Returns one aggregated row per group.");
+  } else {
+    lines.push("Returns a list of rows.");
+  }
+
+  return lines;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function describeFilter(filter: Record<string, unknown>): string {
+  // Compound operators
+  if ("$and" in filter && Array.isArray(filter["$and"])) {
+    return `Filters rows where ALL of ${filter["$and"].length} conditions match ($and).`;
+  }
+  if ("$or" in filter && Array.isArray(filter["$or"])) {
+    return `Filters rows where ANY of ${filter["$or"].length} conditions match ($or).`;
+  }
+
+  const parts: string[] = [];
+  for (const [field, condition] of Object.entries(filter)) {
+    if (condition === null) {
+      parts.push(`\`${field}\` is null`);
+      continue;
+    }
+    if (typeof condition !== "object" || Array.isArray(condition)) {
+      parts.push(`\`${field}\` = ${JSON.stringify(condition)}`);
+      continue;
+    }
+    const ops = condition as Record<string, unknown>;
+    if ("$oneof" in ops) {
+      const arr = ops["$oneof"];
+      const count = Array.isArray(arr) ? arr.length : "?";
+      parts.push(`\`${field}\` is one of ${count} value${count !== 1 ? "s" : ""}`);
+    } else if ("$gte" in ops && "$lte" in ops) {
+      parts.push(`\`${field}\` between ${String(ops["$gte"])} and ${String(ops["$lte"])}`);
+    } else if ("$gte" in ops) {
+      parts.push(`\`${field}\` ≥ ${String(ops["$gte"])}`);
+    } else if ("$lte" in ops) {
+      parts.push(`\`${field}\` ≤ ${String(ops["$lte"])}`);
+    } else if ("$like" in ops) {
+      parts.push(`\`${field}\` matches pattern ${JSON.stringify(ops["$like"])}`);
+    } else {
+      const opKeys = Object.keys(ops).join(", ");
+      parts.push(`\`${field}\` filtered by ${opKeys}`);
+    }
+  }
+
+  if (parts.length === 0) return "No effective filter conditions.";
+  if (parts.length === 1) return `Filters where ${parts[0]}.`;
+  return `Filters where ${parts.slice(0, -1).join(", ")} and ${parts[parts.length - 1]}.`;
+}
+
+function describeSelect(
+  select: Array<string | Record<string, unknown>> | Record<string, unknown>
+): string {
+  if (!Array.isArray(select)) {
+    return "Selects fields using an object expression.";
+  }
+
+  const simple: string[] = [];
+  const aggregates: string[] = [];
+
+  for (const item of select) {
+    if (typeof item === "string") {
+      simple.push(`\`${item}\``);
+    } else if (typeof item === "object" && item !== null) {
+      for (const [alias, expr] of Object.entries(item)) {
+        if (typeof expr === "object" && expr !== null) {
+          const fn = Object.keys(expr as object)[0];
+          aggregates.push(`\`${alias}\` (${fn})`);
+        } else {
+          aggregates.push(`\`${alias}\``);
+        }
+      }
+    }
+  }
+
+  const parts: string[] = [];
+  if (simple.length > 0) {
+    parts.push(`fields ${simple.join(", ")}`);
+  }
+  if (aggregates.length > 0) {
+    parts.push(`aggregates ${aggregates.join(", ")}`);
+  }
+
+  return `Selects ${parts.join(" and ")}.`;
+}
+
+function describeCalculate(calculate: Record<string, unknown>): string {
+  const fn = Object.keys(calculate)[0];
+  const operand = calculate[fn];
+  const operandStr =
+    typeof operand === "string" ? operand : JSON.stringify(operand);
+
+  const fnNames: Record<string, string> = {
+    $count: "counts",
+    $sum: "sums",
+    $avg: "averages",
+    $min: "finds the minimum of",
+    $max: "finds the maximum of",
+  };
+
+  const desc = fnNames[fn] ?? `computes ${fn} of`;
+  return `Computes a scalar — ${desc} \`${operandStr}\` across matching rows.`;
+}
+
+function describeOrderBy(
+  orderBy: Array<string | Record<string, "asc" | "desc">>
+): string {
+  const parts: string[] = [];
+  for (const item of orderBy) {
+    if (typeof item === "string") {
+      parts.push(`\`${item}\` (asc)`);
+    } else if (typeof item === "object" && item !== null) {
+      for (const [field, dir] of Object.entries(item)) {
+        parts.push(`\`${field}\` (${dir})`);
+      }
+    }
+  }
+  return `Orders results by ${parts.join(", ")}.`;
+}

--- a/src/features/query/lib/queryFormatting.ts
+++ b/src/features/query/lib/queryFormatting.ts
@@ -1,0 +1,51 @@
+/**
+ * Formats a raw JSON string with 2-space indentation.
+ * Returns the original string unchanged if it is not valid JSON.
+ */
+export function formatJson(input: string): string {
+  try {
+    return JSON.stringify(JSON.parse(input), null, 2);
+  } catch {
+    return input;
+  }
+}
+
+// ─── Table cell helpers ───────────────────────────────────────────────────────
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T.*)?$/;
+
+/**
+ * Formats an ISO 8601 date or datetime string as a locale-aware human-readable
+ * date (e.g. "Jan 15, 2024"). Returns null if the value does not match the
+ * pattern or cannot be parsed.
+ *
+ * Date-only strings (YYYY-MM-DD) are parsed at local midnight to avoid UTC
+ * off-by-one-day issues.
+ */
+export function formatIsoDate(v: string): string | null {
+  if (!ISO_DATE_RE.test(v)) return null;
+  try {
+    const d = v.length === 10 ? new Date(`${v}T00:00:00`) : new Date(v);
+    if (isNaN(d.getTime())) return null;
+    return d.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Formats an integer amount stored in cents as a locale-aware decimal string.
+ * No currency symbol is included — the budget currency is not known to the UI.
+ *
+ * Examples: 1200 → "12.00",  -45050 → "-450.50",  0 → "0.00"
+ */
+export function formatCents(v: number): string {
+  return (v / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}

--- a/src/features/query/lib/queryPacks.ts
+++ b/src/features/query/lib/queryPacks.ts
@@ -12,7 +12,12 @@ export type QueryPack = {
   name: string;
   description?: string;
   group: string;
-  query: string; // full wrapped JSON string
+  /**
+   * Full wrapped JSON string, or a factory that produces it at insertion time.
+   * Use a factory for queries that embed dynamic values (e.g. the current month)
+   * so the string is computed fresh when the user clicks the example.
+   */
+  query: string | (() => string);
 };
 
 export type QueryPackGroup = {
@@ -29,8 +34,6 @@ function getCurrentMonth(): string {
   const month = String(now.getMonth() + 1).padStart(2, "0");
   return `${year}-${month}`;
 }
-
-const CURRENT_MONTH = getCurrentMonth();
 
 // ─── Data inspection ──────────────────────────────────────────────────────────
 
@@ -117,7 +120,7 @@ const DATA_INSPECTION: QueryPack[] = [
     name: "Transactions this month",
     description: "Transactions in the current month.",
     group: "data",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -125,7 +128,7 @@ const DATA_INSPECTION: QueryPack[] = [
           filter: {
             date: {
               $transform: "$month",
-              $eq: CURRENT_MONTH,
+              $eq: getCurrentMonth(),
             },
           },
           select: [
@@ -155,7 +158,7 @@ const CLEANUP: QueryPack[] = [
     description:
       "Current-month transactions with no category, excluding transfers and off-budget activity.",
     group: "cleanup",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -165,7 +168,7 @@ const CLEANUP: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { category: null },
@@ -189,7 +192,7 @@ const CLEANUP: QueryPack[] = [
     description:
       "Transaction counts grouped by payee for the current month, excluding transfers and off-budget activity.",
     group: "cleanup",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -199,7 +202,7 @@ const CLEANUP: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { "account.offbudget": false },
@@ -227,7 +230,7 @@ const CLEANUP: QueryPack[] = [
     description:
       "Transaction counts grouped by category for the current month (note: this does not include truly unused categories).",
     group: "cleanup",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -237,7 +240,7 @@ const CLEANUP: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { category: { $ne: null } },
@@ -306,7 +309,7 @@ const AGGREGATION: QueryPack[] = [
     name: "Transactions per payee",
     description: "Count of non-transfer transactions grouped by payee this month.",
     group: "aggregation",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -316,7 +319,7 @@ const AGGREGATION: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { "account.offbudget": false },
@@ -343,7 +346,7 @@ const AGGREGATION: QueryPack[] = [
     description:
       "Total non-transfer transaction amount grouped by category for the current month.",
     group: "aggregation",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -353,7 +356,7 @@ const AGGREGATION: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { category: { $ne: null } },
@@ -381,7 +384,7 @@ const AGGREGATION: QueryPack[] = [
     description:
       "Total non-transfer transaction amount grouped by payee for the current month.",
     group: "aggregation",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -391,7 +394,7 @@ const AGGREGATION: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { "account.offbudget": false },
@@ -418,7 +421,7 @@ const AGGREGATION: QueryPack[] = [
     description:
       "Total non-transfer transaction amount grouped by category group for the current month.",
     group: "aggregation",
-    query: JSON.stringify(
+    query: () => JSON.stringify(
       {
         ActualQLquery: {
           table: "transactions",
@@ -428,7 +431,7 @@ const AGGREGATION: QueryPack[] = [
               {
                 date: {
                   $transform: "$month",
-                  $eq: CURRENT_MONTH,
+                  $eq: getCurrentMonth(),
                 },
               },
               { category: { $ne: null } },

--- a/src/features/query/lib/queryPacks.ts
+++ b/src/features/query/lib/queryPacks.ts
@@ -1,0 +1,604 @@
+/**
+ * Built-in ActualQL example query packs.
+ *
+ * All queries are stored in the full wrapped format that the editor uses:
+ *   { "ActualQLquery": { "table": "...", ... } }
+ *
+ * Grouped by purpose. Each example is insertable into the editor in one click.
+ */
+
+export type QueryPack = {
+  id: string;
+  name: string;
+  description?: string;
+  group: string;
+  query: string; // full wrapped JSON string
+};
+
+export type QueryPackGroup = {
+  id: string;
+  label: string;
+  packs: QueryPack[];
+};
+
+// ─── Dynamic date helpers ─────────────────────────────────────────────────────
+
+function getCurrentMonth(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+const CURRENT_MONTH = getCurrentMonth();
+
+// ─── Data inspection ──────────────────────────────────────────────────────────
+
+const DATA_INSPECTION: QueryPack[] = [
+  {
+    id: "list-payees",
+    name: "List payees",
+    description: "All payees ordered by name.",
+    group: "data",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "payees",
+          select: ["id", "name"],
+          orderBy: ["name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "list-categories",
+    name: "List categories",
+    description: "All categories with their category group.",
+    group: "data",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "categories",
+          select: ["id", "name", "group", "group.name"],
+          orderBy: ["name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "list-schedules",
+    name: "List schedules",
+    description: "All schedules with their next due date.",
+    group: "data",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "schedules",
+          select: ["id", "name", "next_date"],
+          orderBy: ["next_date", "name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "latest-transactions",
+    name: "Latest 20 transactions",
+    description: "The 20 most recent transactions.",
+    group: "data",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          select: [
+            "id",
+            "date",
+            "amount",
+            "payee.name",
+            "category.name",
+            "notes",
+          ],
+          orderBy: [{ date: "desc" }],
+          limit: 20,
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "transactions-this-month",
+    name: "Transactions this month",
+    description: "Transactions in the current month.",
+    group: "data",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            date: {
+              $transform: "$month",
+              $eq: CURRENT_MONTH,
+            },
+          },
+          select: [
+            "id",
+            "date",
+            "amount",
+            "payee.name",
+            "category.name",
+            "notes",
+          ],
+          orderBy: [{ date: "desc" }],
+          limit: 100,
+        },
+      },
+      null,
+      2
+    ),
+  },
+];
+
+// ─── Cleanup / validation ─────────────────────────────────────────────────────
+
+const CLEANUP: QueryPack[] = [
+  {
+    id: "uncategorized-transactions",
+    name: "Uncategorized transactions",
+    description:
+      "Current-month transactions with no category, excluding transfers and off-budget activity.",
+    group: "cleanup",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { category: null },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          select: ["id", "date", "amount", "payee.name", "notes"],
+          orderBy: [{ date: "desc" }],
+          limit: 100,
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "payees-high-transaction-count",
+    name: "Payee transaction counts",
+    description:
+      "Transaction counts grouped by payee for the current month, excluding transfers and off-budget activity.",
+    group: "cleanup",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          groupBy: ["payee", "payee.name"],
+          select: [
+            "payee",
+            "payee.name",
+            { transactionCount: { $count: "$id" } },
+          ],
+          orderBy: ["payee.name"],
+          limit: 20,
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "least-used-categories",
+    name: "Category usage counts",
+    description:
+      "Transaction counts grouped by category for the current month (note: this does not include truly unused categories).",
+    group: "cleanup",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { category: { $ne: null } },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          groupBy: ["category", "category.name"],
+          select: [
+            "category",
+            "category.name",
+            { transactionCount: { $count: "$id" } },
+          ],
+          orderBy: ["category.name"],
+          limit: 20,
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "schedules-missing-linked-rule",
+    name: "Schedules missing linked rule",
+    description: "Schedules that do not appear to have a linked rule.",
+    group: "cleanup",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "schedules",
+          filter: {
+            $or: [{ rule: null }, { rule: "" }],
+          },
+          select: ["id", "name", "next_date", "posts_transaction"],
+          orderBy: ["name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+];
+
+// ─── Aggregation ──────────────────────────────────────────────────────────────
+
+const AGGREGATION: QueryPack[] = [
+  {
+    id: "count-rules",
+    name: "Count rules",
+    description: "Total number of rules defined in the budget.",
+    group: "aggregation",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "rules",
+          calculate: { $count: "$id" },
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "transactions-per-payee",
+    name: "Transactions per payee",
+    description: "Count of non-transfer transactions grouped by payee this month.",
+    group: "aggregation",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          groupBy: ["payee", "payee.name"],
+          select: [
+            "payee",
+            "payee.name",
+            { transactionCount: { $count: "$id" } },
+          ],
+          orderBy: ["payee.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "amount-by-category",
+    name: "Amount by category this month",
+    description:
+      "Total non-transfer transaction amount grouped by category for the current month.",
+    group: "aggregation",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { category: { $ne: null } },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          groupBy: ["category", "category.name"],
+          select: [
+            "category",
+            "category.name",
+            { totalAmount: { $sum: "$amount" } },
+          ],
+          orderBy: ["category.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "amount-by-payee",
+    name: "Amount by payee this month",
+    description:
+      "Total non-transfer transaction amount grouped by payee for the current month.",
+    group: "aggregation",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          groupBy: ["payee", "payee.name"],
+          select: [
+            "payee",
+            "payee.name",
+            { totalAmount: { $sum: "$amount" } },
+          ],
+          orderBy: ["payee.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "amount-by-category-group",
+    name: "Amount by category group this month",
+    description:
+      "Total non-transfer transaction amount grouped by category group for the current month.",
+    group: "aggregation",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            $and: [
+              {
+                date: {
+                  $transform: "$month",
+                  $eq: CURRENT_MONTH,
+                },
+              },
+              { category: { $ne: null } },
+              { "account.offbudget": false },
+              { transfer_id: null },
+              { "payee.transfer_acct": null },
+            ],
+          },
+          groupBy: ["category.group", "category.group.name"],
+          select: [
+            "category.group",
+            "category.group.name",
+            { totalAmount: { $sum: "$amount" } },
+          ],
+          orderBy: ["category.group.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+];
+
+// ─── Targeted subset queries ──────────────────────────────────────────────────
+
+const TARGETED: QueryPack[] = [
+  {
+    id: "count-selected-payees",
+    name: "Count transactions for selected payees",
+    description:
+      "Counts transactions for a sample set of payee IDs. Replace the sample IDs before running.",
+    group: "targeted",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            payee: {
+              $oneof: [
+                "sample-payee-id-1",
+                "sample-payee-id-2",
+                "sample-payee-id-3",
+              ],
+            },
+          },
+          groupBy: ["payee", "payee.name"],
+          select: [
+            "payee",
+            "payee.name",
+            { transactionCount: { $count: "$id" } },
+          ],
+          orderBy: ["payee.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "count-selected-categories",
+    name: "Count transactions for selected categories",
+    description:
+      "Counts transactions for a sample set of category IDs. Replace the sample IDs before running.",
+    group: "targeted",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            category: {
+              $oneof: [
+                "sample-category-id-1",
+                "sample-category-id-2",
+                "sample-category-id-3",
+              ],
+            },
+          },
+          groupBy: ["category", "category.name"],
+          select: [
+            "category",
+            "category.name",
+            { transactionCount: { $count: "$id" } },
+          ],
+          orderBy: ["category.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+  {
+    id: "count-selected-accounts",
+    name: "Count transactions for selected accounts",
+    description:
+      "Counts transactions for a sample set of account IDs. Replace the sample IDs before running.",
+    group: "targeted",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            account: {
+              $oneof: [
+                "sample-account-id-1",
+                "sample-account-id-2",
+                "sample-account-id-3",
+              ],
+            },
+          },
+          groupBy: ["account", "account.name"],
+          select: [
+            "account",
+            "account.name",
+            { transactionCount: { $count: "$id" } },
+          ],
+          orderBy: ["account.name"],
+        },
+      },
+      null,
+      2
+    ),
+  },
+];
+
+// ─── Notes / tags ─────────────────────────────────────────────────────────────
+
+const NOTES: QueryPack[] = [
+  {
+    id: "notes-hashtag-search",
+    name: "Transactions with hashtag in notes",
+    description:
+      "Searches for transactions whose notes contain a sample hashtag. Update the hashtag before running.",
+    group: "notes",
+    query: JSON.stringify(
+      {
+        ActualQLquery: {
+          table: "transactions",
+          options: { splits: "inline" },
+          filter: {
+            notes: {
+              $like: "%#sample-tag%",
+            },
+          },
+          select: [
+            "id",
+            "date",
+            "amount",
+            "payee.name",
+            "category.name",
+            "notes",
+          ],
+          orderBy: [{ date: "desc" }],
+          limit: 100,
+        },
+      },
+      null,
+      2
+    ),
+  },
+];
+
+// ─── Exported groups ──────────────────────────────────────────────────────────
+
+export const QUERY_PACK_GROUPS: QueryPackGroup[] = [
+  { id: "data", label: "Data inspection", packs: DATA_INSPECTION },
+  { id: "cleanup", label: "Cleanup & validation", packs: CLEANUP },
+  { id: "aggregation", label: "Aggregation", packs: AGGREGATION },
+  { id: "targeted", label: "Targeted subset", packs: TARGETED },
+  { id: "notes", label: "Notes & tags", packs: NOTES },
+];

--- a/src/features/query/lib/queryStorage.ts
+++ b/src/features/query/lib/queryStorage.ts
@@ -36,7 +36,11 @@ function readSaved(budgetSyncId: string): SavedQuery[] {
 
 function writeSaved(budgetSyncId: string, queries: SavedQuery[]): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(savedKey(budgetSyncId), JSON.stringify(queries));
+  try {
+    localStorage.setItem(savedKey(budgetSyncId), JSON.stringify(queries));
+  } catch {
+    // Storage quota exceeded or access denied — degrade gracefully.
+  }
 }
 
 export function getSavedQueries(budgetSyncId: string): SavedQuery[] {
@@ -146,5 +150,9 @@ export function addToHistory(
     ...(meta?.execTime !== undefined && { execTime: meta.execTime }),
     ...(meta?.rowCount !== undefined && { rowCount: meta.rowCount }),
   };
-  sessionStorage.setItem(historyKey(budgetSyncId), JSON.stringify([entry, ...deduped]));
+  try {
+    sessionStorage.setItem(historyKey(budgetSyncId), JSON.stringify([entry, ...deduped]));
+  } catch {
+    // Storage quota exceeded or access denied — degrade gracefully.
+  }
 }

--- a/src/features/query/lib/queryStorage.ts
+++ b/src/features/query/lib/queryStorage.ts
@@ -123,7 +123,11 @@ export function getHistory(budgetSyncId: string): QueryHistoryEntry[] {
 
 export function clearHistory(budgetSyncId: string): void {
   if (typeof window === "undefined") return;
-  sessionStorage.removeItem(historyKey(budgetSyncId));
+  try {
+    sessionStorage.removeItem(historyKey(budgetSyncId));
+  } catch {
+    // Storage unavailable — degrade gracefully.
+  }
 }
 
 /**

--- a/src/features/query/lib/queryStorage.ts
+++ b/src/features/query/lib/queryStorage.ts
@@ -1,0 +1,150 @@
+/**
+ * Persistence layer for the ActualQL query workspace.
+ *
+ * Saved queries:  localStorage  — `actualql-saved-queries:${budgetSyncId}`
+ * History:        sessionStorage — `actualql-history:${budgetSyncId}`
+ *
+ * Both are keyed by `budgetSyncId` so each budget has its own independent
+ * set of saved queries and history. History is session-scoped (cleared when
+ * the browser tab closes), matching the lifetime of the connection credentials.
+ */
+
+import { generateId } from "@/lib/uuid";
+import type { SavedQuery, QueryHistoryEntry } from "../types";
+
+// ─── Key helpers ──────────────────────────────────────────────────────────────
+
+function savedKey(budgetSyncId: string): string {
+  return `actualql-saved-queries:${budgetSyncId}`;
+}
+
+function historyKey(budgetSyncId: string): string {
+  return `actualql-history:${budgetSyncId}`;
+}
+
+// ─── Saved queries (localStorage) ────────────────────────────────────────────
+
+function readSaved(budgetSyncId: string): SavedQuery[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(savedKey(budgetSyncId));
+    return raw ? (JSON.parse(raw) as SavedQuery[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeSaved(budgetSyncId: string, queries: SavedQuery[]): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(savedKey(budgetSyncId), JSON.stringify(queries));
+}
+
+export function getSavedQueries(budgetSyncId: string): SavedQuery[] {
+  return readSaved(budgetSyncId);
+}
+
+export function saveQuery(
+  budgetSyncId: string,
+  name: string,
+  query: string
+): SavedQuery {
+  const existing = readSaved(budgetSyncId);
+  const now = new Date().toISOString();
+  const entry: SavedQuery = {
+    id: generateId(),
+    name,
+    query,
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeSaved(budgetSyncId, [...existing, entry]);
+  return entry;
+}
+
+export function updateSavedQuery(
+  budgetSyncId: string,
+  id: string,
+  patch: Partial<Pick<SavedQuery, "name" | "query" | "isFavorite">>
+): void {
+  const queries = readSaved(budgetSyncId);
+  writeSaved(
+    budgetSyncId,
+    queries.map((q) =>
+      q.id === id ? { ...q, ...patch, updatedAt: new Date().toISOString() } : q
+    )
+  );
+}
+
+export function deleteSavedQuery(budgetSyncId: string, id: string): void {
+  writeSaved(
+    budgetSyncId,
+    readSaved(budgetSyncId).filter((q) => q.id !== id)
+  );
+}
+
+export function duplicateSavedQuery(
+  budgetSyncId: string,
+  id: string
+): SavedQuery | null {
+  const source = readSaved(budgetSyncId).find((q) => q.id === id);
+  if (!source) return null;
+  const now = new Date().toISOString();
+  const copy: SavedQuery = {
+    ...source,
+    id: generateId(),
+    name: `${source.name} (copy)`,
+    createdAt: now,
+    updatedAt: now,
+    isFavorite: false,
+  };
+  writeSaved(budgetSyncId, [...readSaved(budgetSyncId), copy]);
+  return copy;
+}
+
+// ─── History (sessionStorage) ─────────────────────────────────────────────────
+
+function readHistory(budgetSyncId: string): QueryHistoryEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = sessionStorage.getItem(historyKey(budgetSyncId));
+    return raw ? (JSON.parse(raw) as QueryHistoryEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getHistory(budgetSyncId: string): QueryHistoryEntry[] {
+  return readHistory(budgetSyncId);
+}
+
+export function clearHistory(budgetSyncId: string): void {
+  if (typeof window === "undefined") return;
+  sessionStorage.removeItem(historyKey(budgetSyncId));
+}
+
+/**
+ * Prepends a query to the history, deduplicating by exact raw JSON string.
+ * If the same query already exists, it is moved to the top (most recent).
+ * No hard cap — sessionStorage lifetime and the clear button bound growth naturally.
+ *
+ * @param meta - Optional execution metadata to persist with the entry.
+ *   `execTime` — wall-clock milliseconds for the successful run.
+ *   `rowCount` — length of the result array; omit for scalar results.
+ */
+export function addToHistory(
+  budgetSyncId: string,
+  query: string,
+  meta?: { execTime: number; rowCount?: number }
+): void {
+  if (typeof window === "undefined") return;
+  const existing = readHistory(budgetSyncId);
+  const deduped = existing.filter((h) => h.query !== query);
+  const entry: QueryHistoryEntry = {
+    id: generateId(),
+    query,
+    executedAt: new Date().toISOString(),
+    ...(meta?.execTime !== undefined && { execTime: meta.execTime }),
+    ...(meta?.rowCount !== undefined && { rowCount: meta.rowCount }),
+  };
+  sessionStorage.setItem(historyKey(budgetSyncId), JSON.stringify([entry, ...deduped]));
+}

--- a/src/features/query/lib/queryValidation.ts
+++ b/src/features/query/lib/queryValidation.ts
@@ -44,22 +44,27 @@ export function parseQuery(input: string): ParsedQuery | Error {
 
   const obj = parsed as Record<string, unknown>;
 
+  // Accept both the wrapped format { "ActualQLquery": { ... } } and a bare
+  // ActualQL body { "table": "...", ... } typed directly.
+  let inner: Record<string, unknown>;
   if (
-    !("ActualQLquery" in obj) ||
-    typeof obj.ActualQLquery !== "object" ||
-    obj.ActualQLquery === null ||
-    Array.isArray(obj.ActualQLquery)
+    "ActualQLquery" in obj &&
+    typeof obj.ActualQLquery === "object" &&
+    obj.ActualQLquery !== null &&
+    !Array.isArray(obj.ActualQLquery)
   ) {
+    inner = obj.ActualQLquery as Record<string, unknown>;
+  } else if (typeof obj.table === "string") {
+    inner = obj;
+  } else {
     return new Error(
-      'Wrap your query: { "ActualQLquery": { "table": "..." } }'
+      'Wrap your query: { "ActualQLquery": { "table": "..." } } or provide a bare object with a "table" field.'
     );
   }
 
-  const inner = obj.ActualQLquery as Record<string, unknown>;
-
   if (typeof inner.table !== "string" || !inner.table.trim()) {
     return new Error(
-      'The "ActualQLquery" object must have a "table" string field.'
+      'The query must have a "table" string field.'
     );
   }
 

--- a/src/features/query/lib/queryValidation.ts
+++ b/src/features/query/lib/queryValidation.ts
@@ -1,0 +1,169 @@
+/**
+ * Query parsing and lint rules for the ActualQL workspace.
+ *
+ * parseQuery: validates the full wrapped JSON string `{ "ActualQLquery": { ... } }`
+ * and returns { body, inner } or an Error describing why the input is invalid.
+ * Called before every network request and displayed inline in the editor.
+ *
+ * lintQuery: runs non-blocking heuristic checks against a valid inner query and
+ * returns a list of warnings. Warnings are informative — they never block
+ * execution. The proxy has a 15-second request timeout, so the unbounded
+ * transaction scan warning is particularly important for user experience.
+ */
+
+import type { ActualQLQuery, LintWarning } from "../types";
+
+// ─── ParsedQuery ──────────────────────────────────────────────────────────────
+
+export type ParsedQuery = {
+  /** Full wrapped body ready to pass to runQuery. */
+  body: { ActualQLquery: ActualQLQuery };
+  /** Inner query — used for linting, explaining, and cURL generation. */
+  inner: ActualQLQuery;
+};
+
+// ─── Parse ────────────────────────────────────────────────────────────────────
+
+export function parseQuery(input: string): ParsedQuery | Error {
+  if (!input.trim()) {
+    return new Error("Query is empty.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    return new Error("Invalid JSON — check syntax.");
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return new Error(
+      'Query must be a JSON object with an "ActualQLquery" key.'
+    );
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (
+    !("ActualQLquery" in obj) ||
+    typeof obj.ActualQLquery !== "object" ||
+    obj.ActualQLquery === null ||
+    Array.isArray(obj.ActualQLquery)
+  ) {
+    return new Error(
+      'Wrap your query: { "ActualQLquery": { "table": "..." } }'
+    );
+  }
+
+  const inner = obj.ActualQLquery as Record<string, unknown>;
+
+  if (typeof inner.table !== "string" || !inner.table.trim()) {
+    return new Error(
+      'The "ActualQLquery" object must have a "table" string field.'
+    );
+  }
+
+  const innerQuery = inner as unknown as ActualQLQuery;
+
+  return { body: { ActualQLquery: innerQuery }, inner: innerQuery };
+}
+
+// ─── Lint ─────────────────────────────────────────────────────────────────────
+
+export function lintQuery(query: ActualQLQuery): LintWarning[] {
+  const warnings: LintWarning[] = [];
+
+  // Unbounded transaction scan — the proxy enforces a 15-second timeout.
+  // A full transactions table can have thousands of rows. A query with any
+  // filter is considered scoped and does not trigger this warning.
+  if (
+    query.table === "transactions" &&
+    !query.limit &&
+    !query.groupBy?.length &&
+    !query.calculate &&
+    (!query.filter || Object.keys(query.filter).length === 0)
+  ) {
+    warnings.push({
+      id: "unbounded-transactions",
+      message:
+        'Unbounded transaction scan — may return thousands of rows and time out (15s proxy limit). Add "limit", "groupBy", or "calculate" to narrow the scope.',
+    });
+  }
+
+  // Empty $oneof — will silently match nothing
+  if (query.filter && hasEmptyOneof(query.filter)) {
+    warnings.push({
+      id: "empty-oneof",
+      message:
+        'Empty "$oneof" array — this filter matches nothing and will return no results.',
+    });
+  }
+
+  // groupBy without an aggregate in select — every group will return its
+  // raw rows, which is rarely what the user intends
+  if (
+    query.groupBy?.length &&
+    !query.calculate &&
+    Array.isArray(query.select)
+  ) {
+    const hasAggregate = (query.select as Array<unknown>).some(
+      (s) =>
+        typeof s === "object" &&
+        s !== null &&
+        Object.values(s as Record<string, unknown>).some(
+          (v) =>
+            typeof v === "object" &&
+            v !== null &&
+            ("$count" in (v as object) ||
+              "$sum" in (v as object) ||
+              "$avg" in (v as object) ||
+              "$min" in (v as object) ||
+              "$max" in (v as object))
+        )
+    );
+    if (!hasAggregate) {
+      warnings.push({
+        id: "groupby-no-aggregate",
+        message:
+          '"groupBy" without an aggregate — grouped queries typically need a "$count" or "$sum" in "select".',
+      });
+    }
+  }
+
+  return warnings;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function hasEmptyOneof(filter: unknown): boolean {
+  if (!filter || typeof filter !== "object") return false;
+  const obj = filter as Record<string, unknown>;
+
+  // Handle $and / $or compound operators at this level
+  if ("$and" in obj && Array.isArray(obj["$and"])) {
+    return (obj["$and"] as unknown[]).some((clause) => hasEmptyOneof(clause));
+  }
+  if ("$or" in obj && Array.isArray(obj["$or"])) {
+    return (obj["$or"] as unknown[]).some((clause) => hasEmptyOneof(clause));
+  }
+
+  // Check each field's operator object for an empty $oneof
+  for (const val of Object.values(obj)) {
+    if (
+      typeof val === "object" &&
+      val !== null &&
+      "$oneof" in (val as object) &&
+      Array.isArray((val as Record<string, unknown>)["$oneof"]) &&
+      ((val as Record<string, unknown>)["$oneof"] as unknown[]).length === 0
+    ) {
+      return true;
+    }
+
+    // Recurse into nested filter objects (e.g. dotted-path sub-objects)
+    if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+      if (hasEmptyOneof(val)) return true;
+    }
+  }
+
+  return false;
+}

--- a/src/features/query/types.ts
+++ b/src/features/query/types.ts
@@ -1,0 +1,70 @@
+// ─── ActualQL query model ─────────────────────────────────────────────────────
+//
+// Intentionally permissive so the workspace never blocks valid ActualQL patterns.
+// Dotted paths, aggregate expressions, $oneof, $transform, options.splits, etc.
+// all pass through as-is.
+
+export type ActualQLQuery = {
+  table: string;
+  filter?: Record<string, unknown>;
+  select?: Array<string | Record<string, unknown>> | Record<string, unknown>;
+  groupBy?: string[];
+  calculate?: Record<string, unknown>;
+  orderBy?: Array<string | Record<string, "asc" | "desc">>;
+  limit?: number;
+  offset?: number;
+  options?: {
+    splits?: "inline" | "grouped" | "all";
+  };
+};
+
+// ─── Saved query ──────────────────────────────────────────────────────────────
+
+export type SavedQuery = {
+  id: string;
+  name: string;
+  /** Raw JSON string as the user wrote it */
+  query: string;
+  createdAt: string;
+  updatedAt: string;
+  isFavorite?: boolean;
+};
+
+// ─── History entry ────────────────────────────────────────────────────────────
+
+export type QueryHistoryEntry = {
+  id: string;
+  /** Raw JSON string as executed */
+  query: string;
+  executedAt: string;
+  /** Execution time in milliseconds — only present for successful runs. */
+  execTime?: number;
+  /**
+   * Number of rows returned. Set for array results; undefined for scalar
+   * (calculate) results or entries written before this field was added.
+   */
+  rowCount?: number;
+};
+
+// ─── Result view ──────────────────────────────────────────────────────────────
+
+export type QueryResultMode = "table" | "raw" | "scalar" | "tree";
+
+// ─── Last executed request (for cURL generation in Phase 2) ──────────────────
+
+export type LastExecutedRequest = {
+  query: ActualQLQuery;
+  /** Full wrapped editor string at execution time — used for "Copy query JSON". */
+  rawQuery: string;
+  baseUrl: string;
+  budgetSyncId: string;
+  apiKey: string;
+  encryptionPassword?: string;
+};
+
+// ─── Lint warning ─────────────────────────────────────────────────────────────
+
+export type LintWarning = {
+  id: string;
+  message: string;
+};


### PR DESCRIPTION
## Summary

Add the ActualQL query workspace as a first-class feature in Actual Bench.

This PR implements RD-007 by introducing a dedicated **ActualQL Queries** page for power users to explore, validate, troubleshoot, and summarize budget data directly against the active budget. It keeps the query input raw and flexible, while adding enough usability and guidance to make ActualQL practical inside the app.

Included in this PR:
- New sidebar entry and query page for ActualQL
- Wrapped request-body editor with support for both wrapped and bare query input
- Syntax-colored JSON editor with line numbers, active-line highlight, and resizeable editor/results split
- Run, Format, Explain, Copy Query, Save, and Ctrl+Enter execution support
- Inline parse errors and non-blocking query lint warnings
- In-app ActualQL quick reference and plain-English query explanation
- Multiple result views: table, raw JSON, scalar value, and collapsible JSON tree
- Execution metadata bar with status, duration, row count, and payload size
- Copy result JSON, copy executed query JSON, export CSV, and copy sanitized/full cURL actions
- Built-in query packs for data inspection, cleanup, aggregation, targeted subsets, and notes/tags
- Session-scoped query history plus locally saved queries per budget with favorites, rename, duplicate, and delete
- Updates to `FEATURES.md` and `future-roadmap.md` to mark RD-007 complete

Closes #22 

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Manually tested in browser

## Notes

- The workspace is intentionally **not** a visual query builder or full Postman-style API client.
- Queries execute directly against the server and bypass staged unsaved changes; the UI includes warning banners for this.
- Built-in query packs were updated to use safer / more practical examples, including current-month queries where relevant.
- Aggregate aliases are not used in `orderBy` because ActualQL does not support ordering by computed alias fields; sorting for such results should happen in the UI if needed.
- cURL copy supports both sanitized and full variants; full cURL includes sensitive headers when present.
- Saved queries remain local-only in this version; there is no server sync or cross-device sharing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ActualQL Queries workspace: resizable editor/results split (session‑persisted), raw JSON editor, run/format/save/explain actions, undo, inline parse errors, lint warnings, keyboard shortcuts.
  * Result inspection: Table (smart cell formatting, 500‑row preview, CSV export), Raw JSON, Scalar, collapsible Tree, execution metadata bar, copy/export actions (JSON, sanitized or opt‑in full cURL), plain‑English query explanations, reference dialog.
  * Built‑in example packs, per‑budget saved queries (favorites, rename/duplicate/delete), session history (last 10).

* **Updates**
  * Theme and monospace font adjustments; documentation and roadmap updated to reflect the new workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->