### PR TITLE
 feat/Add live budget overview homepage for connected budgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
-        "eslint-config-next": "16.2.1",
+        "eslint-config-next": "^16.2.3",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
         "tailwindcss": "^4",
@@ -2519,9 +2519,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.1.tgz",
-      "integrity": "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
+      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5953,13 +5953,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.1.tgz",
-      "integrity": "sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
+      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.1",
+        "@next/eslint-plugin-next": "16.2.3",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",
@@ -15,7 +15,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.0.1",
-        "next": "16.2.1",
+        "next": "^16.2.3",
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1167,9 +1167,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2513,9 +2513,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
-      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2529,9 +2529,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2545,9 +2545,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2561,9 +2561,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2577,9 +2577,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2593,9 +2593,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2609,9 +2609,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2625,9 +2625,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2641,9 +2641,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -7238,9 +7238,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -10075,12 +10075,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.1",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -10094,14 +10094,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.1",
-        "@next/swc-darwin-x64": "16.2.1",
-        "@next/swc-linux-arm64-gnu": "16.2.1",
-        "@next/swc-linux-arm64-musl": "16.2.1",
-        "@next/swc-linux-x64-gnu": "16.2.1",
-        "@next/swc-linux-x64-musl": "16.2.1",
-        "@next/swc-win32-arm64-msvc": "16.2.1",
-        "@next/swc-win32-x64-msvc": "16.2.1",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
-    "eslint-config-next": "16.2.1",
+    "eslint-config-next": "^16.2.3",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.0.1",
-    "next": "16.2.1",
+    "next": "^16.2.3",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/app/(app)/overview/page.tsx
+++ b/src/app/(app)/overview/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { BudgetOverviewView } from "@/features/overview/components/BudgetOverviewView";
+
+export const metadata: Metadata = {
+  title: "Budget Overview — Actual Bench",
+};
+
+export default function OverviewPage() {
+  return <BudgetOverviewView />;
+}

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import Image from "next/image";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { Loader2, AlertCircle, CheckCircle2, Server, Plus, Check } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { useConnectForm } from "./useConnectForm";
 import { ConnectionCard } from "./ConnectionCard";
 import { deriveLabel } from "./utils";
 
 export function ConnectForm() {
+  const router = useRouter();
+  const hydrated = useIsHydrated();
+  const connectedInstance = useConnectionStore(selectActiveInstance);
+
   const {
     instances,
     activeInstance,
@@ -47,6 +55,16 @@ export function ConnectForm() {
     handleKeyDown,
     handleConnect,
   } = useConnectForm();
+
+  useEffect(() => {
+    if (hydrated && connectedInstance) {
+      router.replace("/overview");
+    }
+  }, [hydrated, connectedInstance, router]);
+
+  if (hydrated && connectedInstance) {
+    return null;
+  }
 
   // ── Panels ──────────────────────────────────────────────────────────────────
 

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -136,7 +136,7 @@ export function useConnectForm() {
       setActiveInstance(instance.id);
       toast.success("Connected! Redirecting…");
       await new Promise((r) => setTimeout(r, 600));
-      router.push("/rules");
+      router.push("/overview");
     } finally {
       setReconnectBusyId(null);
     }
@@ -286,7 +286,7 @@ export function useConnectForm() {
       setConnectStatus({ kind: "success" });
       toast.success("Connected! Redirecting…");
       await new Promise((r) => setTimeout(r, 800));
-      router.push("/rules");
+      router.push("/overview");
     } catch (err) {
       const status =
         err && typeof err === "object" && "status" in err

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { useEffect, useSyncExternalStore } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { TopBar } from "./TopBar";
 import { Sidebar } from "./Sidebar";
 import { DraftPanel } from "./DraftPanel";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { usePreloadEntities } from "@/hooks/useAllEntities";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
-
-// useSyncExternalStore is the React-recommended way to detect client-side
-// hydration without calling setState inside useEffect.
-const emptySubscribe = () => () => {};
-function useIsHydrated(): boolean {
-  return useSyncExternalStore(emptySubscribe, () => true, () => false);
-}
+import { useIsHydrated } from "@/hooks/useIsHydrated";
 
 /**
  * The four-panel app shell:
@@ -28,14 +22,15 @@ function useIsHydrated(): boolean {
  */
 export function AppShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
+  const pathname = usePathname();
   const activeInstance = useConnectionStore(selectActiveInstance);
 
-  // Prefetch all entity types in parallel so any page has data immediately.
-  // Hooks are disabled when there is no active connection (enabled: !!connection).
-  usePreloadEntities();
+  // Overview is a lightweight landing page, so avoid booting the full entity
+  // preload set while the user is on /overview. Other app routes keep the
+  // existing eager-preload behavior.
+  usePreloadEntities(pathname !== "/overview");
   useKeyboardShortcuts();
 
-  // Returns false on the server, true on the client — no setState needed.
   const hydrated = useIsHydrated();
 
   useEffect(() => {
@@ -44,7 +39,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     }
   }, [hydrated, activeInstance, router]);
 
-  // Show nothing until we know whether the user is connected.
   if (!hydrated) {
     return null;
   }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   ExternalLink,
   AlertCircle,
   BookOpen,
+  LayoutDashboard,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -44,6 +45,7 @@ type NavItem = {
 };
 
 const NAV_ITEMS: NavItem[] = [
+  { label: "Overview", href: "/overview", icon: LayoutDashboard },
   { label: "Rules", href: "/rules", icon: ScrollText },
   { label: "Accounts", href: "/accounts", icon: Landmark },
   { label: "Payees", href: "/payees", icon: Users },

--- a/src/features/accounts/hooks/useAccounts.ts
+++ b/src/features/accounts/hooks/useAccounts.ts
@@ -6,11 +6,15 @@ import { getAccounts } from "@/lib/api/accounts";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
+type PreloadOptions = {
+  enabled?: boolean;
+};
+
 /**
  * Fetches accounts from the API and loads them into the staged store.
  * Re-runs whenever the active connection changes.
  */
-export function useAccounts() {
+export function useAccounts(options: PreloadOptions = {}) {
   const connection = useConnectionStore(selectActiveInstance);
   const loadAccounts = useStagedStore((s) => s.loadAccounts);
 
@@ -20,7 +24,7 @@ export function useAccounts() {
       if (!connection) throw new Error("No active connection");
       return getAccounts(connection);
     },
-    enabled: !!connection,
+    enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.
   });
 

--- a/src/features/accounts/hooks/useAccountsSave.ts
+++ b/src/features/accounts/hooks/useAccountsSave.ts
@@ -112,6 +112,7 @@ export function useAccountsSave() {
     await queryClient.invalidateQueries({ queryKey: ["accounts", connection.id] });
     await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "account", connection.id] });
 
+    await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });
     return { succeeded, failed, idMap };
   }
 

--- a/src/features/categories/hooks/useCategoriesSave.ts
+++ b/src/features/categories/hooks/useCategoriesSave.ts
@@ -111,6 +111,7 @@ export function useCategoriesSave() {
     await queryClient.invalidateQueries({ queryKey: ["categoryGroups", connection.id] });
     await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "category", connection.id] });
 
+    await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });
     return { succeeded, failed, idMap };
   }
 

--- a/src/features/categories/hooks/useCategoryGroups.ts
+++ b/src/features/categories/hooks/useCategoryGroups.ts
@@ -6,11 +6,15 @@ import { getCategoryGroups } from "@/lib/api/categoryGroups";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
+type PreloadOptions = {
+  enabled?: boolean;
+};
+
 /**
  * Fetches category groups (with nested categories) from the API and loads
  * both into the staged store in a single call.
  */
-export function useCategoryGroups() {
+export function useCategoryGroups(options: PreloadOptions = {}) {
   const connection = useConnectionStore(selectActiveInstance);
   const loadCategoryGroups = useStagedStore((s) => s.loadCategoryGroups);
 
@@ -20,7 +24,7 @@ export function useCategoryGroups() {
       if (!connection) throw new Error("No active connection");
       return getCategoryGroups(connection);
     },
-    enabled: !!connection,
+    enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.
   });
 

--- a/src/features/categories/hooks/useCategoryGroupsSave.ts
+++ b/src/features/categories/hooks/useCategoryGroupsSave.ts
@@ -108,6 +108,7 @@ export function useCategoryGroupsSave() {
     await queryClient.invalidateQueries({ queryKey: ["categoryGroups", connection.id] });
     await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "category", connection.id] });
 
+    await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });
     return { succeeded, failed, idMap };
   }
 

--- a/src/features/overview/components/BudgetOverviewView.test.tsx
+++ b/src/features/overview/components/BudgetOverviewView.test.tsx
@@ -1,0 +1,152 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useConnectionStore } from "@/store/connection";
+import type {
+  BudgetOverviewSnapshot,
+  BudgetOverviewStats,
+  OverviewRefreshResult,
+  UseBudgetOverviewResult,
+} from "../types";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("../hooks/useBudgetOverview", () => ({
+  useBudgetOverview: jest.fn(),
+}));
+
+import { BudgetOverviewView } from "./BudgetOverviewView";
+import { useBudgetOverview } from "../hooks/useBudgetOverview";
+
+const mockUseBudgetOverview = useBudgetOverview as jest.MockedFunction<typeof useBudgetOverview>;
+
+const loadedStats: BudgetOverviewStats = {
+  transactions: 17,
+  accounts: 12,
+  payees: 30,
+  categoryGroups: 4,
+  categories: 31,
+  rules: 9,
+  schedules: 3,
+};
+
+const loadedSnapshot: BudgetOverviewSnapshot = {
+  stats: loadedStats,
+  budgetingSince: "Jan 2019",
+};
+
+function buildHookResult(overrides: Partial<UseBudgetOverviewResult> = {}): UseBudgetOverviewResult {
+  return {
+    snapshot: loadedSnapshot,
+    isLoading: false,
+    isError: false,
+    hasPartialFailure: false,
+    refresh: jest.fn().mockResolvedValue({
+      ok: true,
+      hasPartialFailure: false,
+    }),
+    ...overrides,
+  };
+}
+
+describe("BudgetOverviewView", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-12T12:00:00Z"));
+    useConnectionStore.setState({
+      instances: [
+        {
+          id: "conn-1",
+          label: "Household Budget",
+          baseUrl: "http://localhost:5006",
+          apiKey: "key",
+          budgetSyncId: "budget-1",
+        },
+      ],
+      activeInstanceId: "conn-1",
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    sessionStorage.clear();
+    act(() => {
+      useConnectionStore.setState({ instances: [], activeInstanceId: null });
+    });
+    mockUseBudgetOverview.mockReset();
+  });
+
+  it("shows the selected budget name immediately and a loading badge during budget switches", () => {
+    mockUseBudgetOverview.mockReturnValue(
+      buildHookResult({ snapshot: null, isLoading: true })
+    );
+
+    render(<BudgetOverviewView />);
+
+    expect(screen.getByText("Household Budget")).toBeInTheDocument();
+    expect(screen.getByText("Loading budget")).toBeInTheDocument();
+    expect(document.querySelectorAll("span[aria-hidden='true']")).toHaveLength(7);
+  });
+
+  it("shows loading placeholders while a manual refresh is in progress and updates the timestamp on success", async () => {
+    let resolveRefresh: ((value: OverviewRefreshResult) => void) | undefined;
+    const refresh = jest.fn(
+      () =>
+        new Promise<OverviewRefreshResult>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    mockUseBudgetOverview.mockReturnValue(buildHookResult({ refresh }));
+
+    render(<BudgetOverviewView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated just now")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(screen.getByRole("button", { name: "Refreshing" })).toBeDisabled();
+    expect(document.querySelectorAll("span[aria-hidden='true']")).toHaveLength(7);
+
+    await act(async () => {
+      resolveRefresh?.({ ok: true, hasPartialFailure: false });
+    });
+
+    expect(screen.getByText("Updated just now")).toBeInTheDocument();
+  });
+
+  it("keeps the previous refresh timestamp when refresh completes with partial failures", async () => {
+    const refresh = jest.fn().mockResolvedValue({
+      ok: false,
+      hasPartialFailure: true,
+    });
+
+    mockUseBudgetOverview.mockReturnValue(buildHookResult({ refresh }));
+
+    render(<BudgetOverviewView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated just now")).toBeInTheDocument();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+
+    expect(screen.getByText("Last refreshed 1m ago")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Last refreshed 1m ago")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/overview/components/BudgetOverviewView.tsx
+++ b/src/features/overview/components/BudgetOverviewView.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { selectActiveInstance, useConnectionStore } from "@/store/connection";
+import { useBudgetOverview } from "../hooks/useBudgetOverview";
+import { useOverviewHeaderState } from "../hooks/useOverviewHeaderState";
+import { OverviewHeader } from "./OverviewHeader";
+import { OverviewNavigationSection } from "./OverviewNavigationSection";
+import { OverviewStatsSection } from "./OverviewStatsSection";
+
+export function BudgetOverviewView() {
+  const { snapshot, isLoading, refresh } = useBudgetOverview();
+  const connection = useConnectionStore(selectActiveInstance);
+  const headerState = useOverviewHeaderState({
+    hasStats: !!snapshot,
+    isLoading,
+    refresh,
+  });
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 sm:py-5">
+        <OverviewHeader
+          budgetLabel={connection?.label ?? ""}
+          statusLabel={headerState.statusLabel}
+          statusDotClass={headerState.statusDotClass}
+          refreshButtonLabel={headerState.refreshButtonLabel}
+          refreshStatusLabel={headerState.refreshStatusLabel}
+          isRefreshing={headerState.isRefreshing}
+          onRefresh={headerState.handleRefresh}
+        />
+
+        <OverviewStatsSection
+          snapshot={
+            headerState.isRefreshing
+              ? undefined
+              : snapshot ?? undefined
+          }
+          isLoading={isLoading || headerState.isRefreshing}
+        />
+        <OverviewNavigationSection />
+      </div>
+    </div>
+  );
+}

--- a/src/features/overview/components/OverviewHeader.tsx
+++ b/src/features/overview/components/OverviewHeader.tsx
@@ -1,0 +1,48 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+
+type OverviewHeaderProps = {
+  budgetLabel: string;
+  statusLabel: string;
+  statusDotClass: string;
+  refreshButtonLabel: string;
+  refreshStatusLabel: string | null;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+};
+
+export function OverviewHeader({
+  budgetLabel,
+  statusLabel,
+  statusDotClass,
+  refreshButtonLabel,
+  refreshStatusLabel,
+  isRefreshing,
+  onRefresh,
+}: OverviewHeaderProps) {
+  return (
+    <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="space-y-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-xl font-semibold tracking-tight">Budget Overview</h1>
+          <Badge variant="outline" className="gap-1.5">
+            <span className={statusDotClass} />
+            {statusLabel}
+          </Badge>
+          <span className="text-sm font-medium text-foreground/85">{budgetLabel}</span>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-start gap-1 sm:items-end">
+        <Button variant="outline" size="sm" onClick={() => void onRefresh()} disabled={isRefreshing}>
+          <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
+          {refreshButtonLabel}
+        </Button>
+        <div className="min-h-4 text-xs text-muted-foreground" aria-live="polite">
+          {refreshStatusLabel}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/features/overview/components/OverviewNavigationSection.tsx
+++ b/src/features/overview/components/OverviewNavigationSection.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  ADVANCED_TOOLS_DESCRIPTION,
+  ENTITY_CARDS,
+  MANAGE_DATA_DESCRIPTION,
+  MANAGE_DATA_TITLE,
+  TOOL_CARDS,
+} from "../lib/overviewCards";
+import type { OverviewActionCard } from "../types";
+
+function ActionCard({ card }: { card: OverviewActionCard }) {
+  const isDisabled = Boolean(card.comingSoon);
+  const isTool = card.tone === "tool";
+
+  const className = cn(
+    "group rounded-xl border px-4 py-3.5 transition-colors",
+    isDisabled
+      ? "cursor-default border-dashed border-border/60 bg-background/35 opacity-60"
+      : isTool
+        ? "border-border/70 bg-muted/16 hover:border-foreground/15 hover:bg-muted/24"
+        : "border-border/70 bg-background hover:border-foreground/15 hover:bg-accent/15"
+  );
+
+  const content = (
+    <div className="flex items-start gap-3">
+      <div
+        className={cn(
+          "rounded-lg border p-2",
+          isDisabled
+            ? "border-border/50 bg-background/55"
+            : isTool
+              ? "border-border/60 bg-background/70"
+              : "border-border/70 bg-muted/25"
+        )}
+      >
+        <card.icon
+          className={cn(
+            "h-4 w-4 text-muted-foreground",
+            isDisabled && "text-muted-foreground/70"
+          )}
+        />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <div className="text-sm font-medium tracking-tight sm:text-[15px]">{card.label}</div>
+          {isDisabled && (
+            <span className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+              Planned
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-sm leading-5 text-muted-foreground">{card.description}</p>
+      </div>
+
+      {!isDisabled && (
+        <ArrowRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      )}
+    </div>
+  );
+
+  if (!card.href || isDisabled) {
+    return <div className={className}>{content}</div>;
+  }
+
+  return (
+    <Link href={card.href} className={className}>
+      {content}
+    </Link>
+  );
+}
+
+export function OverviewNavigationSection() {
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3 pt-2">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold tracking-tight">{MANAGE_DATA_TITLE}</h2>
+          <p className="max-w-6xl text-sm text-muted-foreground">{MANAGE_DATA_DESCRIPTION}</p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {ENTITY_CARDS.map((card) => (
+            <ActionCard key={card.id} card={card} />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3 border-t border-border/60 pt-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold tracking-tight">Advanced Tools</h2>
+          <p className="max-w-3xl text-sm text-muted-foreground">{ADVANCED_TOOLS_DESCRIPTION}</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {TOOL_CARDS.map((card) => (
+            <ActionCard key={card.id} card={card} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/overview/components/OverviewStatsSection.tsx
+++ b/src/features/overview/components/OverviewStatsSection.tsx
@@ -1,0 +1,129 @@
+import {
+  ArrowLeftRight,
+  Calendar,
+  Landmark,
+  LayoutList,
+  ScrollText,
+  Users,
+} from "lucide-react";
+import type { ComponentType } from "react";
+import type { BudgetOverviewSnapshot, BudgetOverviewStats, OverviewStatKey } from "../types";
+
+type OverviewStatsSectionProps = {
+  snapshot: BudgetOverviewSnapshot | undefined;
+  isLoading: boolean;
+};
+
+type CountStatConfig = {
+  key: Extract<OverviewStatKey, "transactions" | "accounts" | "payees" | "categories" | "schedules" | "rules">;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+const COUNT_STATS: CountStatConfig[] = [
+  { key: "transactions", label: "Transactions", icon: ArrowLeftRight },
+  { key: "accounts", label: "Accounts", icon: Landmark },
+  { key: "payees", label: "Payees", icon: Users },
+  { key: "categories", label: "Categories", icon: LayoutList },
+  { key: "schedules", label: "Schedules", icon: Calendar },
+  { key: "rules", label: "Rules", icon: ScrollText },
+];
+
+const numberFormatter = new Intl.NumberFormat();
+
+function formatCount(value: number | null | undefined): string {
+  if (value == null) return "...";
+  return numberFormatter.format(value);
+}
+
+function LoadingMetric() {
+  return (
+    <span
+      aria-hidden="true"
+      className="mx-auto mt-1 block h-4 w-10 animate-pulse rounded-md bg-muted-foreground/20 sm:h-[1.125rem] sm:w-12"
+    />
+  );
+}
+
+function SnapshotCount({
+  label,
+  icon: Icon,
+  value,
+  isLoading,
+}: {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  value: number | null | undefined;
+  isLoading: boolean;
+}) {
+  const shouldShowLoadingIndicator = isLoading && value == null;
+
+  return (
+    <div className="min-w-0 text-center">
+      <dt className="flex items-center justify-center gap-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground sm:text-[10px]">
+        <Icon className="h-3 w-3 shrink-0 sm:h-3.5 sm:w-3.5" />
+        <span className="truncate">{label}</span>
+      </dt>
+      {shouldShowLoadingIndicator ? (
+        <LoadingMetric />
+      ) : (
+        <dd className="mt-0.5 text-center text-sm font-semibold tabular-nums text-foreground sm:text-[0.95rem]">
+          {formatCount(value)}
+        </dd>
+      )}
+    </div>
+  );
+}
+
+function SnapshotText({ label, value, isLoading }: { label: string; value: string | null | undefined; isLoading: boolean }) {
+  const shouldShowLoadingIndicator = isLoading && value == null;
+
+  return (
+    <div className="min-w-0 text-center">
+      <dt className="text-[9px] uppercase tracking-[0.12em] text-muted-foreground sm:text-[10px]">
+        {label}
+      </dt>
+      {shouldShowLoadingIndicator ? (
+        <LoadingMetric />
+      ) : (
+        <dd className="mt-0.5 truncate text-center text-sm font-semibold text-foreground sm:text-[0.95rem]">
+          {value ?? "..."}
+        </dd>
+      )}
+    </div>
+  );
+}
+
+export function OverviewStatsSection({
+  snapshot,
+  isLoading,
+}: OverviewStatsSectionProps) {
+  const stats: BudgetOverviewStats | undefined = snapshot?.stats;
+
+  return (
+    <section className="w-full rounded-xl border border-border/70 bg-muted/15 px-4 py-2.5 sm:px-5 sm:py-3">
+      <div className="space-y-2.5">
+        <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+          Snapshot
+        </div>
+
+        <dl className="mx-auto grid w-full max-w-6xl grid-cols-2 gap-x-3 gap-y-2 sm:grid-cols-3 md:grid-cols-7 md:gap-x-2 lg:gap-x-3">
+          {COUNT_STATS.map(({ key, label, icon }) => (
+            <SnapshotCount
+              key={key}
+              label={label}
+              icon={icon}
+              value={stats?.[key]}
+              isLoading={isLoading}
+            />
+          ))}
+          <SnapshotText
+            label="Budgeting since"
+            value={snapshot?.budgetingSince}
+            isLoading={isLoading}
+          />
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/src/features/overview/hooks/useBudgetOverview.ts
+++ b/src/features/overview/hooks/useBudgetOverview.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import type {
+  BudgetOverviewSnapshot,
+  OverviewRefreshResult,
+  UseBudgetOverviewResult,
+} from "../types";
+import { fetchAllOverviewStats } from "../lib/overviewQueries";
+
+function hasPartialFailure(snapshot: BudgetOverviewSnapshot | null | undefined): boolean {
+  if (!snapshot) return false;
+
+  return (
+    snapshot.budgetingSince === null ||
+    Object.values(snapshot.stats).some((value) => value === null)
+  );
+}
+
+export function useBudgetOverview(): UseBudgetOverviewResult {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const query = useQuery({
+    queryKey: ["budget-overview", connection?.id],
+    queryFn: () => fetchAllOverviewStats(connection!),
+    enabled: !!connection,
+  });
+
+  const snapshot = query.data ?? null;
+  const snapshotHasPartialFailure = hasPartialFailure(snapshot);
+
+  return {
+    snapshot,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    hasPartialFailure: snapshotHasPartialFailure,
+    refresh: async (): Promise<OverviewRefreshResult> => {
+      const result = await query.refetch();
+      const refreshedSnapshot = result.data ?? null;
+      const refreshedHasPartialFailure = hasPartialFailure(refreshedSnapshot);
+
+      return {
+        ok: !result.error && !!refreshedSnapshot && !refreshedHasPartialFailure,
+        hasPartialFailure: refreshedHasPartialFailure,
+      };
+    },
+  };
+}

--- a/src/features/overview/hooks/useOverviewHeaderState.ts
+++ b/src/features/overview/hooks/useOverviewHeaderState.ts
@@ -68,7 +68,15 @@ export function useOverviewHeaderState({
     setEllipsisIndex(0);
 
     try {
-      const result = await refresh();
+      let result: OverviewRefreshResult;
+
+      try {
+        result = await refresh();
+      } catch (error) {
+        console.warn("[overview] Refresh failed", error);
+        result = { ok: false, hasPartialFailure: false };
+      }
+
       if (result.ok) {
         setLastRefreshedAt(new Date());
         setNow(Date.now());

--- a/src/features/overview/hooks/useOverviewHeaderState.ts
+++ b/src/features/overview/hooks/useOverviewHeaderState.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { OverviewRefreshResult } from "../types";
+
+type UseOverviewHeaderStateParams = {
+  hasStats: boolean;
+  isLoading: boolean;
+  refresh: () => Promise<OverviewRefreshResult>;
+};
+
+function getRelativeRefreshLabel(date: Date | null, now: number): string | null {
+  if (!date) return null;
+
+  const diffMs = Math.max(0, now - date.getTime());
+  const diffSeconds = Math.floor(diffMs / 1000);
+
+  if (diffSeconds < 10) return "Updated just now";
+  if (diffSeconds < 60) return `Updated ${diffSeconds}s ago`;
+
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) return `Last refreshed ${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `Last refreshed ${diffHours}h ago`;
+
+  return `Last refreshed ${date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`;
+}
+
+const ELLIPSIS_FRAMES = [".", "..", "..."] as const;
+
+export function useOverviewHeaderState({
+  hasStats,
+  isLoading,
+  refresh,
+}: UseOverviewHeaderStateParams) {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [ellipsisIndex, setEllipsisIndex] = useState(0);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<Date | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (hasStats && !lastRefreshedAt) {
+      setLastRefreshedAt(new Date());
+    }
+  }, [hasStats, lastRefreshedAt]);
+
+  useEffect(() => {
+    if (!isRefreshing) return;
+
+    const intervalId = window.setInterval(() => {
+      setEllipsisIndex((current) => (current + 1) % ELLIPSIS_FRAMES.length);
+    }, 420);
+
+    return () => window.clearInterval(intervalId);
+  }, [isRefreshing]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setNow(Date.now());
+    }, 15000);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  async function handleRefresh() {
+    setIsRefreshing(true);
+    setEllipsisIndex(0);
+
+    try {
+      const result = await refresh();
+      if (result.ok) {
+        setLastRefreshedAt(new Date());
+        setNow(Date.now());
+      }
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
+
+  const isHeaderLoading = isLoading || isRefreshing;
+
+  return {
+    isRefreshing,
+    isHeaderLoading,
+    refreshButtonLabel: isRefreshing ? "Refreshing" : "Refresh",
+    refreshStatusLabel: isRefreshing
+      ? `Refreshing${ELLIPSIS_FRAMES[ellipsisIndex]}`
+      : getRelativeRefreshLabel(lastRefreshedAt, now),
+    statusLabel: isHeaderLoading ? "Loading budget" : "Connected",
+    statusDotClass: isHeaderLoading
+      ? "h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse"
+      : "h-1.5 w-1.5 rounded-full bg-green-500",
+    handleRefresh,
+  };
+}

--- a/src/features/overview/lib/overviewCards.ts
+++ b/src/features/overview/lib/overviewCards.ts
@@ -1,0 +1,97 @@
+import {
+  Calendar,
+  FileSearch,
+  Landmark,
+  LayoutList,
+  ScrollText,
+  Tag,
+  Terminal,
+  Users,
+} from "lucide-react";
+import type { OverviewActionCard } from "../types";
+
+export const MANAGE_DATA_TITLE = "Advanced Data Management";
+
+export const MANAGE_DATA_DESCRIPTION =
+  "Manage accounts, payees, categories, rules, schedules, and tags with bulk editing, CSV import/export, usage visibility, and advanced rule support.";
+
+export const ADVANCED_TOOLS_DESCRIPTION =
+  "Tools for deeper inspection and analysis.";
+
+export const ENTITY_CARDS: OverviewActionCard[] = [
+  {
+    id: "rules",
+    label: "Rules",
+    description:
+      "Review, refine, and consolidate rules, with visibility into where they are used.",
+    href: "/rules",
+    icon: ScrollText,
+    tone: "entity",
+  },
+  {
+    id: "accounts",
+    label: "Accounts",
+    description:
+      "Maintain accounts with balance visibility and linked rule usage.",
+    href: "/accounts",
+    icon: Landmark,
+    tone: "entity",
+  },
+  {
+    id: "payees",
+    label: "Payees",
+    description:
+      "Clean up and maintain payees through editing, bulk actions, and merge-based consolidation.",
+    href: "/payees",
+    icon: Users,
+    tone: "entity",
+  },
+  {
+    id: "categories",
+    label: "Categories",
+    description:
+      "Review and refine the category structure, manage groups, and see which categories have linked rules.",
+    href: "/categories",
+    icon: LayoutList,
+    tone: "entity",
+  },
+  {
+    id: "schedules",
+    label: "Schedules",
+    description:
+      "View and maintain schedules in one focused place, with access to the linked rule when needed.",
+    href: "/schedules",
+    icon: Calendar,
+    tone: "entity",
+  },
+  {
+    id: "tags",
+    label: "Tags",
+    description:
+      "Review and clean up tags by editing names, descriptions, and colors.",
+    href: "/tags",
+    icon: Tag,
+    tone: "entity",
+  },
+];
+
+export const TOOL_CARDS: OverviewActionCard[] = [
+  {
+    id: "query",
+    label: "ActualQL Queries",
+    description:
+      "Explore budget data with custom ActualQL queries, inspect the results, and export the output.",
+    href: "/query",
+    icon: Terminal,
+    tone: "tool",
+  },
+  {
+    id: "diagnostics",
+    label: "Budget Diagnostics",
+    description:
+      "Inspect exported budget snapshots in a read-only workspace with overview, diagnostics, and data browsing.",
+    icon: FileSearch,
+    tone: "disabled",
+    comingSoon: true,
+  },
+];

--- a/src/features/overview/lib/overviewQueries.test.ts
+++ b/src/features/overview/lib/overviewQueries.test.ts
@@ -1,0 +1,148 @@
+import type { ConnectionInstance } from "@/store/connection";
+import {
+  COUNT_QUERIES,
+  fetchAllOverviewStats,
+  fetchEntityCount,
+  OLDEST_TRANSACTION_QUERY,
+} from "./overviewQueries";
+
+jest.mock("../../../lib/api/query", () => ({
+  runQuery: jest.fn(),
+}));
+
+import { runQuery } from "../../../lib/api/query";
+
+const mockRunQuery = runQuery as jest.MockedFunction<typeof runQuery>;
+
+const connection: ConnectionInstance = {
+  id: "conn-1",
+  label: "Test Budget",
+  baseUrl: "http://localhost:5006",
+  apiKey: "test-key",
+  budgetSyncId: "budget-1",
+};
+
+describe("overviewQueries", () => {
+  beforeEach(() => {
+    mockRunQuery.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  it("returns a scalar count when runQuery resolves with a number", async () => {
+    mockRunQuery.mockResolvedValueOnce({ data: 42 });
+
+    await expect(fetchEntityCount(connection, COUNT_QUERIES.transactions)).resolves.toBe(42);
+    expect(mockRunQuery).toHaveBeenCalledWith(connection, COUNT_QUERIES.transactions);
+  });
+
+  it("returns null when runQuery rejects", async () => {
+    mockRunQuery.mockRejectedValueOnce(new Error("invalid table"));
+
+    await expect(fetchEntityCount(connection, COUNT_QUERIES.transactions)).resolves.toBeNull();
+  });
+
+  it("retries a failed stat once before returning the final overview stats", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    let scheduleAttempts = 0;
+
+    mockRunQuery.mockImplementation(async (_connection, query) => {
+      if (query === COUNT_QUERIES.transactions) return { data: 100 };
+      if (query === COUNT_QUERIES.accounts) return { data: 5 };
+      if (query === COUNT_QUERIES.payees) return { data: 12 };
+      if (query === COUNT_QUERIES.categoryGroups) return { data: 4 };
+      if (query === COUNT_QUERIES.categories) return { data: 18 };
+      if (query === COUNT_QUERIES.rules) return { data: 7 };
+      if (query === COUNT_QUERIES.schedules) {
+        scheduleAttempts += 1;
+        if (scheduleAttempts === 1) {
+          throw new Error("temporary schedules failure");
+        }
+        return { data: 3 };
+      }
+      if (query === OLDEST_TRANSACTION_QUERY) {
+        return { data: [{ date: "2019-01-01", id: "tx-1" }] };
+      }
+      throw new Error("Unexpected query");
+    });
+
+    await expect(fetchAllOverviewStats(connection)).resolves.toEqual({
+      stats: {
+        transactions: 100,
+        accounts: 5,
+        payees: 12,
+        categoryGroups: 4,
+        categories: 18,
+        rules: 7,
+        schedules: 3,
+      },
+      budgetingSince: "Jan 2019",
+    });
+
+    expect(scheduleAttempts).toBe(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[overview] Failed to fetch schedules count (attempt 1/2)",
+      expect.any(Error)
+    );
+  });
+
+  it("returns No transactions when there is no oldest transaction row", async () => {
+    mockRunQuery
+      .mockResolvedValueOnce({ data: 100 })
+      .mockResolvedValueOnce({ data: 5 })
+      .mockResolvedValueOnce({ data: 12 })
+      .mockResolvedValueOnce({ data: 4 })
+      .mockResolvedValueOnce({ data: 18 })
+      .mockResolvedValueOnce({ data: 7 })
+      .mockResolvedValueOnce({ data: 3 })
+      .mockResolvedValueOnce({ data: [] });
+
+    await expect(fetchAllOverviewStats(connection)).resolves.toEqual({
+      stats: {
+        transactions: 100,
+        accounts: 5,
+        payees: 12,
+        categoryGroups: 4,
+        categories: 18,
+        rules: 7,
+        schedules: 3,
+      },
+      budgetingSince: "No transactions",
+    });
+  });
+
+  it("fetches all overview stats and returns the normalized record", async () => {
+    mockRunQuery
+      .mockResolvedValueOnce({ data: 100 })
+      .mockResolvedValueOnce({ data: 5 })
+      .mockResolvedValueOnce({ data: 12 })
+      .mockResolvedValueOnce({ data: 4 })
+      .mockResolvedValueOnce({ data: 18 })
+      .mockResolvedValueOnce({ data: 7 })
+      .mockResolvedValueOnce({ data: 3 })
+      .mockResolvedValueOnce({ data: [{ date: "2019-01-01", id: "tx-1" }] });
+
+    await expect(fetchAllOverviewStats(connection)).resolves.toEqual({
+      stats: {
+        transactions: 100,
+        accounts: 5,
+        payees: 12,
+        categoryGroups: 4,
+        categories: 18,
+        rules: 7,
+        schedules: 3,
+      },
+      budgetingSince: "Jan 2019",
+    });
+
+    expect(mockRunQuery.mock.calls).toEqual([
+      [connection, COUNT_QUERIES.transactions],
+      [connection, COUNT_QUERIES.accounts],
+      [connection, COUNT_QUERIES.payees],
+      [connection, COUNT_QUERIES.categoryGroups],
+      [connection, COUNT_QUERIES.categories],
+      [connection, COUNT_QUERIES.rules],
+      [connection, COUNT_QUERIES.schedules],
+      [connection, OLDEST_TRANSACTION_QUERY],
+    ]);
+  });
+});

--- a/src/features/overview/lib/overviewQueries.ts
+++ b/src/features/overview/lib/overviewQueries.ts
@@ -1,0 +1,191 @@
+import { runQuery } from "@/lib/api/query";
+import type { ConnectionInstance } from "@/store/connection";
+import type { BudgetOverviewSnapshot, OverviewStatKey } from "../types";
+
+type ScalarCountQuery = {
+  ActualQLquery: {
+    table: string;
+    calculate: { $count: "$id" };
+  };
+};
+
+type OldestTransactionQuery = {
+  ActualQLquery: {
+    table: "transactions";
+    select: ["date"];
+    orderBy: [{ date: "asc" }, "id"];
+    limit: 1;
+  };
+};
+
+type OldestTransactionRow = {
+  date: string;
+  id?: string;
+};
+
+type OverviewCountKey = keyof typeof COUNT_QUERIES;
+
+const OVERVIEW_QUERY_MAX_ATTEMPTS = 2;
+
+export const TRANSACTION_COUNT_QUERY = {
+  ActualQLquery: { table: "transactions", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const ACCOUNT_COUNT_QUERY = {
+  ActualQLquery: { table: "accounts", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const PAYEE_COUNT_QUERY = {
+  ActualQLquery: { table: "payees", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const CATEGORY_GROUP_COUNT_QUERY = {
+  ActualQLquery: { table: "category_groups", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const CATEGORY_COUNT_QUERY = {
+  ActualQLquery: { table: "categories", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const RULE_COUNT_QUERY = {
+  ActualQLquery: { table: "rules", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const SCHEDULE_COUNT_QUERY = {
+  ActualQLquery: { table: "schedules", calculate: { $count: "$id" } },
+} as const satisfies ScalarCountQuery;
+
+export const OLDEST_TRANSACTION_QUERY = {
+  ActualQLquery: {
+    table: "transactions",
+    select: ["date"],
+    orderBy: [{ date: "asc" }, "id"],
+    limit: 1,
+  },
+} as const satisfies OldestTransactionQuery;
+
+export const COUNT_QUERIES = {
+  transactions: TRANSACTION_COUNT_QUERY,
+  accounts: ACCOUNT_COUNT_QUERY,
+  payees: PAYEE_COUNT_QUERY,
+  categoryGroups: CATEGORY_GROUP_COUNT_QUERY,
+  categories: CATEGORY_COUNT_QUERY,
+  rules: RULE_COUNT_QUERY,
+  schedules: SCHEDULE_COUNT_QUERY,
+} as const;
+
+const COUNT_QUERY_KEYS = Object.keys(COUNT_QUERIES) as OverviewCountKey[];
+
+async function runScalarCountQuery(
+  connection: ConnectionInstance,
+  query: ScalarCountQuery
+): Promise<number> {
+  const result = await runQuery<{ data: number }>(connection, query);
+
+  if (typeof result.data !== "number") {
+    throw new Error("Overview count query returned a non-numeric result");
+  }
+
+  return result.data;
+}
+
+function logOverviewQueryFailure(
+  label: string,
+  attempt: number,
+  error: unknown
+) {
+  console.warn(
+    `[overview] Failed to fetch ${label} (attempt ${attempt}/${OVERVIEW_QUERY_MAX_ATTEMPTS})`,
+    error
+  );
+}
+
+function formatBudgetingSince(dateString: string): string {
+  const [year, month] = dateString.split("-");
+  const monthIndex = Number(month) - 1;
+  const parsedYear = Number(year);
+
+  if (!Number.isInteger(monthIndex) || monthIndex < 0 || monthIndex > 11 || !Number.isInteger(parsedYear)) {
+    throw new Error("Oldest transaction query returned an invalid date");
+  }
+
+  return new Date(Date.UTC(parsedYear, monthIndex, 1)).toLocaleString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+async function fetchOverviewCountWithRetry(
+  connection: ConnectionInstance,
+  statKey: OverviewCountKey
+): Promise<number | null> {
+  const query = COUNT_QUERIES[statKey];
+
+  for (let attempt = 1; attempt <= OVERVIEW_QUERY_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await runScalarCountQuery(connection, query);
+    } catch (error) {
+      logOverviewQueryFailure(`${statKey} count`, attempt, error);
+      if (attempt === OVERVIEW_QUERY_MAX_ATTEMPTS) {
+        return null;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function fetchBudgetingSinceWithRetry(
+  connection: ConnectionInstance
+): Promise<string | null> {
+  for (let attempt = 1; attempt <= OVERVIEW_QUERY_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await runQuery<{ data: OldestTransactionRow[] }>(connection, OLDEST_TRANSACTION_QUERY);
+      const oldest = result.data[0];
+
+      if (!oldest) {
+        return "No transactions";
+      }
+
+      return formatBudgetingSince(oldest.date);
+    } catch (error) {
+      logOverviewQueryFailure("budgetingSince", attempt, error);
+      if (attempt === OVERVIEW_QUERY_MAX_ATTEMPTS) {
+        return null;
+      }
+    }
+  }
+
+  return null;
+}
+
+export async function fetchEntityCount(
+  connection: ConnectionInstance,
+  query: ScalarCountQuery
+): Promise<number | null> {
+  try {
+    return await runScalarCountQuery(connection, query);
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchAllOverviewStats(
+  connection: ConnectionInstance
+): Promise<BudgetOverviewSnapshot> {
+  const [entries, budgetingSince] = await Promise.all([
+    Promise.all(
+      COUNT_QUERY_KEYS.map(async (statKey) => {
+        const value = await fetchOverviewCountWithRetry(connection, statKey);
+        return [statKey, value] as const;
+      })
+    ),
+    fetchBudgetingSinceWithRetry(connection),
+  ]);
+
+  return {
+    stats: Object.fromEntries(entries) as Record<OverviewStatKey, number | null>,
+    budgetingSince,
+  };
+}

--- a/src/features/overview/types.ts
+++ b/src/features/overview/types.ts
@@ -1,0 +1,42 @@
+import type { ComponentType } from "react";
+
+export type OverviewStatKey =
+  | "transactions"
+  | "accounts"
+  | "payees"
+  | "categoryGroups"
+  | "categories"
+  | "rules"
+  | "schedules";
+
+export type BudgetOverviewStats = Record<OverviewStatKey, number | null>;
+
+export type BudgetOverviewSnapshot = {
+  stats: BudgetOverviewStats;
+  budgetingSince: string | null;
+};
+
+export type OverviewActionTone = "entity" | "tool" | "disabled";
+
+export type OverviewActionCard = {
+  id: string;
+  label: string;
+  description: string;
+  href?: string;
+  icon: ComponentType<{ className?: string }>;
+  tone: OverviewActionTone;
+  comingSoon?: boolean;
+};
+
+export type OverviewRefreshResult = {
+  ok: boolean;
+  hasPartialFailure: boolean;
+};
+
+export type UseBudgetOverviewResult = {
+  snapshot: BudgetOverviewSnapshot | null;
+  isLoading: boolean;
+  isError: boolean;
+  hasPartialFailure: boolean;
+  refresh: () => Promise<OverviewRefreshResult>;
+};

--- a/src/features/payees/hooks/usePayees.ts
+++ b/src/features/payees/hooks/usePayees.ts
@@ -6,11 +6,15 @@ import { getPayees } from "@/lib/api/payees";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
+type PreloadOptions = {
+  enabled?: boolean;
+};
+
 /**
  * Fetches payees from the API and loads them into the staged store.
  * Re-runs whenever the active connection changes.
  */
-export function usePayees() {
+export function usePayees(options: PreloadOptions = {}) {
   const connection = useConnectionStore(selectActiveInstance);
   const loadPayees = useStagedStore((s) => s.loadPayees);
 
@@ -20,7 +24,7 @@ export function usePayees() {
       if (!connection) throw new Error("No active connection");
       return getPayees(connection);
     },
-    enabled: !!connection,
+    enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.
   });
 

--- a/src/features/payees/hooks/usePayeesSave.ts
+++ b/src/features/payees/hooks/usePayeesSave.ts
@@ -152,6 +152,7 @@ export function usePayeesSave() {
       await queryClient.invalidateQueries({ queryKey: ["rules", connection.id] });
     }
 
+    await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });
     return { succeeded, failed, idMap };
   }
 

--- a/src/features/rules/hooks/useRules.ts
+++ b/src/features/rules/hooks/useRules.ts
@@ -6,7 +6,11 @@ import { getRules } from "@/lib/api/rules";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
-export function useRules() {
+type PreloadOptions = {
+  enabled?: boolean;
+};
+
+export function useRules(options: PreloadOptions = {}) {
   const connection = useConnectionStore(selectActiveInstance);
   const loadRules = useStagedStore((s) => s.loadRules);
 
@@ -16,7 +20,7 @@ export function useRules() {
       if (!connection) throw new Error("No active connection");
       return getRules(connection);
     },
-    enabled: !!connection,
+    enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.
   });
 

--- a/src/features/rules/hooks/useRulesSave.ts
+++ b/src/features/rules/hooks/useRulesSave.ts
@@ -214,6 +214,7 @@ export function useRulesSave() {
 
     await queryClient.invalidateQueries({ queryKey: ["rules", connection.id] });
 
+    await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });
     return { succeeded, failed, idMap: {} };
   }
 

--- a/src/features/schedules/hooks/useSchedules.ts
+++ b/src/features/schedules/hooks/useSchedules.ts
@@ -6,7 +6,11 @@ import { getSchedules } from "@/lib/api/schedules";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
-export function useSchedules() {
+type PreloadOptions = {
+  enabled?: boolean;
+};
+
+export function useSchedules(options: PreloadOptions = {}) {
   const connection = useConnectionStore(selectActiveInstance);
   const loadSchedules = useStagedStore((s) => s.loadSchedules);
 
@@ -16,7 +20,7 @@ export function useSchedules() {
       if (!connection) throw new Error("No active connection");
       return getSchedules(connection);
     },
-    enabled: !!connection,
+    enabled: !!connection && (options.enabled ?? true),
   });
 
   useEffect(() => {

--- a/src/features/schedules/hooks/useSchedulesSave.ts
+++ b/src/features/schedules/hooks/useSchedulesSave.ts
@@ -139,6 +139,7 @@ export function useSchedulesSave() {
     await queryClient.invalidateQueries({ queryKey: ["rules", connection.id] });
     await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "schedule", connection.id] });
 
+    await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });
     return { succeeded, failed, idMap };
     } finally {
       setIsSaving(false);

--- a/src/hooks/useAllEntities.ts
+++ b/src/hooks/useAllEntities.ts
@@ -14,10 +14,10 @@ import { useSchedules } from "@/features/schedules/hooks/useSchedules";
  * which page the user is on. TanStack Query deduplicates the requests — page-
  * level hooks that call the same fetch hook will share the cached result.
  */
-export function usePreloadEntities() {
-  useAccounts();
-  usePayees();
-  useCategoryGroups();
-  useRules();
-  useSchedules();
+export function usePreloadEntities(enabled = true) {
+  useAccounts({ enabled });
+  usePayees({ enabled });
+  useCategoryGroups({ enabled });
+  useRules({ enabled });
+  useSchedules({ enabled });
 }

--- a/src/hooks/useIsHydrated.ts
+++ b/src/hooks/useIsHydrated.ts
@@ -1,0 +1,7 @@
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+
+export function useIsHydrated(): boolean {
+  return useSyncExternalStore(emptySubscribe, () => true, () => false);
+}


### PR DESCRIPTION

  ## Summary

  Implements RD-025 by adding a dedicated /overview homepage for the active connected budget.

  This PR adds a compact live snapshot powered by ActualQL, including transactions, accounts, payees, categories, schedules, rules, and budgeting-since. It also adds clear entry points into the main data-management pages and a separate advanced-tools section so Overview becomes the primary navigation hub after connect.

  The connect and reconnect flows now land on /overview, already-connected users are redirected away from /connect, and the Overview query is invalidated after supported saves so the page stays in sync with live server state. The app shell also skips eager entity preloading on /overview to keep the page lighter than the main entity pages.

Closes #62 

<img width="1172" height="769" alt="image" src="https://github.com/user-attachments/assets/e6af22c9-91d4-4544-b733-e9bbb8c2907b" />


  ## Test plan

  - [x] npm run lint passes
  - [x] npx tsc --noEmit passes
  - [x] npm run build passes
  - [x] npm test passes
  - [x] Manually tested in browser

  ## Notes

  - Overview uses multiple ActualQL reads, not a single batched backend call.
  - The shipped snapshot intentionally excludes Tags, and Category Groups are still fetched but not displayed.
  - Budget Diagnostics is present as a planned disabled card only; this PR does not implement that workspace.
  - Targeted Overview Jest coverage was added for query behavior, budget switching, refresh loading state, and refresh timestamp handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Budget Overview page with snapshot stats, "Budgeting Since" metric, manual refresh with live status, and a navigation hub for managing data and tools.
  * "Overview" added to the main sidebar; users are redirected to Overview after connecting.

* **Bug Fixes / Improvements**
  * Preload behavior refined to avoid eager preload on the Overview route.

* **Tests**
  * Added test coverage for the Budget Overview UI and data queries.

* **Chores**
  * Bumped app version and updated Next.js/ESLint package ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->