### PR TITLE
docs: refresh repository guidance and product docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ agents/
 
 .next
 .next-build
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,19 +38,10 @@ import { generateId } from "@/lib/uuid";
 
 **Version endpoints** (`/v1/actualhttpapiversion`, `/actualserverversion`) are optional — always `Promise.allSettled()`, never block on failure.
 
-**Staged row colors** — use semantic Tailwind tokens, never hardcode Tailwind color names:
-```tsx
-// ❌ "bg-green-500"  "bg-amber-400"  "bg-muted-foreground/40"
-// ✅
-"bg-staged-new"        // new rows
-"bg-staged-updated"    // updated rows
-"bg-staged-deleted"    // deleted rows
-// tokens defined in globals.css via @theme inline
-```
 
-**Git** — never auto-commit or auto-push. Always: show diff → propose message → wait for approval. PRs target `main`. Never work directly on `main` — always use a feature or fix branch. Use `x-rous` as the GitHub username and `Manaf` as the author name for all commits and PRs.
+**Git** — never auto-commit or auto-push. Always: show diff → propose message → wait for approval. PRs target `main`. Never work directly on `main` — always use a short-lived branch with an approved prefix (`feat/*`, `fix/*`, `refactor/*`, or `docs/*`). Use `x-rous` as the GitHub username and `Manaf` as the author name for all commits and PRs.
 ```
-feat/* or fix/*  →  main  →  release (tag v1.x.x)
+feat/* | fix/* | refactor/* | docs/*  →  main  →  release (tag v1.x.x)
 ```
 
 ---
@@ -61,6 +52,7 @@ feat/* or fix/*  →  main  →  release (tag v1.x.x)
 | TanStack Query | Server snapshots (read-only) |
 | Zustand `staged.ts` | Pending mutations + undo/redo |
 | Zustand `connection.ts` | Active connection (`sessionStorage` — do NOT change to `localStorage`) |
+| Zustand `savedServers.ts` | Saved server presets (`sessionStorage`) |
 | Local state | Ephemeral UI only |
 
 ---
@@ -77,10 +69,11 @@ feat/* or fix/*  →  main  →  release (tag v1.x.x)
 | Docker changes | `docker/Dockerfile.prod` |
 | Query client config | `src/lib/queryClient.ts` |
 
-**Feature folder structure** (mandatory):
+**Feature folder structure** (mandatory baseline):
 ```
 src/features/<entity>/
   components/   hooks/   csv/   schemas/
+  lib/          utils/   # optional, when the feature needs them
 ```
 
 **Proxy responsibilities:**
@@ -104,6 +97,12 @@ Read these **before** implementing anything in the relevant area.
 | `agents/requirements/` | Before making architectural decisions |
 | `CONTRIBUTING.md` | Before touching git, workflows, or the release process |
 | `FEATURES.md` | Before and after shipping a feature — must be updated |
+| `README.md` | When entry points, setup flow, or product positioning changes |
+
+When shipping user-facing work:
+- Update `FEATURES.md` for shipped behavior.
+- Update `README.md` if the main app entry points or product positioning changed.
+- Update `agents/future-roadmap.md` when a roadmap item's status changes.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Contributions are welcome — bug reports, feature requests, and pull requests a
 ## Branch Model
 
 ```
-feat/* or fix/*  ──PR──►  main  ──push──►  :edge Docker + deploy
-                               ──tag v1.x.0──►  :latest + :<version> + GitHub Release
+feat/* | fix/* | refactor/* | docs/*  ──PR──►  main  ──CI success──►  :edge Docker + deploy
+                                                    ──tag v1.x.0──►  :latest + :<version> + GitHub Release
 ```
 
 | Branch | Purpose | Docker tag |
@@ -36,7 +36,7 @@ Open an issue using the **Feature request** template. Check open issues first to
 ### Prerequisites
 
 - Node.js 20+
-- A running [actual-http-api](https://github.com/sakowicz/actual-http-api) server (or use a test budget)
+- A running [actual-http-api](https://github.com/jhonderson/actual-http-api) server (or use a test budget)
 
 ### Setup
 
@@ -93,6 +93,11 @@ The `feat/* → main` PR is the source of truth for the release draft. Two thing
 
 The PR description is for reviewers — explain what changed, why, and include screenshots where relevant. It does not appear in the changelog.
 
+For user-facing changes:
+
+- Update [FEATURES.md](FEATURES.md) when a feature ships or materially changes
+- Update [README.md](README.md) when the main app entry points or product positioning change
+
 ### What to work on
 
 Check issues labelled [`good first issue`](https://github.com/x-rous/actual-bench/issues?q=is%3Aissue+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/x-rous/actual-bench/issues?q=is%3Aissue+label%3A%22help+wanted%22).
@@ -113,8 +118,12 @@ src/
   features/
     accounts/       # Accounts page, hooks, components
     categories/     # Categories page, hooks, components
+    overview/       # Budget Overview page, snapshot, navigation cards
     payees/         # Payees page, hooks, components
+    query/          # ActualQL query workspace
     rules/          # Rules page, drawer, condition/action builder
+    schedules/      # Schedules page, hooks, components
+    tags/           # Tags page, hooks, components
   lib/api/          # Typed API functions per entity
   store/
     connection.ts   # Zustand store — saved connections (sessionStorage)
@@ -127,7 +136,7 @@ src/
 - **TypeScript** — strict mode; no `any`
 - **Styling** — Tailwind CSS v4; use `cn()` for conditional classes
 - **State** — Zustand stores for global state; TanStack Query for server data
-- **Components** — React Server Components where possible; `"use client"` only when needed
+- **Components** — prefer server components where practical, but most authenticated workbench UI is client-side; use `"use client"` for interactive staged-editing flows without hesitation
 - **Commits** — one logical change per commit; keep PRs focused
 - **IDs** — always use `generateId()` from `src/lib/uuid.ts`; never `crypto.randomUUID()` directly (fails on HTTP)
 
@@ -138,7 +147,7 @@ src/
 | Workflow | Trigger | What it does |
 |---|---|---|
 | **CI** (`.github/workflows/ci.yml`) | All pushes + PRs | Lint, type-check, test, build — must pass before any merge |
-| **Edge** (`.github/workflows/edge.yml`) | Push to `main` | Builds and pushes `:edge` + `:edge-{sha}` Docker tags, deploys to VPS |
+| **Edge** (`.github/workflows/edge.yml`) | `workflow_run` after CI succeeds on `main` | Builds and pushes the `:edge` Docker tag, deploys to VPS |
 | **Release Drafter** (`.github/workflows/release-drafter.yml`) | Push to `main` | Updates a draft GitHub Release with all merged PRs since the last tag |
 | **Release** (`.github/workflows/release.yml`) | Push `v*` tag | Runs full CI, verifies version, builds and pushes `:latest` + `:<version>` Docker tags, deploys to VPS, publishes the draft GitHub Release |
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,6 +9,16 @@
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed
 
+## Budget Overview
+
+- `/overview` is the default landing page after connecting or reconnecting to a budget
+- Compact snapshot row showing live saved-state metrics for transactions, accounts, payees, categories, schedules, and rules
+- Derived snapshot context includes **Budget Mode** (`Envelope`, `Tracking`, or `Unidentified`) and **Budgeting since** from the oldest transaction date
+- Manual refresh button with loading state and last-refreshed status
+- Snapshot values switch to loading placeholders immediately during budget switching or manual refresh
+- Main navigation hub for the connected budget with direct links to the core entity pages and ActualQL Queries
+- Budget Diagnostics appears as a planned disabled tool card only — the diagnostics workspace is not implemented yet
+
 ## Rules
 
 - Create, edit, and delete rules with a full condition/action builder
@@ -215,7 +225,7 @@ Transaction counts are fetched lazily when the drawer opens, gated by the same `
 
 ## Navigation & Layout
 
-- Collapsible sidebar with navigation links to all sections; collapse state persists across reloads
+- Collapsible sidebar with a standalone `Overview` item and grouped `Data Management` / `Tools` sections; collapse state persists across reloads
 - Top bar shows the active connection with a switcher dropdown, undo/redo, discard, save, and a refresh button — refresh prompts for confirmation when unsaved changes exist
 - Toast notifications for all success, error, and warning states
 - Entity counts shown in page headers
@@ -225,4 +235,4 @@ Transaction counts are fetched lazily when the drawer opens, gated by the same `
 ---
 
 > Planned features and improvements are tracked in [`agents/future-roadmap.md`](agents/future-roadmap.md).
-> When a roadmap item ships, add it to the relevant section above and log it in [`CHANGELOG.md`](CHANGELOG.md).
+> When a roadmap item ships, add it to the relevant section above and let the merged PR title feed the next GitHub Release draft.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@
   <a href="https://github.com/x-rous/actual-bench/blob/main/LICENSE"><img src="https://img.shields.io/github/license/x-rous/actual-bench" alt="License" /></a>
 </p>
 
-A power-user workbench for [Actual Budget](https://github.com/actualbudget/actual). It connects to a self-hosted [actual-http-api](https://github.com/jhonderson/actual-http-api) server and gives you a dedicated UI for bulk operations, advanced rules management, and diagnostics, things that are difficult or impossible to do from the native Actual Budget interface.
+A power-user workbench for [Actual Budget](https://github.com/actualbudget/actual). It connects to a self-hosted [actual-http-api](https://github.com/jhonderson/actual-http-api) server and gives you a dedicated UI for bulk operations, advanced rules management, budget overview, and diagnostics, things that are difficult to do from the native Actual Budget interface.
 
 Useful for power users who want more control over their budget data, and for testers setting up or validating a fresh Actual Budget instance.
 
 ## Why actual-bench?
 
 - **Bulk CSV import/export** for every entity - seed a fresh budget with hundreds of rules, payees, categories, or schedules in one go
+- **Budget Overview homepage** - land on a compact overview with live budget metrics, budget mode, budgeting-since, and quick links into the main admin pages
 - **Advanced rules management** - visual condition/action builder, merge, duplicate, stage filtering, and template mode in one focused view
 - **Staged editing with undo/redo** - review every change locally before anything touches the server
 - **Multi-server, multi-budget** - save and switch between connections without leaking data between sessions
 - **Schedules management** - create and edit one-time and recurring schedules with full recurrence controls, amount modes, and weekend adjustment
 - **ActualQL query workspace** - run ad-hoc ActualQL queries against your budget, inspect results as table / raw JSON / scalar / collapsible tree, save and replay named query packs, and copy a cURL command for any executed query
-- **SQLite budget diagnostic** *(coming soon)* - inspect a `.sqlite` budget file client-side: table overview, row counts, and a read-only table browser
+- **Budget Diagnostics** *(planned)* - inspect exported budget snapshots in a read-only workspace with diagnostics and data browsing
 
 ## Architecture
 
@@ -31,7 +32,7 @@ Browser
               └─► Actual Budget  (SQLite budget file)
 ```
 
-All browser requests route through an internal Next.js proxy - no direct browser-to-API calls. Credentials never leave the server proxy; session storage is cleared when the tab is closed. For Docker deployments, ensure actual-bench and http-api reside on the same Docker network to allow internal network connectivity.
+All browser requests route through an internal Next.js proxy - no direct browser-to-API calls to `actual-http-api`. Connection credentials are sent only to actual-bench and proxied server-side to the API; session storage is cleared when the tab is closed. For Docker deployments, ensure actual-bench and http-api reside on the same Docker network to allow internal network connectivity.
 
 ## Screenshots
 
@@ -50,11 +51,12 @@ All browser requests route through an internal Next.js proxy - no direct browser
 ## Features
 
 - **Multi-connection support** - save and switch between multiple Actual Budget servers or budget files; staged data and query cache are scoped per connection
+- **Budget Overview** - connected budgets land on `/overview` with live snapshot metrics, budget mode, budgeting-since, refresh status, and direct links into core admin pages
 - **Staged editing** - all changes are held locally until you click Save; nothing touches the server until you confirm
 - **Undo / Redo** - step backwards and forwards through your edits before committing
-- **Accounts** - view and rename accounts, toggle on/off budget status; CSV import/export
-- **Payees** - view, rename, and delete payees; CSV import/export
-- **Categories** - view, rename, show/hide, and reorder categories within groups; CSV import/export
+- **Accounts** - create, edit, close, reopen, and delete accounts with live balance visibility; CSV import/export
+- **Payees** - view, edit, bulk-manage, and merge multiple payees; CSV import/export
+- **Categories** - manage groups and categories, visibility, and hierarchy; CSV import/export
 - **Rules** - view, filter by stage, create, edit, and merge rules with a full condition/action builder; CSV import/export
 - **Schedules** - create and manage one-time and recurring schedules with amount modes, weekend adjustment, and end conditions; overdue dates are highlighted; CSV import/export
 - **Tags** - create, rename, and color-code tags (requires Actual Budget v26.3.0+); CSV import/export
@@ -106,7 +108,7 @@ The Connect screen uses a two-step flow:
 | **Server URL** | Base URL of your actual-http-api server (e.g. `https://actual-api.example.com`) |
 | **API Key** | The `ACTUAL_API_KEY` you set on the server |
 
-Click **Validate** to fetch the list of budgets available on that server.
+Click **Load Budgets** to fetch the list of budgets available on that server.
 
 **Step 2 - Select a budget and connect**
 
@@ -115,7 +117,7 @@ Click **Validate** to fetch the list of budgets available on that server.
 | **Budget** | Pick from the list of budgets returned by the server |
 | **Encryption Password** | Only required if the budget is end-to-end encrypted |
 
-Click **Connect** to finish. The connection is saved in **session storage** - credentials are cleared automatically when the tab is closed. Multiple connections can be saved and switched between; previously saved connections appear at the top of the Connect screen for one-click reconnect.
+Click **Connect** to finish. Successful connect and reconnect flows land on **Overview**. The connection is saved in **session storage** - credentials are cleared automatically when the tab is closed. Multiple connections can be saved and switched between; previously saved connections appear at the top of the Connect screen for one-click reconnect.
 
 ## Staged Editing Workflow
 
@@ -170,7 +172,7 @@ Ready-to-use sample CSV files are included in [`public/samples csv/`](public/sam
 ## Coming Soon
 
 - **Rule diagnostics** - detect conflicting, shadowed, or redundant rules across stages
-- **SQLite budget diagnostic** - drop a `.sqlite` file to inspect tables, row counts, and schema version without uploading anything to a server
+- **Budget Diagnostics** - inspect exported budget snapshots in a read-only workspace with overview, diagnostics, and data browsing
 
 ## Known Limitations
 

--- a/agents/future-roadmap.md
+++ b/agents/future-roadmap.md
@@ -14,15 +14,14 @@
 ## Claude Session Rules
 
 **Git workflow — STRICT:**
-- Run lint (`npm run lint`) after making changes, then STOP.
 - Do NOT stage, commit, or push anything without explicit user approval.
 - Show the proposed commit title + description and wait for "yes" before touching git.
 - Never push to remote without a separate explicit confirmation.
 
 **Testing workflow:**
-- The dev server at `actual-bench-dev.nafverse.com` is linked to the source code live.
-- After lint passes, tell the user to test on the dev server. Wait for their feedback before proceeding.
-- Do NOT run `npm run build` — builds run in CI, not locally.
+- Before asking to commit a feature or fix, run `npm run lint`, `npx tsc --noEmit`, and `npm test` unless the user explicitly says not to.
+- The dev server at `actual-bench-dev.nafverse.com` is useful for manual browser validation when a change needs UI testing.
+- Do NOT run `npm run build` unless the user asks for a build-specific check or the change is likely to affect CI/build output.
 
 ---
 
@@ -47,10 +46,10 @@ All API functions live here. Every function imports `apiRequest` from `./client`
 All browser fetches route through here — no direct browser→API calls. The proxy serializes requests per-server via a `serverQueueTails` Map to prevent concurrent budget open/close races in actual-http-api. Budget-scoped paths are automatically prefixed: `path = "/accounts"` → `GET /v1/budgets/{budgetSyncId}/accounts`. The proxy currently calls `upstreamResponse.json()` on all 200 responses — binary responses (e.g. budget export ZIP) require special handling.
 
 **Entity types** (`src/types/entities.ts`)
-Internal normalized types. `Schedule` and `RecurConfig` are fully defined. `Tag` exists but is missing `color` and `description` fields (added in Actual Budget v26.3.0). `Transaction` type does not exist yet.
+Internal normalized types. `Schedule` and `RecurConfig` are fully defined. `Tag` includes `color` and `description` fields. `Transaction` type does not exist yet.
 
 **Staged store** (`src/store/staged.ts`)
-All mutations go through `stageNew`, `stageUpdate`, `stageDelete`. Data is not sent to the server until `Save` is clicked. The store holds `accounts`, `payees`, `categoryGroups`, `categories`, `rules`, `schedules` slices. All entity slices including rules are prefetched on every page via `usePreloadEntities()` in AppShell — `stagedRules` is populated as soon as the app loads.
+All mutations go through `stageNew`, `stageUpdate`, `stageDelete`. Data is not sent to the server until `Save` is clicked. The store holds `accounts`, `payees`, `categoryGroups`, `categories`, `rules`, `schedules`, and `tags` slices. Most entity slices are eagerly prefetched via `usePreloadEntities()` in AppShell, but `/overview` intentionally skips that preload path to stay lighter.
 
 **Connection** (`src/store/connection.ts`)
 `ConnectionInstance` type: `{ id, label, baseUrl, apiKey, budgetSyncId, encryptionPassword? }`. Persisted to sessionStorage via Zustand persist middleware.
@@ -91,7 +90,9 @@ RD-018 (Saved servers)       — complete
 RD-019 (Grouped categories)  — complete
 RD-020 (Rule editing improvements) — complete
 RD-023 (Rule diagnostics)    — depends on RD-007 (now complete); enhanced by RD-016 if available; unblocked
-RD-024 (SQLite diagnostic)   — independent; fully client-side (WASM SQLite)
+RD-024 (Budget diagnostics)  — independent; planned read-only exported-budget workspace
+RD-025 (Budget overview)     — complete
+RD-026 (Sidebar grouping)    — complete
 ```
 
 ---
@@ -1174,7 +1175,7 @@ type RuleDiagnostic = {
 
 ---
 
-### RD-024 — SQLite Budget File Diagnostic
+### RD-024 — Budget Diagnostics
 
 | | |
 |---|---|
@@ -1183,60 +1184,112 @@ type RuleDiagnostic = {
 | **Status** | pending |
 | **Depends on** | nothing (fully client-side) |
 
-**What:** A diagnostic view that lets users drop or pick a `.sqlite` Actual Budget file and inspect its contents entirely in the browser. No file is uploaded to any server — processing happens via WASM SQLite.
+**What:** A read-only diagnostics workspace that lets users open an exported Actual Budget snapshot locally and inspect its contents in the browser. No file is uploaded to any server — processing happens client-side, likely via WASM SQLite.
 
 **Why:**
 - Useful for testers and power users who want to inspect raw budget state without writing SQL manually
 - Complements ActualQL (RD-007) by providing a structural overview before running queries
 - Fully offline — no server-side risk or data exposure
-- Natural fit for actual-bench's "workbench" positioning
+- Fits actual-bench's workbench positioning better than a generic file browser
+
+**Current product state:**
+- Overview already exposes **Budget Diagnostics** as a planned disabled tool card
+- The diagnostics workspace itself does **not** exist yet
+- Do not add a live sidebar route until the page is implemented
 
 **Scope v1:**
-- File picker and drag-and-drop zone that reads the `.sqlite` file client-side
-- Display: file size, Actual schema version (from `migrations` or `meta` table), list of all tables with row counts
-- Read-only paginated table browser — pick any table, browse rows
+- File picker and drag-and-drop zone that reads an exported budget snapshot client-side
+- Display: file size, schema/version details, list of all tables with row counts
+- Read-only paginated table browser — pick any table and browse rows
 - Powered by [`sql.js`](https://github.com/sql-js/sql.js) or `wa-sqlite` (WASM SQLite); no native Node.js SQLite dependency
 
 **Non-goals:**
 - No file upload to actual-http-api or any server
-- No writes to the SQLite file
-- No transaction import from this view
-- No query execution in v1 (that is RD-007's scope)
+- No writes to the opened budget snapshot
+- No mutation flows from this workspace
+- No query execution in v1 (ActualQL already covers that workflow)
 
 **Files to create:**
 ```text
-src/features/sqlite-diagnostic/
-  components/SqliteDiagnosticView.tsx   — drop zone + file info + table list
-  components/TableBrowser.tsx           — paginated read-only row viewer
-  lib/sqliteReader.ts                   — sql.js wrapper: open file, list tables, count rows, fetch page
-src/app/(app)/sqlite-diagnostic/
+src/features/budget-diagnostics/
+  components/BudgetDiagnosticsView.tsx   — drop zone + file info + table list
+  components/TableBrowser.tsx            — paginated read-only row viewer
+  lib/sqliteReader.ts                    — WASM SQLite wrapper: open file, list tables, count rows, fetch page
+src/app/(app)/budget-diagnostics/
   page.tsx
 ```
 
 **Files to update:**
-- `src/components/layout/Sidebar.tsx` — add nav entry (e.g. "SQLite Diagnostic")
-- `src/app/(app)/layout.tsx` if any route-level setup is needed
+- `src/components/layout/Sidebar.tsx` — add nav entry only when the route exists
+- `src/features/overview/lib/overviewCards.ts` — switch the planned card to a live link when the workspace ships
 
 **Implementation notes:**
-- `sql.js` is loaded from CDN or bundled as a dynamic import to avoid bloating the main bundle
-- The WASM binary must be served from `public/` or imported via a worker
-- File reading uses the `FileReader` API — no server roundtrip
-- v1 is intentionally read-only and stateless; the file is never persisted between sessions
+- `sql.js` can be dynamically imported to avoid bloating the main bundle
+- The WASM binary must be served from `public/` or bundled appropriately
+- File reading should use the `FileReader` API — no server roundtrip
+- v1 should stay read-only and stateless; the opened file is never persisted between sessions
 
 **UI notes:**
-- Provide summary cards at the top: total issues, errors, warnings, infos
-- Table columns: severity, rule, issue, suggested action
-- Clicking a diagnostic should open or focus the related rule in the Rules page where possible
-- Allow filters by severity and issue type
-
-**Design guardrails:**
-- Do not attempt to reimplement Actual's full evaluation engine
-- Prefer transparent heuristics over overly clever scoring
-- False positives are acceptable if the explanation is clear and the severity is conservative
+- Show compact file summary cards at the top: filename, file size, schema/version, table count
+- Use a simple table list + row browser layout instead of trying to mimic a full database IDE
+- Keep system-table visibility explicit so power users can inspect raw structures when needed
 
 **Possible future integration:**
-- Show a small warning badge on the Rules nav item when diagnostics detect errors
-- Link to RD-021 Usage Inspector for missing-entity and reference-related issues
-- Offer export to CSV / JSON later if users find the diagnostics useful
+- Launch an ActualQL draft from a selected table/schema context
+- Offer export of a selected table view to CSV / JSON later if users find the diagnostics useful
+- Add higher-level structural checks once the basic browser exists
+
+---
+
+### RD-025 — Budget Overview Homepage
+
+| | |
+|---|---|
+| **Priority** | High |
+| **Effort** | M |
+| **Status** | complete |
+| **Depends on** | nothing |
+
+**What:** Add `/overview` as the default connected-budget homepage with a compact live snapshot and direct navigation into the main admin workflows.
+
+**Shipped scope:**
+- `/overview` route added and used as the landing page after connect/reconnect
+- Snapshot metrics for transactions, accounts, payees, categories, schedules, and rules
+- Derived snapshot context for **Budget Mode** and **Budgeting since**
+- Manual refresh with loading state and last-refreshed status
+- Overview-specific preload behavior so the app shell skips eager entity preload on `/overview`
+- Main action grids for core data-management pages and advanced tools
+- Budget Diagnostics represented as a planned disabled tool card only
+
+**Primary files:**
+- `src/app/(app)/overview/page.tsx`
+- `src/features/overview/`
+- `src/components/connect/useConnectForm.ts`
+- `src/components/layout/AppShell.tsx`
+- save hooks that invalidate `['budget-overview', connection.id]`
+
+---
+
+### RD-026 — Sidebar Navigation Grouping
+
+| | |
+|---|---|
+| **Priority** | Medium |
+| **Effort** | S |
+| **Status** | complete |
+| **Depends on** | RD-025 helpful, but not required |
+
+**What:** Reorganize the sidebar into a clearer navigation model without introducing heavy nesting or collapsible tree controls.
+
+**Shipped scope:**
+- `Overview` promoted to a standalone top-level nav item
+- `Data Management` and `Tools` rendered as lightweight non-clickable section headers
+- Active route highlighting preserved for exact and nested matches
+- Collapsed mode keeps the same icon-first behavior while hiding section labels
+- Current tools section includes ActualQL only; Budget Diagnostics intentionally stays out of the sidebar until the route exists
+- Sidebar footer/version placement and accessibility semantics were refined alongside the grouping work
+
+**Primary file:**
+- `src/components/layout/Sidebar.tsx`
 
 ---


### PR DESCRIPTION
  Align repository documentation with the current app and workflow.

  - update AGENTS.md and CONTRIBUTING.md branch/workflow guidance
  - document the Overview landing page and current navigation structure
  - refresh README and FEATURES copy for current product behavior
  - update roadmap notes for overview, sidebar grouping, and planned budget diagnostics
  - ignore .claude/ in .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Budget Overview: New default landing page with live snapshot metrics, quick navigation links, and manual refresh controls.
  * Enhanced sidebar navigation with grouped Data Management and Tools sections.
  * Budget Diagnostics: Planned read-only workspace for budget analysis and data browsing.

* **Documentation**
  * Updated guides and project documentation to reflect new Budget Overview workflow and navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->