### PR TITLE
feat/add account and category note previews

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -51,6 +51,7 @@
 - CSV import and export
 - Duplicate name detection with visual warning
 - Rules count displayed per account — click it to jump to the rules list filtered to that account
+- Accounts with notes show a note indicator beside the name; click it to open the read-only note text without leaving the table
 - Every delete and close action (single and bulk) shows a confirmation dialog pre-populated with the account's outstanding balance, transaction count, and rule reference count before staging the mutation; accounts with non-zero balances receive an explicit warning about budget consistency
 - Info button on each row opens the Usage Inspector drawer (see below)
 
@@ -78,6 +79,7 @@
 - Sort by name
 - CSV import and export with full group hierarchy preserved
 - Duplicate group name prevention
+- Categories and category groups with notes show a note indicator beside the name; click it to open the read-only note text inline from the table
 - Every delete action confirms with an impact dialog: single category shows transaction count and rule references; group delete additionally shows the child category count and aggregated transaction count across all children with a cascade warning; bulk delete computes effective group and category sets, deduplicates implicit deletions, and aggregates totals
 - Info button on each category and group row opens the Usage Inspector drawer (see below)
 

--- a/agents/future-roadmap.md
+++ b/agents/future-roadmap.md
@@ -646,26 +646,31 @@ GET /budgets/{id}/actualserverversion → { version: "x.y.z" }
 |---|---|
 | **Priority** | Low |
 | **Effort** | S |
-| **Status** | pending |
+| **Status** | complete |
 | **Depends on** | nothing |
 
-**What:** Actual Budget stores free-text notes on accounts, categories, and budget months. The API can read these. Display them as a tooltip or expandable inline element in the respective tables.
+**What:** Actual Budget stores free-text notes on accounts, categories, category groups, and budget months. The API can read these. Display them from the Accounts and Categories tables without adding a dedicated notes column.
 
 **API endpoints:**
 ```
-GET /budgets/{id}/notes/account-{accountId}    → { note: string }
-GET /budgets/{id}/notes/category-{categoryId}  → { note: string }
+GET /budgets/{id}/notes/account/{accountId}    → { note: string }
+GET /budgets/{id}/notes/category/{entityId}    → { note: string }   // categories and category groups
 ```
 
 **Files to update:**
-- `src/lib/api/` — add `notes.ts` with `getAccountNote(connection, accountId)` and `getCategoryNote(connection, categoryId)`
-- `src/features/accounts/components/AccountsTable.tsx` — show a note icon (`StickyNote`) in the row if note exists; tooltip on hover shows the text
-- `src/features/categories/components/CategoriesTable.tsx` — same pattern
+- `src/lib/api/notes.ts` — add `getNotesIndex(connection)`, `getAccountNote(connection, accountId)`, and `getCategoryLikeNote(connection, entityId)`
+- `src/hooks/` — add read-only note hooks for the preload index and lazy note body fetch
+- `src/components/ui/entity-note-button.tsx` — shared note trigger + dialog
+- `src/features/accounts/components/AccountsTable.tsx` — show a persistent note icon beside the account name when a note exists
+- `src/features/categories/components/CategoriesTable.tsx` — same pattern for categories and category groups
 
 **Implementation notes:**
-- Fetch notes lazily — do not block page load. Use `useQuery` per entity with `enabled: !!entityId`, `staleTime: 300_000` (intentional override of the global `Infinity` default — notes may change outside the app).
+- Preload note presence with a single ActualQL query against the `notes` table (`select: "id"`), then lazily fetch the note body only when the user opens it.
+- Keep notes in TanStack Query only — they are read-only server snapshots and do not belong in the staged store.
+- Use `GET /notes/category/{id}` for both category and category-group notes.
+- Use `staleTime: 300_000` (intentional override of the global `Infinity` default — notes may change outside the app).
 - Read-only for now. When the API adds write support for notes, promote to an editable inline field.
-- Do not add a notes column — too much visual noise. Use a subtle icon in the row actions area.
+- Do not add a notes column — too much visual noise. Use a subtle visible icon inline with the entity name.
 
 ---
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -99,7 +99,10 @@ type SidebarNavLinkProps = {
 };
 
 function SidebarNavLink({ item, collapsed, pathname }: SidebarNavLinkProps) {
-  const active = pathname === item.href || pathname.startsWith(item.href + "/");
+  const isExactMatch = pathname === item.href;
+  const isAncestorMatch = pathname.startsWith(item.href + "/");
+  const active = isExactMatch || isAncestorMatch;
+  const ariaCurrent = isExactMatch ? "page" : isAncestorMatch ? "location" : undefined;
   const Icon = item.icon;
 
   return (
@@ -108,7 +111,7 @@ function SidebarNavLink({ item, collapsed, pathname }: SidebarNavLinkProps) {
       title={collapsed ? item.label : undefined}
       aria-label={collapsed ? item.label : undefined}
       data-active={active ? "true" : undefined}
-      aria-current={active ? "page" : undefined}
+      aria-current={ariaCurrent}
       className={cn(
         "flex items-center rounded-md px-2 py-1.5 text-sm font-medium transition-colors",
         collapsed ? "justify-center" : "gap-2.5 px-3",

--- a/src/components/ui/entity-note-button.test.tsx
+++ b/src/components/ui/entity-note-button.test.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { EntityNoteButton } from "./entity-note-button";
+
+jest.mock("../../hooks/useEntityNote", () => ({
+  useEntityNote: jest.fn(),
+}));
+
+jest.mock("@base-ui/react/preview-card", () => {
+  const React = jest.requireActual("react") as typeof import("react");
+
+  type PreviewContextValue = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  };
+
+  const PreviewContext = React.createContext<PreviewContextValue>({
+    open: false,
+    onOpenChange: () => {},
+  });
+
+  return {
+    PreviewCard: {
+      Root: ({
+        open,
+        onOpenChange,
+        children,
+      }: {
+        open: boolean;
+        onOpenChange: (open: boolean) => void;
+        children: React.ReactNode;
+      }) => (
+        <PreviewContext.Provider value={{ open, onOpenChange }}>
+          {children}
+        </PreviewContext.Provider>
+      ),
+      Trigger: ({
+        children,
+        render,
+        onMouseEnter,
+        onFocus,
+        onMouseDown,
+        onClick,
+        ...props
+      }: {
+        children: React.ReactNode;
+        render: React.ReactElement;
+        onMouseEnter?: React.MouseEventHandler;
+        onFocus?: React.FocusEventHandler;
+        onMouseDown?: React.MouseEventHandler;
+        onClick?: React.MouseEventHandler;
+      }) => {
+        const ctx = React.useContext(PreviewContext);
+        return React.cloneElement(
+          render as React.ReactElement<Record<string, unknown>>,
+          {
+            ...props,
+            onMouseEnter: (e: React.MouseEvent) => {
+              onMouseEnter?.(e);
+              ctx.onOpenChange(true);
+            },
+            onFocus: (e: React.FocusEvent) => {
+              onFocus?.(e);
+              ctx.onOpenChange(true);
+            },
+            onMouseDown,
+            onClick,
+          },
+          children
+        );
+      },
+      Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+      Positioner: ({
+        children,
+        className,
+      }: {
+        children: React.ReactNode;
+        className?: string;
+      }) => <div className={className}>{children}</div>,
+      Popup: ({
+        children,
+        className,
+      }: {
+        children: React.ReactNode;
+        className?: string;
+      }) => {
+        const ctx = React.useContext(PreviewContext);
+        if (!ctx.open) return null;
+        return <div className={className}>{children}</div>;
+      },
+    },
+  };
+});
+
+const mockUseEntityNote = jest.requireMock(
+  "../../hooks/useEntityNote"
+).useEntityNote as jest.Mock;
+
+describe("EntityNoteButton", () => {
+  beforeEach(() => {
+    mockUseEntityNote.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("shows a markdown preview after a short hover delay", () => {
+    jest.useFakeTimers();
+
+    mockUseEntityNote.mockReturnValue({
+      data: "# Preview Title\n\n1. First\n   - Nested",
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <EntityNoteButton
+        entityId="acc-1"
+        entityKind="account"
+        entityLabel="Checking"
+        entityTypeLabel="Account"
+      />
+    );
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "Preview note for Account Checking" })
+    );
+
+    expect(screen.queryByText("Note Preview")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(349);
+    });
+    expect(screen.queryByText("Note Preview")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByText("Note Preview")).toBeInTheDocument();
+    expect(screen.getByText("Preview Title")).toBeInTheDocument();
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Nested")).toBeInTheDocument();
+  });
+
+  it("pins the preview open on click and renders markdown content", () => {
+    mockUseEntityNote.mockReturnValue({
+      data: "## Full View\n\n__bold__ and _soft_",
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <EntityNoteButton
+        entityId="cat-1"
+        entityKind="category"
+        entityLabel="Groceries"
+        entityTypeLabel="Category"
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Preview note for Category Groceries" })
+    );
+
+    expect(screen.getByText("Note")).toBeInTheDocument();
+    expect(screen.getByText("Full View")).toBeInTheDocument();
+    expect(screen.getByText("bold")).toBeInTheDocument();
+    expect(screen.getByText("soft")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("immediately closes the first pinned popover when another note is opened", () => {
+    mockUseEntityNote.mockImplementation((kind: string, id: string) => ({
+      data: `# ${kind}:${id}`,
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    }));
+
+    render(
+      <>
+        <EntityNoteButton
+          entityId="acc-1"
+          entityKind="account"
+          entityLabel="Checking"
+          entityTypeLabel="Account"
+        />
+        <EntityNoteButton
+          entityId="acc-2"
+          entityKind="account"
+          entityLabel="Savings"
+          entityTypeLabel="Account"
+        />
+      </>
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Preview note for Account Checking" })
+    );
+    expect(screen.getByText("account:acc-1")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Preview note for Account Savings" })
+    );
+
+    expect(screen.queryByText("account:acc-1")).not.toBeInTheDocument();
+    expect(screen.getByText("account:acc-2")).toBeInTheDocument();
+  });
+
+  it("transfers the active preview when hovering another note", () => {
+    jest.useFakeTimers();
+
+    mockUseEntityNote.mockImplementation((kind: string, id: string) => ({
+      data: `# ${kind}:${id}`,
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    }));
+
+    render(
+      <>
+        <EntityNoteButton
+          entityId="acc-1"
+          entityKind="account"
+          entityLabel="Checking"
+          entityTypeLabel="Account"
+        />
+        <EntityNoteButton
+          entityId="acc-2"
+          entityKind="account"
+          entityLabel="Savings"
+          entityTypeLabel="Account"
+        />
+      </>
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Preview note for Account Checking" })
+    );
+    expect(screen.getByText("account:acc-1")).toBeInTheDocument();
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "Preview note for Account Savings" })
+    );
+
+    expect(screen.queryByText("account:acc-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("account:acc-2")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(349);
+    });
+
+    expect(screen.queryByText("account:acc-2")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.queryByText("account:acc-1")).not.toBeInTheDocument();
+    expect(screen.getByText("account:acc-2")).toBeInTheDocument();
+    expect(screen.getByText("Note Preview")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/entity-note-button.tsx
+++ b/src/components/ui/entity-note-button.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { PreviewCard } from "@base-ui/react/preview-card";
+import { Loader2, RefreshCw, StickyNote } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { MarkdownPreview } from "@/components/ui/markdown-preview";
+import { useEntityNote, type EntityNoteKind } from "@/hooks/useEntityNote";
+import { cn } from "@/lib/utils";
+
+let pinnedNoteKeyStore: string | null = null;
+let previewNoteKeyStore: string | null = null;
+const pinnedNoteListeners = new Set<() => void>();
+const previewNoteListeners = new Set<() => void>();
+const HOVER_PREVIEW_DELAY_MS = 350;
+
+function subscribePinnedNote(listener: () => void) {
+  pinnedNoteListeners.add(listener);
+  return () => {
+    pinnedNoteListeners.delete(listener);
+  };
+}
+
+function getPinnedNoteSnapshot() {
+  return pinnedNoteKeyStore;
+}
+
+function setPinnedNoteKey(nextKey: string | null) {
+  if (pinnedNoteKeyStore === nextKey) return;
+  pinnedNoteKeyStore = nextKey;
+  for (const listener of pinnedNoteListeners) {
+    listener();
+  }
+}
+
+function subscribePreviewNote(listener: () => void) {
+  previewNoteListeners.add(listener);
+  return () => {
+    previewNoteListeners.delete(listener);
+  };
+}
+
+function getPreviewNoteSnapshot() {
+  return previewNoteKeyStore;
+}
+
+function setPreviewNoteKey(nextKey: string | null) {
+  if (previewNoteKeyStore === nextKey) return;
+  previewNoteKeyStore = nextKey;
+  for (const listener of previewNoteListeners) {
+    listener();
+  }
+}
+
+type EntityNoteButtonProps = {
+  entityId: string;
+  entityKind: EntityNoteKind;
+  entityLabel: string;
+  entityTypeLabel: string;
+  className?: string;
+};
+
+export function EntityNoteButton({
+  entityId,
+  entityKind,
+  entityLabel,
+  entityTypeLabel,
+  className,
+}: EntityNoteButtonProps) {
+  const [shouldLoad, setShouldLoad] = useState(false);
+  const hoverTimerRef = useRef<number | null>(null);
+  const noteKey = useMemo(() => `${entityKind}:${entityId}`, [entityId, entityKind]);
+  const pinnedNoteKey = useSyncExternalStore(
+    subscribePinnedNote,
+    getPinnedNoteSnapshot,
+    () => null
+  );
+  const previewNoteKey = useSyncExternalStore(
+    subscribePreviewNote,
+    getPreviewNoteSnapshot,
+    () => null
+  );
+  const pinnedOpen = pinnedNoteKey === noteKey;
+  const previewOpen = previewNoteKey === noteKey;
+  const open = pinnedOpen || previewOpen;
+  const noteQuery = useEntityNote(
+    entityKind,
+    entityId,
+    shouldLoad || open
+  );
+
+  const trimmedNote = noteQuery.data?.trim() ?? "";
+  const hasMeaningfulNote = trimmedNote.length > 0;
+
+  function clearHoverTimer() {
+    if (hoverTimerRef.current !== null) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }
+
+  function stopEvent(e: React.SyntheticEvent) {
+    e.stopPropagation();
+  }
+
+  function clearActiveNote() {
+    if (previewNoteKey !== null && previewNoteKey !== noteKey) {
+      setPreviewNoteKey(null);
+    }
+    if (pinnedNoteKey !== null && pinnedNoteKey !== noteKey) {
+      setPinnedNoteKey(null);
+    }
+  }
+
+  function handleHoverPreviewIntent() {
+    setShouldLoad(true);
+    clearHoverTimer();
+    clearActiveNote();
+    hoverTimerRef.current = window.setTimeout(() => {
+      setPreviewNoteKey(noteKey);
+      hoverTimerRef.current = null;
+    }, HOVER_PREVIEW_DELAY_MS);
+  }
+
+  function handleFocusPreviewIntent() {
+    setShouldLoad(true);
+    clearHoverTimer();
+    clearActiveNote();
+    setPreviewNoteKey(noteKey);
+  }
+
+  useEffect(() => {
+    return () => {
+      clearHoverTimer();
+      if (getPreviewNoteSnapshot() === noteKey) {
+        setPreviewNoteKey(null);
+      }
+      if (getPinnedNoteSnapshot() === noteKey) {
+        setPinnedNoteKey(null);
+      }
+    };
+  }, [noteKey]);
+
+  return (
+    <>
+      <PreviewCard.Root
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (nextOpen) return;
+          clearHoverTimer();
+          if (pinnedOpen) setPinnedNoteKey(null);
+          if (!pinnedOpen && previewOpen) setPreviewNoteKey(null);
+        }}
+      >
+        <PreviewCard.Trigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className={cn(
+                "h-5 w-5 shrink-0 touch-manipulation text-muted-foreground/80 hover:text-foreground focus-visible:text-foreground",
+                className
+              )}
+            />
+          }
+          aria-label={`Preview note for ${entityTypeLabel} ${entityLabel || entityId}`}
+          onMouseEnter={handleHoverPreviewIntent}
+          onFocus={handleFocusPreviewIntent}
+          onMouseDown={stopEvent}
+          onClick={(e: React.MouseEvent) => {
+            stopEvent(e);
+            clearHoverTimer();
+            setShouldLoad(true);
+            setPreviewNoteKey(null);
+            setPinnedNoteKey(pinnedOpen ? null : noteKey);
+          }}
+        >
+          <StickyNote className="h-3.5 w-3.5" aria-hidden="true" />
+        </PreviewCard.Trigger>
+
+        <PreviewCard.Portal>
+          <PreviewCard.Positioner
+            side="right"
+            align="start"
+            sideOffset={10}
+            className="z-[80]"
+          >
+            <PreviewCard.Popup
+              className="z-[80] w-[min(30rem,calc(100vw-2rem))] origin-(--transform-origin) rounded-xl bg-popover p-0 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 motion-reduce:data-open:animate-none motion-reduce:data-closed:animate-none"
+              onMouseDown={stopEvent}
+              onClick={stopEvent}
+            >
+              <div className="border-b border-border px-3 py-2">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium text-muted-foreground">
+                      {pinnedOpen ? "Note" : "Note Preview"}
+                    </p>
+                    <p className="truncate text-sm text-foreground">
+                      {entityLabel || entityId}
+                    </p>
+                  </div>
+                  {pinnedOpen && (
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => setPinnedNoteKey(null)}
+                    >
+                      Close
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              {noteQuery.isLoading ? (
+                <div
+                  aria-live="polite"
+                  className="flex min-h-20 items-center justify-center gap-2 px-3 py-4 text-sm text-muted-foreground"
+                >
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading note…
+                </div>
+              ) : noteQuery.isError ? (
+                <div aria-live="polite" className="space-y-2 px-3 py-4">
+                  <p className="text-sm text-destructive">
+                    Could not load this note. Try again.
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void noteQuery.refetch()}
+                  >
+                    <RefreshCw />
+                    Retry
+                  </Button>
+                </div>
+              ) : hasMeaningfulNote ? (
+                <>
+                  <div
+                    aria-live="polite"
+                    className="max-h-80 min-h-32 overflow-auto overscroll-contain px-3 py-3"
+                  >
+                    <MarkdownPreview markdown={trimmedNote} />
+                  </div>
+                  {!pinnedOpen && (
+                    <div className="border-t border-border px-3 py-2 text-[13px] text-muted-foreground">
+                      Click the note icon to keep this open.
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div aria-live="polite" className="px-3 py-4 text-sm text-muted-foreground">
+                  This note is empty.
+                </div>
+              )}
+            </PreviewCard.Popup>
+          </PreviewCard.Positioner>
+        </PreviewCard.Portal>
+      </PreviewCard.Root>
+    </>
+  );
+}

--- a/src/components/ui/markdown-preview.tsx
+++ b/src/components/ui/markdown-preview.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { renderMarkdownToHtml } from "@/lib/markdown";
+import { cn } from "@/lib/utils";
+
+export function MarkdownPreview({
+  markdown,
+  className,
+}: {
+  markdown: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "space-y-3 text-sm text-foreground [&_a]:underline [&_a]:underline-offset-4 [&_blockquote]:my-0 [&_code]:break-words [&_del]:opacity-80 [&_em]:italic [&_h1]:mb-2 [&_h2]:mb-2 [&_h3]:mb-1 [&_ol]:list-decimal [&_ol]:space-y-1 [&_ol]:pl-5 [&_p]:my-0 [&_pre]:my-0 [&_strong]:font-semibold [&_ul]:my-0",
+        className
+      )}
+      dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(markdown) }}
+    />
+  );
+}

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -4,10 +4,12 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useInlineEdit } from "@/hooks/useInlineEdit";
+import { useNotesIndex } from "@/hooks/useNotesIndex";
 import { useTableSelection } from "@/hooks/useTableSelection";
 import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
 import { NameInput } from "@/components/ui/editable-cell";
 import type { DoneAction } from "@/components/ui/editable-cell";
+import { EntityNoteButton } from "@/components/ui/entity-note-button";
 import {
   Archive, ArchiveRestore, RotateCcw, Trash2, RefreshCw,
   ArrowUpDown, ArrowUp, ArrowDown, AlertTriangle, Info,
@@ -111,6 +113,12 @@ export function AccountsTable({
 
   // ── Account balances ─────────────────────────────────────────────────────────
   const { data: balances } = useAccountBalances();
+  const { data: notesIndex } = useNotesIndex();
+
+  const accountIdsWithNotes = useMemo(
+    () => new Set(notesIndex?.accountIdsWithNotes ?? []),
+    [notesIndex]
+  );
 
   // ── Duplicate name detection ─────────────────────────────────────────────────
   const duplicateNames = useMemo(() => {
@@ -483,7 +491,6 @@ export function AccountsTable({
                     />
                   </th>
                   <th className="w-1 p-0" />
-
                   <th
                     className="cursor-pointer select-none px-2 py-1.5 text-left hover:bg-muted/30"
                     onClick={() => toggleSort("name")}
@@ -492,6 +499,10 @@ export function AccountsTable({
                       Account Name
                       <SortIndicator col="name" sortCol={sortCol} sortDir={sortDir} />
                     </span>
+                  </th>
+
+                  <th className="w-8 p-0">
+                    <span className="sr-only">Notes</span>
                   </th>
 
                   <th className="w-32 px-4 py-1.5 text-right">
@@ -609,6 +620,19 @@ export function AccountsTable({
                               </span>
                             )}
                           </div>
+                        )}
+                      </td>
+
+                      {/* Note */}
+                      <td className="w-8 px-0 py-0.5 text-center">
+                        {!isNew && accountIdsWithNotes.has(entity.id) && (
+                          <EntityNoteButton
+                            entityId={entity.id}
+                            entityKind="account"
+                            entityLabel={entity.name || "Unnamed account"}
+                            entityTypeLabel="Account"
+                            className="mx-auto"
+                          />
                         )}
                       </td>
 

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -4,8 +4,10 @@ import React, { useState, useRef, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useInlineEdit } from "@/hooks/useInlineEdit";
+import { useNotesIndex } from "@/hooks/useNotesIndex";
 import { useTableSelection } from "@/hooks/useTableSelection";
 import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
+import { EntityNoteButton } from "@/components/ui/entity-note-button";
 import { NameInput } from "@/components/ui/editable-cell";
 import type { DoneAction } from "@/components/ui/editable-cell";
 import {
@@ -149,6 +151,12 @@ export function CategoriesTable({
   const categoryRuleCount = useMemo(
     () => buildRuleReferenceMap(stagedRules, ["category"]),
     [stagedRules]
+  );
+  const { data: notesIndex } = useNotesIndex();
+
+  const rawEntityIdsWithNotes = useMemo(
+    () => new Set(notesIndex?.rawEntityIdsWithNotes ?? []),
+    [notesIndex]
   );
 
   // ── Lazy tx counts for delete confirm dialogs ─────────────────────────────────
@@ -533,6 +541,19 @@ export function CategoriesTable({
           </div>
         </td>
 
+        {/* Note */}
+        <td className="w-8 px-0 py-0.5 text-center">
+          {!isNew && rawEntityIdsWithNotes.has(entity.id) && (
+            <EntityNoteButton
+              entityId={entity.id}
+              entityKind="category"
+              entityLabel={entity.name || "Unnamed group"}
+              entityTypeLabel="Category group"
+              className="mx-auto"
+            />
+          )}
+        </td>
+
         {/* Type badge */}
         <td className="w-48 px-2 py-0.5">
           <Badge variant={entity.isIncome ? "status-active" : "secondary"} className="text-xs font-normal">
@@ -702,6 +723,19 @@ export function CategoriesTable({
               </div>
             )}
           </div>
+        </td>
+
+        {/* Note */}
+        <td className="w-8 px-0 py-0.5 text-center">
+          {!isNew && rawEntityIdsWithNotes.has(entity.id) && (
+            <EntityNoteButton
+              entityId={entity.id}
+              entityKind="category"
+              entityLabel={entity.name || "Unnamed category"}
+              entityTypeLabel="Category"
+              className="mx-auto"
+            />
+          )}
         </td>
 
         {/* Move to group */}
@@ -890,6 +924,9 @@ export function CategoriesTable({
                     <SortIndicator active={sortNameDir !== null} dir={sortNameDir ?? "asc"} />
                   </span>
                 </th>
+                <th className="w-8 p-0">
+                  <span className="sr-only">Notes</span>
+                </th>
                 <th className="w-48 px-2 py-1.5 text-left text-xs font-medium text-muted-foreground">Type / Group</th>
                 <th className="w-36 px-2 py-1.5 text-left text-xs font-medium text-muted-foreground">Visibility</th>
                 <th className="w-44 px-2 py-1.5 text-left text-xs font-medium text-muted-foreground">Rules</th>
@@ -902,7 +939,7 @@ export function CategoriesTable({
               {(typeFilter === "all" || typeFilter === "income") && (
                 <>
                   <tr>
-                    <td colSpan={7} className="border-b border-border/80 bg-muted/90 px-3 py-1.5">
+                    <td colSpan={8} className="border-b border-border/80 bg-muted/90 px-3 py-1.5">
                       <div className="flex items-center justify-between">
                         <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                           Income
@@ -912,7 +949,7 @@ export function CategoriesTable({
                   </tr>
                   {incomeGroups.length === 0 && (
                     <tr>
-                      <td colSpan={7} className="px-4 py-3 text-xs text-muted-foreground">
+                      <td colSpan={8} className="px-4 py-3 text-xs text-muted-foreground">
                         <span>No income groups{search || visibilityFilter !== "all" || rulesFilter !== "all" ? " matching the current filters" : ""}.</span>
                         {(search || visibilityFilter !== "all" || rulesFilter !== "all") && (
                           <button className="ml-2 underline hover:text-foreground" onClick={() => { setSearch(""); setVisibilityFilter("all"); setRulesFilter("all"); }}>
@@ -931,7 +968,7 @@ export function CategoriesTable({
                         {!collapsed && cats.map((cat) => renderCategoryRow(cat, group))}
                         {!collapsed && !group.isDeleted && (
                           <tr>
-                            <td colSpan={7} className="border-b border-border/80 bg-muted/90 px-3 py-1.5">
+                            <td colSpan={8} className="border-b border-border/80 bg-muted/90 px-3 py-1.5">
                               <button
                                 onClick={() => addCategory(group.entity.id)}
                                 className="text-xs text-muted-foreground hover:text-foreground"
@@ -951,7 +988,7 @@ export function CategoriesTable({
               {(typeFilter === "all" || typeFilter === "expense") && (
                 <>
                   <tr>
-                    <td colSpan={7} className="border-b border-border/60 bg-muted/40 px-3 py-1">
+                    <td colSpan={8} className="border-b border-border/60 bg-muted/40 px-3 py-1">
                       <div className="flex items-center justify-between">
                         <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                           Expense
@@ -968,7 +1005,7 @@ export function CategoriesTable({
                   </tr>
                   {expenseGroups.length === 0 && (
                     <tr>
-                      <td colSpan={7} className="px-4 py-3 text-xs text-muted-foreground">
+                      <td colSpan={8} className="px-4 py-3 text-xs text-muted-foreground">
                         <span>No expense groups{search || visibilityFilter !== "all" || rulesFilter !== "all" ? " matching the current filters" : ""}.</span>
                         {(search || visibilityFilter !== "all" || rulesFilter !== "all") && (
                           <button className="ml-2 underline hover:text-foreground" onClick={() => { setSearch(""); setVisibilityFilter("all"); setRulesFilter("all"); }}>
@@ -987,7 +1024,7 @@ export function CategoriesTable({
                         {!collapsed && cats.map((cat) => renderCategoryRow(cat, group))}
                         {!collapsed && !group.isDeleted && (
                           <tr>
-                            <td colSpan={7} className="border-b border-border/20 px-2 py-0.5 pl-14">
+                            <td colSpan={8} className="border-b border-border/20 px-2 py-0.5 pl-14">
                               <button
                                 onClick={() => addCategory(group.entity.id)}
                                 className="text-xs text-muted-foreground hover:text-foreground"

--- a/src/hooks/useEntityNote.ts
+++ b/src/hooks/useEntityNote.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getAccountNote, getCategoryLikeNote } from "@/lib/api/notes";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+
+export type EntityNoteKind = "account" | "category";
+
+export function useEntityNote(
+  kind: EntityNoteKind,
+  id: string,
+  enabled: boolean
+) {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  return useQuery({
+    queryKey: ["entityNote", kind, connection?.id, id],
+    queryFn: () => {
+      if (!connection) throw new Error("No active connection");
+      return kind === "account"
+        ? getAccountNote(connection, id)
+        : getCategoryLikeNote(connection, id);
+    },
+    enabled: !!connection && enabled && !!id,
+    staleTime: 300_000,
+  });
+}

--- a/src/hooks/useNotesIndex.ts
+++ b/src/hooks/useNotesIndex.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getNotesIndex } from "@/lib/api/notes";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+
+export function useNotesIndex(options: { enabled?: boolean } = {}) {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  return useQuery({
+    queryKey: ["notesIndex", connection?.id],
+    queryFn: () => {
+      if (!connection) throw new Error("No active connection");
+      return getNotesIndex(connection);
+    },
+    enabled: !!connection && (options.enabled ?? true),
+    staleTime: 300_000,
+  });
+}

--- a/src/lib/api/notes.test.ts
+++ b/src/lib/api/notes.test.ts
@@ -1,0 +1,113 @@
+import {
+  getAccountNote,
+  getCategoryLikeNote,
+  getNotesIndex,
+  parseNotesIndexIds,
+  toAccountNoteId,
+  toBudgetNoteId,
+} from "./notes";
+import type { ConnectionInstance } from "@/store/connection";
+
+jest.mock("./client", () => ({
+  apiRequest: jest.fn(),
+}));
+
+jest.mock("./query", () => ({
+  runQuery: jest.fn(),
+}));
+
+import { apiRequest } from "./client";
+import { runQuery } from "./query";
+
+const mockApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
+const mockRunQuery = runQuery as jest.MockedFunction<typeof runQuery>;
+
+const connection: ConnectionInstance = {
+  id: "conn-1",
+  label: "Test",
+  baseUrl: "http://localhost:5006",
+  apiKey: "test-key",
+  budgetSyncId: "budget-1",
+};
+
+describe("notes api helpers", () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset();
+    mockRunQuery.mockReset();
+  });
+
+  it("parses account, raw entity, and budget note ids", () => {
+    expect(
+      parseNotesIndexIds([
+        "account-a1",
+        "cat-1",
+        "group-1",
+        "budget-2026-04",
+        "account-a1",
+      ])
+    ).toEqual({
+      accountIdsWithNotes: ["a1"],
+      rawEntityIdsWithNotes: ["cat-1", "group-1"],
+      budgetMonthsWithNotes: ["2026-04"],
+    });
+  });
+
+  it("builds account and budget note ids", () => {
+    expect(toAccountNoteId("acc-1")).toBe("account-acc-1");
+    expect(toBudgetNoteId("2026-04")).toBe("budget-2026-04");
+  });
+
+  it("loads and parses the notes index via ActualQL", async () => {
+    mockRunQuery.mockResolvedValueOnce({
+      data: [
+        { id: "account-acc-1" },
+        { id: "cat-1" },
+        { id: "group-1" },
+        { id: "budget-2026-04" },
+      ],
+    });
+
+    await expect(getNotesIndex(connection)).resolves.toEqual({
+      accountIdsWithNotes: ["acc-1"],
+      rawEntityIdsWithNotes: ["cat-1", "group-1"],
+      budgetMonthsWithNotes: ["2026-04"],
+    });
+
+    expect(mockRunQuery).toHaveBeenCalledWith(connection, {
+      ActualQLquery: {
+        table: "notes",
+        select: "id",
+      },
+    });
+  });
+
+  it("loads an account note from the account endpoint", async () => {
+    mockApiRequest.mockResolvedValueOnce({ data: { note: "Account note" } });
+
+    await expect(getAccountNote(connection, "acc-1")).resolves.toBe("Account note");
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      connection,
+      "/notes/account/acc-1"
+    );
+  });
+
+  it("loads a category-like note from the category endpoint", async () => {
+    mockApiRequest.mockResolvedValueOnce({ note: "Category note" });
+
+    await expect(getCategoryLikeNote(connection, "cat-1")).resolves.toBe("Category note");
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      connection,
+      "/notes/category/cat-1"
+    );
+  });
+
+  it("handles note payloads returned as plain strings", async () => {
+    mockApiRequest.mockResolvedValueOnce("Plain note");
+    await expect(getCategoryLikeNote(connection, "group-1")).resolves.toBe("Plain note");
+  });
+
+  it("returns an empty string for malformed note payloads", async () => {
+    mockApiRequest.mockResolvedValueOnce({ data: { value: 123 } });
+    await expect(getAccountNote(connection, "acc-1")).resolves.toBe("");
+  });
+});

--- a/src/lib/api/notes.ts
+++ b/src/lib/api/notes.ts
@@ -1,0 +1,111 @@
+import { apiRequest } from "./client";
+import { runQuery } from "./query";
+import type { ConnectionInstance } from "@/store/connection";
+
+type NoteIndexRow = {
+  id: string;
+};
+
+export type NotesIndex = {
+  accountIdsWithNotes: string[];
+  rawEntityIdsWithNotes: string[];
+  budgetMonthsWithNotes: string[];
+};
+
+type NotePayload =
+  | string
+  | { note?: unknown; data?: unknown }
+  | null
+  | undefined;
+
+function extractNote(payload: NotePayload): string {
+  if (typeof payload === "string") return payload;
+  if (!payload || typeof payload !== "object") return "";
+
+  if ("note" in payload && typeof payload.note === "string") {
+    return payload.note;
+  }
+
+  if ("data" in payload) {
+    return extractNote(payload.data as NotePayload);
+  }
+
+  return "";
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+export function toAccountNoteId(accountId: string): string {
+  return `account-${accountId}`;
+}
+
+export function toBudgetNoteId(month: string): string {
+  return `budget-${month}`;
+}
+
+export function parseNotesIndexIds(ids: string[]): NotesIndex {
+  const accountIds = new Set<string>();
+  const rawEntityIds = new Set<string>();
+  const budgetMonths = new Set<string>();
+
+  for (const id of ids) {
+    if (id.startsWith("account-")) {
+      const entityId = id.slice("account-".length).trim();
+      if (entityId) accountIds.add(entityId);
+      continue;
+    }
+
+    if (id.startsWith("budget-")) {
+      const month = id.slice("budget-".length).trim();
+      if (month) budgetMonths.add(month);
+      continue;
+    }
+
+    if (id.trim()) {
+      rawEntityIds.add(id);
+    }
+  }
+
+  return {
+    accountIdsWithNotes: uniqueSorted(accountIds),
+    rawEntityIdsWithNotes: uniqueSorted(rawEntityIds),
+    budgetMonthsWithNotes: uniqueSorted(budgetMonths),
+  };
+}
+
+export async function getNotesIndex(
+  connection: ConnectionInstance
+): Promise<NotesIndex> {
+  const response = await runQuery<{ data: NoteIndexRow[] }>(connection, {
+    ActualQLquery: {
+      table: "notes",
+      select: "id",
+    },
+  });
+
+  return parseNotesIndexIds(response.data.map((row) => row.id));
+}
+
+export async function getAccountNote(
+  connection: ConnectionInstance,
+  accountId: string
+): Promise<string> {
+  const response = await apiRequest<NotePayload>(
+    connection,
+    `/notes/account/${accountId}`
+  );
+  return extractNote(response);
+}
+
+export async function getCategoryLikeNote(
+  connection: ConnectionInstance,
+  id: string
+): Promise<string> {
+  const response = await apiRequest<NotePayload>(
+    connection,
+    `/notes/category/${id}`
+  );
+  return extractNote(response);
+}

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,50 @@
+import { renderMarkdownToHtml } from "./markdown";
+
+describe("renderMarkdownToHtml", () => {
+  it("renders headings, emphasis, and lists", () => {
+    const html = renderMarkdownToHtml(`# Heading
+
+**Bold** and *italic* and __strong__ and _soft_
+
+- One
+- Two`);
+
+    expect(html).toContain("<h1");
+    expect(html).toContain("<strong>Bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<strong>strong</strong>");
+    expect(html).toContain("<em>soft</em>");
+    expect(html).toContain("<ul");
+    expect(html).toContain("<li");
+  });
+
+  it("escapes raw html while rendering markdown", () => {
+    const html = renderMarkdownToHtml(`<script>alert(1)</script> **safe**`);
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("<strong>safe</strong>");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("renders inline code, fenced code, and links", () => {
+    const html = renderMarkdownToHtml(
+      "`code`\n\n```ts\nconst x = 1;\n```\n\n[Docs](https://example.com)"
+    );
+
+    expect(html).toContain("<code");
+    expect(html).toContain("<pre");
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it("renders ordered lists and nested lists", () => {
+    const html = renderMarkdownToHtml(`1. First
+2. Second
+   - Nested child
+   - Nested sibling
+3. Third`);
+
+    expect(html).toContain("<ol");
+    expect(html).toContain("<ul");
+    expect(html).toContain("Nested child");
+    expect(html).toContain("Nested sibling");
+  });
+});

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,265 @@
+function escapeHtml(input: string): string {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function sanitizeUrl(rawUrl: string): string | null {
+  const trimmed = rawUrl.trim();
+  if (
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("mailto:")
+  ) {
+    return escapeHtml(trimmed);
+  }
+  return null;
+}
+
+type ListLine = {
+  indent: number;
+  type: "ul" | "ol";
+  content: string;
+};
+
+function parseListLine(rawLine: string): ListLine | null {
+  const expanded = rawLine.replace(/\t/g, "  ");
+  const match = /^(\s*)([-*+]|\d+\.)\s+(.+)$/.exec(expanded);
+  if (!match) return null;
+
+  return {
+    indent: match[1].length,
+    type: /\d+\./.test(match[2]) ? "ol" : "ul",
+    content: match[3],
+  };
+}
+
+function renderInlineMarkdown(text: string): string {
+  const codeSegments: string[] = [];
+  let html = escapeHtml(text);
+
+  html = html.replace(/`([^`]+)`/g, (_, code: string) => {
+    const token = `__CODE_SEGMENT_${codeSegments.length}__`;
+    codeSegments.push(
+      `<code class="rounded bg-muted/70 px-1 py-0.5 font-mono text-[0.92em] text-foreground">${code}</code>`
+    );
+    return token;
+  });
+
+  html = html.replace(
+    /\[([^\]]+)\]\(([^)\s]+)\)/g,
+    (_, label: string, url: string) => {
+      const safeUrl = sanitizeUrl(url);
+      if (!safeUrl) {
+        return label;
+      }
+      return `<a href="${safeUrl}" target="_blank" rel="noreferrer" class="underline decoration-border underline-offset-4 hover:text-foreground">${label}</a>`;
+    }
+  );
+
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/__([^_]+)__/g, "<strong>$1</strong>");
+  html = html.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, "$1<em>$2</em>$3");
+  html = html.replace(/(^|[^\w])_([^_]+)_([^\w]|$)/g, "$1<em>$2</em>$3");
+  html = html.replace(/~~([^~]+)~~/g, "<del>$1</del>");
+  html = html.replace(/\n/g, "<br />");
+
+  return html.replace(/__CODE_SEGMENT_(\d+)__/g, (_, index: string) => {
+    return codeSegments[Number(index)] ?? "";
+  });
+}
+
+function flushParagraph(paragraphLines: string[], blocks: string[]) {
+  if (paragraphLines.length === 0) return;
+  blocks.push(
+    `<p class="break-words leading-relaxed">${renderInlineMarkdown(
+      paragraphLines.join("\n")
+    )}</p>`
+  );
+  paragraphLines.length = 0;
+}
+
+function renderListBlock(lines: string[]): string {
+  let index = 0;
+
+  function parseList(expectedIndent: number): string {
+    let html = "";
+
+    while (index < lines.length) {
+      const line = parseListLine(lines[index]);
+      if (!line || line.indent < expectedIndent) break;
+      if (line.indent > expectedIndent) break;
+
+      const tag = line.type === "ol" ? "ol" : "ul";
+      const className =
+        line.type === "ol"
+          ? "list-decimal space-y-1 pl-5"
+          : "list-disc space-y-1 pl-5";
+
+      html += `<${tag} class="${className}">`;
+
+      while (index < lines.length) {
+        const current = parseListLine(lines[index]);
+        if (
+          !current ||
+          current.indent !== expectedIndent ||
+          current.type !== line.type
+        ) {
+          break;
+        }
+
+        let itemHtml = `<li class="break-words leading-relaxed">${renderInlineMarkdown(
+          current.content
+        )}`;
+        index += 1;
+
+        while (index < lines.length) {
+          const nextRaw = lines[index];
+          if (!nextRaw.trim()) {
+            index += 1;
+            continue;
+          }
+
+          const nested = parseListLine(nextRaw);
+          if (nested) {
+            if (nested.indent > expectedIndent) {
+              itemHtml += parseList(nested.indent);
+              continue;
+            }
+            break;
+          }
+
+          if (/^\s{2,}\S/.test(nextRaw)) {
+            itemHtml += `<br />${renderInlineMarkdown(nextRaw.trim())}`;
+            index += 1;
+            continue;
+          }
+
+          break;
+        }
+
+        itemHtml += "</li>";
+        html += itemHtml;
+      }
+
+      html += `</${tag}>`;
+    }
+
+    return html;
+  }
+
+  const firstLine = parseListLine(lines[0]);
+  if (!firstLine) return "";
+  return parseList(firstLine.indent);
+}
+
+export function renderMarkdownToHtml(markdown: string): string {
+  const normalized = markdown.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return "";
+
+  const lines = normalized.split("\n");
+  const blocks: string[] = [];
+  const paragraphLines: string[] = [];
+
+  let inCodeBlock = false;
+  let codeBlockLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+
+    if (line.startsWith("```")) {
+      flushParagraph(paragraphLines, blocks);
+
+      if (inCodeBlock) {
+        blocks.push(
+          `<pre class="overflow-auto rounded-lg border border-border bg-muted/50 p-3 font-mono text-xs leading-relaxed text-foreground"><code>${escapeHtml(
+            codeBlockLines.join("\n")
+          )}</code></pre>`
+        );
+        inCodeBlock = false;
+        codeBlockLines = [];
+      } else {
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeBlockLines.push(line);
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushParagraph(paragraphLines, blocks);
+      continue;
+    }
+
+    if (parseListLine(line)) {
+      flushParagraph(paragraphLines, blocks);
+
+      const listBlockLines = [line];
+      while (i + 1 < lines.length) {
+        const nextLine = lines[i + 1];
+        if (
+          !nextLine.trim() ||
+          !!parseListLine(nextLine) ||
+          /^\s{2,}\S/.test(nextLine)
+        ) {
+          listBlockLines.push(nextLine);
+          i += 1;
+          continue;
+        }
+        break;
+      }
+
+      blocks.push(renderListBlock(listBlockLines));
+      continue;
+    }
+
+    const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line);
+    if (headingMatch) {
+      flushParagraph(paragraphLines, blocks);
+      const level = headingMatch[1].length;
+      const sizeClass =
+        level === 1
+          ? "text-lg font-semibold"
+          : level === 2
+            ? "text-base font-semibold"
+            : "text-sm font-semibold";
+      blocks.push(
+        `<h${level} class="${sizeClass} text-pretty break-words">${renderInlineMarkdown(
+          headingMatch[2]
+        )}</h${level}>`
+      );
+      continue;
+    }
+
+    const quoteMatch = /^>\s?(.+)$/.exec(line);
+    if (quoteMatch) {
+      flushParagraph(paragraphLines, blocks);
+      blocks.push(
+        `<blockquote class="border-l-2 border-border pl-3 text-muted-foreground">${renderInlineMarkdown(
+          quoteMatch[1]
+        )}</blockquote>`
+      );
+      continue;
+    }
+
+    paragraphLines.push(line);
+  }
+
+  flushParagraph(paragraphLines, blocks);
+
+  if (inCodeBlock) {
+    blocks.push(
+      `<pre class="overflow-auto rounded-lg border border-border bg-muted/50 p-3 font-mono text-xs leading-relaxed text-foreground"><code>${escapeHtml(
+        codeBlockLines.join("\n")
+      )}</code></pre>`
+    );
+  }
+
+  return blocks.join("");
+}


### PR DESCRIPTION
## Summary

  Implements `RD-011` by adding read-only note indicators and markdown previews for accounts, categories, and category groups.

  ## What Changed

  - preload note presence with a single ActualQL query against the `notes` table
  - lazy-load note bodies from the Actual notes endpoints
  - add a dedicated notes column immediately after the name column in Accounts and Categories tables
  - show hover-intent note previews with markdown rendering
  - allow click-to-pin note previews while keeping only one active note surface at a time
  - support category-group notes through the category notes endpoint
  - add tests for notes API parsing, markdown rendering, and note-button interactions
  - update `FEATURES.md` and `agents/future-roadmap.md`

  Closes #55
  ## Notes

  - account notes use the `/notes/account/{accountId}` endpoint
  - category and category-group notes use the `/notes/category/{id}` endpoint
  - budget note parsing support remains in the helper layer for future work, but budget notes are not surfaced in this PR

  ## Verification

  - `npm run lint`
  - `npx tsc --noEmit`
  - `npm test`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added note indicators next to accounts, categories, and category groups; click to view read-only notes with markdown support.
  * Enhanced sidebar navigation to correctly highlight both exact and ancestor route matches.

* **Documentation**
  * Updated feature documentation and development roadmap.

* **Tests**
  * Added comprehensive test coverage for note functionality and markdown rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->