### PR TITLE
feat/add budget management workspace

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -61,6 +61,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ feat/* | fix/* | refactor/* | docs/*  →  main  →  release (tag v1.x.x)
 | Store | Owns |
 |---|---|
 | TanStack Query | Server snapshots (read-only) |
-| Zustand `staged.ts` | Pending mutations + undo/redo |
+| Zustand `staged.ts` | Pending mutations + undo/redo (entity pages) |
+| Zustand `budgetEdits.ts` | Budget cell edits + undo/redo (budget-management only — `BudgetCellKey` composite keys are incompatible with `staged.ts`) |
 | Zustand `connection.ts` | Active connection (`sessionStorage` — do NOT change to `localStorage`) |
 | Zustand `savedServers.ts` | Saved server presets (`sessionStorage`) |
 | Local state | Ephemeral UI only |
@@ -62,7 +63,9 @@ feat/* | fix/* | refactor/* | docs/*  →  main  →  release (tag v1.x.x)
 |---|---|
 | API logic | `src/lib/api/<entity>.ts` |
 | Proxy | `src/app/api/proxy/route.ts` |
-| Staged store | `src/store/staged.ts` |
+| Staged store (entity pages) | `src/store/staged.ts` |
+| Budget cell edits store | `src/store/budgetEdits.ts` |
+| Budget mode shared utility | `src/lib/budget/deriveBudgetMode.ts` |
 | Pages | `src/app/(app)/<page>/page.tsx` |
 | Connection fields | `src/store/connection.ts` |
 | CI/CD workflows | `.github/workflows/` |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -128,6 +128,98 @@
 - CSV import and export
 - Info button on each row opens the Usage Inspector drawer; tags show the rules badge and a note that transaction data is not available for tags
 
+## Budget Management Workspace
+
+URL: `/budget-management`
+
+A multi-month budget editing workspace with staged cell editing, a draft review panel, right-click bulk actions, CSV import/export, and envelope-mode immediate actions.
+
+### Toolbar
+- Budget mode badge (`Envelope`, `Tracking`, or `Unknown`) always visible at the left
+- 12-month window navigator: back/forward by 1 month (`‹ ›`) or 1 year (`«»`), plus a "go to current year" calendar button; range label displays as "Jan '26 – Dec '26"
+- Cell-view toggle: **Budget** / **Actuals** / **Balance** — switches what value each month cell displays
+- Expand all / Collapse all group buttons
+- Show / Hide hidden categories toggle
+- Import and Export buttons (UTF-8 CSV with BOM)
+
+### Multi-Month Grid
+- CSS-grid layout: category label column (flexible width), a fixed 32 px notes column, and one fixed-width column per visible month (12 columns)
+- Category and month header row is sticky — stays visible while scrolling down; category name column is sticky — stays visible while scrolling right; all sticky cells use solid opaque backgrounds to prevent bleed-through
+- Group rows show aggregate totals per month; collapsed groups hide their category rows but keep the group total visible
+- Mode-specific summary section above the category groups:
+  - **Envelope mode**: Available Funds (+), Overspent Last Month (−), Budgeted (−), For Next Month (−), and a **To Budget / Overbudget** (=) total row
+  - **Tracking mode**: Expenses consumption bar, Income consumption bar, and a Balance row
+- The 12-month window defaults to January of the current year; the user can navigate freely to any period
+
+### Staged Cell Editing
+- Click, double-click, Enter, or F2 to enter edit mode; blur or Enter to commit; Escape to cancel
+- Accepts numeric amounts and arithmetic expressions (`+`, `-`, `*`, `/`, parentheses)
+- Staged edits displayed in amber; reverting a cell back to its original server value automatically removes the staged edit (no phantom dirty state)
+- Cells with a save error are highlighted in red with a red dot indicator; cells with a staged delta exceeding $5,000 show an orange dot indicator in the top-right corner
+- Income categories are hard-blocked (non-interactive) in envelope mode
+- Undo / Redo with Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z; up to 50 undo steps
+- Delete or Backspace on a focused cell sets it to zero; if the original value is already zero the staged edit is removed
+
+### Selection & Keyboard Navigation
+- Click a cell to select it; Shift+click to extend a rectangular multi-cell selection
+- Arrow keys navigate between cells; Tab moves forward through the grid; all navigation closes any open context menu
+- Clicking outside the grid (toolbar, sidebar, top bar), or clicking non-interactive areas inside the grid (summary rows, section headers, group row gutters, column headers), clears the current selection and shows the year summary in the draft panel
+
+### Right-Click Context Menu
+- Right-clicking any category budget cell opens a compact context menu with two sections:
+  - **Cell actions**: Enable / Disable Rollover (carryover); Transfer Budget (envelope mode only, opens the transfer dialog)
+  - **Set Budget**: inline bulk actions — Copy previous month, Copy specific month…, Set to zero, Set to fixed amount…, Apply % change…, Set to 3 months average, Set to 6 months average, Set to yearly average
+- No-input actions (copy previous, set to zero, the three averages) execute immediately and are staged as one undo step; input-required actions (copy specific month, set fixed, apply %) open a dialog
+- Average actions look back N months before the cell's month using TanStack Query cache; pre-window months are included if previously loaded
+- Selecting a new cell or group dismisses the context menu
+
+### Draft Panel (right side)
+- **Year summary** (default, when no cell or group is selected): shows Expenses (budgeted + spent), Income (received; tracking mode also shows budgeted), and an overall total ("To Budget" in envelope mode, "Net Balance" in tracking mode). Below the totals: a Monthly Trend section with three sparkbar rows — Expenses, Income, and Balance — one bar per month in the active window; bars for months without server data are shown as stubs
+- **Category cell selected**: category name, group, and month label; metrics for budgeted (amber when staged), actuals, balance (colour-coded), carryover status, and previous-month budgeted; if a staged edit exists, a separator row shows the original value and the signed delta; save errors appear as a red message below the diff
+- **Group row selected**: group name and type (income / expense); aggregate budgeted, actuals, balance, and previous-month budgeted; if staged edits exist for any category in the group, shows original total and signed delta
+- **Staged Changes** section (always visible when edits exist, regardless of selection): header with live count badge ("N changes"); changes grouped by month, each entry showing category name and signed delta; save-error markers on failed rows
+
+### Clipboard Paste
+- Paste tab-delimited data from spreadsheets into the grid starting from the top-left selected cell; fills the corresponding rectangle without requiring pre-selection of exact dimensions
+
+### Save Flow
+- **Single edit**: clicking Save in the top bar sends one `PATCH /months/{month}/categories/{id}` and shows a toast with the result
+- **Multiple edits**: clicking Save opens a non-dismissable progress dialog that sends one `PATCH` per cell sequentially (never in parallel) to avoid server race conditions
+  - In-progress state: "Saving budget changes — N of M cells saved…" with a live progress bar
+  - All-success state: cell count and affected months; dialog auto-closes after 3 seconds (manual close also available)
+  - Partial or full failure state: amber header with a scrollable list of failed cells (month / category ID / error message); "Retry Failed" button re-reads only the still-failed keys from the store and re-sends them
+- Failed cells always remain in the store with their `saveError` set — only cells that received a 200 response are cleared; TanStack Query cache is invalidated per succeeded month
+
+### CSV Export
+- Three month-selection modes in the export dialog:
+  - **Quick Range**: preset buttons — Current View, This Month, Last 3 Months, This Year, Last Year, All — each showing a live count badge; Current View is pre-selected on open
+  - **Date Range**: From / To dropdowns constrained to available months; auto-corrects if From > To
+  - **Select**: searchable multi-select combobox (same component as Rules payee picker) — search and pick individual months as chips; only existing months are selectable
+- Always-visible resolution summary: "N months selected: Jan '26 – Dec '26" updates live as the selection changes
+- Options: include hidden categories, include income groups, export with staged (unsaved) values
+- Download blank CSV template (same structure, all amount cells empty)
+- Exported files include a UTF-8 BOM for correct rendering in Excel and Google Sheets
+
+### CSV Import
+- Upload a CSV file → parser strips UTF-8 BOM if present → review exact / suggested / unmatched rows with approval checkboxes → preview proposed changes with before/after values → confirm → all changes staged in the grid as one undo step
+- Levenshtein-distance fuzzy matching (distance ≤ 2) offers suggestions for near-miss category names
+- Out-of-range months (exist in budget but outside the current 12-month window) shown with an "Extend visible range" option; absent months (not in `GET /months`) rejected with a clear error
+
+### Envelope-Mode Immediate Actions
+- **Hold toggle**: each "To Budget" cell in the summary section has a hold toggle button (arrow icon, left of the amount). Clicking it when no hold is active opens the "Next Month Hold for YYYY-MM" dialog to set an amount; the dialog closes immediately on save. Clicking it when a hold is active shows a confirmation dialog ("Free the hold for YYYY-MM?") before clearing. Both actions are immediate and bypass the staged save panel
+- **Transfer**: right-click any category cell → Transfer Budget → opens the Category Transfer dialog; moves budget between non-income categories immediately
+- Hold and Transfer are only available in envelope mode; they do not appear in tracking mode
+
+### Navigation Safety
+- Browser close / refresh prompts confirmation when staged changes exist (`beforeunload`)
+- Browser back/forward navigation prompts confirmation when staged changes exist (`popstate`)
+- Entry guard: if unsaved entity changes exist on another page, the workspace shows a blocking screen with a "Discard changes and continue" option rather than silently mixing two edit stores
+
+### v1 Limitations
+- Carryover is read-only in this release; shown in the context panel but not editable
+- Category-to-pool transfers (omitting source or destination category) are not supported in v1
+- No virtualization; very large category lists may scroll slowly in the grid
+
 ## ActualQL Queries
 
 - Dedicated query workspace for running arbitrary ActualQL JSON queries against the open budget

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Useful for power users who want more control over their budget data, and for tes
 
 - **Bulk CSV import/export** for every entity - seed a fresh budget with hundreds of rules, payees, categories, or schedules in one go
 - **Budget Overview homepage** - land on a compact overview with live budget metrics, budget mode, budgeting-since, and quick links into the main admin pages
+- **Budget Management Workspace** — edit a 12-month budgeting window in a spreadsheet-like grid with staged changes, right-click bulk actions, a draft panel, and mode-aware envelope/tracking behavior
 - **Advanced rules management** - visual condition/action builder, merge, duplicate, stage filtering, and template mode in one focused view
 - **Staged editing with undo/redo** - review every change locally before anything touches the server
 - **Multi-server, multi-budget** - save and switch between connections without leaking data between sessions
@@ -58,9 +59,11 @@ All browser requests route through an internal Next.js proxy - no direct browser
 - **Payees** - view, edit, bulk-manage, and merge multiple payees; CSV import/export
 - **Categories** - manage groups and categories, visibility, and hierarchy; CSV import/export
 - **Rules** - view, filter by stage, create, edit, and merge rules with a full condition/action builder; CSV import/export
-- **Schedules** - create and manage one-time and recurring schedules with amount modes, weekend adjustment, and end conditions; overdue dates are highlighted; CSV import/export
+- **Schedules** - create and manage one-time and recurring schedules with amount modes, weekend adjustment, and end conditions; overdue dates are highlighted; CSV import/
+export
 - **Tags** - create, rename, and color-code tags (requires Actual Budget v26.3.0+); CSV import/export
 - **ActualQL Queries** - syntax-highlighted query editor with run / format / save / explain actions; four result views (table, raw JSON, scalar, collapsible tree); built-in example packs; saved queries with favorites; query history; cURL copy; lint warnings; and an inline quick reference dialog
+- **Budget Management Workspace** - adds a multi-month budgeting workspace with a 12-month grid, staged cell editing, Budget / Actuals / Balance view toggle, year summary draft panel, keyboard navigation, clipboard paste, right-click bulk actions, supports both tracking and envelope-mode with support for next-month hold and category transfer
 
 → See [FEATURES.md](FEATURES.md) for the full feature reference.
 
@@ -144,6 +147,7 @@ Ready-to-use sample CSV files are included in [`public/samples csv/`](public/sam
 | [`sample-rules.csv`](public/samples%20csv/sample-rules.csv) | 10 rules demonstrating multi-condition, multi-action, `or` logic, stage filtering, and payee auto-creation |
 | [`sample-schedules.csv`](public/samples%20csv/sample-schedules.csv) | 6 schedules - one-time, monthly, weekly, yearly, and range-amount examples |
 | [`sample-tags.csv`](public/samples%20csv/sample-tags.csv) | 8 tags with varied colors and descriptions |
+| [`sample-tags.csv`](public/samples%20csv/sample-budget.csv) | budget import template with groups, categories, and budgeted amounts per month |
 
 ### CSV Formats
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",

--- a/public/samples csv/sample-budget.csv
+++ b/public/samples csv/sample-budget.csv
@@ -1,0 +1,16 @@
+Group Name,Category Name,2026-04,2026-05,2026-06
+Income,Salary,5000.00,5000.00,5000.00
+Income,Freelance,,750.00,600.00
+Housing,Rent / Mortgage,1800.00,1800.00,1800.00
+Housing,Utilities,220.00,210.00,
+Housing,Internet & Phone,95.00,95.00,95.00
+Food,Groceries,650.00,675.00,700.00
+Food,Restaurants & Takeout,180.00,160.00,150.00
+Transport,Fuel,140.00,150.00,150.00
+Transport,Public Transit,60.00,60.00,60.00
+Health,Medical,100.00,100.00,125.00
+Subscriptions,Streaming Services,45.00,45.00,45.00
+Subscriptions,Software & Apps,30.00,30.00,30.00
+Personal,Clothing,75.00,75.00,100.00
+Savings,Emergency Fund,300.00,300.00,500.00
+Savings,Vacation Fund,150.00,200.00,200.00

--- a/src/app/(app)/budget-management/page.tsx
+++ b/src/app/(app)/budget-management/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { BudgetManagementView } from "@/features/budget-management/components/BudgetManagementView";
+
+export const metadata: Metadata = {
+  title: "Budget Management — Actual Bench",
+};
+
+export default function BudgetManagementPage() {
+  return <BudgetManagementView />;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { TopBar } from "./TopBar";
 import { Sidebar } from "./Sidebar";
 import { DraftPanel } from "./DraftPanel";
+import { BudgetDraftPanel } from "@/features/budget-management/components/BudgetDraftPanel";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { usePreloadEntities } from "@/hooks/useAllEntities";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -13,12 +14,16 @@ import { useIsHydrated } from "@/hooks/useIsHydrated";
 /**
  * The four-panel app shell:
  *   TopBar (full width)
- *   └─ Sidebar | Main content | DraftPanel
+ *   └─ Sidebar | Main content | DraftPanel (or BudgetDraftPanel on /budget-management)
  *
  * Guards against unauthenticated access — redirects to /connect if no active
  * connection is present. The guard is intentionally deferred by one tick so
  * that Zustand's sessionStorage rehydration (which runs after mount) has time
  * to populate the store before we decide to redirect.
+ *
+ * On the /budget-management route, the normal DraftPanel (entity staged changes)
+ * is replaced by BudgetDraftPanel (budget cell staged changes) so both panel
+ * systems never compete for the same layout slot.
  */
 export function AppShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -47,6 +52,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     return null;
   }
 
+  const isBudgetPage = pathname?.startsWith("/budget-management") ?? false;
+
   return (
     <div className="flex h-full flex-col">
       <TopBar />
@@ -55,7 +62,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {children}
         </main>
-        <DraftPanel />
+        {isBudgetPage ? <BudgetDraftPanel /> : <DraftPanel />}
       </div>
     </div>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   AlertCircle,
   BookOpen,
   LayoutDashboard,
+  Wallet,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -71,6 +72,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
       id: "data-management",
       label: "Data Management",
       items: [
+        { id: "budget-management", label: "Budget", href: "/budget-management", icon: Wallet },
         { id: "rules", label: "Rules", href: "/rules", icon: ScrollText },
         { id: "accounts", label: "Accounts", href: "/accounts", icon: Landmark },
         { id: "payees", label: "Payees", href: "/payees", icon: Users },

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw } from "lucide-react";
@@ -35,7 +35,11 @@ import {
   selectCanUndo,
   selectCanRedo,
 } from "@/store/staged";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useBudgetSavePipeline } from "./useBudgetSavePipeline";
+import { useBudgetSave } from "@/features/budget-management/hooks/useBudgetSave";
+import { BudgetSaveProgressDialog } from "@/features/budget-management/components/BudgetSaveProgressDialog";
+import type { BudgetCellKey, StagedBudgetEdit } from "@/features/budget-management/types";
 
 type PendingAction =
   | { kind: "switch"; id: string }
@@ -69,9 +73,11 @@ function TopBarVersionChip({
 
 export function TopBar() {
   const router = useRouter();
+  const pathname = usePathname();
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
 
   const activeInstance = useConnectionStore(selectActiveInstance);
   const instances = useConnectionStore((s) => s.instances);
@@ -79,15 +85,41 @@ export function TopBar() {
   const clearAll = useConnectionStore((s) => s.clearAll);
   const clearServers = useSavedServersStore((s) => s.clearServers);
 
-  const hasChanges = useStagedStore(selectHasChanges);
-  const canUndo = useStagedStore(selectCanUndo);
-  const canRedo = useStagedStore(selectCanRedo);
-  const undo = useStagedStore((s) => s.undo);
-  const redo = useStagedStore((s) => s.redo);
-  const discardAll = useStagedStore((s) => s.discardAll);
+  // Entity pages store
+  const stagedHasChanges = useStagedStore(selectHasChanges);
+  const stagedCanUndo = useStagedStore(selectCanUndo);
+  const stagedCanRedo = useStagedStore(selectCanRedo);
+  const stagedUndo = useStagedStore((s) => s.undo);
+  const stagedRedo = useStagedStore((s) => s.redo);
+  const stagedDiscardAll = useStagedStore((s) => s.discardAll);
   const clearHistory = useStagedStore((s) => s.clearHistory);
+  const { saveAll, isSaving: isEntitySaving } = useBudgetSavePipeline();
 
-  const { saveAll, isSaving } = useBudgetSavePipeline();
+  // Budget page store (always called — hooks cannot be conditional)
+  const budgetHasChanges = useBudgetEditsStore(
+    (s) => Object.keys(s.edits).length > 0
+  );
+  const budgetCanUndo = useBudgetEditsStore((s) => s.undoStack.length > 0);
+  const budgetCanRedo = useBudgetEditsStore((s) => s.redoStack.length > 0);
+  const budgetUndo = useBudgetEditsStore((s) => s.undo);
+  const budgetRedo = useBudgetEditsStore((s) => s.redo);
+  const budgetDiscardAll = useBudgetEditsStore((s) => s.discardAll);
+  const { save: saveBudgetCells, isSaving: isBudgetSaving } = useBudgetSave();
+
+  // Route-aware resolution
+  const isBudgetPage = pathname?.startsWith("/budget-management") ?? false;
+  const hasChanges = isBudgetPage ? budgetHasChanges : stagedHasChanges;
+  const canUndo = isBudgetPage ? budgetCanUndo : stagedCanUndo;
+  const canRedo = isBudgetPage ? budgetCanRedo : stagedCanRedo;
+  const isSaving = isBudgetPage ? (isBudgetSaving || budgetSaveEdits !== null) : isEntitySaving;
+
+  function handleDiscardAll() {
+    if (isBudgetPage) {
+      budgetDiscardAll();
+    } else {
+      stagedDiscardAll();
+    }
+  }
 
   // ── Guarded action helpers ────────────────────────────────────────────────────
 
@@ -101,17 +133,17 @@ export function TopBar() {
 
   async function executeAction(action: PendingAction) {
     if (action.kind === "switch") {
-      discardAll();
+      handleDiscardAll();
       queryClient.clear();
       setActive(action.id);
     } else if (action.kind === "addConnection") {
-      discardAll();
+      handleDiscardAll();
       await queryClient.cancelQueries();
       queryClient.clear();
       setActive(null);
       router.push("/connect");
     } else if (action.kind === "disconnect") {
-      discardAll();
+      handleDiscardAll();
       queryClient.clear();
       clearAll();
       clearServers();
@@ -128,21 +160,50 @@ export function TopBar() {
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
   async function handleSave() {
-    try {
-      const { totalSucceeded, totalFailed } = await saveAll();
-      clearHistory();
-      if (totalFailed === 0) {
-        toast.success(`Saved ${totalSucceeded} item${totalSucceeded !== 1 ? "s" : ""} successfully.`);
-      } else {
-        toast.error(`${totalSucceeded} saved, ${totalFailed} failed.`);
+    if (isBudgetPage) {
+      const edits = useBudgetEditsStore.getState().edits;
+      const editCount = Object.keys(edits).length;
+      if (editCount > 1) {
+        // Multi-edit: open progress dialog — it handles save internally
+        setBudgetSaveEdits({ ...edits });
+        return;
       }
-    } catch (err) {
-      const msg =
-        err instanceof Error ? err.message :
-        (typeof err === "object" && err !== null && "message" in err)
-          ? String((err as { message: unknown }).message)
-          : "Save failed.";
-      toast.error(msg);
+      // Single edit: inline save with toast
+      try {
+        const results = await saveBudgetCells(edits);
+        const succeeded = results.filter((r) => r.status === "success").length;
+        const failed = results.filter((r) => r.status === "error").length;
+        if (failed === 0) {
+          toast.success(
+            `Saved ${succeeded} budget cell${succeeded !== 1 ? "s" : ""} successfully.`
+          );
+        } else {
+          toast.error(`${succeeded} saved, ${failed} failed.`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Budget save failed.";
+        toast.error(msg);
+      }
+    } else {
+      try {
+        const { totalSucceeded, totalFailed } = await saveAll();
+        clearHistory();
+        if (totalFailed === 0) {
+          toast.success(
+            `Saved ${totalSucceeded} item${totalSucceeded !== 1 ? "s" : ""} successfully.`
+          );
+        } else {
+          toast.error(`${totalSucceeded} saved, ${totalFailed} failed.`);
+        }
+      } catch (err) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : typeof err === "object" && err !== null && "message" in err
+            ? String((err as { message: unknown }).message)
+            : "Save failed.";
+        toast.error(msg);
+      }
     }
   }
 
@@ -157,7 +218,7 @@ export function TopBar() {
         action: {
           label: "Discard & Refresh",
           onClick: async () => {
-            discardAll();
+            handleDiscardAll();
             setIsRefreshing(true);
             await queryClient.resetQueries();
             setIsRefreshing(false);
@@ -248,7 +309,7 @@ export function TopBar() {
             size="icon"
             className="h-7 w-7"
             disabled={!canUndo}
-            onClick={undo}
+            onClick={isBudgetPage ? budgetUndo : stagedUndo}
             title="Undo"
           >
             <Undo2 className="h-3.5 w-3.5" />
@@ -258,7 +319,7 @@ export function TopBar() {
             size="icon"
             className="h-7 w-7"
             disabled={!canRedo}
-            onClick={redo}
+            onClick={isBudgetPage ? budgetRedo : stagedRedo}
             title="Redo"
           >
             <Redo2 className="h-3.5 w-3.5" />
@@ -280,7 +341,10 @@ export function TopBar() {
             size="sm"
             className="h-7 text-xs"
             disabled={!hasChanges}
-            onClick={() => { discardAll(); queryClient.resetQueries(); }}
+            onClick={() => {
+              handleDiscardAll();
+              if (!isBudgetPage) void queryClient.resetQueries();
+            }}
           >
             <X className="mr-1 h-3.5 w-3.5" />
             Discard
@@ -300,6 +364,13 @@ export function TopBar() {
           </Button>
         </div>
       </header>
+
+      {budgetSaveEdits !== null && (
+        <BudgetSaveProgressDialog
+          edits={budgetSaveEdits}
+          onClose={() => setBudgetSaveEdits(null)}
+        />
+      )}
 
       <Dialog open={pendingAction !== null} onOpenChange={(open) => { if (!open) setPendingAction(null); }}>
         <DialogContent showCloseButton={false}>

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import { useEffectiveMonthData } from "../hooks/useEffectiveMonthData";
+import { parseBudgetExpression } from "../lib/budgetMath";
+import { isIncomeBlocked, isLargeChange } from "../lib/budgetValidation";
+import type { BudgetCellKey, BudgetMode, CellView, LoadedCategory, NavDirection } from "../types";
+
+type Props = {
+  category: LoadedCategory;
+  month: string;
+  budgetMode: BudgetMode;
+  cellView: CellView;
+  isSelected: boolean;
+  isAnchor: boolean;
+  onFocus: (categoryId: string, month: string) => void;
+  onRangeSelect: (categoryId: string, month: string) => void;
+  onNavigate?: (dir: NavDirection) => void;
+  /** Shared drag-state ref from BudgetGrid — set to true when mouse moves across cells. */
+  isDraggingRef?: { current: boolean };
+  /** Called when the user right-clicks the cell. */
+  onContextMenuRequest?: (catId: string, month: string, carryover: boolean, x: number, y: number) => void;
+  /** When true, renders the cell at 50% opacity (hidden category/group shown). */
+  isDimmed?: boolean;
+};
+
+function formatAmount(minor: number): string {
+  return (minor / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+
+/**
+ * A single budget grid cell for a (category, month) intersection.
+ *
+ * Displays the budgeted amount (staged or persisted) for the specific month.
+ * In edit mode, accepts numeric values or arithmetic expressions.
+ * Income cells are hard-blocked in envelope mode.
+ * Supports drag-to-select (via isDraggingRef) and shift+arrow range extension.
+ */
+export function BudgetCell({
+  category,
+  month,
+  budgetMode,
+  cellView,
+  isSelected,
+  isAnchor,
+  onFocus,
+  onRangeSelect,
+  onNavigate,
+  isDraggingRef,
+  onContextMenuRequest,
+  isDimmed,
+}: Props) {
+  const dimClass = isDimmed ? " opacity-50" : "";
+  const key: BudgetCellKey = `${month}:${category.id}`;
+  const edits = useBudgetEditsStore((s) => s.edits);
+  const stageEdit = useBudgetEditsStore((s) => s.stageEdit);
+  const removeEdit = useBudgetEditsStore((s) => s.removeEdit);
+
+  // Load this month's effective data (server state + staged deltas applied locally).
+  // useEffectiveMonthData is cached by TanStack Query — one API call per unique month.
+  const { data: effectiveData } = useEffectiveMonthData(month);
+  const effectiveCategory = effectiveData?.categoriesById[category.id] ?? category;
+
+  const stagedEdit = edits[key];
+  const currentBudgeted = effectiveCategory.budgeted;
+  const blocked = isIncomeBlocked(category, budgetMode);
+  // Editing is only possible in the "budgeted" view.
+  const viewBlocked = cellView !== "budgeted";
+
+  // The value shown in the cell (effective value for all views).
+  // In Envelope mode, income cells always show actuals (received) — there is
+  // no budget or variance concept for income in envelope budgeting.
+  const envelopeIncome = budgetMode === "envelope" && category.isIncome;
+  const displayMinor = envelopeIncome
+    ? effectiveCategory.actuals
+    : cellView === "spent"
+    ? effectiveCategory.actuals
+    : cellView === "balance"
+    ? effectiveCategory.balance
+    : currentBudgeted;
+
+
+  const [editing, setEditing] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const enterEdit = (initialValue?: string) => {
+    if (blocked || viewBlocked || editing) return;
+    setInputValue(initialValue ?? formatAmount(currentBudgeted));
+    setInputError(null);
+    setEditing(true);
+    requestAnimationFrame(() => {
+      if (initialValue !== undefined) {
+        const len = initialValue.length;
+        inputRef.current?.focus();
+        inputRef.current?.setSelectionRange(len, len);
+      } else {
+        inputRef.current?.select();
+      }
+    });
+  };
+
+  /** Returns true if commit succeeded (valid parse), false on error. */
+  const commitEdit = (): boolean => {
+    if (!editing) return true;
+    const result = parseBudgetExpression(inputValue);
+    if (!result.ok) {
+      setInputError(result.error);
+      return false;
+    }
+    setEditing(false);
+    setInputError(null);
+    // originalValue is the server-persisted value before any staged edits.
+    const originalValue = stagedEdit?.previousBudgeted ?? effectiveCategory.budgeted;
+    if (result.value === originalValue) {
+      // User reverted to the original — remove the staged edit so the cell is clean.
+      if (stagedEdit) removeEdit(key);
+    } else if (result.value !== currentBudgeted) {
+      // Value genuinely changed from current — stage the edit.
+      stageEdit({
+        month,
+        categoryId: category.id,
+        nextBudgeted: result.value,
+        previousBudgeted: originalValue,
+        source: "manual",
+      });
+    }
+    return true;
+  };
+
+  const cancelEdit = () => {
+    setEditing(false);
+    setInputError(null);
+    setInputValue("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (commitEdit()) onNavigate?.("down");
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEdit();
+    } else if (e.key === "Tab") {
+      e.preventDefault();
+      if (commitEdit()) onNavigate?.(e.shiftKey ? "shift-tab" : "tab");
+    }
+  };
+
+  const handleCellKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (blocked || viewBlocked) return;
+
+    if (e.key === "Enter" || e.key === "F2") {
+      e.preventDefault();
+      enterEdit();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      onNavigate?.(e.shiftKey ? "shift-up" : "up");
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      onNavigate?.(e.shiftKey ? "shift-down" : "down");
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      onNavigate?.(e.shiftKey ? "shift-left" : "left");
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      onNavigate?.(e.shiftKey ? "shift-right" : "right");
+    } else if (e.key === "Tab") {
+      e.preventDefault();
+      onNavigate?.(e.shiftKey ? "shift-tab" : "tab");
+    } else if (e.key === "Delete" || e.key === "Backspace") {
+      e.preventDefault();
+      if (currentBudgeted !== 0) {
+        const originalValue = stagedEdit?.previousBudgeted ?? effectiveCategory.budgeted;
+        if (originalValue === 0) {
+          // Going back to the original value of 0 — remove the staged edit.
+          if (stagedEdit) removeEdit(key);
+        } else {
+          stageEdit({
+            month,
+            categoryId: category.id,
+            nextBudgeted: 0,
+            previousBudgeted: originalValue,
+            source: "manual",
+          });
+        }
+      }
+    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      enterEdit(e.key);
+    }
+  };
+
+  /** On mousedown: reset drag flag and set this cell as the selection anchor. */
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (e.shiftKey) return; // shift+click handled by click handler
+    if (isDraggingRef) isDraggingRef.current = false;
+    onFocus(category.id, month);
+  };
+
+  /**
+   * On mouseenter with left button held: extend the selection (drag-select).
+   * Works for both blocked and editable cells so you can drag across the grid.
+   */
+  const handleMouseEnter = (e: React.MouseEvent) => {
+    if (e.buttons === 1) {
+      if (isDraggingRef) isDraggingRef.current = true;
+      onRangeSelect(category.id, month);
+    }
+  };
+
+  /** Click: if shift, extend selection; otherwise enter edit (unless drag just ended). */
+  const handleClick = (e: React.MouseEvent) => {
+    if (e.shiftKey) {
+      onRangeSelect(category.id, month);
+    } else if (!isDraggingRef?.current) {
+      // Anchor was already set in mousedown; just open the editor.
+      enterEdit();
+    }
+    // When isDragging=true the mousedown already handled selection extension;
+    // don't enter edit mode or collapse the range.
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    onContextMenuRequest?.(category.id, month, effectiveCategory.carryover, e.clientX, e.clientY);
+  };
+
+  const hasSaveError = !!stagedEdit?.saveError;
+  const hasLargeChange =
+    stagedEdit != null &&
+    isLargeChange(stagedEdit.previousBudgeted, stagedEdit.nextBudgeted);
+
+  // Carryover indicator (top-right triangle)
+  const carryoverIndicator = effectiveCategory.carryover ? (
+    <span
+      className="absolute top-0 right-0 border-[5px] border-transparent border-t-blue-400/80 border-r-blue-400/80"
+      title="Rollover enabled"
+      aria-hidden="true"
+    />
+  ) : null;
+
+  // Hover tooltip: show spent/balance when in budgeted view (they aren't directly visible).
+  const hoverTitle =
+    cellView === "budgeted"
+      ? `Spent: ${formatAmount(effectiveCategory.actuals)} | Balance: ${formatAmount(effectiveCategory.balance)}`
+      : undefined;
+
+  // ─── Blocked / read-only cell ────────────────────────────────────────────────
+  if (blocked || viewBlocked) {
+    const blockedLabel = blocked
+      ? `${category.name} budget for ${month} — income editing blocked in envelope mode`
+      : `${category.name} ${cellView} for ${month}`;
+
+    let blockedCellClass =
+      "relative h-7 px-2 flex items-center justify-end text-xs font-sans tabular-nums select-none outline-none border-r border-b border-border/50 cursor-not-allowed";
+
+    blockedCellClass += " bg-muted/30";
+
+    return (
+      <div
+        className={`${blockedCellClass}${dimClass}`}
+        role="gridcell"
+        aria-label={blockedLabel}
+        aria-readonly="true"
+        aria-disabled={blocked ? "true" : undefined}
+        onMouseDown={handleMouseDown}
+        onMouseEnter={handleMouseEnter}
+        onContextMenu={handleContextMenu}
+        tabIndex={0}
+        title={hoverTitle}
+        data-month={month}
+        data-category-id={category.id}
+      >
+        {carryoverIndicator}
+        <span
+          className={
+            cellView === "balance" && displayMinor < 0
+              ? "text-destructive"
+              : cellView === "spent"
+              ? "text-foreground"
+              : "text-muted-foreground"
+          }
+        >
+          {formatAmount(displayMinor)}
+        </span>
+      </div>
+    );
+  }
+
+  // ─── Editing cell ────────────────────────────────────────────────────────────
+  if (editing) {
+    return (
+      <div
+        className={`relative h-7 px-0.5 flex items-center border-r border-b border-border/50 bg-background ring-2 ring-inset ring-foreground/80 z-10${dimClass}`}
+        role="gridcell"
+        onMouseEnter={handleMouseEnter}
+        onContextMenu={handleContextMenu}
+        data-month={month}
+        data-category-id={category.id}
+      >
+        {carryoverIndicator}
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            setInputError(null);
+          }}
+          onKeyDown={handleKeyDown}
+          onBlur={commitEdit}
+          className="w-full h-full px-1.5 text-xs font-sans tabular-nums bg-transparent outline-none text-right"
+          aria-label={`Edit budget for ${category.name} in ${month}`}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        {inputError && (
+          <div
+            className="absolute top-full left-0 z-20 bg-destructive text-destructive-foreground text-xs px-2 py-1 rounded shadow"
+            role="alert"
+          >
+            {inputError}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ─── Normal cell ─────────────────────────────────────────────────────────────
+  let cellClass =
+    "relative h-7 px-2 flex items-center justify-end text-xs font-sans tabular-nums select-none outline-none border-r border-b border-border/50 cursor-default transition-colors";
+
+  if (isAnchor) {
+    cellClass += " ring-2 ring-inset ring-foreground/80";
+  } else if (isSelected) {
+    cellClass += " bg-primary/10";
+  } else {
+    cellClass += " hover:bg-muted/40 focus:bg-muted/40";
+  }
+
+  if (stagedEdit) {
+    cellClass += " bg-amber-50 dark:bg-amber-950/20";
+  }
+
+  if (hasSaveError) {
+    cellClass += " bg-red-50 dark:bg-red-950/20";
+  }
+
+  return (
+    <div
+      className={`${cellClass}${dimClass}`}
+      role="gridcell"
+      tabIndex={0}
+      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " — save error" : ""}`}
+      aria-selected={isSelected}
+      onMouseDown={handleMouseDown}
+      onMouseEnter={handleMouseEnter}
+      onClick={handleClick}
+      onKeyDown={handleCellKeyDown}
+      onContextMenu={handleContextMenu}
+      title={hoverTitle}
+      data-month={month}
+      data-category-id={category.id}
+    >
+      {carryoverIndicator}
+      <span
+        className={
+          stagedEdit
+            ? "text-amber-700 dark:text-amber-400 font-semibold"
+            : hasSaveError
+            ? "text-destructive"
+            : "text-foreground"
+        }
+      >
+        {formatAmount(displayMinor)}
+      </span>
+
+      {hasLargeChange && (
+        <span
+          className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-orange-400"
+          aria-hidden="true"
+          title="Large change"
+        />
+      )}
+
+      {hasSaveError && (
+        <span
+          className="absolute top-0.5 left-0.5 w-1.5 h-1.5 rounded-full bg-destructive"
+          aria-hidden="true"
+          title={stagedEdit?.saveError}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -154,9 +154,8 @@ export function BudgetCell({
   };
 
   const handleCellKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (blocked || viewBlocked) return;
-
     if (e.key === "Enter" || e.key === "F2") {
+      if (blocked || viewBlocked) return;
       e.preventDefault();
       enterEdit();
     } else if (e.key === "ArrowUp") {
@@ -175,6 +174,10 @@ export function BudgetCell({
       e.preventDefault();
       onNavigate?.(e.shiftKey ? "shift-tab" : "tab");
     } else if (e.key === "Delete" || e.key === "Backspace") {
+      if (blocked || viewBlocked) {
+        e.preventDefault();
+        return;
+      }
       e.preventDefault();
       if (currentBudgeted !== 0) {
         const originalValue = stagedEdit?.previousBudgeted ?? effectiveCategory.budgeted;
@@ -192,6 +195,7 @@ export function BudgetCell({
         }
       }
     } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (blocked || viewBlocked) return;
       e.preventDefault();
       enterEdit(e.key);
     }
@@ -272,6 +276,7 @@ export function BudgetCell({
         aria-disabled={blocked ? "true" : undefined}
         onMouseDown={handleMouseDown}
         onMouseEnter={handleMouseEnter}
+        onKeyDown={handleCellKeyDown}
         onContextMenu={handleContextMenu}
         tabIndex={0}
         title={hoverTitle}

--- a/src/features/budget-management/components/BudgetCellContextMenu.tsx
+++ b/src/features/budget-management/components/BudgetCellContextMenu.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { RefreshCw, ArrowRightLeft, Copy, Percent, ZapOff, Calendar, TrendingUp } from "lucide-react";
+import type { BudgetMode } from "../types";
+import type { BulkActionType } from "../hooks/useBulkAction";
+
+type Props = {
+  x: number;
+  y: number;
+  carryover: boolean;
+  budgetMode: BudgetMode;
+  onToggleCarryover: () => void;
+  onOpenTransfer: () => void;
+  /** Called with the action type — BudgetWorkspace decides immediate vs. dialog. */
+  onBulkAction: (action: BulkActionType) => void;
+  onClose: () => void;
+};
+
+type BulkItem = {
+  action: BulkActionType;
+  label: string;
+  icon: React.ReactNode;
+  needsInput: boolean;
+};
+
+const BULK_ITEMS: BulkItem[] = [
+  { action: "copy-previous-month", label: "Copy previous month",     icon: <Copy className="h-3 w-3" />,       needsInput: false },
+  { action: "copy-from-month",     label: "Copy specific month…",    icon: <Calendar className="h-3 w-3" />,   needsInput: true  },
+  { action: "set-to-zero",         label: "Set to zero",             icon: <ZapOff className="h-3 w-3" />,    needsInput: false },
+  { action: "set-fixed",           label: "Set to fixed amount…",    icon: <Percent className="h-3 w-3" />,   needsInput: true  },
+  { action: "apply-percentage",    label: "Apply % change…",         icon: <Percent className="h-3 w-3" />,   needsInput: true  },
+  { action: "avg-3-months",        label: "Set to 3 months average", icon: <TrendingUp className="h-3 w-3" />, needsInput: false },
+  { action: "avg-6-months",        label: "Set to 6 months average", icon: <TrendingUp className="h-3 w-3" />, needsInput: false },
+  { action: "avg-12-months",       label: "Set to yearly average",   icon: <TrendingUp className="h-3 w-3" />, needsInput: false },
+];
+
+export function BudgetCellContextMenu({
+  x,
+  y,
+  carryover,
+  budgetMode,
+  onToggleCarryover,
+  onOpenTransfer,
+  onBulkAction,
+  onClose,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleDown);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleDown);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [onClose]);
+
+  const style: React.CSSProperties = { position: "fixed", top: y, left: x, zIndex: 50 };
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label="Cell actions"
+      style={style}
+      className="bg-popover border border-border rounded-lg shadow-xl py-1 min-w-[210px] text-xs"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Cell-level actions */}
+      <button
+        role="menuitem"
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-muted transition-colors"
+        onClick={() => { onToggleCarryover(); onClose(); }}
+      >
+        <RefreshCw className="h-3 w-3 text-muted-foreground shrink-0" />
+        <span>{carryover ? "Disable Rollover" : "Enable Rollover"}</span>
+        <span className="ml-auto text-[10px] text-muted-foreground">(this month+)</span>
+      </button>
+      {budgetMode === "envelope" && (
+        <button
+          role="menuitem"
+          type="button"
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-muted transition-colors"
+          onClick={() => { onOpenTransfer(); onClose(); }}
+        >
+          <ArrowRightLeft className="h-3 w-3 text-muted-foreground shrink-0" />
+          Transfer Budget
+        </button>
+      )}
+
+      {/* Bulk actions */}
+      <div className="h-px bg-border/50 my-1" />
+      <p className="px-3 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground select-none">
+        Set Budget
+      </p>
+      {BULK_ITEMS.map(({ action, label, icon }) => (
+        <button
+          key={action}
+          role="menuitem"
+          type="button"
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-muted transition-colors"
+          onClick={() => { onBulkAction(action); onClose(); }}
+        >
+          <span className="text-muted-foreground shrink-0">{icon}</span>
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetDraftPanel.tsx
+++ b/src/features/budget-management/components/BudgetDraftPanel.tsx
@@ -1,0 +1,750 @@
+"use client";
+
+import { useMemo } from "react";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import { useMonthData } from "../hooks/useMonthData";
+import { useEffectiveMonthData } from "../hooks/useEffectiveMonthData";
+import { useAvailableMonths } from "../hooks/useAvailableMonths";
+import { useBudgetMode } from "../hooks/useBudgetMode";
+import type {
+  BudgetCellKey,
+  BudgetMode,
+  LoadedCategory,
+  LoadedMonthState,
+  StagedBudgetEdit,
+} from "../types";
+
+// ─── Format helpers ────────────────────────────────────────────────────────────
+
+function fmtAmount(minor: number): string {
+  const sign = minor < 0 ? "−" : "";
+  return `${sign}${(Math.abs(minor) / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function fmtMonthLabel(month: string): string {
+  const [yearStr, moStr] = month.split("-");
+  const year = parseInt(yearStr ?? "2000", 10);
+  const mo = parseInt(moStr ?? "1", 10);
+  return new Date(year, mo - 1, 1).toLocaleString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function getPrevMonth(month: string): string {
+  const [yearStr, monthStr] = month.split("-");
+  const year = parseInt(yearStr ?? "2000", 10);
+  const mo = parseInt(monthStr ?? "1", 10);
+  const prevDate = new Date(year, mo - 2, 1);
+  return `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, "0")}`;
+}
+
+// ─── MetricRow helper ──────────────────────────────────────────────────────────
+
+function MetricRow({
+  label,
+  value,
+  valueClass,
+}: {
+  label: string;
+  value: string;
+  valueClass?: string;
+}) {
+  return (
+    <div className="flex justify-between items-baseline gap-2">
+      <span className="text-muted-foreground shrink-0 text-[11px]">{label}</span>
+      <span
+        className={`font-sans tabular-nums text-right text-[11px] ${valueClass ?? "text-foreground"}`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ─── Section 1: Selected cell details ─────────────────────────────────────────
+
+function CellDetailsSection({
+  selectedMonth,
+  selectedCategoryId,
+  edits,
+}: {
+  selectedMonth: string | null;
+  selectedCategoryId: string | null;
+  edits: Record<BudgetCellKey, StagedBudgetEdit>;
+}) {
+  const { data: monthData } = useMonthData(selectedMonth);
+  const prevMonth = selectedMonth ? getPrevMonth(selectedMonth) : null;
+  const { data: prevMonthData } = useMonthData(prevMonth);
+
+  if (!selectedMonth || !selectedCategoryId) {
+    return (
+      <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+        <div className="mb-1">No cell selected</div>
+        <div className="text-[10px] text-muted-foreground/50">
+          Click a cell to inspect
+        </div>
+      </div>
+    );
+  }
+
+  const category = monthData?.categoriesById[selectedCategoryId];
+  const prevCategory = prevMonthData?.categoriesById[selectedCategoryId];
+
+  const key: BudgetCellKey = `${selectedMonth}:${selectedCategoryId}`;
+  const stagedEdit = edits[key];
+  const displayBudgeted =
+    stagedEdit != null ? stagedEdit.nextBudgeted : (category?.budgeted ?? 0);
+
+  const monthLabel = fmtMonthLabel(selectedMonth);
+
+  return (
+    <div className="px-3 py-2">
+      {/* Category header */}
+      {category ? (
+        <div className="mb-2 pb-2 border-b border-border/40">
+          <div className="font-semibold text-sm truncate leading-tight">
+            {category.name}
+          </div>
+          <div className="text-[11px] text-muted-foreground truncate mt-0.5">
+            {category.groupName}
+          </div>
+          <div className="text-[10px] text-muted-foreground/60 mt-1 font-sans tabular-nums">
+            {monthLabel}
+          </div>
+        </div>
+      ) : (
+        <div className="text-muted-foreground text-xs mb-2">
+          {monthData ? "Category not found" : "Loading…"}
+        </div>
+      )}
+
+      {/* Metrics */}
+      {category && (
+        <div className="space-y-1.5">
+          <MetricRow
+            label="Budgeted"
+            value={fmtAmount(displayBudgeted)}
+            valueClass={
+              stagedEdit
+                ? "text-amber-700 dark:text-amber-400 font-semibold"
+                : undefined
+            }
+          />
+          <MetricRow label="Actuals" value={fmtAmount(category.actuals)} />
+          <MetricRow
+            label="Balance"
+            value={fmtAmount(category.balance)}
+            valueClass={
+              category.balance < 0
+                ? "text-destructive"
+                : category.balance > 0
+                ? "text-emerald-700 dark:text-emerald-400"
+                : undefined
+            }
+          />
+          {category.carryover && (
+            <MetricRow label="Carryover" value="On" />
+          )}
+          {prevCategory !== undefined && (
+            <MetricRow
+              label="Prev month"
+              value={fmtAmount(prevCategory.budgeted)}
+            />
+          )}
+
+          {/* Staged diff rows */}
+          {stagedEdit && (
+            <>
+              <div className="h-px bg-border/50 my-1" />
+              <MetricRow
+                label="Was"
+                value={fmtAmount(stagedEdit.previousBudgeted)}
+              />
+              <MetricRow
+                label="Diff"
+                value={`${stagedEdit.nextBudgeted - stagedEdit.previousBudgeted >= 0 ? "+" : ""}${fmtAmount(stagedEdit.nextBudgeted - stagedEdit.previousBudgeted)}`}
+                valueClass={
+                  stagedEdit.nextBudgeted - stagedEdit.previousBudgeted >= 0
+                    ? "text-emerald-700 dark:text-emerald-400"
+                    : "text-destructive"
+                }
+              />
+              {stagedEdit.saveError && (
+                <div className="text-[10px] text-destructive mt-0.5">
+                  {stagedEdit.saveError}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+    
+    </div>
+  );
+}
+
+// ─── Section 2: Staged changes grouped by month ────────────────────────────────
+
+function StagedChangesSection({
+  edits,
+  allCategories,
+}: {
+  edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  allCategories: LoadedCategory[];
+}) {
+  const editList = Object.values(edits);
+
+  const byMonth = useMemo(() => {
+    const grouped: Record<string, StagedBudgetEdit[]> = {};
+    for (const edit of editList) {
+      if (!grouped[edit.month]) grouped[edit.month] = [];
+      grouped[edit.month]!.push(edit);
+    }
+    return grouped;
+  }, [editList]);
+
+  const months = useMemo(() => Object.keys(byMonth).sort(), [byMonth]);
+
+  if (editList.length === 0) {
+    return (
+      <div className="px-3 py-4 text-[11px] text-muted-foreground text-center">
+        No staged changes
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-3 py-2">
+      <p className="mb-2 text-[10px] text-muted-foreground">
+        {editList.length} pending change{editList.length !== 1 ? "s" : ""} in{" "}
+        {months.length} month{months.length !== 1 ? "s" : ""}
+      </p>
+
+      {months.map((month) => {
+        const monthEdits = (byMonth[month] ?? []).slice().sort((a, b) => {
+          const nameA =
+            allCategories.find((c) => c.id === a.categoryId)?.name ?? a.categoryId;
+          const nameB =
+            allCategories.find((c) => c.id === b.categoryId)?.name ?? b.categoryId;
+          return nameA.localeCompare(nameB);
+        });
+
+        return (
+          <div key={month} className="mb-3">
+            <p className="text-[11px] font-semibold text-foreground/80 mb-1">
+              {fmtMonthLabel(month)}
+            </p>
+            {monthEdits.map((edit) => {
+              const catName =
+                allCategories.find((c) => c.id === edit.categoryId)?.name ??
+                edit.categoryId.slice(0, 8);
+              const delta = edit.nextBudgeted - edit.previousBudgeted;
+              const deltaStr = `${delta >= 0 ? "+" : ""}${fmtAmount(delta)}`;
+              const deltaClass =
+                delta >= 0
+                  ? "text-emerald-700 dark:text-emerald-400"
+                  : "text-destructive";
+
+              return (
+                <div
+                  key={`${edit.month}:${edit.categoryId}`}
+                  className="flex items-baseline justify-between gap-1 py-0.5"
+                >
+                  <span
+                    className="truncate text-[10px] text-foreground/80 min-w-0 flex-1"
+                    title={catName}
+                  >
+                    {catName}
+                  </span>
+                  <span
+                    className={`font-sans tabular-nums text-[10px] shrink-0 ${deltaClass}`}
+                  >
+                    {deltaStr}
+                  </span>
+                  {edit.saveError && (
+                    <span
+                      className="text-[9px] text-destructive shrink-0"
+                      title={edit.saveError}
+                    >
+                      !
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Section 1b: Selected group details ───────────────────────────────────────
+
+function GroupDetailsSection({
+  selectedMonth,
+  selectedGroupId,
+  edits,
+}: {
+  selectedMonth: string | null;
+  selectedGroupId: string | null;
+  edits: Record<BudgetCellKey, StagedBudgetEdit>;
+}) {
+  const { data: effectiveData } = useEffectiveMonthData(selectedMonth);
+  const { data: serverData } = useMonthData(selectedMonth);
+  const prevMonth = selectedMonth ? getPrevMonth(selectedMonth) : null;
+  const { data: prevMonthData } = useMonthData(prevMonth);
+
+  if (!selectedMonth || !selectedGroupId) return null;
+
+  const effectiveGroup = effectiveData?.groupsById[selectedGroupId];
+  const serverGroup = serverData?.groupsById[selectedGroupId];
+  const prevGroup = prevMonthData?.groupsById[selectedGroupId];
+  const group = effectiveGroup ?? serverGroup;
+
+  if (!group) {
+    return (
+      <div className="px-3 py-2 text-[11px] text-muted-foreground">
+        {effectiveData ? "Group not found" : "Loading…"}
+      </div>
+    );
+  }
+
+  // Determine if any staged edits exist for categories in this group+month.
+  const groupCatIds = new Set(group.categoryIds);
+  const hasEdits = Object.keys(edits).some((key) => {
+    const sep = key.indexOf(":");
+    return sep !== -1 && key.slice(0, sep) === selectedMonth && groupCatIds.has(key.slice(sep + 1));
+  });
+
+  const wasBudgeted = serverGroup?.budgeted ?? group.budgeted;
+  const diff = group.budgeted - wasBudgeted;
+
+  return (
+    <div className="px-3 py-2">
+      {/* Group header */}
+      <div className="mb-2 pb-2 border-b border-border/40">
+        <div className="font-semibold text-sm truncate leading-tight">
+          {group.name}
+        </div>
+        <div className="text-[11px] text-muted-foreground truncate mt-0.5">
+          {group.isIncome ? "Income group" : "Expense group"}
+        </div>
+        <div className="text-[10px] text-muted-foreground/60 mt-1 font-sans tabular-nums">
+          {fmtMonthLabel(selectedMonth)}
+        </div>
+      </div>
+
+      {/* Metrics */}
+      <div className="space-y-1.5">
+        <MetricRow label="Budgeted" value={fmtAmount(group.budgeted)} />
+        <MetricRow label="Actuals" value={fmtAmount(Math.abs(group.actuals))} />
+        <MetricRow
+          label="Balance"
+          value={fmtAmount(group.balance)}
+          valueClass={
+            group.balance < 0
+              ? "text-destructive"
+              : group.balance > 0
+              ? "text-emerald-700 dark:text-emerald-400"
+              : undefined
+          }
+        />
+        {prevGroup !== undefined && (
+          <MetricRow label="Prev month" value={fmtAmount(prevGroup.budgeted)} />
+        )}
+
+        {hasEdits && (
+          <>
+            <div className="h-px bg-border/50 my-1" />
+            <MetricRow label="Was" value={fmtAmount(wasBudgeted)} />
+            <MetricRow
+              label="Diff"
+              value={`${diff >= 0 ? "+" : ""}${fmtAmount(diff)}`}
+              valueClass={
+                diff >= 0
+                  ? "text-emerald-700 dark:text-emerald-400"
+                  : "text-destructive"
+              }
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Section 3: Year summary ───────────────────────────────────────────────────
+
+function fmtYearRange(displayMonths: string[]): string {
+  const first = displayMonths[0];
+  const last = displayMonths[displayMonths.length - 1];
+  if (!first || !last) return "";
+  const [y1, m1] = first.split("-");
+  const [y2, m2] = last.split("-");
+  const year1 = parseInt(y1 ?? "2026", 10);
+  const mo1 = parseInt(m1 ?? "1", 10);
+  const year2 = parseInt(y2 ?? "2026", 10);
+  const mo2 = parseInt(m2 ?? "12", 10);
+  if (year1 === year2) return String(year1);
+  const d1 = new Date(year1, mo1 - 1, 1);
+  const d2 = new Date(year2, mo2 - 1, 1);
+  const fmt = new Intl.DateTimeFormat("en-US", { month: "short", year: "numeric" });
+  return `${fmt.format(d1)} – ${fmt.format(d2)}`;
+}
+
+function SparkRow({
+  label,
+  values,
+  barClass,
+  balanceMode = false,
+}: {
+  label: string;
+  values: (number | null)[];
+  barClass?: string;
+  balanceMode?: boolean;
+}) {
+  const max = Math.max(0, ...values.map((v) => (v !== null ? Math.abs(v) : 0)));
+
+  return (
+    <div>
+      <span className="text-[10px] text-muted-foreground mb-1 block">{label}</span>
+      <div className="flex items-end gap-px h-5">
+        {values.map((v, i) => {
+          if (v === null) {
+            return (
+              <div key={i} className="flex-1 h-[2px] rounded-[1px] bg-muted/40" />
+            );
+          }
+          const absV = Math.abs(v);
+          const pct = max > 0 ? absV / max : 0;
+          const heightPx = Math.max(2, Math.round(pct * 20));
+          const cls = balanceMode
+            ? v >= 0
+              ? "bg-emerald-500/60 dark:bg-emerald-400/50"
+              : "bg-destructive/60"
+            : (barClass ?? "bg-primary/60");
+          return (
+            <div key={i} className="flex-1 flex flex-col justify-end h-5">
+              <div className={`rounded-[1px] ${cls}`} style={{ height: `${heightPx}px` }} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+type MonthEntry = { month: string; state: LoadedMonthState };
+
+function YearSummaryDisplay({
+  displayMonths,
+  monthsData,
+  budgetMode,
+  isLoading,
+}: {
+  displayMonths: string[];
+  monthsData: MonthEntry[];
+  budgetMode: BudgetMode;
+  isLoading: boolean;
+}) {
+  const isEnvelope = budgetMode === "envelope";
+  const availableSet = useMemo(
+    () => new Set(monthsData.map((d) => d.month)),
+    [monthsData]
+  );
+
+  const yearRangeLabel = useMemo(() => fmtYearRange(displayMonths), [displayMonths]);
+
+  const totals = useMemo(() => {
+    let expBudgeted = 0;
+    let expSpent = 0;
+    let incReceived = 0;
+    let incBudgeted = 0;
+    let overallTracking = 0;
+    let lastState: LoadedMonthState | undefined;
+
+    for (const { state } of monthsData) {
+      expBudgeted += Math.abs(state.summary.totalBudgeted);
+      expSpent += Math.abs(state.summary.totalSpent);
+      incReceived += state.summary.totalIncome;
+      overallTracking += state.summary.totalBalance;
+      lastState = state;
+
+      const monthIncBudgeted = Object.values(state.groupsById)
+        .filter((g) => g.isIncome)
+        .reduce((s, g) => s + g.budgeted, 0);
+      incBudgeted += monthIncBudgeted;
+    }
+
+    const overall = isEnvelope
+      ? (lastState?.summary.toBudget ?? 0)
+      : overallTracking;
+
+    return { expBudgeted, expSpent, incReceived, incBudgeted, overall };
+  }, [monthsData, isEnvelope]);
+
+  const sparkExpenses = displayMonths.map((m) => {
+    if (!availableSet.has(m)) return null;
+    return Math.abs(monthsData.find((d) => d.month === m)?.state.summary.totalSpent ?? 0);
+  });
+
+  const sparkIncome = displayMonths.map((m) => {
+    if (!availableSet.has(m)) return null;
+    return monthsData.find((d) => d.month === m)?.state.summary.totalIncome ?? 0;
+  });
+
+  const sparkBalance = displayMonths.map((m) => {
+    if (!availableSet.has(m)) return null;
+    const entry = monthsData.find((d) => d.month === m);
+    if (!entry) return null;
+    return isEnvelope
+      ? entry.state.summary.toBudget
+      : entry.state.summary.totalBalance;
+  });
+
+  if (isLoading && monthsData.length === 0) {
+    return (
+      <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+        Loading…
+      </div>
+    );
+  }
+
+  if (monthsData.length === 0) {
+    return (
+      <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+        No data available
+      </div>
+    );
+  }
+
+  const { overall } = totals;
+
+  return (
+    <div className="px-3 py-2 space-y-3">
+      {/* Header */}
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Year Summary
+        </p>
+        <p className="text-[10px] text-muted-foreground/60 mt-0.5">{yearRangeLabel}</p>
+      </div>
+
+      {/* Expenses */}
+      <div>
+        <p className="text-[10px] font-semibold text-foreground/70 mb-1">Expenses</p>
+        <div className="space-y-1">
+          <MetricRow label="Budgeted" value={fmtAmount(totals.expBudgeted)} />
+          <MetricRow label="Spent" value={fmtAmount(totals.expSpent)} />
+        </div>
+      </div>
+
+      {/* Income */}
+      <div>
+        <p className="text-[10px] font-semibold text-foreground/70 mb-1">Income</p>
+        <div className="space-y-1">
+          {!isEnvelope && (
+            <MetricRow label="Budgeted" value={fmtAmount(totals.incBudgeted)} />
+          )}
+          <MetricRow label="Received" value={fmtAmount(totals.incReceived)} />
+        </div>
+      </div>
+
+      {/* Overall result */}
+      <div className="border-t border-border/40 pt-2">
+        <div className="flex justify-between items-baseline gap-2">
+          <span className="text-[11px] font-semibold text-foreground/80">
+            {isEnvelope ? "To Budget" : "Net Balance"}
+          </span>
+          <span
+            className={`font-sans tabular-nums text-right text-sm font-semibold ${
+              overall > 0
+                ? "text-emerald-700 dark:text-emerald-400"
+                : overall < 0
+                ? "text-destructive"
+                : "text-foreground"
+            }`}
+          >
+            {fmtAmount(overall)}
+          </span>
+        </div>
+      </div>
+
+      {/* Monthly Trend sparkbars */}
+      <div className="border-t border-border/40 pt-2 space-y-2.5">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Monthly Trend
+        </p>
+        <SparkRow
+          label="Expenses"
+          values={sparkExpenses}
+          barClass="bg-destructive/60"
+        />
+        <SparkRow
+          label="Income"
+          values={sparkIncome}
+          barClass="bg-emerald-500/60 dark:bg-emerald-400/50"
+        />
+        <SparkRow label="Balance" values={sparkBalance} balanceMode />
+      </div>
+    </div>
+  );
+}
+
+function YearSummaryDataLoader({
+  displayMonths,
+  availableMonths,
+}: {
+  displayMonths: string[];
+  availableMonths: string[];
+}) {
+  const { data: budgetModeRaw } = useBudgetMode();
+  const budgetMode: BudgetMode = budgetModeRaw ?? "unidentified";
+
+  const r0  = useEffectiveMonthData(displayMonths[0]  ?? null);
+  const r1  = useEffectiveMonthData(displayMonths[1]  ?? null);
+  const r2  = useEffectiveMonthData(displayMonths[2]  ?? null);
+  const r3  = useEffectiveMonthData(displayMonths[3]  ?? null);
+  const r4  = useEffectiveMonthData(displayMonths[4]  ?? null);
+  const r5  = useEffectiveMonthData(displayMonths[5]  ?? null);
+  const r6  = useEffectiveMonthData(displayMonths[6]  ?? null);
+  const r7  = useEffectiveMonthData(displayMonths[7]  ?? null);
+  const r8  = useEffectiveMonthData(displayMonths[8]  ?? null);
+  const r9  = useEffectiveMonthData(displayMonths[9]  ?? null);
+  const r10 = useEffectiveMonthData(displayMonths[10] ?? null);
+  const r11 = useEffectiveMonthData(displayMonths[11] ?? null);
+
+  const allResults = [r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11];
+
+  const availableSet = useMemo(() => new Set(availableMonths), [availableMonths]);
+
+  const monthsData = useMemo<MonthEntry[]>(() => {
+    const entries: MonthEntry[] = [];
+    for (let i = 0; i < displayMonths.length; i++) {
+      const month = displayMonths[i]!;
+      if (!availableSet.has(month)) continue;
+      const state = allResults[i]?.data;
+      if (state) entries.push({ month, state });
+    }
+    return entries;
+    // allResults identity is stable across the fixed hook calls — keys never change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayMonths, availableSet, r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11]);
+
+  const isLoading = allResults.some((r) => r.isLoading);
+
+  return (
+    <YearSummaryDisplay
+      displayMonths={displayMonths}
+      monthsData={monthsData}
+      budgetMode={budgetMode}
+      isLoading={isLoading}
+    />
+  );
+}
+
+// ─── BudgetDraftPanel ──────────────────────────────────────────────────────────
+
+/**
+ * Right-side draft panel for the Budget Management page.
+ *
+ * Self-contained: reads selected cell from budgetEdits.ts uiSelection,
+ * budget mode from useBudgetMode, and category data from useMonthData.
+ *
+ * Rendered by AppShell at the same layout position as DraftPanel (after
+ * <main>) when the pathname is /budget-management. No props required.
+ *
+ * Visually matches the DraftPanel shell (collapsed w-10 strip when idle,
+ * expanded aside when active) but shows budget-specific content:
+ *   Section 1 — selected cell details (category metrics, staged diff)
+ *   Section 2 — all staged changes grouped by month with count summary
+ */
+export function BudgetDraftPanel() {
+  const edits = useBudgetEditsStore((s) => s.edits);
+  const { month: selectedMonth, categoryId: selectedCategoryId, groupId: selectedGroupId } =
+    useBudgetEditsStore((s) => s.uiSelection);
+  const displayMonths = useBudgetEditsStore((s) => s.displayMonths);
+  const { data: availableMonths } = useAvailableMonths();
+
+  const totalCount = Object.keys(edits).length;
+  const hasPendingEdits = totalCount > 0;
+  // Fetch categories for the selected month (or first staged edit's month)
+  // to resolve category names in StagedChangesSection.
+  const lookupMonth =
+    selectedMonth ?? Object.values(edits)[0]?.month ?? null;
+  const { data: lookupMonthData } = useMonthData(lookupMonth);
+  const allCategories = lookupMonthData
+    ? Object.values(lookupMonthData.categoriesById)
+    : [];
+
+  const showYearSummary = !selectedCategoryId && !selectedGroupId;
+
+  return (
+    <aside className="flex w-[17rem] shrink-0 flex-col border-l border-border bg-background">
+      {/* Header */}
+      <div className="flex items-center px-3 h-10 shrink-0">
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Budget Details
+        </span>
+      </div>
+      <Separator />
+
+      {/* Body */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {showYearSummary ? (
+          /* Section 0: Year summary — shown when no cell/group is selected */
+          displayMonths.length > 0 ? (
+            <YearSummaryDataLoader
+              displayMonths={displayMonths}
+              availableMonths={availableMonths ?? []}
+            />
+          ) : (
+            <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+              Loading…
+            </div>
+          )
+        ) : (
+          /* Section 1: Cell or group details */
+          selectedGroupId ? (
+            <GroupDetailsSection
+              selectedMonth={selectedMonth}
+              selectedGroupId={selectedGroupId}
+              edits={edits}
+            />
+          ) : (
+            <CellDetailsSection
+              selectedMonth={selectedMonth}
+              selectedCategoryId={selectedCategoryId}
+              edits={edits}
+            />
+          )
+        )}
+
+        {/* Section 2: Staged changes */}
+        {hasPendingEdits && (
+          <>
+            <Separator />
+            <div className="flex items-center justify-between px-3 h-10 shrink-0">
+              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Staged Changes
+              </span>
+              <Badge variant="outline" className="text-xs text-amber-600 border-amber-300">
+                {totalCount} change{totalCount !== 1 ? "s" : ""}
+              </Badge>
+            </div>
+            <Separator />
+            <StagedChangesSection edits={edits} allCategories={allCategories} />
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/features/budget-management/components/BudgetExportDialog.tsx
+++ b/src/features/budget-management/components/BudgetExportDialog.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MultiSearchableCombobox } from "@/components/ui/combobox";
+import type { ComboboxOption } from "@/components/ui/combobox";
+import { exportToCsv, exportBlankTemplate } from "../lib/budgetCsv";
+import type { LoadedCategory, LoadedGroup, StagedBudgetEdit, BudgetCellKey } from "../types";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SelectionMode = "quick" | "range" | "select";
+type QuickPreset = "current-view" | "this-month" | "last-3" | "this-year" | "last-year" | "all";
+
+type Props = {
+  availableMonths: string[];
+  activeMonths: string[];
+  groups: LoadedGroup[];
+  categoriesById: Record<string, LoadedCategory>;
+  stagedEdits?: Record<BudgetCellKey, StagedBudgetEdit>;
+  onClose: () => void;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmtMonthLabel(month: string): string {
+  const [y, mo] = month.split("-");
+  return new Date(parseInt(y ?? "2026", 10), parseInt(mo ?? "1", 10) - 1, 1)
+    .toLocaleString("en-US", { month: "short", year: "2-digit" });
+}
+
+function fmtSummaryRange(months: string[]): string {
+  if (months.length === 0) return "No months selected";
+  const sorted = [...months].sort();
+  if (sorted.length === 1) return fmtMonthLabel(sorted[0]!);
+  return `${fmtMonthLabel(sorted[0]!)} – ${fmtMonthLabel(sorted[sorted.length - 1]!)}`;
+}
+
+function subtractMonths(monthStr: string, delta: number): string {
+  const [y, mo] = monthStr.split("-");
+  const d = new Date(parseInt(y ?? "2026", 10), parseInt(mo ?? "1", 10) - 1 - delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function resolveQuickPreset(
+  preset: QuickPreset,
+  available: string[],
+  activeMonths: string[]
+): string[] {
+  if (available.length === 0) return [];
+  const now = new Date();
+  const thisMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const thisYear = String(now.getFullYear());
+  const lastYear = String(now.getFullYear() - 1);
+
+  switch (preset) {
+    case "current-view":
+      return [...activeMonths].sort();
+    case "this-month":
+      return available.filter((m) => m === thisMonth);
+    case "last-3": {
+      const cutoff = subtractMonths(thisMonth, 2);
+      return available.filter((m) => m >= cutoff && m <= thisMonth).sort();
+    }
+    case "this-year":
+      return available.filter((m) => m.startsWith(thisYear)).sort();
+    case "last-year":
+      return available.filter((m) => m.startsWith(lastYear)).sort();
+    case "all":
+      return [...available].sort();
+  }
+}
+
+
+const QUICK_PRESETS: { id: QuickPreset; label: string }[] = [
+  { id: "current-view", label: "Current View" },
+  { id: "this-month",   label: "This Month" },
+  { id: "last-3",       label: "Last 3 Months" },
+  { id: "this-year",    label: "This Year" },
+  { id: "last-year",    label: "Last Year" },
+  { id: "all",          label: "All" },
+];
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Dialog for exporting budget data to CSV.
+ *
+ * Month selection via three progressive modes:
+ *   Quick Range – presets with count badges (default, "Current View" pre-selected)
+ *   Date Range  – From / To dropdowns constrained to availableMonths
+ *   Manual      – tag-chip input for individual YYYY-MM months with inline validation
+ */
+export function BudgetExportDialog({
+  availableMonths,
+  activeMonths,
+  groups,
+  categoriesById,
+  stagedEdits,
+  onClose,
+}: Props) {
+  const [mode, setMode] = useState<SelectionMode>("quick");
+  const [quickPreset, setQuickPreset] = useState<QuickPreset>("current-view");
+  const [rangeFrom, setRangeFrom] = useState<string>(
+    availableMonths[0] ?? activeMonths[0] ?? ""
+  );
+  const [rangeTo, setRangeTo] = useState<string>(
+    availableMonths[availableMonths.length - 1] ?? activeMonths[activeMonths.length - 1] ?? ""
+  );
+  const [selectMonths, setSelectMonths] = useState<string[]>([]);
+
+  const [includeHidden, setIncludeHidden] = useState(false);
+  const [includeIncome, setIncludeIncome] = useState(false);
+  const [includeStagedView, setIncludeStagedView] = useState(false);
+
+  // Combobox options for the Select tab — one option per available month.
+  const monthOptions = useMemo<ComboboxOption[]>(
+    () => availableMonths.map((m) => ({ id: m, name: fmtMonthLabel(m) })),
+    [availableMonths]
+  );
+
+  // Derive the resolved month list from the current mode.
+  const selectedMonths = useMemo<string[]>(() => {
+    if (mode === "quick") {
+      return resolveQuickPreset(quickPreset, availableMonths, activeMonths);
+    }
+    if (mode === "range") {
+      if (!rangeFrom || !rangeTo) return [];
+      const from = rangeFrom <= rangeTo ? rangeFrom : rangeTo;
+      const to   = rangeFrom <= rangeTo ? rangeTo   : rangeFrom;
+      return availableMonths.filter((m) => m >= from && m <= to).sort();
+    }
+    // select — months chosen via combobox, already constrained to availableMonths
+    return [...selectMonths].sort();
+  }, [mode, quickPreset, rangeFrom, rangeTo, selectMonths, availableMonths, activeMonths]);
+
+  // Per-preset counts for badges.
+  const presetCounts = useMemo<Record<QuickPreset, number>>(
+    () => ({
+      "current-view": activeMonths.length,
+      "this-month":   resolveQuickPreset("this-month",  availableMonths, activeMonths).length,
+      "last-3":       resolveQuickPreset("last-3",      availableMonths, activeMonths).length,
+      "this-year":    resolveQuickPreset("this-year",   availableMonths, activeMonths).length,
+      "last-year":    resolveQuickPreset("last-year",   availableMonths, activeMonths).length,
+      all:            availableMonths.length,
+    }),
+    [availableMonths, activeMonths]
+  );
+
+  const canExport = selectedMonths.length > 0;
+
+  const triggerDownload = (content: string, filename: string) => {
+    // Prepend UTF-8 BOM so Excel and other tools open the file with the correct encoding.
+    const blob = new Blob(["\uFEFF", content], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExport = () => {
+    if (!canExport) return;
+    const opts = { months: selectedMonths, includeHidden, includeIncome };
+    const edits = includeStagedView ? stagedEdits : undefined;
+    const csv = exportToCsv(selectedMonths, groups, categoriesById, opts, edits);
+    const filename = `budget-export-${selectedMonths[0]}-to-${selectedMonths[selectedMonths.length - 1]}.csv`;
+    triggerDownload(csv, filename);
+    onClose();
+  };
+
+  const handleTemplate = () => {
+    if (!canExport) return;
+    const opts = { months: selectedMonths, includeHidden, includeIncome };
+    const csv = exportBlankTemplate(selectedMonths, groups, categoriesById, opts);
+    const filename = `budget-template-${selectedMonths[0]}-to-${selectedMonths[selectedMonths.length - 1]}.csv`;
+    triggerDownload(csv, filename);
+    onClose();
+  };
+
+  const handleRangeFromChange = (val: string) => {
+    setRangeFrom(val);
+    if (val > rangeTo) setRangeTo(val);
+  };
+
+  const handleRangeToChange = (val: string) => {
+    setRangeTo(val);
+    if (val < rangeFrom) setRangeFrom(val);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Export budget data"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-md mx-4 p-5">
+        <h2 className="text-base font-semibold mb-4">Export Budget Data</h2>
+
+        {/* Mode segmented control */}
+        <div
+          className="flex rounded border border-border overflow-hidden mb-4 text-xs font-medium"
+          role="group"
+          aria-label="Month selection mode"
+        >
+          {(["quick", "range", "select"] as SelectionMode[]).map((m, i, arr) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              aria-pressed={mode === m}
+              className={`flex-1 py-1.5 capitalize transition-colors ${
+                i < arr.length - 1 ? "border-r border-border" : ""
+              } ${
+                mode === m
+                  ? "bg-primary/10 text-foreground"
+                  : "text-muted-foreground hover:bg-muted/50"
+              }`}
+            >
+              {m === "quick" ? "Quick Range" : m === "range" ? "Date Range" : "Select"}
+            </button>
+          ))}
+        </div>
+
+        {/* Quick Range */}
+        {mode === "quick" && (
+          <div className="flex flex-wrap gap-1.5 mb-4" role="group" aria-label="Quick range presets">
+            {QUICK_PRESETS.map(({ id, label }) => {
+              const count = presetCounts[id];
+              const active = quickPreset === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setQuickPreset(id)}
+                  aria-pressed={active}
+                  disabled={count === 0}
+                  className={`inline-flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                    active
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground hover:bg-muted/80"
+                  }`}
+                >
+                  {label}
+                  <span
+                    className={`tabular-nums ${active ? "opacity-80" : "opacity-60"}`}
+                    aria-label={`${count} months`}
+                  >
+                    ({count})
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Date Range */}
+        {mode === "range" && (
+          <div className="flex items-center gap-2 mb-4">
+            <div className="flex-1">
+              <label className="block text-xs text-muted-foreground mb-1">From</label>
+              <select
+                value={rangeFrom}
+                onChange={(e) => handleRangeFromChange(e.target.value)}
+                className="w-full text-xs border border-border rounded px-2 py-1.5 bg-background font-mono"
+                aria-label="Range start month"
+              >
+                {availableMonths.map((m) => (
+                  <option key={m} value={m}>{fmtMonthLabel(m)}</option>
+                ))}
+              </select>
+            </div>
+            <span className="mt-4 text-muted-foreground text-xs shrink-0">–</span>
+            <div className="flex-1">
+              <label className="block text-xs text-muted-foreground mb-1">To</label>
+              <select
+                value={rangeTo}
+                onChange={(e) => handleRangeToChange(e.target.value)}
+                className="w-full text-xs border border-border rounded px-2 py-1.5 bg-background font-mono"
+                aria-label="Range end month"
+              >
+                {availableMonths.map((m) => (
+                  <option key={m} value={m}>{fmtMonthLabel(m)}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        )}
+
+        {/* Select — searchable multi-select combobox constrained to availableMonths */}
+        {mode === "select" && (
+          <div className="mb-4">
+            <label className="block text-xs text-muted-foreground mb-1">
+              Pick individual months
+            </label>
+            <MultiSearchableCombobox
+              options={monthOptions}
+              values={selectMonths}
+              onChange={setSelectMonths}
+              placeholder="Search and select months…"
+            />
+          </div>
+        )}
+
+        {/* Resolution summary — always visible */}
+        <div
+          className={`mb-4 px-3 py-2 rounded text-xs ${
+            canExport
+              ? "bg-muted/50 text-foreground"
+              : "bg-muted/30 text-muted-foreground"
+          }`}
+          aria-live="polite"
+          aria-label="Month selection summary"
+        >
+          {canExport ? (
+            <>
+              <span className="font-semibold">{selectedMonths.length} month{selectedMonths.length !== 1 ? "s" : ""}</span>
+              {" selected: "}
+              <span className="font-mono">{fmtSummaryRange(selectedMonths)}</span>
+            </>
+          ) : (
+            "No months selected"
+          )}
+        </div>
+
+        {/* Options */}
+        <fieldset className="mb-4 space-y-2">
+          <legend className="text-sm font-medium mb-2">Options</legend>
+
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeHidden}
+              onChange={(e) => setIncludeHidden(e.target.checked)}
+              aria-label="Include hidden categories"
+            />
+            Include hidden categories
+          </label>
+
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeIncome}
+              onChange={(e) => setIncludeIncome(e.target.checked)}
+              aria-label="Include income groups"
+            />
+            Include income groups
+          </label>
+
+          {stagedEdits && Object.keys(stagedEdits).length > 0 && (
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="checkbox"
+                checked={includeStagedView}
+                onChange={(e) => setIncludeStagedView(e.target.checked)}
+                aria-label="Export with staged (unsaved) values"
+              />
+              Export with staged (unsaved) values
+            </label>
+          )}
+        </fieldset>
+
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleTemplate}
+            disabled={!canExport}
+            aria-label="Download blank CSV template for the selected months"
+            className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Blank template
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={!canExport}
+            aria-label={`Export ${selectedMonths.length} month${selectedMonths.length !== 1 ? "s" : ""} to CSV`}
+            className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Export CSV
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -1,0 +1,1186 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { ArrowRight, ChevronDown, ChevronRight, StickyNote, Undo2 } from "lucide-react";
+import { useMonthData } from "../hooks/useMonthData";
+import { useEffectiveMonthData } from "../hooks/useEffectiveMonthData";
+import { useNextMonthHold } from "../hooks/useNextMonthHold";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import { BudgetCell } from "./BudgetCell";
+import { NextMonthHoldDialog } from "./NextMonthHoldDialog";
+import { EntityNoteButton } from "@/components/ui/entity-note-button";
+import { useEntityNote } from "@/hooks/useEntityNote";
+import type {
+  BudgetCellSelection,
+  BudgetMode,
+  BudgetMonthSummary,
+  CellView,
+  LoadedCategory,
+  LoadedGroup,
+  LoadedMonthState,
+  NavDirection,
+} from "../types";
+
+// ─── Summary row configuration ────────────────────────────────────────────────
+
+type SummaryRowConfig = {
+  label: string;
+  dynamicLabel?: (s: BudgetMonthSummary) => string;
+  getDynamicRowLabel?: (s: BudgetMonthSummary) => string;
+  getValue: (s: BudgetMonthSummary) => number;
+  colorClass?: (s: BudgetMonthSummary) => string;
+  isConsumptionBar?: boolean;
+  getActual?: (s: BudgetMonthSummary, state: LoadedMonthState) => number;
+  getTarget?: (s: BudgetMonthSummary, state: LoadedMonthState) => number;
+  barMode?: "expense" | "income";
+  /** Compact input row — rendered smaller to group visually under a total row. */
+  isSubRow?: boolean;
+  /** Operator prefix shown in the label cell to convey formula structure (+, −, =). */
+  operator?: "+" | "−" | "=";
+  /** Override the default row height Tailwind class. */
+  rowHeight?: string;
+  /** Suppress the top border that normally appears on non-sub, non-bar rows. */
+  noBorder?: boolean;
+  /** Renders a per-month hold toggle button inside the cell (envelope "To Budget" row). */
+  isHoldCell?: boolean;
+};
+
+const TRACKING_SUMMARY_ROWS: SummaryRowConfig[] = [
+  {
+    label: "Expenses",
+    getValue: (s) => s.totalSpent,
+    isConsumptionBar: true,
+    barMode: "expense",
+    getActual: (s) => Math.abs(s.totalSpent),
+    getTarget: (_s, state) =>
+      state.groupOrder
+        .map((id) => state.groupsById[id]!)
+        .filter((g) => !g.isIncome && !g.hidden)
+        .reduce((sum, g) => sum + Math.abs(g.budgeted), 0),
+  },
+  {
+    label: "Income",
+    getValue: (s) => s.totalIncome,
+    isConsumptionBar: true,
+    barMode: "income",
+    getActual: (s) => s.totalIncome,
+    getTarget: (_s, state) =>
+      state.groupOrder
+        .map((id) => state.groupsById[id]!)
+        .filter((g) => g.isIncome && !g.hidden)
+        .reduce((sum, g) => sum + g.budgeted, 0),
+  },
+  {
+    label: "Balance",
+    dynamicLabel: (s) => (s.totalBalance >= 0 ? "Savings" : "Overspent"),
+    getValue: (s) => s.totalBalance,
+    colorClass: (s) =>
+      s.totalBalance >= 0
+        ? "text-emerald-600 dark:text-emerald-400"
+        : "text-destructive",
+    rowHeight: "h-10",
+    noBorder: true,
+  },
+];
+
+const ENVELOPE_SUMMARY_ROWS: SummaryRowConfig[] = [
+  {
+    label: "Available Funds",
+    getValue: (s) => s.incomeAvailable,
+    colorClass: () => "text-foreground/75",
+    isSubRow: true,
+    operator: "+",
+  },
+  {
+    label: "Overspent Last Month",
+    getValue: (s) => s.lastMonthOverspent,
+    colorClass: () => "text-foreground/75",
+    isSubRow: true,
+    operator: "−",
+  },
+  {
+    label: "Budgeted",
+    getValue: (s) => s.totalBudgeted,
+    colorClass: () => "text-foreground/75",
+    isSubRow: true,
+    operator: "−",
+  },
+  {
+    label: "For next month",
+    getValue: (s) => s.forNextMonth <= 0 ? 0 : -Math.abs(s.forNextMonth),
+    colorClass: () => "text-foreground/75",
+    isSubRow: true,
+    operator: "−",
+  },
+  {
+    label: "To Budget / Overbudget",
+    getValue: (s) => s.toBudget,
+    colorClass: (s) =>
+      s.toBudget <= 0
+        ? "text-destructive"
+        : "text-emerald-600 dark:text-emerald-400",
+    operator: "=",
+    noBorder: true,
+    isHoldCell: true,
+  },
+];
+
+// ─── NoteCell ─────────────────────────────────────────────────────────────────
+
+/** Renders EntityNoteButton only when the entity actually has a note. */
+function NoteCell({
+  entityId,
+  entityLabel,
+  entityTypeLabel,
+}: {
+  entityId: string;
+  entityLabel: string;
+  entityTypeLabel: string;
+}) {
+  const { data: note } = useEntityNote("category", entityId, true);
+  if (!(note?.trim())) return null;
+  return (
+    <EntityNoteButton
+      entityId={entityId}
+      entityKind="category"
+      entityLabel={entityLabel}
+      entityTypeLabel={entityTypeLabel}
+      className="mx-auto"
+    />
+  );
+}
+
+// ─── Format helpers ────────────────────────────────────────────────────────────
+
+/** Full precision — used for group aggregates and individual cells. */
+function fmt(n: number): string {
+  return (n / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/** Whole-number format — used for summary rows (less visual noise). */
+function fmtSummary(n: number): string {
+  return Math.round(n / 100).toLocaleString("en-US");
+}
+
+// ─── Hold toggle (envelope "To Budget" cell) ──────────────────────────────────
+
+function HoldClearConfirmDialog({
+  month,
+  forNextMonth,
+  onConfirm,
+  onCancel,
+  isPending,
+}: {
+  month: string;
+  forNextMonth: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Confirm free hold"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-xs mx-4 p-4">
+        <p className="text-sm font-medium text-foreground mb-0.5">Free the hold for <span className="font-mono">{month}</span>?</p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Currently holding{" "}
+          <span className="font-semibold tabular-nums text-foreground">
+            {(forNextMonth / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+          </span>
+        </p>
+        <p className="text-xs bg-amber-50 dark:bg-amber-950/20 text-amber-700 dark:text-amber-400 rounded px-2.5 py-1.5 mb-4">
+          This action takes effect immediately and does not go through the save panel.
+        </p>
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="px-3 py-1.5 text-sm text-foreground rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className="px-3 py-1.5 text-sm text-foreground rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
+          >
+            {isPending ? "Clearing…" : "Free Hold"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HoldToggleButton({
+  month,
+  forNextMonth,
+  toBudget,
+}: {
+  month: string;
+  forNextMonth: number;
+  toBudget: number;
+}) {
+  const holdActive = forNextMonth !== 0;
+  const { clearHold, isPending } = useNextMonthHold();
+  const [showSetDialog, setShowSetDialog] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (holdActive) {
+      setShowConfirm(true);
+    } else {
+      setShowSetDialog(true);
+    }
+  };
+
+  const handleConfirmClear = async () => {
+    await clearHold(month);
+    setShowConfirm(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isPending}
+        title={
+          holdActive
+            ? `Held: ${(forNextMonth / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })} — click to free`
+            : "Hold funds for next month"
+        }
+        className={`group flex items-center justify-center w-5 h-5 rounded transition-colors shrink-0 ${
+          holdActive
+            ? "text-blue-500 dark:text-blue-400 hover:text-orange-500 dark:hover:text-orange-400"
+            : "text-muted-foreground/30 hover:text-muted-foreground/70"
+        }`}
+      >
+        {holdActive ? (
+          <>
+            <ArrowRight className="h-3 w-3 group-hover:hidden" aria-hidden="true" />
+            <Undo2 className="h-3 w-3 hidden group-hover:block" aria-hidden="true" />
+          </>
+        ) : (
+          <ArrowRight className="h-3 w-3" aria-hidden="true" />
+        )}
+      </button>
+
+      {showSetDialog && (
+        <NextMonthHoldDialog
+          month={month}
+          defaultAmount={toBudget > 0 ? toBudget : undefined}
+          setOnly
+          onClose={() => setShowSetDialog(false)}
+        />
+      )}
+
+      {showConfirm && (
+        <HoldClearConfirmDialog
+          month={month}
+          forNextMonth={forNextMonth}
+          onConfirm={() => void handleConfirmClear()}
+          onCancel={() => setShowConfirm(false)}
+          isPending={isPending}
+        />
+      )}
+    </>
+  );
+}
+
+// ─── Props ─────────────────────────────────────────────────────────────────────
+
+type SelectionBounds = {
+  minCatIdx: number;
+  maxCatIdx: number;
+  minMonthIdx: number;
+  maxMonthIdx: number;
+};
+
+type Props = {
+  activeMonths: string[];
+  availableMonths: string[];
+  budgetMode: BudgetMode;
+  cellView: CellView;
+  selection: BudgetCellSelection | null;
+  groupSelection?: { groupId: string; month: string } | null;
+  /** Collapse state lifted to BudgetManagementView so toolbar can control it. */
+  collapsedGroups: Set<string>;
+  onToggleCollapse: (groupId: string) => void;
+  /** When true, hidden groups/categories are rendered dimmed; when false they are omitted. */
+  showHidden: boolean;
+  onCellFocus: (categoryId: string, month: string) => void;
+  onCellRangeSelect: (categoryId: string, month: string) => void;
+  onCellNavigate?: (categoryId: string, month: string, dir: NavDirection) => void;
+  onCellContextMenu?: (
+    catId: string,
+    month: string,
+    carryover: boolean,
+    x: number,
+    y: number
+  ) => void;
+  onGroupFocus?: (groupId: string, month: string) => void;
+  onGroupNavigate?: (groupId: string, month: string, dir: NavDirection) => void;
+  /** Called when clicking a non-interactive area inside the grid (summary rows, headers, gutters). */
+  onClearSelection?: () => void;
+};
+
+// ─── Month column header ───────────────────────────────────────────────────────
+
+function MonthColumnHeader({
+  month,
+  availableMonths,
+}: {
+  month: string;
+  availableMonths: string[];
+}) {
+  const hasStagedEdits = useBudgetEditsStore((s) =>
+    Object.keys(s.edits).some((k) => k.startsWith(`${month}:`))
+  );
+  const isAvailable = availableMonths.includes(month);
+
+  const [year, mo] = month.split("-");
+  const label = new Date(
+    parseInt(year ?? "2000", 10),
+    parseInt(mo ?? "1", 10) - 1,
+    1
+  ).toLocaleString("en-US", { month: "short", year: "numeric" });
+
+  const dotColor = !isAvailable
+    ? "bg-muted-foreground/40"
+    : hasStagedEdits
+    ? "bg-amber-400"
+    : "bg-green-500";
+
+  const dotTitle = !isAvailable
+    ? "Month not yet created on server"
+    : hasStagedEdits
+    ? "Has unsaved staged changes"
+    : "Loaded, no staged changes";
+
+  return (
+    <div
+      className="h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 border-border bg-muted text-xs font-semibold text-foreground sticky top-0 z-10"
+      aria-label={`Month: ${label}`}
+    >
+      <span
+        className={`h-2 w-2 rounded-full shrink-0 ${dotColor}`}
+        title={dotTitle}
+        aria-hidden="true"
+      />
+      {label}
+    </div>
+  );
+}
+
+// ─── Consumption bar cell ──────────────────────────────────────────────────────
+
+function ConsumptionBarCell({
+  month,
+  config,
+}: {
+  month: string;
+  config: SummaryRowConfig;
+}) {
+  const { data, error } = useEffectiveMonthData(month);
+  if (error || !data) return <div className="h-10 bg-transparent" />;
+
+  const actual = config.getActual ? config.getActual(data.summary, data) : 0;
+  const target = config.getTarget ? config.getTarget(data.summary, data) : 0;
+  const ratio = target > 0 ? actual / target : 0;
+  const pct = Math.max(0, Math.min(ratio * 100, 100));
+
+  const isExpense = config.barMode === "expense";
+  const barColor = isExpense
+    ? ratio <= 1
+      ? "bg-emerald-500"
+      : "bg-red-500"
+    : ratio >= 1
+    ? "bg-emerald-500"
+    : "bg-amber-400";
+
+  const ratioText = target > 0 ? `${Math.round(ratio * 100)}%` : "—";
+  const tooltipText = target > 0
+    ? `${isExpense ? "Spent" : "Received"}: ${fmtSummary(actual)}  /  Budgeted: ${fmtSummary(target)}`
+    : "No budget set";
+
+  return (
+    <div
+      className="h-10 px-2 pt-1.5 pb-1.5 flex flex-col gap-0.5 bg-transparent font-sans tabular-nums"
+      title={tooltipText}
+    >
+      <div className="flex items-center justify-end gap-1.5">
+        <span className="text-[10px] text-foreground/80 shrink-0">{fmtSummary(actual)}</span>
+        <span className="text-[10px] text-muted-foreground/60 shrink-0">({ratioText})</span>
+      </div>
+      <div className="w-full h-2 rounded-full bg-muted/40 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Summary header rows ───────────────────────────────────────────────────────
+
+function SummaryHeaderRow({
+  config,
+  activeMonths,
+}: {
+  config: SummaryRowConfig;
+  activeMonths: string[];
+}) {
+  const { data: firstMonthData } = useMonthData(activeMonths[0] ?? null);
+  const rowLabel =
+    config.getDynamicRowLabel && firstMonthData
+      ? config.getDynamicRowLabel(firstMonthData.summary)
+      : config.label;
+
+  const isSubRow = config.isSubRow;
+  const rowH = config.rowHeight ?? (config.isConsumptionBar ? "h-10" : isSubRow ? "h-5" : "h-8");
+  // Total row gets a top border to visually separate it from the sub-rows above.
+  const borderClass = !isSubRow && !config.isConsumptionBar && !config.noBorder ? "border-t border-border/60" : "";
+
+  return (
+    <>
+      <div
+        className={`${rowH} px-3 flex items-center bg-background text-[11px] text-foreground/75 sticky left-0 z-10 ${borderClass}`}
+        role="rowheader"
+      >
+        {config.operator && (
+          <span className="mr-1.5 w-3 shrink-0 text-center text-[10px] text-muted-foreground/50 font-mono select-none">
+            {config.operator}
+          </span>
+        )}
+        <span className={config.operator === "=" ? "font-semibold" : ""}>{rowLabel}</span>
+      </div>
+      <div className={`${rowH} bg-transparent ${borderClass}`} aria-hidden="true" />
+      {activeMonths.map((month) =>
+        config.isConsumptionBar ? (
+          <ConsumptionBarCell key={month} month={month} config={config} />
+        ) : (
+          <SummaryHeaderCell key={month} month={month} config={config} />
+        )
+      )}
+    </>
+  );
+}
+
+function SummaryHeaderCell({
+  month,
+  config,
+}: {
+  month: string;
+  config: SummaryRowConfig;
+}) {
+  const { data, error } = useEffectiveMonthData(month);
+  const isSubRow = config.isSubRow;
+  const rowH = config.rowHeight ?? (isSubRow ? "h-6" : "h-8");
+  const borderClass = !isSubRow && !config.isConsumptionBar && !config.noBorder ? "border-t border-border/60" : "";
+
+  if (error || !data) return <div className={`${rowH} bg-transparent ${borderClass}`} />;
+
+  const value = config.getValue(data.summary);
+  const dynamicLabel = config.dynamicLabel
+    ? config.dynamicLabel(data.summary)
+    : null;
+  const colorClass = config.colorClass
+    ? config.colorClass(data.summary)
+    : "text-foreground/75";
+
+  if (config.isHoldCell) {
+    return (
+      <div
+        className={`${rowH} px-1.5 flex items-center gap-1 bg-transparent font-sans tabular-nums leading-tight text-[11px] ${borderClass} ${colorClass}`}
+      >
+        <HoldToggleButton
+          month={month}
+          forNextMonth={data.summary.forNextMonth}
+          toBudget={data.summary.toBudget}
+        />
+        <div className="flex flex-col items-end flex-1 min-w-0">
+          {dynamicLabel && (
+            <span className="text-[9px] font-semibold leading-none mb-0.5">
+              {dynamicLabel}
+            </span>
+          )}
+          <span>{fmtSummary(value)}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${rowH} px-2 flex flex-col items-end justify-center bg-transparent font-sans tabular-nums leading-tight text-[11px] ${borderClass} ${colorClass}`}
+    >
+      {dynamicLabel && (
+        <span className="text-[9px] font-semibold leading-none mb-0.5">
+          {dynamicLabel}
+        </span>
+      )}
+      <span>{fmtSummary(value)}</span>
+    </div>
+  );
+}
+
+// ─── Section total row ─────────────────────────────────────────────────────────
+
+type SectionFilter = "expense" | "income";
+
+const SECTION_LABELS: Record<SectionFilter, Record<CellView, string>> = {
+  expense: {
+    budgeted: "Total Budgeted Expenses",
+    spent:    "Total Spent Expenses",
+    balance:  "Total Expense Variance",
+  },
+  income: {
+    budgeted: "Total Budgeted Income",
+    spent:    "Total Received Income",
+    balance:  "Total Income Variance",
+  },
+};
+
+function SectionTotalCell({
+  month,
+  filter,
+  cellView,
+  budgetMode,
+}: {
+  month: string;
+  filter: SectionFilter;
+  cellView: CellView;
+  budgetMode: BudgetMode;
+}) {
+  const { data } = useEffectiveMonthData(month);
+  if (!data) {
+    return (
+      <div className="h-8 bg-muted/15 border-b border-border/50 animate-pulse" />
+    );
+  }
+
+  // In Envelope mode the income section always sums actuals (received).
+  const effectiveView =
+    budgetMode === "envelope" && filter === "income" ? "spent" : cellView;
+
+  let total: number;
+
+  if (budgetMode === "tracking") {
+    // Tracking: sum category-level values, excluding hidden groups and hidden cats.
+    const cats = data.groupOrder
+      .map((id) => data.groupsById[id]!)
+      .filter((g) => !g.hidden && (filter === "expense" ? !g.isIncome : g.isIncome))
+      .flatMap((g) =>
+        g.categoryIds
+          .map((catId) => data.categoriesById[catId])
+          .filter((c): c is NonNullable<typeof c> => !!c && !c.hidden)
+      );
+    total =
+      effectiveView === "spent"
+        ? cats.reduce((sum, c) => sum + c.actuals, 0)
+        : effectiveView === "balance"
+        ? cats.reduce((sum, c) => sum + c.balance, 0)
+        : cats.reduce((sum, c) => sum + c.budgeted, 0);
+  } else {
+    // Envelope: group-level aggregates include all hidden rows.
+    const groups = data.groupOrder
+      .map((id) => data.groupsById[id]!)
+      .filter((g) => (filter === "expense" ? !g.isIncome : g.isIncome));
+    total =
+      effectiveView === "spent"
+        ? groups.reduce((sum, g) => sum + g.actuals, 0)
+        : effectiveView === "balance"
+        ? groups.reduce((sum, g) => sum + g.balance, 0)
+        : groups.reduce((sum, g) => sum + g.budgeted, 0);
+  }
+
+  return (
+    <div className="h-8 px-2 flex items-center justify-end bg-muted/15 border-b border-border/50 text-xs font-sans tabular-nums font-semibold text-foreground">
+      {fmt(total)}
+    </div>
+  );
+}
+
+function SectionTotalRow({
+  filter,
+  cellView,
+  budgetMode,
+  activeMonths,
+}: {
+  filter: SectionFilter;
+  cellView: CellView;
+  budgetMode: BudgetMode;
+  activeMonths: string[];
+}) {
+  // In Envelope mode the income section always uses the "received" label.
+  const effectiveView =
+    budgetMode === "envelope" && filter === "income" ? "spent" : cellView;
+  const label = SECTION_LABELS[filter][effectiveView];
+  return (
+    <>
+      <div
+        className="h-8 px-3 flex items-center bg-background border-b border-border/50 text-xs font-semibold text-foreground/80 sticky left-0 z-10"
+        role="rowheader"
+      >
+        {label}
+      </div>
+      <div
+        className="h-8 bg-muted/15 border-b border-border/50"
+        aria-hidden="true"
+      />
+      {activeMonths.map((month) => (
+        <SectionTotalCell key={month} month={month} filter={filter} cellView={cellView} budgetMode={budgetMode} />
+      ))}
+    </>
+  );
+}
+
+// ─── Group aggregate cell ──────────────────────────────────────────────────────
+
+function GroupMonthAggregate({
+  month,
+  groupId,
+  cellView,
+  budgetMode,
+  isDimmed,
+  isSelected,
+  onFocus,
+  onNavigate,
+}: {
+  month: string;
+  groupId: string;
+  cellView: CellView;
+  budgetMode: BudgetMode;
+  isDimmed?: boolean;
+  isSelected?: boolean;
+  onFocus?: () => void;
+  onNavigate?: (dir: NavDirection) => void;
+}) {
+  const { data, error } = useEffectiveMonthData(month);
+  const group = data?.groupsById[groupId];
+
+  const baseClass =
+    "h-7 border-r border-b border-border bg-[#F7F8FA] dark:bg-zinc-800 dark:border-zinc-700";
+  const dimClass = isDimmed ? " opacity-50" : "";
+
+  if (error) return <div className={`${baseClass}${dimClass}`} />;
+  if (!group) return <div className={`${baseClass} animate-pulse${dimClass}`} />;
+
+  // In Envelope mode, income groups always show actuals (received).
+  const effectiveView =
+    budgetMode === "envelope" && group.isIncome ? "spent" : cellView;
+
+  let displayValue: number;
+  if (budgetMode === "tracking") {
+    // Tracking: sum non-hidden categories only.
+    const cats = group.categoryIds
+      .map((id) => data?.categoriesById[id])
+      .filter((c): c is NonNullable<typeof c> => !!c && !c.hidden);
+    displayValue =
+      effectiveView === "spent"
+        ? cats.reduce((sum, c) => sum + c.actuals, 0)
+        : effectiveView === "balance"
+        ? cats.reduce((sum, c) => sum + c.balance, 0)
+        : cats.reduce((sum, c) => sum + c.budgeted, 0);
+  } else {
+    // Envelope: group-level aggregates include all hidden rows.
+    displayValue =
+      effectiveView === "spent"
+        ? group.actuals
+        : effectiveView === "balance"
+        ? group.balance
+        : group.budgeted;
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowUp") { e.preventDefault(); onNavigate?.("up"); }
+    else if (e.key === "ArrowDown") { e.preventDefault(); onNavigate?.("down"); }
+    else if (e.key === "ArrowLeft") { e.preventDefault(); onNavigate?.("left"); }
+    else if (e.key === "ArrowRight") { e.preventDefault(); onNavigate?.("right"); }
+    else if (e.key === "Tab") { e.preventDefault(); onNavigate?.(e.shiftKey ? "shift-tab" : "tab"); }
+  };
+
+  return (
+    <div
+      className={`${baseClass}${dimClass} px-2 flex items-center justify-end text-xs font-sans tabular-nums text-black dark:text-zinc-200 cursor-default outline-none${isSelected ? " ring-2 ring-inset ring-foreground/80" : ""}`}
+      role="gridcell"
+      tabIndex={0}
+      aria-selected={isSelected}
+      aria-label={`${group.name} total for ${month}: ${fmt(displayValue)}`}
+      title={`Budgeted: ${fmt(group.budgeted)} | Actuals: ${fmt(Math.abs(group.actuals))} | Balance: ${fmt(group.balance)}`}
+      data-group-id={groupId}
+      data-group-month={month}
+      onClick={onFocus}
+      onFocus={onFocus}
+      onKeyDown={handleKeyDown}
+    >
+      {fmt(displayValue)}
+    </div>
+  );
+}
+
+// ─── Main grid ─────────────────────────────────────────────────────────────────
+
+/**
+ * Budget grid — CSS grid layout.
+ *
+ * Column layout: [category label (flex)] [notes (32 px)] [month columns…]
+ *
+ * Sections:
+ *   1. Mode-specific summary rows
+ *   2. Expense groups (isIncome = false) with "Total Budgeted Expenses" header
+ *   3. Income groups (isIncome = true) with "Total Budgeted Income" header
+ *
+ * Each group can be collapsed/expanded via a chevron button.
+ * Month column headers show a status dot (green / amber / gray).
+ */
+export function BudgetGrid({
+  activeMonths,
+  availableMonths,
+  budgetMode,
+  cellView,
+  selection,
+  groupSelection,
+  collapsedGroups,
+  onToggleCollapse,
+  showHidden,
+  onCellFocus,
+  onCellRangeSelect,
+  onCellNavigate,
+  onCellContextMenu,
+  onGroupFocus,
+  onGroupNavigate,
+  onClearSelection,
+}: Props) {
+  const firstMonth = activeMonths[0] ?? null;
+  const { data: firstMonthData, isLoading, error } = useMonthData(firstMonth);
+
+  const isDraggingRef = useRef<boolean>(false);
+
+  // Build allCategories in visual order: expense groups first, income groups after.
+  // This ensures selection index bounds match the rendered order in the grid.
+  // When showHidden=false, hidden groups and hidden categories are excluded.
+  const allCategories = useMemo(() => {
+    if (!firstMonthData) return [];
+    const { groupOrder, groupsById, categoriesById } = firstMonthData;
+    const expenseIds = groupOrder.filter((id) => !groupsById[id]!.isIncome);
+    const incomeIds = groupOrder.filter((id) => groupsById[id]!.isIncome);
+    return [...expenseIds, ...incomeIds]
+      .filter((id) => showHidden || !groupsById[id]!.hidden)
+      .flatMap((id) =>
+        (groupsById[id]?.categoryIds ?? [])
+          .map((catId) => categoriesById[catId]!)
+          .filter((cat) => showHidden || !cat.hidden)
+      );
+  }, [firstMonthData, showHidden]);
+
+  const categoryIndexMap = useMemo(
+    () => new Map(allCategories.map((c, i) => [c.id, i] as [string, number])),
+    [allCategories]
+  );
+
+  const selectionBounds = useMemo<SelectionBounds | null>(() => {
+    if (!selection) return null;
+    const anchorCatIdx = categoryIndexMap.get(selection.anchorCategoryId) ?? -1;
+    const focusCatIdx = categoryIndexMap.get(selection.focusCategoryId) ?? -1;
+    const anchorMonthIdx = activeMonths.indexOf(selection.anchorMonth);
+    const focusMonthIdx = activeMonths.indexOf(selection.focusMonth);
+    if (
+      anchorCatIdx === -1 ||
+      focusCatIdx === -1 ||
+      anchorMonthIdx === -1 ||
+      focusMonthIdx === -1
+    )
+      return null;
+    return {
+      minCatIdx: Math.min(anchorCatIdx, focusCatIdx),
+      maxCatIdx: Math.max(anchorCatIdx, focusCatIdx),
+      minMonthIdx: Math.min(anchorMonthIdx, focusMonthIdx),
+      maxMonthIdx: Math.max(anchorMonthIdx, focusMonthIdx),
+    };
+  }, [selection, categoryIndexMap, activeMonths]);
+
+  if (!firstMonth) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm p-8">
+        No months selected
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex-1 flex items-center justify-center"
+        aria-busy="true"
+        aria-label="Loading budget data…"
+      >
+        <div className="text-sm text-muted-foreground">Loading budget data…</div>
+      </div>
+    );
+  }
+
+  if (error || !firstMonthData) {
+    return (
+      <div
+        className="flex-1 flex items-center justify-center text-destructive text-sm p-8"
+        role="alert"
+      >
+        No budget data available for this period. Use the navigation above to
+        find months with data.
+      </div>
+    );
+  }
+
+  const { groupOrder, groupsById, categoriesById } = firstMonthData;
+  // When !showHidden, hidden groups are omitted entirely.
+  // When showHidden, hidden groups are rendered but dimmed.
+  const expenseGroups = groupOrder
+    .map((id) => groupsById[id]!)
+    .filter((g) => !g.isIncome && (showHidden || !g.hidden));
+  const incomeGroups = groupOrder
+    .map((id) => groupsById[id]!)
+    .filter((g) => g.isIncome && (showHidden || !g.hidden));
+
+  const summaryRows =
+    budgetMode === "tracking"
+      ? TRACKING_SUMMARY_ROWS
+      : budgetMode === "envelope"
+      ? ENVELOPE_SUMMARY_ROWS
+      : [];
+
+  const gridStyle: React.CSSProperties = {
+    display: "grid",
+    // Category label: wider flexible column; notes: 32 px; months: narrower
+    gridTemplateColumns: `minmax(180px, 1fr) 32px repeat(${activeMonths.length}, minmax(69px, 94px))`,
+  };
+
+  const sharedGroupProps = {
+    activeMonths,
+    budgetMode,
+    cellView,
+    selection,
+    groupSelection,
+    selectionBounds,
+    categoryIndexMap,
+    categoriesById,
+    isDraggingRef,
+    showHidden,
+    onCellFocus,
+    onCellRangeSelect,
+    onCellNavigate,
+    onCellContextMenu,
+    onGroupFocus,
+    onGroupNavigate,
+  };
+
+  return (
+    <div
+      role="grid"
+      aria-label="Budget grid"
+      aria-colcount={activeMonths.length + 2}
+      style={gridStyle}
+      className="flex-1 text-sm border-t border-border/50"
+      onClick={(e) => {
+        if (!(e.target as Element).closest("[data-category-id],[data-group-id]")) {
+          onClearSelection?.();
+        }
+      }}
+    >
+      {/* ── Column headers ── */}
+      <div
+        className="h-8 px-3 flex items-center border-b-2 border-border bg-muted text-xs font-bold text-foreground sticky left-0 top-0 z-20"
+        role="columnheader"
+        aria-label="Category"
+      >
+        Category
+      </div>
+      <div
+        className="h-8 flex items-center justify-center border-b-2 border-border bg-muted sticky top-0 z-10"
+        role="columnheader"
+        aria-label="Notes"
+      >
+        <StickyNote
+          className="h-3.5 w-3.5 text-muted-foreground/60"
+          aria-hidden="true"
+        />
+      </div>
+      {activeMonths.map((month) => (
+        <MonthColumnHeader
+          key={month}
+          month={month}
+          availableMonths={availableMonths}
+        />
+      ))}
+
+      {/* ── Section 1: Summary rows ── */}
+      {summaryRows.map((config, i) => (
+        <SummaryHeaderRow
+          key={`summary-${i}`}
+          config={config}
+          activeMonths={activeMonths}
+        />
+      ))}
+
+      {/* Separator between summary and data */}
+      {summaryRows.length > 0 && (
+        <div
+          style={{ gridColumn: `1 / ${activeMonths.length + 3}` }}
+          className="h-px bg-border/60"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* ── Section 2: Expense groups ── */}
+      {expenseGroups.length > 0 && (
+        <>
+          <SectionTotalRow
+            filter="expense"
+            cellView={cellView}
+            budgetMode={budgetMode}
+            activeMonths={activeMonths}
+          />
+          {expenseGroups.map((group) => (
+            <BudgetGridGroupRows
+              key={group.id}
+              group={group}
+              collapsed={collapsedGroups.has(group.id)}
+              onToggleCollapse={() => onToggleCollapse(group.id)}
+              {...sharedGroupProps}
+            />
+          ))}
+        </>
+      )}
+
+      {/* Separator between expense and income sections */}
+      {expenseGroups.length > 0 && incomeGroups.length > 0 && (
+        <div
+          style={{ gridColumn: `1 / ${activeMonths.length + 3}` }}
+          className="h-0.5 bg-border/60"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* ── Section 3: Income groups ── */}
+      {incomeGroups.length > 0 && (
+        <>
+          <SectionTotalRow
+            filter="income"
+            cellView={cellView}
+            budgetMode={budgetMode}
+            activeMonths={activeMonths}
+          />
+          {incomeGroups.map((group) => (
+            <BudgetGridGroupRows
+              key={group.id}
+              group={group}
+              collapsed={collapsedGroups.has(group.id)}
+              onToggleCollapse={() => onToggleCollapse(group.id)}
+              {...sharedGroupProps}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Group rows ────────────────────────────────────────────────────────────────
+
+type GroupRowsProps = {
+  group: LoadedGroup;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  activeMonths: string[];
+  budgetMode: BudgetMode;
+  cellView: CellView;
+  selection: BudgetCellSelection | null;
+  selectionBounds: SelectionBounds | null;
+  categoryIndexMap: Map<string, number>;
+  /** First-month categoriesById for category metadata (name, isIncome, etc.). */
+  categoriesById: Record<string, LoadedCategory>;
+  isDraggingRef: { current: boolean };
+  showHidden: boolean;
+  groupSelection?: Props["groupSelection"];
+  onCellFocus: Props["onCellFocus"];
+  onCellRangeSelect: Props["onCellRangeSelect"];
+  onCellNavigate?: Props["onCellNavigate"];
+  onCellContextMenu?: Props["onCellContextMenu"];
+  onGroupFocus?: Props["onGroupFocus"];
+  onGroupNavigate?: Props["onGroupNavigate"];
+};
+
+/**
+ * Group header row + (when not collapsed) one category row per category.
+ * Light #F7F8FA background with black text; dark mode uses zinc-800.
+ */
+function BudgetGridGroupRows({
+  group,
+  collapsed,
+  onToggleCollapse,
+  activeMonths,
+  budgetMode,
+  cellView,
+  selection,
+  selectionBounds,
+  categoryIndexMap,
+  categoriesById,
+  isDraggingRef,
+  showHidden,
+  groupSelection,
+  onCellFocus,
+  onCellRangeSelect,
+  onCellNavigate,
+  onCellContextMenu,
+  onGroupFocus,
+  onGroupNavigate,
+}: GroupRowsProps) {
+  // When showHidden=true and this group is hidden, dim all its rows.
+  const groupDimmed = showHidden && group.hidden;
+  const groupDimClass = groupDimmed ? " opacity-50" : "";
+
+  return (
+    <>
+      {/* Group header — light bg, black text */}
+      <div
+        className={`h-7 px-2 flex items-center border-r border-b border-border bg-[#F7F8FA] dark:bg-zinc-800 dark:border-zinc-700 text-xs font-semibold text-black dark:text-zinc-100 sticky left-0 z-10${groupDimClass}`}
+        role="rowheader"
+        aria-label={`Category group: ${group.name}`}
+        aria-expanded={!collapsed}
+      >
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className="mr-1.5 shrink-0 text-black/40 dark:text-zinc-500 hover:text-black dark:hover:text-zinc-100 transition-colors"
+          aria-label={collapsed ? `Expand ${group.name}` : `Collapse ${group.name}`}
+        >
+          {collapsed ? (
+            <ChevronRight className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5" />
+          )}
+        </button>
+        <span className="truncate">{group.name}</span>
+      </div>
+
+      {/* Notes column for group row */}
+      <div
+        className={`h-7 flex items-center justify-center border-r border-b border-border bg-[#F7F8FA] dark:bg-zinc-800 dark:border-zinc-700${groupDimClass}`}
+      >
+        <NoteCell
+          entityId={group.id}
+          entityLabel={group.name}
+          entityTypeLabel="Category group"
+        />
+      </div>
+
+      {/* Group aggregate cells */}
+      {activeMonths.map((month) => (
+        <GroupMonthAggregate
+          key={month}
+          month={month}
+          groupId={group.id}
+          cellView={cellView}
+          budgetMode={budgetMode}
+          isDimmed={groupDimmed}
+          isSelected={groupSelection?.groupId === group.id && groupSelection?.month === month}
+          onFocus={() => onGroupFocus?.(group.id, month)}
+          onNavigate={(dir) => onGroupNavigate?.(group.id, month, dir)}
+        />
+      ))}
+
+      {/* Category rows — hidden when collapsed */}
+      {!collapsed &&
+        group.categoryIds.map((catId) => {
+          const cat = categoriesById[catId];
+          if (!cat) return null;
+          // Skip hidden cats when not showing hidden; dim them when showing hidden.
+          if (!showHidden && cat.hidden) return null;
+          const catDimmed = groupDimmed || (showHidden && cat.hidden);
+          const catDimClass = catDimmed ? " opacity-50" : "";
+
+          return (
+            <div
+              key={cat.id}
+              style={{ display: "contents" }}
+              role="row"
+              aria-label={cat.name}
+            >
+              {/* Category label */}
+              <div
+                className={`h-7 px-4 flex items-center border-r border-b border-border/50 text-xs truncate sticky left-0 bg-background${catDimClass}`}
+                role="rowheader"
+                aria-label={`Category: ${cat.name}`}
+              >
+                {cat.name}
+              </div>
+
+              {/* Notes column */}
+              <div
+                className={`h-7 flex items-center justify-center border-r border-b border-border/50 bg-background${catDimClass}`}
+              >
+                <NoteCell
+                  entityId={cat.id}
+                  entityLabel={cat.name}
+                  entityTypeLabel="Category"
+                />
+              </div>
+
+              {/* Budget cells */}
+              {activeMonths.map((month, monthIdx) => {
+                const catIdx = categoryIndexMap.get(cat.id) ?? -1;
+                const isAnchor =
+                  selection?.anchorCategoryId === cat.id &&
+                  selection?.anchorMonth === month;
+                const isSelected = isCellSelected(catIdx, monthIdx, selectionBounds);
+
+                return (
+                  <BudgetCell
+                    key={`${month}:${cat.id}`}
+                    category={cat}
+                    month={month}
+                    budgetMode={budgetMode}
+                    cellView={cellView}
+                    isSelected={isSelected}
+                    isAnchor={isAnchor}
+                    isDraggingRef={isDraggingRef}
+                    isDimmed={catDimmed}
+                    onFocus={onCellFocus}
+                    onRangeSelect={onCellRangeSelect}
+                    onNavigate={(dir) => onCellNavigate?.(cat.id, month, dir)}
+                    onContextMenuRequest={onCellContextMenu}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+    </>
+  );
+}
+
+function isCellSelected(
+  catIdx: number,
+  monthIdx: number,
+  bounds: SelectionBounds | null
+): boolean {
+  if (!bounds || catIdx === -1 || monthIdx === -1) return false;
+  return (
+    catIdx >= bounds.minCatIdx &&
+    catIdx <= bounds.maxCatIdx &&
+    monthIdx >= bounds.minMonthIdx &&
+    monthIdx <= bounds.maxMonthIdx
+  );
+}

--- a/src/features/budget-management/components/BudgetImportDialog.tsx
+++ b/src/features/budget-management/components/BudgetImportDialog.tsx
@@ -19,6 +19,10 @@ type Props = {
 
 type Step = "upload" | "match" | "preview";
 
+function getImportRowId(index: number): string {
+  return String(index);
+}
+
 function formatAmount(minor: number): string {
   return `$${(minor / 100).toLocaleString("en-US", {
     minimumFractionDigits: 2,
@@ -72,8 +76,12 @@ export function BudgetImportDialog({
         // Auto-approve exact matches
         const autoApproved = new Set<string>(
           results
-            .filter((r) => r.matchStatus === "exact" && r.matchedCategoryId !== null)
-            .map((r) => r.matchedCategoryId!)
+            .map((r, index) =>
+              r.matchStatus === "exact" && r.matchedCategoryId !== null
+                ? getImportRowId(index)
+                : null
+            )
+            .filter((rowId): rowId is string => rowId !== null)
         );
         setApprovedIds(autoApproved);
         setParseError(null);
@@ -99,11 +107,11 @@ export function BudgetImportDialog({
 
   // ---------- Step 2: Match Review ----------
 
-  const toggleApproval = (categoryId: string) => {
+  const toggleApproval = (rowId: string) => {
     setApprovedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(categoryId)) next.delete(categoryId);
-      else next.add(categoryId);
+      if (next.has(rowId)) next.delete(rowId);
+      else next.add(rowId);
       return next;
     });
   };
@@ -126,7 +134,7 @@ export function BudgetImportDialog({
 
   const handleBuildPreview = () => {
     const approved = matchResults.filter(
-      (r) => r.matchedCategoryId && approvedIds.has(r.matchedCategoryId)
+      (r, index) => r.matchedCategoryId && approvedIds.has(getImportRowId(index))
     );
     const preview = buildImportPreview(approved, groups, categoriesById);
     setPreviewRows(preview);
@@ -246,8 +254,9 @@ export function BudgetImportDialog({
                 </thead>
                 <tbody>
                   {matchResults.map((result, i) => {
+                    const rowId = getImportRowId(i);
                     const isApproved = result.matchedCategoryId
-                      ? approvedIds.has(result.matchedCategoryId)
+                      ? approvedIds.has(rowId)
                       : false;
                     const hasError = result.matchStatus === "unmatched" ||
                       Object.values(result.monthAvailability).some((s) => s === "absent");
@@ -262,7 +271,7 @@ export function BudgetImportDialog({
                             <input
                               type="checkbox"
                               checked={isApproved}
-                              onChange={() => toggleApproval(result.matchedCategoryId!)}
+                              onChange={() => toggleApproval(rowId)}
                               aria-label={`Approve import of ${result.csvRow.categoryName}`}
                             />
                           )}

--- a/src/features/budget-management/components/BudgetImportDialog.tsx
+++ b/src/features/budget-management/components/BudgetImportDialog.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { parseCsv, matchImportRows, buildImportPreview } from "../lib/budgetCsv";
+import type { ImportRowResult, ImportPreviewEntry } from "../lib/budgetCsv";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import type { LoadedCategory, LoadedGroup } from "../types";
+
+type Props = {
+  availableMonths: string[];
+  activeMonths: string[];
+  categories: LoadedCategory[];
+  groups: LoadedGroup[];
+  categoriesById: Record<string, LoadedCategory>;
+  onClose: () => void;
+  /** Called when user accepts "extend visible range" to add out-of-range months */
+  onExtendRange?: (months: string[]) => void;
+};
+
+type Step = "upload" | "match" | "preview";
+
+function formatAmount(minor: number): string {
+  return `$${(minor / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/**
+ * Three-step import wizard:
+ *   1. Upload — file input + drag-and-drop → parseCsv
+ *   2. Match review — exact/suggested/out-of-range/absent/unmatched rows
+ *   3. Preview — approve changes → stageBulkEdits
+ */
+export function BudgetImportDialog({
+  availableMonths,
+  activeMonths,
+  categories,
+  groups,
+  categoriesById,
+  onClose,
+  onExtendRange,
+}: Props) {
+  const stageBulkEdits = useBudgetEditsStore((s) => s.stageBulkEdits);
+
+  const [step, setStep] = useState<Step>("upload");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [matchResults, setMatchResults] = useState<ImportRowResult[]>([]);
+  const [approvedIds, setApprovedIds] = useState<Set<string>>(new Set());
+  const [previewRows, setPreviewRows] = useState<ImportPreviewEntry[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ---------- Step 1: Upload ----------
+
+  const handleFile = (file: File) => {
+    if (!file.name.endsWith(".csv") && file.type !== "text/csv") {
+      setParseError("Please upload a .csv file.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const raw = e.target?.result as string;
+      try {
+        const rows = parseCsv(raw);
+        if (rows.length === 0) {
+          setParseError("The CSV file contains no data rows.");
+          return;
+        }
+        const results = matchImportRows(rows, categories, availableMonths, activeMonths);
+        setMatchResults(results);
+        // Auto-approve exact matches
+        const autoApproved = new Set<string>(
+          results
+            .filter((r) => r.matchStatus === "exact" && r.matchedCategoryId !== null)
+            .map((r) => r.matchedCategoryId!)
+        );
+        setApprovedIds(autoApproved);
+        setParseError(null);
+        setStep("match");
+      } catch {
+        setParseError("Failed to parse the CSV file. Please check the file format.");
+      }
+    };
+    reader.readAsText(file, "UTF-8");
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+
+  // ---------- Step 2: Match Review ----------
+
+  const toggleApproval = (categoryId: string) => {
+    setApprovedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(categoryId)) next.delete(categoryId);
+      else next.add(categoryId);
+      return next;
+    });
+  };
+
+  const outOfRangeMonths = Array.from(
+    new Set(
+      matchResults.flatMap((r) =>
+        Object.entries(r.monthAvailability)
+          .filter(([, status]) => status === "out-of-range")
+          .map(([month]) => month)
+      )
+    )
+  ).sort();
+
+  const handleExtendRange = () => {
+    if (onExtendRange && outOfRangeMonths.length > 0) {
+      onExtendRange(outOfRangeMonths);
+    }
+  };
+
+  const handleBuildPreview = () => {
+    const approved = matchResults.filter(
+      (r) => r.matchedCategoryId && approvedIds.has(r.matchedCategoryId)
+    );
+    const preview = buildImportPreview(approved, groups, categoriesById);
+    setPreviewRows(preview);
+    setStep("preview");
+  };
+
+  // ---------- Step 3: Preview + Confirm ----------
+
+  const handleConfirm = () => {
+    stageBulkEdits(
+      previewRows.map((row) => ({
+        month: row.month,
+        categoryId: row.categoryId,
+        nextBudgeted: row.nextBudgeted,
+        previousBudgeted: row.previousBudgeted,
+        source: "import",
+      }))
+    );
+    onClose();
+  };
+
+  // ---------- Render ----------
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import budget data from CSV"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-lg mx-4 p-5 max-h-[90vh] flex flex-col">
+
+        {step === "upload" && (
+          <>
+            <h2 className="text-base font-semibold mb-4">Import Budget CSV</h2>
+
+            <div
+              role="button"
+              tabIndex={0}
+              aria-label="Drop CSV file here or click to select"
+              className={`flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-8 mb-4 cursor-pointer transition-colors ${
+                isDragging
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:border-primary/50 hover:bg-muted/30"
+              }`}
+              onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") fileInputRef.current?.click(); }}
+            >
+              <span className="text-sm text-muted-foreground text-center">
+                Drag and drop a CSV file here, or click to browse
+              </span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".csv,text/csv"
+                onChange={handleFileInput}
+                className="sr-only"
+                aria-label="Select CSV file to import"
+              />
+            </div>
+
+            {parseError && (
+              <p className="text-xs text-destructive mb-3" role="alert">{parseError}</p>
+            )}
+
+            <p className="text-xs text-muted-foreground mb-4">
+              Expected format: CSV with columns{" "}
+              <code className="font-mono bg-muted px-1 rounded">Group Name, Category Name, YYYY-MM, …</code>
+            </p>
+
+            <div className="flex justify-end">
+              <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors">
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "match" && (
+          <>
+            <h2 className="text-base font-semibold mb-1">Review Matches</h2>
+            <p className="text-xs text-muted-foreground mb-3">
+              {approvedIds.size} of {matchResults.length} rows approved. Exact matches are pre-selected.
+            </p>
+
+            {outOfRangeMonths.length > 0 && (
+              <div className="mb-3 p-2 rounded bg-orange-50 dark:bg-orange-950/20 text-xs text-orange-700 dark:text-orange-400" role="alert">
+                Some rows reference months outside the current visible range:{" "}
+                <strong>{outOfRangeMonths.join(", ")}</strong>.{" "}
+                {onExtendRange && (
+                  <button
+                    type="button"
+                    onClick={handleExtendRange}
+                    className="underline hover:no-underline"
+                    aria-label={`Extend visible range to include ${outOfRangeMonths.join(", ")}`}
+                  >
+                    Extend visible range
+                  </button>
+                )}
+              </div>
+            )}
+
+            <div className="flex-1 overflow-y-auto border border-border rounded text-xs mb-4 min-h-0">
+              <table className="w-full" role="grid" aria-label="CSV import match review">
+                <thead className="bg-muted/40 sticky top-0">
+                  <tr>
+                    <th className="px-2 py-1.5 text-left font-medium w-8">
+                      <span className="sr-only">Approved</span>
+                    </th>
+                    <th className="px-2 py-1.5 text-left font-medium">CSV row</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Match</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {matchResults.map((result, i) => {
+                    const isApproved = result.matchedCategoryId
+                      ? approvedIds.has(result.matchedCategoryId)
+                      : false;
+                    const hasError = result.matchStatus === "unmatched" ||
+                      Object.values(result.monthAvailability).some((s) => s === "absent");
+
+                    return (
+                      <tr
+                        key={i}
+                        className={`border-t border-border/50 ${hasError ? "opacity-50" : ""}`}
+                      >
+                        <td className="px-2 py-1">
+                          {result.matchedCategoryId && result.matchStatus !== "unmatched" && (
+                            <input
+                              type="checkbox"
+                              checked={isApproved}
+                              onChange={() => toggleApproval(result.matchedCategoryId!)}
+                              aria-label={`Approve import of ${result.csvRow.categoryName}`}
+                            />
+                          )}
+                        </td>
+                        <td className="px-2 py-1">
+                          <span className="text-muted-foreground">{result.csvRow.groupName}</span>
+                          {" / "}
+                          <span>{result.csvRow.categoryName}</span>
+                        </td>
+                        <td className="px-2 py-1 truncate max-w-32">
+                          {result.matchedCategoryName ?? (
+                            <span className="text-destructive">No match</span>
+                          )}
+                          {result.matchStatus === "suggested" && result.suggestionKey && (
+                            <span className="text-orange-600 dark:text-orange-400 ml-1">
+                              (suggestion: {result.suggestionKey})
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-2 py-1">
+                          {result.matchStatus === "exact" && (
+                            <span className="text-green-600 dark:text-green-400">Exact</span>
+                          )}
+                          {result.matchStatus === "suggested" && (
+                            <span className="text-orange-600 dark:text-orange-400">Suggested</span>
+                          )}
+                          {result.matchStatus === "unmatched" && (
+                            <span className="text-destructive">Unmatched</span>
+                          )}
+                          {Object.values(result.monthAvailability).some((s) => s === "absent") && (
+                            <span className="text-destructive ml-1">— month absent</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button type="button" onClick={() => setStep("upload")} className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors">
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={handleBuildPreview}
+                disabled={approvedIds.size === 0}
+                aria-label={`Preview ${approvedIds.size} approved rows`}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Preview {approvedIds.size} row{approvedIds.size !== 1 ? "s" : ""}
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "preview" && (
+          <>
+            <h2 className="text-base font-semibold mb-1">Preview Changes</h2>
+            <p className="text-xs text-muted-foreground mb-3">
+              {previewRows.length} cell{previewRows.length !== 1 ? "s" : ""} will be staged.
+            </p>
+
+            <div className="flex-1 overflow-y-auto border border-border rounded text-xs mb-4 min-h-0">
+              <table className="w-full" role="grid" aria-label="Import preview">
+                <thead className="bg-muted/40 sticky top-0">
+                  <tr>
+                    <th className="px-2 py-1.5 text-left font-medium">Category</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Month</th>
+                    <th className="px-2 py-1.5 text-right font-medium">Current</th>
+                    <th className="px-2 py-1.5 text-right font-medium">New</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {previewRows.map((row, i) => (
+                    <tr key={i} className="border-t border-border/50">
+                      <td className="px-2 py-1 truncate max-w-32">{row.categoryName}</td>
+                      <td className="px-2 py-1 font-mono">{row.month}</td>
+                      <td className="px-2 py-1 text-right font-mono text-muted-foreground">
+                        {formatAmount(row.previousBudgeted)}
+                      </td>
+                      <td className="px-2 py-1 text-right font-mono font-medium">
+                        {formatAmount(row.nextBudgeted)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button type="button" onClick={() => setStep("match")} className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors">
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                aria-label={`Stage ${previewRows.length} import changes`}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Stage {previewRows.length} change{previewRows.length !== 1 ? "s" : ""}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetManagementView.tsx
+++ b/src/features/budget-management/components/BudgetManagementView.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { CellView } from "../types";
+import { useBudgetMode } from "../hooks/useBudgetMode";
+import { useAvailableMonths } from "../hooks/useAvailableMonths";
+import { useMonthData } from "../hooks/useMonthData";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import { useStagedStore, selectHasChanges } from "@/store/staged";
+import { BudgetToolbar } from "./BudgetToolbar";
+import { BudgetWorkspace } from "./BudgetWorkspace";
+import { BudgetExportDialog } from "./BudgetExportDialog";
+import { BudgetImportDialog } from "./BudgetImportDialog";
+import { CategoryTransferDialog } from "./CategoryTransferDialog";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Add `delta` months to a YYYY-MM string. Returns a YYYY-MM string. */
+function addMonths(monthStr: string, delta: number): string {
+  const [yearStr, moStr] = monthStr.split("-");
+  const year = parseInt(yearStr ?? "2026", 10);
+  const mo = parseInt(moStr ?? "1", 10);
+  const d = new Date(year, mo - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Compute 12 consecutive months from a start month string. */
+function compute12Months(windowStart: string): string[] {
+  return Array.from({ length: 12 }, (_, i) => addMonths(windowStart, i));
+}
+
+/** Default window start: January of the current year. */
+function defaultWindowStart(): string {
+  return `${new Date().getFullYear()}-01`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Top-level page shell for the Budget Management Workspace.
+ *
+ * Owns the 12-month window state and wires the navigation guard that
+ * prevents accidental navigation away with unsaved staged changes.
+ * Always displays exactly 12 consecutive months; the toolbar navigates
+ * forward/backward by 1 month or 1 year.
+ */
+export function BudgetManagementView() {
+  const { data: budgetMode, isLoading: modeLoading, error: modeError } = useBudgetMode();
+  const { data: availableMonths, isLoading: monthsLoading, error: monthsError } = useAvailableMonths();
+  const hasPendingEdits = useBudgetEditsStore((s) => s.hasPendingEdits);
+  const edits = useBudgetEditsStore((s) => s.edits);
+  const setDisplayMonths = useBudgetEditsStore((s) => s.setDisplayMonths);
+  const hasEntityChanges = useStagedStore(selectHasChanges);
+  const discardEntityChanges = useStagedStore((s) => s.discardAll);
+
+  // The window start is the first of the 12 displayed months.
+  // Defaults to January of the current year; user can navigate freely.
+  const [windowStart, setWindowStart] = useState<string>(defaultWindowStart);
+  const activeMonths = useMemo(() => compute12Months(windowStart), [windowStart]);
+
+  // Keep display window in store so BudgetDraftPanel can show year summary without props.
+  useEffect(() => {
+    setDisplayMonths(activeMonths);
+  }, [activeMonths, setDisplayMonths]);
+
+  const [cellView, setCellView] = useState<CellView>("budgeted");
+  const [bulkActionOpen, setBulkActionOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [transferDialogOpen, setTransferDialogOpen] = useState(false);
+
+  // Collapse state lifted here so BudgetToolbar can trigger expand/collapse all.
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [showHidden, setShowHidden] = useState(true);
+
+  const handleToggleGroupCollapse = useCallback((groupId: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
+
+  const handleExpandAll = useCallback(() => {
+    setCollapsedGroups(new Set());
+  }, []);
+
+  // Navigation guard: warn before unload (tab close / refresh)
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!hasPendingEdits()) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasPendingEdits]);
+
+  // Navigation guard: intercept browser back/forward when staged changes exist.
+  useEffect(() => {
+    window.history.pushState(null, "", window.location.href);
+
+    const handlePopState = () => {
+      if (!hasPendingEdits()) return;
+      const confirmed = window.confirm(
+        "You have unsaved budget changes. Leave this page and discard them?"
+      );
+      if (!confirmed) {
+        window.history.pushState(null, "", window.location.href);
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [hasPendingEdits]);
+
+  const handleCloseBulkAction = () => setBulkActionOpen(false);
+  const handleOpenExport = () => setExportDialogOpen(true);
+  const handleCloseExport = () => setExportDialogOpen(false);
+  const handleOpenImport = () => setImportDialogOpen(true);
+  const handleCloseImport = () => setImportDialogOpen(false);
+  const handleOpenTransfer = () => setTransferDialogOpen(true);
+  const handleCloseTransfer = () => setTransferDialogOpen(false);
+
+  // When the import dialog imports months outside the current window,
+  // move the window start to include them.
+  const handleExtendRange = (months: string[]) => {
+    if (months.length === 0) return;
+    const sorted = [...months].sort();
+    const firstImported = sorted[0]!;
+    const windowEnd = addMonths(windowStart, 11);
+    if (firstImported < windowStart || firstImported > windowEnd) {
+      setWindowStart(firstImported.slice(0, 7));
+    }
+  };
+
+  // Load first active month's data for export/import dialogs (already cached by grid).
+  const firstActiveMonth = activeMonths[0] ?? null;
+  const { data: firstMonthData } = useMonthData(firstActiveMonth);
+  const groups = firstMonthData
+    ? firstMonthData.groupOrder.map((id) => firstMonthData.groupsById[id]!).filter(Boolean)
+    : [];
+  const categoriesById = firstMonthData?.categoriesById ?? {};
+  const categories = firstMonthData
+    ? Object.values(firstMonthData.categoriesById)
+    : [];
+
+  const handleCollapseAll = useCallback(() => {
+    setCollapsedGroups(new Set(firstMonthData?.groupOrder ?? []));
+  }, [firstMonthData]);
+
+  const isLoading = modeLoading || monthsLoading;
+  const hasError = !!modeError || !!monthsError;
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-full" aria-busy="true" aria-label="Loading budget management…">
+        <div className="h-12 bg-muted/30 animate-pulse rounded m-4" />
+        <div className="flex-1 bg-muted/10 animate-pulse rounded m-4" />
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div className="flex items-center justify-center h-full p-8 text-destructive" role="alert">
+        Failed to load budget management data. Please check your connection and try again.
+      </div>
+    );
+  }
+
+  // Entry guard: unsaved entity changes must be resolved before entering the budget page.
+  if (hasEntityChanges) {
+    return (
+      <div className="flex flex-col h-full items-center justify-center p-8 gap-4">
+        <div className="max-w-sm text-center space-y-2">
+          <p className="font-semibold text-sm">Unsaved changes on another page</p>
+          <p className="text-sm text-muted-foreground">
+            Please save or discard your pending changes using the top bar before
+            accessing Budget Management.
+          </p>
+          <button
+            type="button"
+            onClick={discardEntityChanges}
+            className="mt-2 px-4 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors text-destructive"
+          >
+            Discard changes and continue
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <BudgetToolbar
+        budgetMode={budgetMode ?? "unidentified"}
+        windowStart={windowStart}
+        onWindowChange={setWindowStart}
+        cellView={cellView}
+        onCellViewChange={setCellView}
+        onExpandAll={handleExpandAll}
+        onCollapseAll={handleCollapseAll}
+        showHidden={showHidden}
+        onToggleShowHidden={() => setShowHidden((v) => !v)}
+        onExport={handleOpenExport}
+        onImport={handleOpenImport}
+      />
+
+      <BudgetWorkspace
+        budgetMode={budgetMode ?? "unidentified"}
+        cellView={cellView}
+        activeMonths={activeMonths}
+        availableMonths={availableMonths ?? []}
+        collapsedGroups={collapsedGroups}
+        onToggleCollapse={handleToggleGroupCollapse}
+        showHidden={showHidden}
+        bulkActionOpen={bulkActionOpen}
+        onBulkActionClose={handleCloseBulkAction}
+        onOpenTransfer={budgetMode === "envelope" ? handleOpenTransfer : undefined}
+      />
+
+      {exportDialogOpen && (
+        <BudgetExportDialog
+          availableMonths={availableMonths ?? []}
+          activeMonths={activeMonths}
+          groups={groups}
+          categoriesById={categoriesById}
+          stagedEdits={edits}
+          onClose={handleCloseExport}
+        />
+      )}
+
+      {importDialogOpen && (
+        <BudgetImportDialog
+          availableMonths={availableMonths ?? []}
+          activeMonths={activeMonths}
+          categories={categories}
+          groups={groups}
+          categoriesById={categoriesById}
+          onClose={handleCloseImport}
+          onExtendRange={handleExtendRange}
+        />
+      )}
+
+      {budgetMode === "envelope" && transferDialogOpen && firstActiveMonth && (
+        <CategoryTransferDialog
+          month={firstActiveMonth}
+          categories={categories}
+          onClose={handleCloseTransfer}
+        />
+      )}
+
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetManagementView.tsx
+++ b/src/features/budget-management/components/BudgetManagementView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CellView } from "../types";
 import { useBudgetMode } from "../hooks/useBudgetMode";
 import { useAvailableMonths } from "../hooks/useAvailableMonths";
@@ -57,6 +57,8 @@ export function BudgetManagementView() {
   // Defaults to January of the current year; user can navigate freely.
   const [windowStart, setWindowStart] = useState<string>(defaultWindowStart);
   const activeMonths = useMemo(() => compute12Months(windowStart), [windowStart]);
+  const hasBudgetPendingEdits = Object.keys(edits).length > 0;
+  const hasPushedNavigationGuard = useRef(false);
 
   // Keep display window in store so BudgetDraftPanel can show year summary without props.
   useEffect(() => {
@@ -101,7 +103,15 @@ export function BudgetManagementView() {
 
   // Navigation guard: intercept browser back/forward when staged changes exist.
   useEffect(() => {
-    window.history.pushState(null, "", window.location.href);
+    if (!hasBudgetPendingEdits) {
+      hasPushedNavigationGuard.current = false;
+      return;
+    }
+
+    if (!hasPushedNavigationGuard.current) {
+      window.history.pushState(null, "", window.location.href);
+      hasPushedNavigationGuard.current = true;
+    }
 
     const handlePopState = () => {
       if (!hasPendingEdits()) return;
@@ -110,12 +120,19 @@ export function BudgetManagementView() {
       );
       if (!confirmed) {
         window.history.pushState(null, "", window.location.href);
+        hasPushedNavigationGuard.current = true;
+        return;
       }
+
+      useBudgetEditsStore.getState().discardAll();
+      discardEntityChanges();
+      hasPushedNavigationGuard.current = false;
+      window.history.back();
     };
 
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [hasPendingEdits]);
+  }, [discardEntityChanges, hasBudgetPendingEdits, hasPendingEdits]);
 
   const handleCloseBulkAction = () => setBulkActionOpen(false);
   const handleOpenExport = () => setExportDialogOpen(true);

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.test.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { BudgetSaveProgressDialog } from "./BudgetSaveProgressDialog";
+import { useBudgetSave } from "../hooks/useBudgetSave";
+import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+
+jest.mock("../hooks/useBudgetSave", () => ({
+  useBudgetSave: jest.fn(),
+}));
+
+const mockUseBudgetSave = useBudgetSave as jest.MockedFunction<typeof useBudgetSave>;
+
+const edits: Record<BudgetCellKey, StagedBudgetEdit> = {
+  "2026-04:cat-1": {
+    month: "2026-04",
+    categoryId: "cat-1",
+    nextBudgeted: 12000,
+    previousBudgeted: 10000,
+    source: "manual",
+  },
+  "2026-05:cat-2": {
+    month: "2026-05",
+    categoryId: "cat-2",
+    nextBudgeted: 5000,
+    previousBudgeted: 7000,
+    source: "manual",
+  },
+};
+
+describe("BudgetSaveProgressDialog", () => {
+  afterEach(() => {
+    mockUseBudgetSave.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  it("surfaces rejected save attempts through the failure UI without retrying on rerender", async () => {
+    const error = new Error("No active connection");
+    const save = jest.fn().mockRejectedValue(error);
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockUseBudgetSave.mockReturnValue({
+      save,
+      isSaving: false,
+      progress: { completed: 0, total: 0 },
+    });
+
+    const { rerender } = render(
+      <BudgetSaveProgressDialog edits={edits} onClose={jest.fn()} />
+    );
+
+    expect(await screen.findByText("Save failed")).toBeInTheDocument();
+    expect(screen.getByText("2 cells could not be saved.")).toBeInTheDocument();
+    expect(screen.getAllByText("No active connection")).toHaveLength(2);
+    expect(consoleError).toHaveBeenCalledWith("Budget save failed", error);
+
+    rerender(<BudgetSaveProgressDialog edits={edits} onClose={jest.fn()} />);
+
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { useBudgetSave } from "../hooks/useBudgetSave";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import type { BudgetCellKey, BudgetSaveResult, StagedBudgetEdit } from "../types";
+
+type Props = {
+  edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  onClose: () => void;
+};
+
+type DialogState = "saving" | "success" | "partial-failure" | "failure";
+
+const AUTO_CLOSE_SECONDS = 3;
+
+function getSaveErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Budget save failed.";
+}
+
+function buildRejectedSaveResults(
+  edits: Record<BudgetCellKey, StagedBudgetEdit>,
+  error: unknown
+): BudgetSaveResult[] {
+  const message = getSaveErrorMessage(error);
+
+  return Object.values(edits).map((edit) => ({
+    month: edit.month,
+    categoryId: edit.categoryId,
+    status: "error",
+    message,
+  }));
+}
+
+export function BudgetSaveProgressDialog({ edits, onClose }: Props) {
+  const { save, isSaving, progress } = useBudgetSave();
+  const [results, setResults] = useState<BudgetSaveResult[]>([]);
+  const [dialogState, setDialogState] = useState<DialogState>("saving");
+  const [countdown, setCountdown] = useState(AUTO_CLOSE_SECONDS);
+  const hasStarted = useRef(false);
+
+  const failedResults = results.filter((r) => r.status === "error");
+  const succeededResults = results.filter((r) => r.status === "success");
+  const successMonths = [...new Set(succeededResults.map((r) => r.month))].sort();
+
+  const applyResults = useCallback((saveResults: BudgetSaveResult[]) => {
+    setResults(saveResults);
+    const failed = saveResults.filter((r) => r.status === "error").length;
+    const succeeded = saveResults.filter((r) => r.status === "success").length;
+    if (failed === 0) {
+      setDialogState("success");
+      setCountdown(AUTO_CLOSE_SECONDS);
+    } else if (succeeded === 0) {
+      setDialogState("failure");
+    } else {
+      setDialogState("partial-failure");
+    }
+  }, []);
+
+  // Start saving on mount
+  useEffect(() => {
+    if (hasStarted.current) return;
+    hasStarted.current = true;
+    void save(edits)
+      .then(applyResults)
+      .catch((error: unknown) => {
+        console.error("Budget save failed", error);
+        applyResults(buildRejectedSaveResults(edits, error));
+      });
+  }, [edits, save, applyResults]);
+
+  // Auto-close countdown for success state
+  useEffect(() => {
+    if (dialogState !== "success") return;
+    if (countdown <= 0) { onClose(); return; }
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [dialogState, countdown, onClose]);
+
+  async function handleRetry() {
+    const currentEdits = useBudgetEditsStore.getState().edits;
+    const failedKeys = new Set(
+      failedResults.map((r) => `${r.month}:${r.categoryId}` as BudgetCellKey)
+    );
+    const retryEdits: Record<BudgetCellKey, StagedBudgetEdit> = {};
+    for (const [key, edit] of Object.entries(currentEdits)) {
+      if (failedKeys.has(key as BudgetCellKey)) {
+        retryEdits[key as BudgetCellKey] = edit;
+      }
+    }
+    setDialogState("saving");
+    setResults([]);
+    const retryResults = await save(retryEdits);
+    applyResults(retryResults);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Budget save progress"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-md mx-4 p-5">
+
+        {dialogState === "saving" && (
+          <>
+            <div className="flex items-center gap-2 mb-4">
+              <Loader2 className="h-4 w-4 animate-spin text-primary" />
+              <h2 className="text-base font-semibold text-foreground">Saving budget changes</h2>
+            </div>
+            <p className="text-sm text-muted-foreground mb-3">
+              {progress.total > 0
+                ? `${progress.completed} of ${progress.total} cells saved…`
+                : "Preparing…"}
+            </p>
+            {progress.total > 0 && (
+              <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-primary transition-all duration-150"
+                  style={{ width: `${(progress.completed / progress.total) * 100}%` }}
+                />
+              </div>
+            )}
+          </>
+        )}
+
+        {dialogState === "success" && (
+          <>
+            <div className="flex items-center gap-2 mb-3">
+              <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+              <h2 className="text-base font-semibold text-foreground">All changes saved</h2>
+            </div>
+            <p className="text-sm text-muted-foreground mb-1">
+              {succeededResults.length} cell{succeededResults.length !== 1 ? "s" : ""} saved
+              {successMonths.length > 0 && ` across ${successMonths.length} month${successMonths.length !== 1 ? "s" : ""}`}.
+            </p>
+            {successMonths.length > 0 && (
+              <p className="text-xs text-muted-foreground mb-4">{successMonths.join(", ")}</p>
+            )}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Close ({countdown})
+              </button>
+            </div>
+          </>
+        )}
+
+        {(dialogState === "partial-failure" || dialogState === "failure") && (
+          <>
+            <div className="flex items-center gap-2 mb-3">
+              <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+              <h2 className="text-base font-semibold text-foreground">
+                {dialogState === "failure" ? "Save failed" : "Partially saved"}
+              </h2>
+            </div>
+            <p className="text-sm text-muted-foreground mb-3">
+              {dialogState === "partial-failure"
+                ? `${succeededResults.length} cell${succeededResults.length !== 1 ? "s" : ""} saved, ${failedResults.length} failed.`
+                : `${failedResults.length} cell${failedResults.length !== 1 ? "s" : ""} could not be saved.`}
+            </p>
+            <div className="mb-4 max-h-44 overflow-y-auto rounded border border-border divide-y divide-border">
+              {failedResults.map((r) => (
+                <div key={`${r.month}:${r.categoryId}`} className="px-3 py-2 text-xs">
+                  <span className="font-mono text-foreground">{r.month}</span>
+                  <span className="mx-1 text-muted-foreground">/</span>
+                  <span className="font-mono text-muted-foreground">{r.categoryId}</span>
+                  {r.message && (
+                    <p className="text-destructive mt-0.5">{r.message}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isSaving}
+                className="px-3 py-1.5 text-sm rounded border border-border text-foreground hover:bg-muted disabled:opacity-40 transition-colors"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleRetry()}
+                disabled={isSaving}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {isSaving ? "Retrying…" : "Retry Failed"}
+              </button>
+            </div>
+          </>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
@@ -91,8 +91,13 @@ export function BudgetSaveProgressDialog({ edits, onClose }: Props) {
     }
     setDialogState("saving");
     setResults([]);
-    const retryResults = await save(retryEdits);
-    applyResults(retryResults);
+    try {
+      const retryResults = await save(retryEdits);
+      applyResults(retryResults);
+    } catch (error) {
+      console.error("Budget save retry failed", error);
+      applyResults(buildRejectedSaveResults(retryEdits, error));
+    }
   }
 
   return (

--- a/src/features/budget-management/components/BudgetSelectionSummary.tsx
+++ b/src/features/budget-management/components/BudgetSelectionSummary.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import type { BudgetCellKey, BudgetCellSelection, LoadedCategory } from "../types";
+import { resolveSelectionCells } from "../lib/budgetSelectionUtils";
+
+type Props = {
+  selection: BudgetCellSelection | null;
+  activeMonths: string[];
+  categories: LoadedCategory[];
+};
+
+function formatDelta(delta: number): string {
+  const sign = delta > 0 ? "+" : delta < 0 ? "−" : "";
+  return `${sign}${(Math.abs(delta) / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+/**
+ * Footer bar showing:
+ * - Global staged-edit count and total delta (always visible, read directly
+ *   from the store — does not depend on categories being loaded).
+ * - Per-selection rectangle statistics when a selection is active and
+ *   categories are available.
+ */
+export function BudgetSelectionSummary({
+  selection,
+  activeMonths,
+  categories,
+}: Props) {
+  const edits = useBudgetEditsStore((s) => s.edits);
+
+  // ── Global stats (no category lookup needed) ──────────────────────────────
+  const editValues = Object.values(edits);
+  const totalStaged = editValues.length;
+  const totalDelta = editValues.reduce(
+    (sum, e) => sum + (e.nextBudgeted - e.previousBudgeted),
+    0
+  );
+
+  // ── Per-selection stats (requires categories to be loaded) ────────────────
+  let selectionCells: { month: string; categoryId: string }[] = [];
+  let selectionStagedCount = 0;
+  let selectionDelta = 0;
+
+  if (selection && categories.length > 0) {
+    selectionCells = resolveSelectionCells(selection, activeMonths, categories);
+    for (const cell of selectionCells) {
+      const key: BudgetCellKey = `${cell.month}:${cell.categoryId}`;
+      const edit = edits[key];
+      if (edit) {
+        selectionStagedCount++;
+        selectionDelta += edit.nextBudgeted - edit.previousBudgeted;
+      }
+    }
+  }
+
+  const selectedMonthSet = new Set(selectionCells.map((c) => c.month));
+  const selectedCatSet = new Set(selectionCells.map((c) => c.categoryId));
+
+  return (
+    <div
+      className="h-8 border-t border-border bg-muted/30 px-4 flex items-center gap-4 text-xs text-muted-foreground"
+      role="status"
+      aria-live="polite"
+      aria-label="Selection summary"
+    >
+      {/* Global staged edits — always visible */}
+      {totalStaged > 0 ? (
+        <>
+          <span
+            className="text-amber-600 dark:text-amber-400 font-medium"
+            aria-label={`${totalStaged} total staged edits`}
+          >
+            {totalStaged} staged
+          </span>
+          <span
+            className={
+              totalDelta === 0
+                ? ""
+                : totalDelta > 0
+                ? "text-emerald-600 dark:text-emerald-400 font-medium"
+                : "text-red-600 dark:text-red-400 font-medium"
+            }
+            aria-label={`Total staged delta: ${formatDelta(totalDelta)}`}
+          >
+            {formatDelta(totalDelta)}
+          </span>
+        </>
+      ) : (
+        <span>No staged edits</span>
+      )}
+
+      {/* Selection rectangle stats */}
+      {selectionCells.length > 0 && (
+        <>
+          <span className="text-border/80 select-none" aria-hidden="true">
+            │
+          </span>
+          <span aria-label={`${selectionCells.length} cells selected`}>
+            {selectionCells.length} cell{selectionCells.length !== 1 ? "s" : ""}
+          </span>
+          <span aria-label={`${selectedMonthSet.size} months, ${selectedCatSet.size} categories`}>
+            ({selectedMonthSet.size} mo × {selectedCatSet.size} cat)
+          </span>
+          {selectionStagedCount > 0 && (
+            <span
+              className={
+                selectionDelta === 0
+                  ? ""
+                  : selectionDelta > 0
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-red-600 dark:text-red-400"
+              }
+              aria-label={`Selection delta: ${formatDelta(selectionDelta)}`}
+            >
+              sel: {formatDelta(selectionDelta)}
+            </span>
+          )}
+        </>
+      )}
+
+      {selectionCells.length === 0 && totalStaged === 0 && !selection && (
+        <span>No selection</span>
+      )}
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetToolbar.tsx
+++ b/src/features/budget-management/components/BudgetToolbar.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { ChevronsLeft, ChevronsRight, ChevronLeft, ChevronRight, CalendarDays, Upload, Download, ChevronsDownUp, ChevronsUpDown, Eye, EyeOff } from "lucide-react";
+import type { BudgetMode, CellView } from "../types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Add `delta` months to a YYYY-MM string. Returns a YYYY-MM string. */
+function addMonths(monthStr: string, delta: number): string {
+  const [yearStr, moStr] = monthStr.split("-");
+  const year = parseInt(yearStr ?? "2026", 10);
+  const mo = parseInt(moStr ?? "1", 10);
+  const d = new Date(year, mo - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Format a YYYY-MM window as "Jan '26 – Dec '26". */
+function formatWindowRange(start: string): string {
+  const end = addMonths(start, 11);
+  const fmt = (m: string) => {
+    const [y, mo] = m.split("-");
+    return new Date(parseInt(y ?? "2026", 10), parseInt(mo ?? "1", 10) - 1, 1)
+      .toLocaleString("en-US", { month: "short", year: "2-digit" });
+  };
+  return `${fmt(start)} – ${fmt(end)}`;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const MODE_LABELS: Record<BudgetMode, string> = {
+  envelope: "Envelope",
+  tracking: "Tracking",
+  unidentified: "Unknown",
+};
+
+const MODE_COLORS: Record<BudgetMode, string> = {
+  envelope: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  tracking: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  unidentified: "bg-muted text-muted-foreground",
+};
+
+const CELL_VIEW_LABELS: Record<CellView, string> = {
+  budgeted: "Budget",
+  spent: "Actuals",
+  balance: "Balance",
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+type Props = {
+  budgetMode: BudgetMode;
+  /** First month of the 12-month display window (YYYY-MM). */
+  windowStart: string;
+  onWindowChange: (start: string) => void;
+  cellView: CellView;
+  onCellViewChange: (view: CellView) => void;
+  onExpandAll?: () => void;
+  onCollapseAll?: () => void;
+  showHidden?: boolean;
+  onToggleShowHidden?: () => void;
+  onExport?: () => void;
+  onImport?: () => void;
+};
+
+function Divider() {
+  return <div className="w-px h-5 bg-border/60 mx-1 shrink-0" aria-hidden="true" />;
+}
+
+/**
+ * Top toolbar for the Budget Management Workspace.
+ *
+ * Contains:
+ * - Budget mode badge
+ * - 12-month window navigator (±1 month, ±1 year with range label)
+ * - Cell-view toggle (Budget / Spent / Balance)
+ * - Action buttons (Bulk, Import, Export, Transfer, Hold)
+ * - Save area (Discard, Save)
+ */
+export function BudgetToolbar({
+  budgetMode,
+  windowStart,
+  onWindowChange,
+  cellView,
+  onCellViewChange,
+  onExpandAll,
+  onCollapseAll,
+  showHidden,
+  onToggleShowHidden,
+  onExport,
+  onImport,
+}: Props) {
+  const rangeLabel = formatWindowRange(windowStart);
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-1 gap-y-1.5 px-3 py-2 border-b border-border bg-background"
+      role="toolbar"
+      aria-label="Budget management toolbar"
+    >
+      {/* Mode badge */}
+      <span
+        className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium shrink-0 ${MODE_COLORS[budgetMode]}`}
+        aria-label={`Budget mode: ${MODE_LABELS[budgetMode]}`}
+      >
+        {MODE_LABELS[budgetMode]}
+      </span>
+
+      <Divider />
+
+      {/* 12-month window navigator */}
+      <div
+        className="flex items-center gap-0.5 shrink-0"
+        role="group"
+        aria-label="Month window navigation"
+      >
+        {/* ◀◀ Back 1 year */}
+        <button
+          type="button"
+          onClick={() => onWindowChange(addMonths(windowStart, -12))}
+          aria-label="Back 1 year"
+          title="Back 1 year"
+          className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <ChevronsLeft className="h-3.5 w-3.5" />
+        </button>
+
+        {/* ◀ Back 1 month */}
+        <button
+          type="button"
+          onClick={() => onWindowChange(addMonths(windowStart, -1))}
+          aria-label="Back 1 month"
+          title="Back 1 month"
+          className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Range label */}
+        <span
+          className="min-w-[130px] text-center text-xs font-semibold text-foreground select-none px-1"
+          aria-live="polite"
+          aria-label={`Displaying ${rangeLabel}`}
+        >
+          {rangeLabel}
+        </span>
+
+        {/* Forward 1 month ▶ */}
+        <button
+          type="button"
+          onClick={() => onWindowChange(addMonths(windowStart, 1))}
+          aria-label="Forward 1 month"
+          title="Forward 1 month"
+          className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Forward 1 year ▶▶ */}
+        <button
+          type="button"
+          onClick={() => onWindowChange(addMonths(windowStart, 12))}
+          aria-label="Forward 1 year"
+          title="Forward 1 year"
+          className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <ChevronsRight className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Jump to current year */}
+        <button
+          type="button"
+          onClick={() => {
+            const currentYear = new Date().getFullYear();
+            onWindowChange(`${currentYear}-01`);
+          }}
+          aria-label="Go to current year"
+          title="Go to current year"
+          className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors ml-0.5"
+        >
+          <CalendarDays className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <Divider />
+
+      {/* Cell-view toggle */}
+      <div
+        className="flex items-center rounded border border-border overflow-hidden shrink-0"
+        role="group"
+        aria-label="Cell display"
+      >
+        {(["budgeted", "spent", "balance"] as const).map((view, idx, arr) => (
+          <button
+            key={view}
+            type="button"
+            onClick={() => onCellViewChange(view)}
+            aria-pressed={cellView === view}
+            className={`px-2 py-1 text-[11px] font-medium transition-colors ${
+              idx < arr.length - 1 ? "border-r border-border" : ""
+            } ${
+              cellView === view
+                ? "bg-primary/10 text-foreground"
+                : "text-muted-foreground hover:bg-muted/50"
+            }`}
+          >
+            {CELL_VIEW_LABELS[view]}
+          </button>
+        ))}
+      </div>
+
+      {(onExpandAll || onCollapseAll || onToggleShowHidden) && <Divider />}
+
+      {/* Expand / Collapse All + Show/Hide hidden */}
+      {(onExpandAll || onCollapseAll || onToggleShowHidden) && (
+        <div
+          className="flex items-center gap-0.5 shrink-0"
+          role="group"
+          aria-label="Group visibility"
+        >
+          {onExpandAll && (
+            <button
+              type="button"
+              onClick={onExpandAll}
+              aria-label="Expand all groups"
+              title="Expand all groups"
+              className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors"
+            >
+              <ChevronsUpDown className="h-3.5 w-3.5" />
+            </button>
+          )}
+          {onCollapseAll && (
+            <button
+              type="button"
+              onClick={onCollapseAll}
+              aria-label="Collapse all groups"
+              title="Collapse all groups"
+              className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors"
+            >
+              <ChevronsDownUp className="h-3.5 w-3.5" />
+            </button>
+          )}
+          {onToggleShowHidden && (
+            <button
+              type="button"
+              onClick={onToggleShowHidden}
+              aria-label={showHidden ? "Hide hidden categories" : "Show hidden categories"}
+              title={showHidden ? "Hide hidden categories" : "Show hidden categories"}
+              aria-pressed={showHidden}
+              className={`flex items-center justify-center w-6 h-6 rounded transition-colors ${
+                showHidden
+                  ? "text-foreground bg-muted"
+                  : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {showHidden ? (
+                <EyeOff className="h-3.5 w-3.5" />
+              ) : (
+                <Eye className="h-3.5 w-3.5" />
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="flex-1" />
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-1 shrink-0">
+        {(onImport || onExport) && <Divider />}
+
+        {onImport && (
+          <button
+            type="button"
+            onClick={onImport}
+            aria-label="Import budget data from CSV"
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded border border-border hover:bg-muted transition-colors"
+          >
+            <Download className="h-3 w-3" aria-hidden="true" />
+            Import
+          </button>
+        )}
+
+        {onExport && (
+          <button
+            type="button"
+            onClick={onExport}
+            aria-label="Export budget data to CSV"
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded border border-border hover:bg-muted transition-colors"
+          >
+            <Upload className="h-3 w-3" aria-hidden="true" />
+            Export
+          </button>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/components/BudgetWorkspace.tsx
+++ b/src/features/budget-management/components/BudgetWorkspace.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMonthData } from "../hooks/useMonthData";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+import { parseBudgetExpression } from "../lib/budgetMath";
+import { parsePastePayload, resolveSelectionCells } from "../lib/budgetSelectionUtils";
+import { useBulkAction, type BulkActionType } from "../hooks/useBulkAction";
+import { BudgetGrid } from "./BudgetGrid";
+import { BudgetSelectionSummary } from "./BudgetSelectionSummary";
+import { BulkActionDialog } from "./BulkActionDialog";
+import { BudgetCellContextMenu } from "./BudgetCellContextMenu";
+import type {
+  BudgetCellKey,
+  BudgetCellSelection,
+  BudgetMode,
+  CellView,
+  LoadedCategory,
+  LoadedMonthState,
+  NavDirection,
+  NavItem,
+  StagedBudgetEdit,
+} from "../types";
+import { useLocalState } from "../hooks/useLocalState";
+
+const IMMEDIATE_BULK_ACTIONS: BulkActionType[] = [
+  "copy-previous-month",
+  "set-to-zero",
+  "avg-3-months",
+  "avg-6-months",
+  "avg-12-months",
+];
+
+type ContextMenuState = {
+  x: number;
+  y: number;
+  categoryId: string;
+  month: string;
+  carryover: boolean;
+} | null;
+
+type Props = {
+  budgetMode: BudgetMode;
+  cellView: CellView;
+  activeMonths: string[];
+  availableMonths: string[];
+  /** Collapse state lifted from BudgetManagementView so toolbar can control it. */
+  collapsedGroups: Set<string>;
+  onToggleCollapse: (groupId: string) => void;
+  /** When true, hidden groups/categories are rendered (dimmed); when false they are hidden. */
+  showHidden?: boolean;
+  /** When true, open the bulk action dialog for the current selection */
+  bulkActionOpen?: boolean;
+  onBulkActionClose?: () => void;
+  onOpenTransfer?: () => void;
+};
+
+/**
+ * Main workspace composite: grid + context panel + selection summary footer.
+ * Owns BudgetCellSelection local state and coordinates paste, copy, undo/redo,
+ * and keyboard navigation across cells.
+ */
+export function BudgetWorkspace({
+  budgetMode,
+  cellView,
+  activeMonths,
+  availableMonths,
+  collapsedGroups,
+  onToggleCollapse,
+  showHidden = false,
+  bulkActionOpen = false,
+  onBulkActionClose,
+  onOpenTransfer,
+}: Props) {
+  const [selection, setSelection] = useLocalState<BudgetCellSelection | null>(null);
+  const [groupSelection, setGroupSelection] = useState<{ groupId: string; month: string } | null>(null);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+  const [pendingBulkAction, setPendingBulkAction] = useState<BulkActionType | null>(null);
+
+  const workspaceRef = useRef<HTMLDivElement>(null);
+  const { preview: previewBulk, apply: applyBulk } = useBulkAction();
+
+  const undo = useBudgetEditsStore((s) => s.undo);
+  const redo = useBudgetEditsStore((s) => s.redo);
+  const stageBulkEdits = useBudgetEditsStore((s) => s.stageBulkEdits);
+  const setUiSelection = useBudgetEditsStore((s) => s.setUiSelection);
+
+  // Sync focused cell or group to store so BudgetDraftPanel can read it.
+  useEffect(() => {
+    if (groupSelection) {
+      setUiSelection(groupSelection.month, null, groupSelection.groupId);
+    } else {
+      setUiSelection(selection?.anchorMonth ?? null, selection?.anchorCategoryId ?? null, null);
+    }
+  }, [selection, groupSelection, setUiSelection]);
+
+  const queryClient = useQueryClient();
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const firstMonth = activeMonths[0] ?? null;
+  const { data: firstMonthData } = useMonthData(firstMonth);
+  // Categories in visual order — used for paste, copy, delete, selection bounds.
+  // When showHidden=false, hidden groups and hidden categories are excluded.
+  const categories = useMemo(() => {
+    if (!firstMonthData) return [];
+    const { groupOrder, groupsById, categoriesById } = firstMonthData;
+    const expenseIds = groupOrder.filter((id) => !groupsById[id]!.isIncome);
+    const incomeIds = groupOrder.filter((id) => groupsById[id]!.isIncome);
+    return [...expenseIds, ...incomeIds]
+      .filter((id) => showHidden || !groupsById[id]!.hidden)
+      .flatMap((id) =>
+        (groupsById[id]?.categoryIds ?? [])
+          .map((catId) => categoriesById[catId]!)
+          .filter((cat) => showHidden || !cat.hidden)
+      );
+  }, [firstMonthData, showHidden]);
+
+  // Interleaved nav list: group row followed by its visible (and expanded) categories.
+  // Used for Up/Down/Tab keyboard navigation so group rows are reachable.
+  const navItems = useMemo((): NavItem[] => {
+    if (!firstMonthData) return [];
+    const { groupOrder, groupsById, categoriesById } = firstMonthData;
+    const expenseIds = groupOrder.filter((id) => !groupsById[id]!.isIncome);
+    const incomeIds = groupOrder.filter((id) => groupsById[id]!.isIncome);
+    const items: NavItem[] = [];
+    for (const groupId of [...expenseIds, ...incomeIds]) {
+      const group = groupsById[groupId];
+      if (!group) continue;
+      if (!showHidden && group.hidden) continue;
+      items.push({ type: "group", id: groupId });
+      if (!collapsedGroups.has(groupId)) {
+        for (const catId of group.categoryIds) {
+          const cat = categoriesById[catId];
+          if (!cat) continue;
+          if (!showHidden && cat.hidden) continue;
+          items.push({ type: "category", id: catId });
+        }
+      }
+    }
+    return items;
+  }, [firstMonthData, showHidden, collapsedGroups]);
+
+  const handleCellFocus = useCallback(
+    (categoryId: string, month: string) => {
+      setContextMenu(null);
+      setGroupSelection(null);
+      setSelection({
+        anchorCategoryId: categoryId,
+        anchorMonth: month,
+        focusCategoryId: categoryId,
+        focusMonth: month,
+      });
+    },
+    [setSelection]
+  );
+
+  const handleGroupFocus = useCallback(
+    (groupId: string, month: string) => {
+      setContextMenu(null);
+      setSelection(null);
+      setGroupSelection({ groupId, month });
+    },
+    [setSelection]
+  );
+
+  const handleCellRangeSelect = useCallback(
+    (categoryId: string, month: string) => {
+      setSelection((prev) => {
+        if (!prev) {
+          return {
+            anchorCategoryId: categoryId,
+            anchorMonth: month,
+            focusCategoryId: categoryId,
+            focusMonth: month,
+          };
+        }
+        return {
+          ...prev,
+          focusCategoryId: categoryId,
+          focusMonth: month,
+        };
+      });
+    },
+    [setSelection]
+  );
+
+  /** Unified navigation: moves focus through the interleaved navItems list. */
+  const navigateFrom = useCallback(
+    (fromItem: NavItem, fromMonth: string, dir: NavDirection) => {
+      const itemIdx = navItems.findIndex(
+        (i) => i.type === fromItem.type && i.id === fromItem.id
+      );
+      const monthIdx = activeMonths.indexOf(fromMonth);
+      if (itemIdx === -1 || monthIdx === -1) return;
+
+      // Shift+arrow: range extension — categories only, skip group items.
+      if (
+        dir === "shift-up" ||
+        dir === "shift-down" ||
+        dir === "shift-left" ||
+        dir === "shift-right"
+      ) {
+        if (fromItem.type !== "category") return;
+        setSelection((prev) => {
+          if (!prev) return prev;
+          const catOnlyItems = navItems.filter((i) => i.type === "category");
+          const focusCatIdx = catOnlyItems.findIndex((i) => i.id === prev.focusCategoryId);
+          const focusMonthIdx = activeMonths.indexOf(prev.focusMonth);
+          let newFocusCatIdx = focusCatIdx;
+          let newFocusMonthIdx = focusMonthIdx;
+          if (dir === "shift-up") newFocusCatIdx = Math.max(0, focusCatIdx - 1);
+          else if (dir === "shift-down") newFocusCatIdx = Math.min(catOnlyItems.length - 1, focusCatIdx + 1);
+          else if (dir === "shift-left") newFocusMonthIdx = Math.max(0, focusMonthIdx - 1);
+          else if (dir === "shift-right") newFocusMonthIdx = Math.min(activeMonths.length - 1, focusMonthIdx + 1);
+          const newFocusItem = catOnlyItems[newFocusCatIdx];
+          const newFocusMonth = activeMonths[newFocusMonthIdx];
+          if (!newFocusItem || !newFocusMonth) return prev;
+          return { ...prev, focusCategoryId: newFocusItem.id, focusMonth: newFocusMonth };
+        });
+        return;
+      }
+
+      let newItemIdx = itemIdx;
+      let newMonthIdx = monthIdx;
+
+      switch (dir) {
+        case "up":    newItemIdx = Math.max(0, itemIdx - 1); break;
+        case "down":  newItemIdx = Math.min(navItems.length - 1, itemIdx + 1); break;
+        case "left":  newMonthIdx = Math.max(0, monthIdx - 1); break;
+        case "right": newMonthIdx = Math.min(activeMonths.length - 1, monthIdx + 1); break;
+        case "tab":
+          if (monthIdx < activeMonths.length - 1) newMonthIdx = monthIdx + 1;
+          else { newMonthIdx = 0; newItemIdx = Math.min(navItems.length - 1, itemIdx + 1); }
+          break;
+        case "shift-tab":
+          if (monthIdx > 0) newMonthIdx = monthIdx - 1;
+          else { newMonthIdx = activeMonths.length - 1; newItemIdx = Math.max(0, itemIdx - 1); }
+          break;
+      }
+
+      const newItem = navItems[newItemIdx];
+      const newMonth = activeMonths[newMonthIdx];
+      if (!newItem || !newMonth) return;
+
+      if (newItem.type === "group") {
+        setContextMenu(null);
+        setSelection(null);
+        setGroupSelection({ groupId: newItem.id, month: newMonth });
+        document
+          .querySelector<HTMLElement>(
+            `[data-group-id="${CSS.escape(newItem.id)}"][data-group-month="${CSS.escape(newMonth)}"]`
+          )
+          ?.focus();
+      } else {
+        setContextMenu(null);
+        setGroupSelection(null);
+        setSelection({
+          anchorCategoryId: newItem.id,
+          anchorMonth: newMonth,
+          focusCategoryId: newItem.id,
+          focusMonth: newMonth,
+        });
+        document
+          .querySelector<HTMLElement>(
+            `[data-month="${CSS.escape(newMonth)}"][data-category-id="${CSS.escape(newItem.id)}"]`
+          )
+          ?.focus();
+      }
+    },
+    [navItems, activeMonths, setSelection]
+  );
+
+  const handleCellNavigate = useCallback(
+    (fromCategoryId: string, fromMonth: string, dir: NavDirection) => {
+      navigateFrom({ type: "category", id: fromCategoryId }, fromMonth, dir);
+    },
+    [navigateFrom]
+  );
+
+  const handleGroupNavigate = useCallback(
+    (fromGroupId: string, fromMonth: string, dir: NavDirection) => {
+      navigateFrom({ type: "group", id: fromGroupId }, fromMonth, dir);
+    },
+    [navigateFrom]
+  );
+
+  /** Copy selected cell values as tab-delimited text (dollar amounts). */
+  const handleCopySelection = useCallback(() => {
+    if (!selection) return;
+
+    const anchorCatIdx = categories.findIndex((c) => c.id === selection.anchorCategoryId);
+    const focusCatIdx = categories.findIndex((c) => c.id === selection.focusCategoryId);
+    const anchorMonthIdx = activeMonths.indexOf(selection.anchorMonth);
+    const focusMonthIdx = activeMonths.indexOf(selection.focusMonth);
+
+    if (anchorCatIdx === -1 || focusCatIdx === -1 || anchorMonthIdx === -1 || focusMonthIdx === -1) return;
+
+    const minCat = Math.min(anchorCatIdx, focusCatIdx);
+    const maxCat = Math.max(anchorCatIdx, focusCatIdx);
+    const minMonth = Math.min(anchorMonthIdx, focusMonthIdx);
+    const maxMonth = Math.max(anchorMonthIdx, focusMonthIdx);
+
+    const currentEdits = useBudgetEditsStore.getState().edits;
+
+    const rows: string[] = [];
+    for (let ci = minCat; ci <= maxCat; ci++) {
+      const cat = categories[ci];
+      if (!cat) continue;
+      const cols: string[] = [];
+      for (let mi = minMonth; mi <= maxMonth; mi++) {
+        const month = activeMonths[mi];
+        if (!month) continue;
+
+        // Read the cached month state to get server value for this month
+        const monthState = queryClient.getQueryData<LoadedMonthState>(
+          ["budget-month-data", connection?.id, month]
+        );
+        const catData = monthState?.categoriesById[cat.id] ?? cat;
+
+        const cellKey: BudgetCellKey = `${month}:${cat.id}`;
+        const staged = currentEdits[cellKey];
+        const minor = staged != null ? staged.nextBudgeted : catData.budgeted;
+        cols.push((minor / 100).toFixed(2));
+      }
+      rows.push(cols.join("\t"));
+    }
+
+    const text = rows.join("\n");
+    navigator.clipboard.writeText(text).catch(() => undefined);
+  }, [selection, categories, activeMonths, queryClient, connection]);
+
+  // Context menu handler
+  const handleCellContextMenu = useCallback(
+    (catId: string, month: string, carryover: boolean, x: number, y: number) => {
+      setContextMenu({ x, y, categoryId: catId, month, carryover });
+    },
+    []
+  );
+
+  // Carryover toggle — immediate API action (not staged)
+  const handleCarryoverToggle = useCallback(async () => {
+    if (!connection || !contextMenu) return;
+    const { categoryId, month, carryover } = contextMenu;
+    const newValue = !carryover;
+    // Apply to this month and all months in activeMonths that are >= this month
+    const monthsToUpdate = activeMonths.filter((m) => m >= month);
+    for (const m of monthsToUpdate) {
+      await apiRequest(connection, `/months/${m}/categories/${categoryId}`, {
+        method: "PATCH",
+        body: { category: { carryover: newValue } },
+      });
+    }
+    // Invalidate affected months
+    for (const m of monthsToUpdate) {
+      await queryClient.invalidateQueries({
+        queryKey: ["budget-month-data", connection.id, m],
+      });
+    }
+  }, [connection, contextMenu, activeMonths, queryClient]);
+
+  // Clear selection on any click outside the workspace div (TopBar, Sidebar, Toolbar, etc.)
+  useEffect(() => {
+    const handleDocMouseDown = (e: MouseEvent) => {
+      const target = e.target as Element;
+      if (target.closest("[role=dialog]")) return;
+      if (workspaceRef.current?.contains(target)) return;
+      setSelection(null);
+      setGroupSelection(null);
+    };
+    document.addEventListener("mousedown", handleDocMouseDown);
+    return () => document.removeEventListener("mousedown", handleDocMouseDown);
+  }, [setSelection]);
+
+  // Execute no-input bulk actions immediately from the context menu.
+  const handleContextMenuBulkAction = useCallback(
+    (action: BulkActionType) => {
+      if (!selection) return;
+      if (IMMEDIATE_BULK_ACTIONS.includes(action)) {
+        const monthDataMap: Record<string, LoadedCategory[]> = {};
+        for (const month of activeMonths) {
+          const state = queryClient.getQueryData<LoadedMonthState>(["budget-month-data", connection?.id, month]);
+          if (state) monthDataMap[month] = Object.values(state.categoriesById);
+        }
+        // For average actions, also pull up to 12 months before the active window from cache.
+        if (action === "avg-3-months" || action === "avg-6-months" || action === "avg-12-months") {
+          const lookback = action === "avg-3-months" ? 3 : action === "avg-6-months" ? 6 : 12;
+          let m = activeMonths[0] ?? "";
+          for (let i = 0; i < lookback; i++) {
+            const [y, mo] = m.split("-");
+            const d = new Date(parseInt(y ?? "2026", 10), parseInt(mo ?? "1", 10) - 2, 1);
+            m = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+            const state = queryClient.getQueryData<LoadedMonthState>(["budget-month-data", connection?.id, m]);
+            if (state) monthDataMap[m] = Object.values(state.categoriesById);
+          }
+        }
+        const rows = previewBulk(action, selection, activeMonths, categories, monthDataMap);
+        if (rows && rows.length > 0) applyBulk(rows);
+      } else {
+        setPendingBulkAction(action);
+      }
+    },
+    [selection, activeMonths, categories, queryClient, connection, previewBulk, applyBulk]
+  );
+
+  // Keyboard: undo/redo/copy/delete on the workspace container
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === "z") {
+        e.preventDefault();
+        undo();
+      } else if (
+        (e.ctrlKey || e.metaKey) &&
+        (e.key === "y" || (e.shiftKey && e.key === "z"))
+      ) {
+        e.preventDefault();
+        redo();
+      } else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === "c") {
+        if (selection) {
+          e.preventDefault();
+          handleCopySelection();
+        }
+      } else if (e.key === "Delete" || e.key === "Backspace") {
+        // Multi-cell Delete: zero out all selected cells.
+        // Single-cell Delete is handled by BudgetCell's own keyDown handler.
+        if (!selection) return;
+        const cells = resolveSelectionCells(selection, activeMonths, categories);
+        if (cells.length <= 1) return; // let BudgetCell handle single-cell
+        e.preventDefault();
+        const newEdits: StagedBudgetEdit[] = cells.map((cell) => {
+          const monthState = queryClient.getQueryData<LoadedMonthState>(
+            ["budget-month-data", connection?.id, cell.month]
+          );
+          const serverCat = monthState?.categoriesById[cell.categoryId];
+          return {
+            month: cell.month,
+            categoryId: cell.categoryId,
+            nextBudgeted: 0,
+            previousBudgeted: serverCat?.budgeted ?? 0,
+            source: "manual" as const,
+          };
+        });
+        stageBulkEdits(newEdits);
+      }
+    },
+    [undo, redo, selection, handleCopySelection, activeMonths, categories,
+     stageBulkEdits, queryClient, connection]
+  );
+
+  // Clipboard paste: parse tab-delimited text and stage bulk edits
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      if (!selection) return;
+      const text = e.clipboardData.getData("text/plain");
+      if (!text) return;
+
+      const pasteGrid = parsePastePayload(text);
+      if (pasteGrid.length === 0 || pasteGrid[0]?.length === 0) return;
+
+      const isSingleValue = pasteGrid.length === 1 && pasteGrid[0]?.length === 1;
+      const singleStr = isSingleValue ? (pasteGrid[0]?.[0] ?? "") : "";
+      const singleResult = isSingleValue ? parseBudgetExpression(singleStr) : null;
+
+      const newEdits: StagedBudgetEdit[] = [];
+
+      if (isSingleValue && singleResult?.ok) {
+        // Single value pasted: fill every cell in the current selection rectangle.
+        const cells = resolveSelectionCells(selection, activeMonths, categories);
+        for (const cell of cells) {
+          const monthState = queryClient.getQueryData<LoadedMonthState>(
+            ["budget-month-data", connection?.id, cell.month]
+          );
+          const serverCat = monthState?.categoriesById[cell.categoryId];
+          newEdits.push({
+            month: cell.month,
+            categoryId: cell.categoryId,
+            nextBudgeted: singleResult.value,
+            previousBudgeted: serverCat?.budgeted ?? 0,
+            source: "paste",
+          });
+        }
+      } else {
+        // Multi-value paste: fill from anchor, expand as far as the paste grid.
+        const anchorCatIdx = categories.findIndex(
+          (c) => c.id === selection.anchorCategoryId
+        );
+        const anchorMonthIdx = activeMonths.indexOf(selection.anchorMonth);
+        if (anchorCatIdx === -1 || anchorMonthIdx === -1) return;
+
+        for (let ri = 0; ri < pasteGrid.length; ri++) {
+          const row = pasteGrid[ri];
+          if (!row) continue;
+          for (let ci = 0; ci < row.length; ci++) {
+            const cellStr = row[ci] ?? "";
+            const result = parseBudgetExpression(cellStr);
+            if (!result.ok) continue;
+
+            const cat = categories[anchorCatIdx + ri];
+            const month = activeMonths[anchorMonthIdx + ci];
+            if (!cat || !month) continue;
+
+            const monthState = queryClient.getQueryData<LoadedMonthState>(
+              ["budget-month-data", connection?.id, month]
+            );
+            const serverCat = monthState?.categoriesById[cat.id];
+
+            newEdits.push({
+              month,
+              categoryId: cat.id,
+              nextBudgeted: result.value,
+              previousBudgeted: serverCat?.budgeted ?? 0,
+              source: "paste",
+            });
+          }
+        }
+      }
+
+      if (newEdits.length > 0) {
+        e.preventDefault();
+        stageBulkEdits(newEdits);
+      }
+    },
+    [selection, categories, activeMonths, stageBulkEdits, queryClient, connection]
+  );
+
+  return (
+    <div
+      ref={workspaceRef}
+      className="flex flex-col flex-1 min-h-0"
+      onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
+      tabIndex={-1}
+      aria-label="Budget workspace"
+    >
+      <div className="flex-1 min-w-0 overflow-auto">
+        <BudgetGrid
+          activeMonths={activeMonths}
+          availableMonths={availableMonths}
+          budgetMode={budgetMode}
+          cellView={cellView}
+          selection={selection}
+          groupSelection={groupSelection}
+          collapsedGroups={collapsedGroups}
+          onToggleCollapse={onToggleCollapse}
+          showHidden={showHidden}
+          onCellFocus={handleCellFocus}
+          onCellRangeSelect={handleCellRangeSelect}
+          onCellNavigate={handleCellNavigate}
+          onCellContextMenu={handleCellContextMenu}
+          onGroupFocus={handleGroupFocus}
+          onGroupNavigate={handleGroupNavigate}
+          onClearSelection={() => {
+            setContextMenu(null);
+            setSelection(null);
+            setGroupSelection(null);
+          }}
+        />
+      </div>
+      <BudgetSelectionSummary
+        selection={selection}
+        activeMonths={activeMonths}
+        categories={categories}
+      />
+
+      {(bulkActionOpen || pendingBulkAction !== null) && selection && (
+        <BulkActionMonthDataLoader
+          selection={selection}
+          activeMonths={activeMonths}
+          categories={categories}
+          initialAction={pendingBulkAction ?? undefined}
+          onClose={() => {
+            onBulkActionClose?.();
+            setPendingBulkAction(null);
+          }}
+        />
+      )}
+
+      {contextMenu && (
+        <BudgetCellContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          carryover={contextMenu.carryover}
+          budgetMode={budgetMode}
+          onToggleCarryover={() => void handleCarryoverToggle()}
+          onOpenTransfer={onOpenTransfer ?? (() => undefined)}
+          onBulkAction={handleContextMenuBulkAction}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Thin loader that calls useMonthData for each active month (hitting TanStack
+ * Query cache warmed by BudgetGrid columns) then renders BulkActionDialog with
+ * the assembled monthDataMap. Isolated as a component so hooks run at a stable
+ * call-site regardless of how many months are active.
+ */
+function BulkActionMonthDataLoader({
+  selection,
+  activeMonths,
+  categories,
+  onClose,
+  initialAction,
+}: {
+  selection: import("../types").BudgetCellSelection;
+  activeMonths: string[];
+  categories: LoadedCategory[];
+  onClose: () => void;
+  initialAction?: BulkActionType;
+}) {
+  // Load each month's data. These are already cached by BudgetGrid columns.
+  const m0 = useMonthData(activeMonths[0] ?? null);
+  const m1 = useMonthData(activeMonths[1] ?? null);
+  const m2 = useMonthData(activeMonths[2] ?? null);
+  const m3 = useMonthData(activeMonths[3] ?? null);
+  const m4 = useMonthData(activeMonths[4] ?? null);
+  const m5 = useMonthData(activeMonths[5] ?? null);
+  const m6 = useMonthData(activeMonths[6] ?? null);
+  const m7 = useMonthData(activeMonths[7] ?? null);
+  const m8 = useMonthData(activeMonths[8] ?? null);
+  const m9 = useMonthData(activeMonths[9] ?? null);
+  const m10 = useMonthData(activeMonths[10] ?? null);
+  const m11 = useMonthData(activeMonths[11] ?? null);
+
+  const allResults = [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11];
+
+  const monthDataMap: Record<string, LoadedCategory[]> = {};
+  for (let i = 0; i < activeMonths.length; i++) {
+    const month = activeMonths[i];
+    const result = allResults[i];
+    if (month && result?.data) {
+      monthDataMap[month] = Object.values(result.data.categoriesById);
+    }
+  }
+
+  return (
+    <BulkActionDialog
+      selection={selection}
+      activeMonths={activeMonths}
+      categories={categories}
+      monthDataMap={monthDataMap}
+      onClose={onClose}
+      initialAction={initialAction}
+    />
+  );
+}

--- a/src/features/budget-management/components/BulkActionDialog.tsx
+++ b/src/features/budget-management/components/BulkActionDialog.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+import { useBulkAction, type BulkActionType, type BulkActionParams, type BulkPreviewRow } from "../hooks/useBulkAction";
+import type { BudgetCellSelection, LoadedCategory } from "../types";
+
+type Props = {
+  selection: BudgetCellSelection;
+  activeMonths: string[];
+  categories: LoadedCategory[];
+  /** Map of month → category list for that month (for copy-from-month operations) */
+  monthDataMap: Record<string, LoadedCategory[]>;
+  onClose: () => void;
+  /** When set, pre-selects the action and hides the action picker. */
+  initialAction?: BulkActionType;
+};
+
+type Step = "action" | "preview" | "done";
+
+function formatAmount(minor: number): string {
+  return `$${(minor / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+const ACTION_LABELS: Record<BulkActionType, string> = {
+  "copy-previous-month": "Copy previous month",
+  "copy-from-month":     "Copy specific month",
+  "set-to-zero":         "Set all to zero",
+  "set-fixed":           "Set to fixed amount",
+  "apply-percentage":    "Apply percentage change",
+  "avg-3-months":        "Set to 3 months average",
+  "avg-6-months":        "Set to 6 months average",
+  "avg-12-months":       "Set to yearly average",
+};
+
+/**
+ * Multi-step dialog for bulk budget actions on a selection.
+ *
+ * Step 1: Choose action type + parameters.
+ * Step 2: Review preview table of proposed changes.
+ * Step 3: Confirmation after apply.
+ */
+export function BulkActionDialog({
+  selection,
+  activeMonths,
+  categories,
+  monthDataMap,
+  onClose,
+  initialAction,
+}: Props) {
+  const { preview, apply } = useBulkAction();
+
+  const [step, setStep] = useState<Step>("action");
+  const [action, setAction] = useState<BulkActionType>(initialAction ?? "copy-previous-month");
+  const [fixedAmount, setFixedAmount] = useState("");
+  const [sourceMonth, setSourceMonth] = useState(activeMonths[0] ?? "");
+  const [percentage, setPercentage] = useState("100");
+  const [previewRows, setPreviewRows] = useState<BulkPreviewRow[]>([]);
+  const [paramError, setParamError] = useState<string | null>(null);
+
+  const needsFixed = action === "set-fixed";
+  const needsSourceMonth = action === "copy-from-month";
+  const needsPercentage = action === "apply-percentage";
+
+  const buildParams = (): BulkActionParams | undefined => {
+    if (needsFixed) {
+      const cents = Math.round(parseFloat(fixedAmount) * 100);
+      if (isNaN(cents)) return undefined;
+      return { fixedAmount: cents };
+    }
+    if (needsSourceMonth) return { sourceMonth };
+    if (needsPercentage) {
+      const pct = parseFloat(percentage);
+      if (isNaN(pct)) return undefined;
+      return { percentage: pct / 100 };
+    }
+    return undefined;
+  };
+
+  const handlePreview = () => {
+    setParamError(null);
+    const params = buildParams();
+
+    if (needsFixed && params?.fixedAmount === undefined) {
+      setParamError("Please enter a valid dollar amount.");
+      return;
+    }
+    if (needsPercentage && params?.percentage === undefined) {
+      setParamError("Please enter a valid percentage.");
+      return;
+    }
+
+    const rows = preview(action, selection, activeMonths, categories, monthDataMap, params);
+    if (!rows || rows.length === 0) {
+      setParamError("No cells would be changed by this action.");
+      return;
+    }
+
+    setPreviewRows(rows);
+    setStep("preview");
+  };
+
+  const handleApply = () => {
+    apply(previewRows);
+    setStep("done");
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Bulk budget action"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-lg mx-4 p-5">
+        {step === "action" && (
+          <>
+            <h2 className="text-base font-semibold mb-4">Bulk Action</h2>
+
+            <div className="space-y-3 mb-4">
+              {!initialAction && (
+                <div>
+                  <label htmlFor="bulk-action-type" className="block text-sm font-medium mb-1">
+                    Action
+                  </label>
+                  <select
+                    id="bulk-action-type"
+                    value={action}
+                    onChange={(e) => setAction(e.target.value as BulkActionType)}
+                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background"
+                  >
+                    {(Object.keys(ACTION_LABELS) as BulkActionType[]).map((a) => (
+                      <option key={a} value={a}>
+                        {ACTION_LABELS[a]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {needsFixed && (
+                <div>
+                  <label htmlFor="bulk-fixed-amount" className="block text-sm font-medium mb-1">
+                    Amount ($)
+                  </label>
+                  <input
+                    id="bulk-fixed-amount"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={fixedAmount}
+                    onChange={(e) => setFixedAmount(e.target.value)}
+                    placeholder="0.00"
+                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+                    aria-label="Fixed amount in dollars"
+                  />
+                </div>
+              )}
+
+              {needsSourceMonth && (
+                <div>
+                  <label htmlFor="bulk-source-month" className="block text-sm font-medium mb-1">
+                    Source month
+                  </label>
+                  <select
+                    id="bulk-source-month"
+                    value={sourceMonth}
+                    onChange={(e) => setSourceMonth(e.target.value)}
+                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background"
+                  >
+                    {activeMonths.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {needsPercentage && (
+                <div>
+                  <label htmlFor="bulk-percentage" className="block text-sm font-medium mb-1">
+                    New value as % of current (e.g. 110 = 10% increase)
+                  </label>
+                  <input
+                    id="bulk-percentage"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={percentage}
+                    onChange={(e) => setPercentage(e.target.value)}
+                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+                    aria-label="Percentage of current value"
+                  />
+                </div>
+              )}
+
+              {paramError && (
+                <p className="text-xs text-destructive" role="alert">{paramError}</p>
+              )}
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handlePreview}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Preview changes
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "preview" && (
+          <>
+            <h2 className="text-base font-semibold mb-1">Preview Changes</h2>
+            <p className="text-xs text-muted-foreground mb-3">
+              {previewRows.length} cell{previewRows.length !== 1 ? "s" : ""} will be updated.
+            </p>
+
+            <div className="max-h-64 overflow-y-auto border border-border rounded text-xs mb-4">
+              <table className="w-full" role="grid" aria-label="Preview of bulk changes">
+                <thead className="bg-muted/40 sticky top-0">
+                  <tr>
+                    <th className="px-2 py-1.5 text-left font-medium">Category</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Month</th>
+                    <th className="px-2 py-1.5 text-right font-medium">Current</th>
+                    <th className="px-2 py-1.5 text-right font-medium">New</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {previewRows.map((row, i) => (
+                    <tr key={i} className="border-t border-border/50">
+                      <td className="px-2 py-1 truncate max-w-32">{row.categoryName}</td>
+                      <td className="px-2 py-1 font-mono">{row.month}</td>
+                      <td className="px-2 py-1 text-right font-mono text-muted-foreground">
+                        {formatAmount(row.previousBudgeted)}
+                      </td>
+                      <td className="px-2 py-1 text-right font-mono font-medium">
+                        {formatAmount(row.nextBudgeted)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={() => setStep("action")}
+                className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={handleApply}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                aria-label={`Apply ${previewRows.length} bulk changes`}
+              >
+                Apply {previewRows.length} change{previewRows.length !== 1 ? "s" : ""}
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "done" && (
+          <>
+            <h2 className="text-base font-semibold mb-3">Changes Staged</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              {previewRows.length} cell{previewRows.length !== 1 ? "s" : ""} staged as a single undo step. Use Ctrl+Z to reverse.
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/components/CategoryTransferDialog.tsx
+++ b/src/features/budget-management/components/CategoryTransferDialog.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { useCategoryTransfer } from "../hooks/useCategoryTransfer";
+import type { LoadedCategory } from "../types";
+
+type Props = {
+  month: string;
+  categories: LoadedCategory[];
+  onClose: () => void;
+};
+
+/**
+ * Envelope-mode: immediate category-to-category budget transfer dialog.
+ *
+ * Filters to non-income spending categories only.
+ * Displays a disclaimer that the action is immediate and bypasses the save panel.
+ */
+export function CategoryTransferDialog({ month, categories, onClose }: Props) {
+  const { transfer, isPending, error } = useCategoryTransfer();
+
+  // Eligible categories: non-income, non-hidden spending categories
+  const eligible = categories.filter((c) => !c.isIncome && !c.hidden);
+
+  const [fromId, setFromId] = useState(eligible[0]?.id ?? "");
+  const [toId, setToId] = useState(eligible[1]?.id ?? "");
+  const [amountStr, setAmountStr] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const handleTransfer = async () => {
+    setLocalError(null);
+
+    if (!fromId || !toId) {
+      setLocalError("Please select source and destination categories.");
+      return;
+    }
+    if (fromId === toId) {
+      setLocalError("Source and destination must be different categories.");
+      return;
+    }
+
+    const amount = Math.round(parseFloat(amountStr) * 100);
+    if (isNaN(amount) || amount <= 0) {
+      setLocalError("Please enter a valid positive amount.");
+      return;
+    }
+
+    try {
+      await transfer(month, {
+        fromCategoryId: fromId,
+        toCategoryId: toId,
+        amount,
+      });
+      setDone(true);
+    } catch {
+      // error is set by the hook
+    }
+  };
+
+  const displayError = localError ?? error;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Transfer budget between categories"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-sm mx-4 p-5">
+        {!done ? (
+          <>
+            <h2 className="text-base font-semibold mb-1">Transfer Budget</h2>
+            <p className="text-xs text-muted-foreground mb-4">
+              Month: <span className="font-mono">{month}</span>
+            </p>
+
+            <div className="space-y-3 mb-4">
+              <div>
+                <label htmlFor="transfer-from" className="block text-sm font-medium mb-1">
+                  From category
+                </label>
+                <select
+                  id="transfer-from"
+                  value={fromId}
+                  onChange={(e) => setFromId(e.target.value)}
+                  disabled={isPending}
+                  className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background"
+                >
+                  {eligible.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="transfer-to" className="block text-sm font-medium mb-1">
+                  To category
+                </label>
+                <select
+                  id="transfer-to"
+                  value={toId}
+                  onChange={(e) => setToId(e.target.value)}
+                  disabled={isPending}
+                  className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background"
+                >
+                  {eligible
+                    .filter((c) => c.id !== fromId)
+                    .map((c) => (
+                      <option key={c.id} value={c.id}>{c.name}</option>
+                    ))}
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="transfer-amount" className="block text-sm font-medium mb-1">
+                  Amount ($)
+                </label>
+                <input
+                  id="transfer-amount"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={amountStr}
+                  onChange={(e) => setAmountStr(e.target.value)}
+                  disabled={isPending}
+                  placeholder="0.00"
+                  className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+                  aria-label="Transfer amount in dollars"
+                />
+              </div>
+            </div>
+
+            <div
+              className="mb-4 p-2 rounded bg-orange-50 dark:bg-orange-950/20 text-xs text-orange-700 dark:text-orange-400"
+              role="note"
+            >
+              This action takes effect immediately and does not go through the save panel.
+            </div>
+
+            {displayError && (
+              <p className="text-xs text-destructive mb-3" role="alert">{displayError}</p>
+            )}
+
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isPending}
+                className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleTransfer()}
+                disabled={isPending || eligible.length < 2}
+                aria-label="Confirm and transfer budget immediately"
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {isPending ? "Transferring…" : "Transfer"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-base font-semibold mb-3">Transfer Complete</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              Budget transferred successfully. The grid has been updated.
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/components/NextMonthHoldDialog.tsx
+++ b/src/features/budget-management/components/NextMonthHoldDialog.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { useNextMonthHold } from "../hooks/useNextMonthHold";
+
+type Props = {
+  month: string;
+  onClose: () => void;
+  /** Pre-fill the amount input (minor units). */
+  defaultAmount?: number;
+  /** When true, hides the Clear Hold button — the caller handles clearing separately. */
+  setOnly?: boolean;
+};
+
+/**
+ * Envelope-mode: immediate next-month budget hold dialog.
+ *
+ * Lets users set or clear the hold for a given month.
+ * Displays a disclaimer that the action is immediate and bypasses the save panel.
+ */
+export function NextMonthHoldDialog({ month, onClose, defaultAmount, setOnly }: Props) {
+  const { setHold, clearHold, isPending, error } = useNextMonthHold();
+
+  const [amountStr, setAmountStr] = useState(
+    defaultAmount != null && defaultAmount > 0
+      ? (defaultAmount / 100).toFixed(2)
+      : ""
+  );
+  const [done, setDone] = useState(false);
+  const [lastAction, setLastAction] = useState<"clear" | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSet = async () => {
+    const amount = Math.round(parseFloat(amountStr) * 100);
+    if (isNaN(amount) || amount < 0) {
+      setValidationError("Please enter a valid amount (0 or greater).");
+      return;
+    }
+    setValidationError(null);
+    try {
+      await setHold(month, { amount });
+      onClose();
+    } catch {
+      // error is set by the hook
+    }
+  };
+
+  const handleClear = async () => {
+    try {
+      await clearHold(month);
+      setLastAction("clear");
+      setDone(true);
+    } catch {
+      // error is set by the hook
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Manage next month budget hold"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-sm mx-4 p-5">
+        {!done ? (
+          <>
+            <h2 className="text-base font-semibold mb-4">Next Month Hold for {month}</h2>
+
+            <div className="mb-4">
+              <label htmlFor="hold-amount" className="block text-sm font-medium mb-1">
+                Hold amount ($)
+              </label>
+              <input
+                id="hold-amount"
+                type="number"
+                min="0"
+                step="0.01"
+                value={amountStr}
+                onChange={(e) => setAmountStr(e.target.value)}
+                disabled={isPending}
+                placeholder="0.00"
+                className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+                aria-label="Hold amount in dollars"
+              />
+            </div>
+
+            <div
+              className="mb-4 p-2 rounded bg-orange-50 dark:bg-orange-950/20 text-xs text-orange-700 dark:text-orange-400"
+              role="note"
+            >
+              This action takes effect immediately and does not go through the save panel.
+            </div>
+
+            {validationError && (
+              <p className="text-xs text-destructive mb-3" role="alert">{validationError}</p>
+            )}
+            {error && (
+              <p className="text-xs text-destructive mb-3" role="alert">{error}</p>
+            )}
+
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isPending}
+                className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
+              >
+                Cancel
+              </button>
+              {!setOnly && (
+                <button
+                  type="button"
+                  onClick={() => void handleClear()}
+                  disabled={isPending}
+                  aria-label="Clear the next month hold immediately"
+                  className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
+                >
+                  {isPending && lastAction === "clear" ? "Clearing…" : "Clear Hold"}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => void handleSet()}
+                disabled={isPending || amountStr === ""}
+                aria-label="Set the next month hold amount immediately"
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {isPending ? "Saving…" : "Set Hold"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-base font-semibold mb-3">Hold Cleared</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              The next-month hold has been cleared. The grid has been updated.
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/budget-management/hooks/useAvailableMonths.ts
+++ b/src/features/budget-management/hooks/useAvailableMonths.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+
+/**
+ * Fetches the list of available months from GET /months.
+ * Returns months sorted ascending (oldest first).
+ */
+export function useAvailableMonths(): {
+  data: string[] | undefined;
+  isLoading: boolean;
+  error: unknown;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const query = useQuery({
+    queryKey: ["budget-months", connection?.id],
+    queryFn: async () => {
+      if (!connection) throw new Error("No active connection");
+      const result = await apiRequest<{ data: string[] }>(
+        connection,
+        "/months"
+      );
+      return [...result.data].sort();
+    },
+    enabled: !!connection,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/src/features/budget-management/hooks/useBudgetMode.ts
+++ b/src/features/budget-management/hooks/useBudgetMode.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { runQuery } from "@/lib/api/query";
+import {
+  ZERO_BUDGET_COUNT_QUERY,
+  REFLECT_BUDGET_COUNT_QUERY,
+} from "@/features/overview/lib/overviewQueries";
+import { deriveBudgetMode } from "@/lib/budget/deriveBudgetMode";
+import type { BudgetMode } from "../types";
+
+/**
+ * Reads the budget mode by running ActualQL queries against zero_budgets and
+ * reflect_budgets tables. Normalizes the result to lowercase BudgetMode as
+ * used within the budget-management feature.
+ */
+export function useBudgetMode(): {
+  data: BudgetMode | undefined;
+  isLoading: boolean;
+  error: unknown;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const query = useQuery({
+    queryKey: ["budget-mode", connection?.id],
+    queryFn: async () => {
+      if (!connection) throw new Error("No active connection");
+
+      const [zeroResult, reflectResult] = await Promise.all([
+        runQuery<{ data: number }>(connection, ZERO_BUDGET_COUNT_QUERY),
+        runQuery<{ data: number }>(connection, REFLECT_BUDGET_COUNT_QUERY),
+      ]);
+
+      const upperMode = deriveBudgetMode(zeroResult.data, reflectResult.data);
+
+      // Normalize to lowercase canonical form for the budget-management feature
+      const modeMap: Record<string, BudgetMode> = {
+        Envelope: "envelope",
+        Tracking: "tracking",
+        Unidentified: "unidentified",
+      };
+      return modeMap[upperMode] ?? "unidentified";
+    },
+    enabled: !!connection,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/src/features/budget-management/hooks/useBudgetSave.ts
+++ b/src/features/budget-management/hooks/useBudgetSave.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import type { BudgetCellKey, BudgetSaveResult, StagedBudgetEdit } from "../types";
+
+type SaveProgress = {
+  completed: number;
+  total: number;
+};
+
+type UseBudgetSaveReturn = {
+  save: (
+    edits: Record<BudgetCellKey, StagedBudgetEdit>
+  ) => Promise<BudgetSaveResult[]>;
+  isSaving: boolean;
+  progress: SaveProgress;
+};
+
+/**
+ * Feature-local save pipeline for budget cell edits.
+ *
+ * Issues PATCH /months/{month}/categories/{categoryId} calls sequentially
+ * (never in parallel) so the server's budget sync state is not raced.
+ *
+ * Pre-save: re-fetches GET /months to verify all target months still exist.
+ * Progress: exposes { completed, total } updated after each PATCH.
+ * Clearing: only keys that received a 200 are removed from the store —
+ * failed keys remain with their saveError set, visible in the grid.
+ */
+export function useBudgetSave(): UseBudgetSaveReturn {
+  const connection = useConnectionStore(selectActiveInstance);
+  const queryClient = useQueryClient();
+  const clearEditsForKeys = useBudgetEditsStore((s) => s.clearEditsForKeys);
+  const setSaveError = useBudgetEditsStore((s) => s.setSaveError);
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [progress, setProgress] = useState<SaveProgress>({ completed: 0, total: 0 });
+
+  const save = useCallback(
+    async (
+      edits: Record<BudgetCellKey, StagedBudgetEdit>
+    ): Promise<BudgetSaveResult[]> => {
+      if (!connection) throw new Error("No active connection");
+
+      const entries = Object.entries(edits) as [BudgetCellKey, StagedBudgetEdit][];
+      if (entries.length === 0) return [];
+
+      // Pre-save: verify all target months still exist in GET /months
+      const monthsResult = await apiRequest<{ data: string[] }>(connection, "/months");
+      const availableSet = new Set(monthsResult.data);
+
+      const validEntries = entries.filter(([, edit]) => availableSet.has(edit.month));
+      const invalidEntries = entries.filter(([, edit]) => !availableSet.has(edit.month));
+
+      const results: BudgetSaveResult[] = invalidEntries.map(([, edit]) => ({
+        month: edit.month,
+        categoryId: edit.categoryId,
+        status: "error",
+        message: `Month ${edit.month} is no longer available in this budget`,
+      }));
+
+      setIsSaving(true);
+      setProgress({ completed: 0, total: validEntries.length });
+
+      const succeededKeys: BudgetCellKey[] = [];
+      const successMonths = new Set<string>();
+
+      for (let i = 0; i < validEntries.length; i++) {
+        const entry = validEntries[i];
+        if (!entry) continue;
+        const [key, edit] = entry;
+
+        try {
+          await apiRequest(connection, `/months/${edit.month}/categories/${edit.categoryId}`, {
+            method: "PATCH",
+            body: { category: { budgeted: edit.nextBudgeted } },
+          });
+
+          // Track at key level — only clear exactly what succeeded.
+          succeededKeys.push(key);
+          successMonths.add(edit.month);
+          results.push({
+            month: edit.month,
+            categoryId: edit.categoryId,
+            status: "success",
+          });
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : "Save failed";
+          setSaveError(key, message);
+          results.push({
+            month: edit.month,
+            categoryId: edit.categoryId,
+            status: "error",
+            message,
+          });
+        }
+
+        setProgress({ completed: i + 1, total: validEntries.length });
+      }
+
+      // Clear only the keys that actually succeeded — failed keys remain in the
+      // store with their saveError property so the grid can show the error state.
+      if (succeededKeys.length > 0) {
+        clearEditsForKeys(succeededKeys);
+        for (const month of successMonths) {
+          await queryClient.invalidateQueries({
+            queryKey: ["budget-month-data", connection.id, month],
+          });
+        }
+      }
+
+      setIsSaving(false);
+      setProgress({ completed: 0, total: 0 });
+
+      return results;
+    },
+    [connection, queryClient, clearEditsForKeys, setSaveError]
+  );
+
+  return { save, isSaving, progress };
+}

--- a/src/features/budget-management/hooks/useBulkAction.ts
+++ b/src/features/budget-management/hooks/useBulkAction.ts
@@ -85,10 +85,14 @@ export function useBulkAction(): UseBulkActionReturn {
       const rows: BulkPreviewRow[] = [];
 
       for (const cell of cells) {
-        const cat = categories.find((c) => c.id === cell.categoryId);
+        const targetMonthCat = monthDataMap[cell.month]?.find(
+          (c) => c.id === cell.categoryId
+        );
+        const metadataCat = categories.find((c) => c.id === cell.categoryId);
+        const cat = targetMonthCat ?? metadataCat;
         if (!cat) continue;
 
-        const currentBudgeted = cat.budgeted;
+        const currentBudgeted = targetMonthCat?.budgeted ?? cat.budgeted;
         let nextBudgeted: number | null = null;
 
         switch (action) {
@@ -152,7 +156,7 @@ export function useBulkAction(): UseBulkActionReturn {
         rows.push({
           month: cell.month,
           categoryId: cell.categoryId,
-          categoryName: cat.name,
+          categoryName: metadataCat?.name ?? cat.name,
           previousBudgeted: currentBudgeted,
           nextBudgeted,
         });

--- a/src/features/budget-management/hooks/useBulkAction.ts
+++ b/src/features/budget-management/hooks/useBulkAction.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback } from "react";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import { resolveSelectionCells } from "../lib/budgetSelectionUtils";
+import type {
+  BudgetCellSelection,
+  LoadedCategory,
+  StagedBudgetEdit,
+} from "../types";
+
+function shiftMonth(monthStr: string, delta: number): string {
+  const [y, mo] = monthStr.split("-");
+  const d = new Date(parseInt(y ?? "2026", 10), parseInt(mo ?? "1", 10) - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+export type BulkActionType =
+  | "copy-previous-month"
+  | "copy-from-month"
+  | "set-to-zero"
+  | "set-fixed"
+  | "apply-percentage"
+  | "avg-3-months"
+  | "avg-6-months"
+  | "avg-12-months";
+
+export type BulkActionParams = {
+  /** For "set-fixed": the fixed amount in minor units */
+  fixedAmount?: number;
+  /** For "copy-from-month": source month string */
+  sourceMonth?: string;
+  /** For "apply-percentage": multiplier, e.g. 1.1 for 10% increase */
+  percentage?: number;
+};
+
+export type BulkPreviewRow = {
+  month: string;
+  categoryId: string;
+  categoryName: string;
+  previousBudgeted: number;
+  nextBudgeted: number;
+};
+
+type UseBulkActionReturn = {
+  /**
+   * Resolve preview rows for a bulk action on a selection.
+   * Returns null if required params are missing or data is unavailable.
+   */
+  preview: (
+    action: BulkActionType,
+    selection: BudgetCellSelection,
+    months: string[],
+    categories: LoadedCategory[],
+    monthDataMap: Record<string, LoadedCategory[]>,
+    params?: BulkActionParams
+  ) => BulkPreviewRow[] | null;
+
+  /**
+   * Stage all preview rows as a single undoable bulk edit.
+   */
+  apply: (rows: BulkPreviewRow[]) => void;
+};
+
+/**
+ * Resolves and applies bulk budget actions on a rectangular cell selection.
+ *
+ * Preview is pure (no side effects). Apply stages all rows as one undo step.
+ */
+export function useBulkAction(): UseBulkActionReturn {
+  const stageBulkEdits = useBudgetEditsStore((s) => s.stageBulkEdits);
+
+  const preview = useCallback(
+    (
+      action: BulkActionType,
+      selection: BudgetCellSelection,
+      months: string[],
+      categories: LoadedCategory[],
+      monthDataMap: Record<string, LoadedCategory[]>,
+      params?: BulkActionParams
+    ): BulkPreviewRow[] | null => {
+      const cells = resolveSelectionCells(selection, months, categories);
+      if (cells.length === 0) return null;
+
+      const rows: BulkPreviewRow[] = [];
+
+      for (const cell of cells) {
+        const cat = categories.find((c) => c.id === cell.categoryId);
+        if (!cat) continue;
+
+        const currentBudgeted = cat.budgeted;
+        let nextBudgeted: number | null = null;
+
+        switch (action) {
+          case "set-to-zero":
+            nextBudgeted = 0;
+            break;
+
+          case "set-fixed":
+            if (params?.fixedAmount === undefined) return null;
+            nextBudgeted = params.fixedAmount;
+            break;
+
+          case "apply-percentage":
+            if (params?.percentage === undefined) return null;
+            nextBudgeted = Math.round(currentBudgeted * params.percentage);
+            break;
+
+          case "copy-previous-month": {
+            const monthIdx = months.indexOf(cell.month);
+            if (monthIdx <= 0) continue;
+            const prevMonth = months[monthIdx - 1];
+            if (!prevMonth) continue;
+            const prevCats = monthDataMap[prevMonth];
+            if (!prevCats) continue;
+            const prevCat = prevCats.find((c) => c.id === cell.categoryId);
+            if (!prevCat) continue;
+            nextBudgeted = prevCat.budgeted;
+            break;
+          }
+
+          case "copy-from-month": {
+            if (!params?.sourceMonth) return null;
+            const sourceCats = monthDataMap[params.sourceMonth];
+            if (!sourceCats) return null;
+            const sourceCat = sourceCats.find((c) => c.id === cell.categoryId);
+            if (!sourceCat) continue;
+            nextBudgeted = sourceCat.budgeted;
+            break;
+          }
+
+          case "avg-3-months":
+          case "avg-6-months":
+          case "avg-12-months": {
+            const n = action === "avg-3-months" ? 3 : action === "avg-6-months" ? 6 : 12;
+            const vals: number[] = [];
+            let m = cell.month;
+            for (let i = 0; i < n; i++) {
+              m = shiftMonth(m, -1);
+              const cats = monthDataMap[m];
+              const found = cats?.find((c) => c.id === cell.categoryId);
+              if (found !== undefined) vals.push(found.budgeted);
+            }
+            if (vals.length === 0) continue;
+            nextBudgeted = Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
+            break;
+          }
+        }
+
+        if (nextBudgeted === null) continue;
+
+        rows.push({
+          month: cell.month,
+          categoryId: cell.categoryId,
+          categoryName: cat.name,
+          previousBudgeted: currentBudgeted,
+          nextBudgeted,
+        });
+      }
+
+      return rows.length > 0 ? rows : null;
+    },
+    []
+  );
+
+  const apply = useCallback(
+    (rows: BulkPreviewRow[]) => {
+      const edits: StagedBudgetEdit[] = rows.map((row) => ({
+        month: row.month,
+        categoryId: row.categoryId,
+        nextBudgeted: row.nextBudgeted,
+        previousBudgeted: row.previousBudgeted,
+        source: "bulk-action",
+      }));
+      stageBulkEdits(edits);
+    },
+    [stageBulkEdits]
+  );
+
+  return { preview, apply };
+}

--- a/src/features/budget-management/hooks/useCategoryTransfer.ts
+++ b/src/features/budget-management/hooks/useCategoryTransfer.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+import type { CategoryTransferInput } from "../types";
+
+type UseCategoryTransferReturn = {
+  transfer: (month: string, input: CategoryTransferInput) => Promise<void>;
+  isPending: boolean;
+  error: string | null;
+};
+
+/**
+ * Envelope-mode: immediate category-to-category budget transfer.
+ *
+ * Calls POST /months/{month}/categorytransfers directly — bypasses the staged
+ * edits pipeline. On success, invalidates the affected month's TanStack Query
+ * cache so the grid reloads with the updated balances.
+ *
+ * This is an immediate action: it takes effect at the time the user confirms.
+ * It does not go through the staged save panel.
+ */
+export function useCategoryTransfer(): UseCategoryTransferReturn {
+  const connection = useConnectionStore(selectActiveInstance);
+  const queryClient = useQueryClient();
+
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const transfer = useCallback(
+    async (month: string, input: CategoryTransferInput): Promise<void> => {
+      if (!connection) throw new Error("No active connection");
+
+      setIsPending(true);
+      setError(null);
+
+      try {
+        await apiRequest(connection, `/months/${month}/categorytransfers`, {
+          method: "POST",
+          body: {
+            amount: input.amount,
+            categoryId: input.fromCategoryId,
+            transferCategoryId: input.toCategoryId,
+          },
+        });
+
+        await queryClient.invalidateQueries({
+          queryKey: ["budget-month-data", connection.id, month],
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Transfer failed";
+        setError(message);
+        throw err;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [connection, queryClient]
+  );
+
+  return { transfer, isPending, error };
+}

--- a/src/features/budget-management/hooks/useEffectiveMonthData.ts
+++ b/src/features/budget-management/hooks/useEffectiveMonthData.ts
@@ -1,0 +1,204 @@
+"use client";
+
+import { useMemo } from "react";
+import { useMonthData } from "./useMonthData";
+import { useIncomeBudgets } from "./useIncomeBudgets";
+import { useBudgetMode } from "./useBudgetMode";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
+import type { LoadedMonthState } from "../types";
+
+/**
+ * Returns a derived LoadedMonthState for the given month with three layers of
+ * local overrides applied — no refetch required on any of them:
+ *
+ * Cascade — Prior-month carry-forward (all modes):
+ *   priorDelta = Σ (nextBudgeted - previousBudgeted) for all edits in months < M
+ *   summary.incomeAvailable -= priorDelta
+ *   summary.toBudget        -= priorDelta
+ *
+ * Layer 1 — Income budgets (Tracking mode only):
+ *   Income category `budgeted` values come from the reflect_budgets query
+ *   (POST /run-query). In Tracking mode, income categories are budgeted but
+ *   the per-month endpoint doesn't carry those values — this layer fills them
+ *   in. Income group `budgeted` is derived as the sum of its categories.
+ *   The summary totals are NOT touched here (the API's summary is already
+ *   correct in Tracking mode).
+ *
+ * Layer 2 — Staged edits:
+ *   delta = edit.nextBudgeted - baselineBudgeted (after Layer 1)
+ *   category.budgeted = edit.nextBudgeted
+ *   category.balance += delta
+ *   group.budgeted += delta
+ *   group.balance += delta
+ *   summary.totalBudgeted -= delta  (skipped in Tracking mode for hidden categories)
+ *   summary.totalBalance += delta   (skipped in Tracking mode for hidden categories)
+ *   summary.toBudget -= delta        (skipped in Tracking mode for hidden categories)
+ *
+ * Returns undefined while server state is loading or month is null.
+ */
+export function useEffectiveMonthData(month: string | null | undefined): {
+  data: LoadedMonthState | undefined;
+  isLoading: boolean;
+  error: unknown;
+} {
+  const { data: serverState, isLoading: monthLoading, error } = useMonthData(month);
+  const { data: budgetMode } = useBudgetMode();
+  const isTracking = budgetMode === "tracking";
+
+  // Collect income category IDs from server state for the income budgets query.
+  // Income categories are consistent across months, so any loaded month works.
+  const incomeCategoryIds = useMemo(
+    () =>
+      serverState
+        ? Object.values(serverState.categoriesById)
+            .filter((c) => c.isIncome)
+            .map((c) => c.id)
+        : [],
+    [serverState]
+  );
+
+  const {
+    data: allIncomeBudgets,
+    isLoading: incomeBudgetsLoading,
+  } = useIncomeBudgets(incomeCategoryIds, isTracking);
+
+  // Subscribe to the full edits map — filter by month inside the memo.
+  const allEdits = useBudgetEditsStore((s) => s.edits);
+
+  const data = useMemo<LoadedMonthState | undefined>(() => {
+    if (!serverState || !month) return serverState;
+
+    // ── Layer 1: Income budgets (Tracking mode) ──────────────────────────────
+    const incomeBudgetForMonth = isTracking ? allIncomeBudgets?.get(month) : undefined;
+
+    // ── Layer 2: Staged edits ─────────────────────────────────────────────────
+    const prefix = `${month}:`;
+    const editEntries = Object.entries(allEdits).filter(([k]) =>
+      k.startsWith(prefix)
+    );
+
+    // Cascade: sum of deltas from all edits in months strictly before this month.
+    // In envelope budgeting, allocating more in a prior month reduces the carry-forward
+    // pool available to every subsequent month (incomeAvailable and toBudget).
+    // In Tracking mode, effectively-hidden category edits are excluded — a category is
+    // effectively hidden if cat.hidden=true OR its parent group is hidden.
+    const priorDelta = Object.entries(allEdits).reduce((sum, [key, edit]) => {
+      const editMonth = key.split(":")[0];
+      if (!editMonth || editMonth >= month) return sum;
+      if (isTracking) {
+        const catId = key.slice(editMonth.length + 1);
+        const cat = serverState.categoriesById[catId];
+        const group = cat ? serverState.groupsById[cat.groupId] : undefined;
+        if (cat?.hidden || group?.hidden) return sum;
+      }
+      return sum + (edit.nextBudgeted - edit.previousBudgeted);
+    }, 0);
+
+    // Skip all work if nothing to apply.
+    if (!incomeBudgetForMonth && editEntries.length === 0 && priorDelta === 0)
+      return serverState;
+
+    // Shallow-clone the structures we will mutate.
+    const summary = { ...serverState.summary };
+    const groupsById = { ...serverState.groupsById };
+    const categoriesById = { ...serverState.categoriesById };
+
+    // ── Apply cascade from prior months ───────────────────────────────────────
+    // Allocating more in an earlier month reduces the carry-forward pool here.
+    if (priorDelta !== 0) {
+      summary.incomeAvailable -= priorDelta;
+      summary.toBudget -= priorDelta;
+    }
+
+    // ── Apply Layer 1 ─────────────────────────────────────────────────────────
+    if (incomeBudgetForMonth) {
+      // Track per-group budget sums so we can update income group totals.
+      const incomeGroupBudgetDelta = new Map<string, number>();
+
+      for (const [catId, budgeted] of incomeBudgetForMonth) {
+        const serverCat = serverState.categoriesById[catId];
+        if (!serverCat?.isIncome) continue;
+        if (serverCat.budgeted === budgeted) continue;
+
+        categoriesById[catId] = { ...serverCat, budgeted };
+
+        const prev = incomeGroupBudgetDelta.get(serverCat.groupId) ?? 0;
+        incomeGroupBudgetDelta.set(
+          serverCat.groupId,
+          prev + (budgeted - serverCat.budgeted)
+        );
+      }
+
+      // Apply accumulated deltas to income groups.
+      for (const [groupId, delta] of incomeGroupBudgetDelta) {
+        const existing = groupsById[groupId] ?? serverState.groupsById[groupId];
+        if (existing) {
+          groupsById[groupId] = {
+            ...existing,
+            budgeted: existing.budgeted + delta,
+          };
+        }
+      }
+      // summary.totalBudgeted is NOT updated — the API's summary already
+      // reflects income budgets in Tracking mode.
+    }
+
+    // ── Apply Layer 2 ─────────────────────────────────────────────────────────
+    for (const [key, edit] of editEntries) {
+      const catId = key.slice(prefix.length);
+      // Use the post-Layer-1 category as baseline (it may have been updated above).
+      const baseCat = categoriesById[catId] ?? serverState.categoriesById[catId];
+      if (!baseCat) continue;
+
+      const delta = edit.nextBudgeted - baseCat.budgeted;
+      if (delta === 0) continue;
+
+      categoriesById[catId] = {
+        ...baseCat,
+        budgeted: edit.nextBudgeted,
+        balance: baseCat.balance + delta,
+      };
+
+      const groupId = baseCat.groupId;
+      const existingGroup = groupsById[groupId] ?? serverState.groupsById[groupId];
+
+      // A category is effectively hidden if its own flag is true OR its parent group
+      // is hidden (group-hidden categories don't carry cat.hidden=true themselves).
+      const effectivelyHidden = baseCat.hidden || (existingGroup?.hidden ?? false);
+
+      // In Tracking mode, an effectively-hidden category only propagates to its group
+      // when the group itself is also hidden. A hidden category inside a visible group
+      // must not pollute the visible group's aggregate.
+      const skipGroupUpdate = isTracking && effectivelyHidden && !(existingGroup?.hidden ?? false);
+
+      if (!skipGroupUpdate && existingGroup) {
+        groupsById[groupId] = {
+          ...existingGroup,
+          budgeted: existingGroup.budgeted + delta,
+          balance: existingGroup.balance + delta,
+        };
+      }
+
+      // In Tracking mode, effectively-hidden category edits never affect the top-level
+      // summary rows regardless of whether the group is hidden or visible.
+      if (!(isTracking && effectivelyHidden)) {
+        // totalBudgeted is always ≤ 0 (more budget allocated → more negative)
+        summary.totalBudgeted -= delta;
+        summary.totalBalance += delta;
+        // toBudget moves opposite to totalBudgeted: budgeting more leaves less to allocate
+        summary.toBudget -= delta;
+      }
+    }
+
+    return {
+      summary,
+      groupsById,
+      categoriesById,
+      groupOrder: serverState.groupOrder,
+    };
+  }, [serverState, allEdits, month, isTracking, allIncomeBudgets]);
+
+  const isLoading = monthLoading || (isTracking && incomeBudgetsLoading);
+
+  return { data, isLoading, error };
+}

--- a/src/features/budget-management/hooks/useEffectiveMonthData.ts
+++ b/src/features/budget-management/hooks/useEffectiveMonthData.ts
@@ -60,6 +60,7 @@ export function useEffectiveMonthData(month: string | null | undefined): {
   const {
     data: allIncomeBudgets,
     isLoading: incomeBudgetsLoading,
+    error: incomeBudgetsError,
   } = useIncomeBudgets(incomeCategoryIds, isTracking);
 
   // Subscribe to the full edits map — filter by month inside the memo.
@@ -119,14 +120,16 @@ export function useEffectiveMonthData(month: string | null | undefined): {
         const serverCat = serverState.categoriesById[catId];
         if (!serverCat?.isIncome) continue;
         if (serverCat.budgeted === budgeted) continue;
+        const delta = budgeted - serverCat.budgeted;
 
-        categoriesById[catId] = { ...serverCat, budgeted };
+        categoriesById[catId] = {
+          ...serverCat,
+          budgeted,
+          balance: serverCat.balance + delta,
+        };
 
         const prev = incomeGroupBudgetDelta.get(serverCat.groupId) ?? 0;
-        incomeGroupBudgetDelta.set(
-          serverCat.groupId,
-          prev + (budgeted - serverCat.budgeted)
-        );
+        incomeGroupBudgetDelta.set(serverCat.groupId, prev + delta);
       }
 
       // Apply accumulated deltas to income groups.
@@ -136,6 +139,7 @@ export function useEffectiveMonthData(month: string | null | undefined): {
           groupsById[groupId] = {
             ...existing,
             budgeted: existing.budgeted + delta,
+            balance: existing.balance + delta,
           };
         }
       }
@@ -199,6 +203,8 @@ export function useEffectiveMonthData(month: string | null | undefined): {
   }, [serverState, allEdits, month, isTracking, allIncomeBudgets]);
 
   const isLoading = monthLoading || (isTracking && incomeBudgetsLoading);
+  const effectiveError =
+    error ?? (isTracking && incomeBudgetsError ? incomeBudgetsError : null);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error: effectiveError };
 }

--- a/src/features/budget-management/hooks/useIncomeBudgets.ts
+++ b/src/features/budget-management/hooks/useIncomeBudgets.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type IncomeBudgetRow = {
+  month: number;    // YYYYMM integer e.g. 202507
+  category: string; // category UUID
+  amount: number;   // budgeted amount in minor units
+  id: string;       // "YYYYMM-categoryId"
+};
+
+/** run-query always wraps its result in { data: ... } */
+type RunQueryResponse = { data: IncomeBudgetRow[] };
+
+/** Converts a YYYYMM integer to a YYYY-MM string. */
+function toMonthString(n: number): string {
+  const s = String(n);
+  return `${s.slice(0, 4)}-${s.slice(4, 6)}`;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches budgeted amounts for income categories across all months via the
+ * ActualQL run-query endpoint (POST /run-query, table: reflect_budgets).
+ *
+ * Returns a two-level Map: YYYY-MM → categoryId → budgeted amount.
+ * The query returns all months at once, so the map covers the full history
+ * without needing per-month fetches.
+ *
+ * Only enabled in Tracking mode — pass `enabled: false` to skip entirely.
+ */
+export function useIncomeBudgets(
+  incomeCategoryIds: string[],
+  enabled: boolean
+): {
+  data: Map<string, Map<string, number>> | undefined;
+  isLoading: boolean;
+  error: unknown;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  // Stable sorted key so React Query deduplicates calls across components.
+  const sortedIds = [...incomeCategoryIds].sort();
+
+  const query = useQuery({
+    queryKey: ["income-budgets", connection?.id, sortedIds.join(",")],
+    queryFn: async () => {
+      if (!connection) throw new Error("No active connection");
+
+      const response = await apiRequest<RunQueryResponse>(
+        connection,
+        "/run-query",
+        {
+          method: "POST",
+          body: {
+            ActualQLquery: {
+              table: "reflect_budgets",
+              filter: {
+                category: { $oneof: sortedIds },
+              },
+              select: ["month", "category", "amount"],
+            },
+          },
+        }
+      );
+
+      // Build a two-level Map: YYYY-MM → categoryId → amount.
+      const result = new Map<string, Map<string, number>>();
+      for (const row of response.data) {
+        const monthStr = toMonthString(row.month);
+        if (!result.has(monthStr)) {
+          result.set(monthStr, new Map());
+        }
+        result.get(monthStr)!.set(row.category, row.amount);
+      }
+      return result;
+    },
+    enabled: enabled && !!connection && sortedIds.length > 0,
+    // Income budgets change infrequently — cache aggressively.
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/src/features/budget-management/hooks/useLocalState.ts
+++ b/src/features/budget-management/hooks/useLocalState.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Thin wrapper around useState that accepts a functional updater overload,
+ * matching React's own setState signature for use with complex local state.
+ */
+export function useLocalState<T>(
+  initial: T | (() => T)
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(initial);
+  const dispatch = useCallback<React.Dispatch<React.SetStateAction<T>>>(
+    (action) => {
+      setValue(action);
+    },
+    []
+  );
+  return [value, dispatch];
+}

--- a/src/features/budget-management/hooks/useMonthData.ts
+++ b/src/features/budget-management/hooks/useMonthData.ts
@@ -1,0 +1,187 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+import type {
+  BudgetMonthSummary,
+  LoadedCategory,
+  LoadedGroup,
+  LoadedMonthState,
+} from "../types";
+
+// ─── API response type ─────────────────────────────────────────────────────────
+
+type ApiMonthResponse = {
+  data: {
+    month: string;
+    incomeAvailable: number;
+    lastMonthOverspent: number;
+    forNextMonth: number;
+    totalBudgeted: number;
+    toBudget: number;
+    fromLastMonth: number;
+    totalIncome: number;
+    totalSpent: number;
+    totalBalance: number;
+    categoryGroups: Array<
+      // Expense group
+      | {
+          id: string;
+          name: string;
+          is_income: false;
+          hidden: boolean;
+          budgeted: number | null;
+          spent: number | null;
+          balance: number | null;
+          categories: Array<{
+            id: string;
+            name: string;
+            is_income: false;
+            hidden?: boolean;
+            group_id: string;
+            budgeted: number | null;
+            spent: number | null;
+            balance: number | null;
+            carryover?: boolean;
+          }>;
+        }
+      // Income group
+      | {
+          id: string;
+          name: string;
+          is_income: true;
+          hidden: boolean;
+          received: number | null;
+          categories: Array<{
+            id: string;
+            name: string;
+            is_income: true;
+            hidden?: boolean;
+            group_id: string;
+            received: number | null;
+          }>;
+        }
+    >;
+  };
+};
+
+/**
+ * Fetches a single month's budget data from GET /months/{month}.
+ *
+ * Parses the response into a normalized LoadedMonthState with map-based
+ * lookup structures for O(1) category and group access.
+ *
+ * Income and expense groups have different schemas: income uses `received`
+ * while expense uses `budgeted`/`spent`/`balance`/`carryover`. The normalized
+ * LoadedCategory always exposes `actuals` (= received for income, spent for expense).
+ *
+ * Query key is scoped by connectionId and month for independent invalidation.
+ */
+export function useMonthData(month: string | null | undefined): {
+  data: LoadedMonthState | undefined;
+  isLoading: boolean;
+  error: unknown;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const query = useQuery({
+    queryKey: ["budget-month-data", connection?.id, month],
+    queryFn: async () => {
+      if (!connection) throw new Error("No active connection");
+      if (!month) throw new Error("No month specified");
+
+      const response = await apiRequest<ApiMonthResponse>(
+        connection,
+        `/months/${month}`
+      );
+
+      const d = response.data;
+
+      const summary: BudgetMonthSummary = {
+        month: d.month,
+        incomeAvailable: d.incomeAvailable,
+        lastMonthOverspent: d.lastMonthOverspent,
+        forNextMonth: d.forNextMonth,
+        // Always store as non-positive: API may return positive or negative depending on version.
+        totalBudgeted: d.totalBudgeted > 0 ? -d.totalBudgeted : d.totalBudgeted,
+        toBudget: d.toBudget,
+        fromLastMonth: d.fromLastMonth,
+        totalIncome: d.totalIncome,
+        totalSpent: d.totalSpent,
+        totalBalance: d.totalBalance,
+      };
+
+      const groupsById: Record<string, LoadedGroup> = {};
+      const categoriesById: Record<string, LoadedCategory> = {};
+      const groupOrder: string[] = [];
+
+      for (const g of d.categoryGroups) {
+        const categoryIds: string[] = [];
+
+        for (const c of g.categories) {
+          const cat: LoadedCategory = g.is_income
+            ? {
+                id: c.id,
+                name: c.name,
+                groupId: g.id,
+                groupName: g.name,
+                isIncome: true,
+                hidden: c.hidden ?? false,
+                budgeted: 0, // placeholder — income budgets fetched separately
+                actuals: (c as { received?: number | null }).received ?? 0,
+                balance: 0,
+                carryover: false,
+              }
+            : {
+                id: c.id,
+                name: c.name,
+                groupId: g.id,
+                groupName: g.name,
+                isIncome: false,
+                hidden: c.hidden ?? false,
+                budgeted: (c as { budgeted?: number | null }).budgeted ?? 0,
+                actuals: (c as { spent?: number | null }).spent ?? 0,
+                balance: (c as { balance?: number | null }).balance ?? 0,
+                carryover: (c as { carryover?: boolean }).carryover ?? false,
+              };
+          categoriesById[c.id] = cat;
+          categoryIds.push(c.id);
+        }
+
+        const group: LoadedGroup = g.is_income
+          ? {
+              id: g.id,
+              name: g.name,
+              isIncome: true,
+              hidden: g.hidden,
+              categoryIds,
+              budgeted: 0,
+              actuals: g.received ?? 0,
+              balance: 0,
+            }
+          : {
+              id: g.id,
+              name: g.name,
+              isIncome: false,
+              hidden: g.hidden,
+              categoryIds,
+              budgeted: g.budgeted ?? 0,
+              actuals: g.spent ?? 0,
+              balance: g.balance ?? 0,
+            };
+        groupsById[g.id] = group;
+        groupOrder.push(g.id);
+      }
+
+      return { summary, groupsById, categoriesById, groupOrder } satisfies LoadedMonthState;
+    },
+    enabled: !!connection && !!month,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/src/features/budget-management/hooks/useNextMonthHold.ts
+++ b/src/features/budget-management/hooks/useNextMonthHold.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { apiRequest } from "@/lib/api/client";
+import type { NextMonthHoldInput } from "../types";
+
+type UseNextMonthHoldReturn = {
+  setHold: (month: string, input: NextMonthHoldInput) => Promise<void>;
+  clearHold: (month: string) => Promise<void>;
+  isPending: boolean;
+  error: string | null;
+};
+
+/**
+ * Envelope-mode: immediate next-month budget hold management.
+ *
+ * setHold calls POST /months/{month}/nextmonthbudgethold.
+ * clearHold calls DELETE /months/{month}/nextmonthbudgethold.
+ * Both bypass the staged edits pipeline and take effect immediately on confirm.
+ * Both invalidate the affected month's TanStack Query cache on success.
+ */
+export function useNextMonthHold(): UseNextMonthHoldReturn {
+  const connection = useConnectionStore(selectActiveInstance);
+  const queryClient = useQueryClient();
+
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const invalidateMonth = useCallback(
+    async (month: string) => {
+      if (!connection) return;
+      await queryClient.invalidateQueries({
+        queryKey: ["budget-month-data", connection.id, month],
+      });
+    },
+    [connection, queryClient]
+  );
+
+  const setHold = useCallback(
+    async (month: string, input: NextMonthHoldInput): Promise<void> => {
+      if (!connection) throw new Error("No active connection");
+
+      setIsPending(true);
+      setError(null);
+
+      try {
+        await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
+          method: "POST",
+          body: { amount: input.amount },
+        });
+        await invalidateMonth(month);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to set hold";
+        setError(message);
+        throw err;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [connection, invalidateMonth]
+  );
+
+  const clearHold = useCallback(
+    async (month: string): Promise<void> => {
+      if (!connection) throw new Error("No active connection");
+
+      setIsPending(true);
+      setError(null);
+
+      try {
+        await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
+          method: "DELETE",
+        });
+        await invalidateMonth(month);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to clear hold";
+        setError(message);
+        throw err;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [connection, invalidateMonth]
+  );
+
+  return { setHold, clearHold, isPending, error };
+}

--- a/src/features/budget-management/lib/budgetCsv.ts
+++ b/src/features/budget-management/lib/budgetCsv.ts
@@ -324,7 +324,9 @@ function minorToDecimal(minor: number): string {
 
 /** Converts a decimal string to minor units integer (e.g. "150.00" → 15000). */
 function decimalToMinor(decimal: string): number {
-  const parsed = parseFloat(decimal.replace(/,/g, ""));
+  const normalized = decimal.replace(/,/g, "").trim();
+  if (!/^[+-]?\d+(?:\.\d+)?$/.test(normalized)) return NaN;
+  const parsed = Number(normalized);
   if (isNaN(parsed)) return NaN;
   return Math.round(parsed * 100);
 }

--- a/src/features/budget-management/lib/budgetCsv.ts
+++ b/src/features/budget-management/lib/budgetCsv.ts
@@ -1,0 +1,397 @@
+/**
+ * Budget CSV serialization, parsing, and import matching.
+ *
+ * CSV format:
+ *   Header: Group Name,Category Name,YYYY-MM,YYYY-MM,...
+ *   Amounts: decimal strings (NOT minor units) — e.g. "150.00"
+ *   Empty cells: no change during import (treated as no-op)
+ */
+
+import type {
+  BudgetCellKey,
+  LoadedCategory,
+  LoadedGroup,
+  StagedBudgetEdit,
+} from "../types";
+
+// ─── Import types (re-exported for convenience) ───────────────────────────────
+
+export type BudgetCsvRow = {
+  groupName: string;
+  categoryName: string;
+  monthValues: Record<string, string>; // month → decimal string
+};
+
+export type ImportMatchStatus = "exact" | "suggested" | "unmatched";
+
+export type ImportMonthAvailability = "available" | "out-of-range" | "absent";
+
+export type ImportRowResult = {
+  csvRow: BudgetCsvRow;
+  matchedCategoryId: string | null;
+  matchedCategoryName: string | null;
+  matchedGroupName: string | null;
+  matchStatus: ImportMatchStatus;
+  suggestionKey?: string;
+  monthAvailability: Record<string, ImportMonthAvailability>;
+};
+
+export type ImportPreviewEntry = {
+  categoryId: string;
+  categoryName: string;
+  groupName: string;
+  month: string;
+  previousBudgeted: number; // minor units
+  nextBudgeted: number;     // minor units
+};
+
+export type BudgetExportOptions = {
+  months: string[];
+  includeHidden: boolean;
+  includeIncome: boolean;
+};
+
+// ─── Export ───────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a CSV string from loaded budget data.
+ * If stagedEdits is provided, cells with staged edits use the staged value
+ * instead of the persisted value (staged-view export, FR-031).
+ */
+export function exportToCsv(
+  months: string[],
+  groups: LoadedGroup[],
+  categoriesById: Record<string, LoadedCategory>,
+  opts: BudgetExportOptions,
+  stagedEdits?: Record<BudgetCellKey, StagedBudgetEdit>
+): string {
+  const header = ["Group Name", "Category Name", ...months]
+    .map(csvEscape)
+    .join(",");
+
+  const rows: string[] = [header];
+
+  for (const group of groups) {
+    if (!opts.includeIncome && group.isIncome) continue;
+    if (!opts.includeHidden && group.hidden) continue;
+
+    for (const catId of group.categoryIds) {
+      const cat = categoriesById[catId];
+      if (!cat) continue;
+      if (!opts.includeHidden && cat.hidden) continue;
+
+      const cells: string[] = [csvEscape(group.name), csvEscape(cat.name)];
+
+      for (const month of months) {
+        const key: BudgetCellKey = `${month}:${cat.id}`;
+        const staged = stagedEdits?.[key];
+        const minorValue = staged != null ? staged.nextBudgeted : cat.budgeted;
+        cells.push(csvEscape(minorToDecimal(minorValue)));
+      }
+
+      rows.push(cells.join(","));
+    }
+  }
+
+  return rows.join("\n");
+}
+
+/**
+ * Builds a blank CSV template (same structure as export, all amount cells empty).
+ */
+export function exportBlankTemplate(
+  months: string[],
+  groups: LoadedGroup[],
+  categoriesById: Record<string, LoadedCategory>,
+  opts: BudgetExportOptions
+): string {
+  const header = ["Group Name", "Category Name", ...months]
+    .map(csvEscape)
+    .join(",");
+
+  const rows: string[] = [header];
+
+  for (const group of groups) {
+    if (!opts.includeIncome && group.isIncome) continue;
+    if (!opts.includeHidden && group.hidden) continue;
+
+    for (const catId of group.categoryIds) {
+      const cat = categoriesById[catId];
+      if (!cat) continue;
+      if (!opts.includeHidden && cat.hidden) continue;
+
+      const blanks = months.map(() => "");
+      rows.push(
+        [csvEscape(group.name), csvEscape(cat.name), ...blanks].join(",")
+      );
+    }
+  }
+
+  return rows.join("\n");
+}
+
+// ─── Import parsing ───────────────────────────────────────────────────────────
+
+/**
+ * Parses raw CSV text into BudgetCsvRows.
+ * Expects first row to be a header with "Group Name", "Category Name",
+ * followed by month column headers.
+ */
+export function parseCsv(raw: string): BudgetCsvRow[] {
+  // Strip UTF-8 BOM that Excel and some tools prepend.
+  const stripped = raw.startsWith("\uFEFF") ? raw.slice(1) : raw;
+  const lines = stripped.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  const headerCells = parseCsvLine(lines[0] ?? "");
+  const monthColumns = headerCells.slice(2);
+
+  const rows: BudgetCsvRow[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCsvLine(lines[i] ?? "");
+    const groupName = (cells[0] ?? "").trim();
+    const categoryName = (cells[1] ?? "").trim();
+
+    if (!groupName && !categoryName) continue;
+
+    const monthValues: Record<string, string> = {};
+    for (let j = 0; j < monthColumns.length; j++) {
+      const month = monthColumns[j];
+      const value = cells[j + 2];
+      if (month && value !== undefined && value !== "") {
+        monthValues[month.trim()] = value.trim();
+      }
+    }
+
+    rows.push({ groupName, categoryName, monthValues });
+  }
+
+  return rows;
+}
+
+// ─── Import matching ──────────────────────────────────────────────────────────
+
+/**
+ * Matches parsed CSV rows to known categories.
+ * Primary match: exact case-insensitive groupName:categoryName key.
+ * Fallback: Levenshtein distance ≤ 2 (suggestion, requires user approval).
+ * Month availability classified as: available | out-of-range | absent.
+ */
+export function matchImportRows(
+  rows: BudgetCsvRow[],
+  categories: LoadedCategory[],
+  availableMonths: string[],
+  visibleMonths: string[]
+): ImportRowResult[] {
+  const availableSet = new Set(availableMonths);
+  const visibleSet = new Set(visibleMonths);
+
+  // Build exact-match lookup: "group:category" → category
+  const exactMap = new Map<string, LoadedCategory>();
+  for (const cat of categories) {
+    const key = makeMatchKey(cat.groupName, cat.name);
+    exactMap.set(key, cat);
+  }
+
+  const allKeys = Array.from(exactMap.keys());
+
+  return rows.map((row) => {
+    const rowKey = makeMatchKey(row.groupName, row.categoryName);
+
+    // Classify month availability for all months in this row
+    const monthAvailability: Record<string, ImportMonthAvailability> = {};
+    for (const month of Object.keys(row.monthValues)) {
+      if (!availableSet.has(month)) {
+        monthAvailability[month] = "absent";
+      } else if (!visibleSet.has(month)) {
+        monthAvailability[month] = "out-of-range";
+      } else {
+        monthAvailability[month] = "available";
+      }
+    }
+
+    // Exact match
+    const exactMatch = exactMap.get(rowKey);
+    if (exactMatch) {
+      return {
+        csvRow: row,
+        matchedCategoryId: exactMatch.id,
+        matchedCategoryName: exactMatch.name,
+        matchedGroupName: exactMatch.groupName,
+        matchStatus: "exact" as const,
+        monthAvailability,
+      };
+    }
+
+    // Suggestion: find closest key by Levenshtein distance ≤ 2
+    let bestKey: string | null = null;
+    let bestDist = Infinity;
+    for (const key of allKeys) {
+      const dist = levenshtein(rowKey, key);
+      if (dist < bestDist && dist <= 2) {
+        bestDist = dist;
+        bestKey = key;
+      }
+    }
+
+    if (bestKey !== null) {
+      const suggested = exactMap.get(bestKey)!;
+      return {
+        csvRow: row,
+        matchedCategoryId: suggested.id,
+        matchedCategoryName: suggested.name,
+        matchedGroupName: suggested.groupName,
+        matchStatus: "suggested" as const,
+        suggestionKey: bestKey,
+        monthAvailability,
+      };
+    }
+
+    return {
+      csvRow: row,
+      matchedCategoryId: null,
+      matchedCategoryName: null,
+      matchedGroupName: null,
+      matchStatus: "unmatched" as const,
+      monthAvailability,
+    };
+  });
+}
+
+/**
+ * Builds the final list of import preview entries from approved import rows.
+ * Only rows with matchStatus "exact" or "suggested" (explicitly approved by user)
+ * and with monthAvailability "available" produce preview entries.
+ * "out-of-range" and "absent" months are excluded — handled separately by UI.
+ */
+export function buildImportPreview(
+  approved: ImportRowResult[],
+  groups: LoadedGroup[],
+  categoriesById: Record<string, LoadedCategory>
+): ImportPreviewEntry[] {
+  const entries: ImportPreviewEntry[] = [];
+
+  for (const result of approved) {
+    if (!result.matchedCategoryId) continue;
+
+    for (const [month, decimalStr] of Object.entries(result.csvRow.monthValues)) {
+      const avail = result.monthAvailability[month];
+      if (avail !== "available") continue;
+
+      const nextBudgeted = decimalToMinor(decimalStr);
+      if (isNaN(nextBudgeted)) continue;
+
+      // Find the current persisted budgeted for this category from categoriesById.
+      const cat = categoriesById[result.matchedCategoryId];
+      const previousBudgeted = cat?.budgeted ?? 0;
+
+      // Resolve groupName from the groups list (for display purposes).
+      let groupName = result.matchedGroupName ?? "";
+      if (!groupName) {
+        for (const g of groups) {
+          if (g.categoryIds.includes(result.matchedCategoryId)) {
+            groupName = g.name;
+            break;
+          }
+        }
+      }
+
+      entries.push({
+        categoryId: result.matchedCategoryId,
+        categoryName: result.matchedCategoryName ?? "",
+        groupName,
+        month,
+        previousBudgeted,
+        nextBudgeted,
+      });
+    }
+  }
+
+  return entries;
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+function makeMatchKey(groupName: string, categoryName: string): string {
+  return `${groupName.trim().toLowerCase()}:${categoryName.trim().toLowerCase()}`;
+}
+
+/** Converts minor units integer to a decimal string (e.g. 15000 → "150.00"). */
+function minorToDecimal(minor: number): string {
+  return (minor / 100).toFixed(2);
+}
+
+/** Converts a decimal string to minor units integer (e.g. "150.00" → 15000). */
+function decimalToMinor(decimal: string): number {
+  const parsed = parseFloat(decimal.replace(/,/g, ""));
+  if (isNaN(parsed)) return NaN;
+  return Math.round(parsed * 100);
+}
+
+/** Escapes a CSV cell value. Wraps in quotes if it contains comma, quote, or newline. */
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Parses a single CSV line, handling quoted fields. */
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 2;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      i++;
+      continue;
+    }
+    if (ch === "," && !inQuotes) {
+      cells.push(current);
+      current = "";
+      i++;
+      continue;
+    }
+    current += ch;
+    i++;
+  }
+  cells.push(current);
+  return cells;
+}
+
+/**
+ * Levenshtein distance between two strings (case-insensitive match keys).
+ * Returns early if distance exceeds threshold to avoid wasted work.
+ */
+function levenshtein(a: string, b: string, threshold = 3): number {
+  if (Math.abs(a.length - b.length) > threshold) return threshold + 1;
+
+  const m = a.length;
+  const n = b.length;
+  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+
+  for (let i = 1; i <= m; i++) {
+    let prev = i;
+    for (let j = 1; j <= n; j++) {
+      const temp = dp[j]!;
+      dp[j] =
+        a[i - 1] === b[j - 1]
+          ? dp[j - 1]!
+          : 1 + Math.min(dp[j - 1]!, dp[j]!, prev);
+      prev = temp;
+    }
+    dp[0] = i;
+  }
+
+  return dp[n]!;
+}

--- a/src/features/budget-management/lib/budgetMath.ts
+++ b/src/features/budget-management/lib/budgetMath.ts
@@ -1,0 +1,166 @@
+/**
+ * Minimal arithmetic expression parser for budget cell inputs.
+ *
+ * Supports: +, -, *, /, parentheses, integer and decimal literals.
+ * No eval — recursive descent only.
+ * Result is rounded to the nearest integer (minor units).
+ */
+
+type ParseResult =
+  | { ok: true; value: number }
+  | { ok: false; error: string };
+
+export function parseBudgetExpression(input: string): ParseResult {
+  // Strip thousands-separator commas so "12,000" parses as 12000.
+  const src = input.trim().replace(/,/g, "");
+  if (src === "") return { ok: false, error: "Empty expression" };
+
+  try {
+    const parser = new ExpressionParser(src);
+    const value = parser.parseExpression();
+    if (!isFinite(value)) {
+      return { ok: false, error: "Result is not a finite number" };
+    }
+    // Input is in dollars; return minor units (cents).
+    return { ok: true, value: Math.round(value * 100) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Parse error" };
+  }
+}
+
+// ─── Parser internals ─────────────────────────────────────────────────────────
+
+class ExpressionParser {
+  private pos = 0;
+
+  constructor(private readonly src: string) {}
+
+  parseExpression(): number {
+    let left = this.parseTerm();
+
+    while (this.pos < this.src.length) {
+      this.skipWhitespace();
+      const ch = this.src[this.pos];
+      if (ch === "+") {
+        this.pos++;
+        left += this.parseTerm();
+      } else if (ch === "-") {
+        this.pos++;
+        left -= this.parseTerm();
+      } else {
+        break;
+      }
+    }
+
+    this.skipWhitespace();
+    if (this.pos < this.src.length) {
+      throw new Error(`Unexpected character: "${this.src[this.pos]}"`);
+    }
+
+    return left;
+  }
+
+  private parseTerm(): number {
+    let left = this.parseFactor();
+
+    while (this.pos < this.src.length) {
+      this.skipWhitespace();
+      const ch = this.src[this.pos];
+      if (ch === "*") {
+        this.pos++;
+        left *= this.parseFactor();
+      } else if (ch === "/") {
+        this.pos++;
+        const divisor = this.parseFactor();
+        if (divisor === 0) throw new Error("Division by zero");
+        left /= divisor;
+      } else {
+        break;
+      }
+    }
+
+    return left;
+  }
+
+  private parseFactor(): number {
+    this.skipWhitespace();
+
+    if (this.pos >= this.src.length) {
+      throw new Error("Unexpected end of expression");
+    }
+
+    const ch = this.src[this.pos];
+
+    if (ch === "(") {
+      this.pos++;
+      const value = this.parseInnerExpression();
+      this.skipWhitespace();
+      if (this.src[this.pos] !== ")") {
+        throw new Error("Missing closing parenthesis");
+      }
+      this.pos++;
+      return value;
+    }
+
+    if (ch === "-") {
+      this.pos++;
+      return -this.parseFactor();
+    }
+
+    return this.parseNumber();
+  }
+
+  /** Like parseExpression but does NOT check for trailing chars (used inside parens). */
+  private parseInnerExpression(): number {
+    let left = this.parseTerm();
+
+    while (this.pos < this.src.length) {
+      this.skipWhitespace();
+      const ch = this.src[this.pos];
+      if (ch === "+") {
+        this.pos++;
+        left += this.parseTerm();
+      } else if (ch === "-") {
+        this.pos++;
+        left -= this.parseTerm();
+      } else {
+        break;
+      }
+    }
+
+    return left;
+  }
+
+  private parseNumber(): number {
+    this.skipWhitespace();
+    const start = this.pos;
+
+    while (
+      this.pos < this.src.length &&
+      /[\d.]/.test(this.src[this.pos] ?? "")
+    ) {
+      this.pos++;
+    }
+
+    if (this.pos === start) {
+      throw new Error(
+        `Expected a number at position ${this.pos}, got "${this.src[this.pos]}"`
+      );
+    }
+
+    const numStr = this.src.slice(start, this.pos);
+    const value = parseFloat(numStr);
+
+    if (isNaN(value)) {
+      throw new Error(`Invalid number: "${numStr}"`);
+    }
+
+    return value;
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.src.length && /\s/.test(this.src[this.pos] ?? "")) {
+      this.pos++;
+    }
+  }
+}

--- a/src/features/budget-management/lib/budgetSelectionUtils.ts
+++ b/src/features/budget-management/lib/budgetSelectionUtils.ts
@@ -1,0 +1,74 @@
+/**
+ * Budget grid selection utilities.
+ *
+ * resolveSelectionCells: converts an anchor/focus BudgetCellSelection into
+ * an explicit flat list of (month, categoryId) pairs for the rectangular region.
+ *
+ * parsePastePayload: splits tab-and-newline-delimited clipboard text (the
+ * format produced by spreadsheet / grid copy operations) into a 2D array of
+ * cell strings. Distinct from parseCsv which handles comma-separated files.
+ */
+
+import type { BudgetCellSelection, LoadedCategory } from "../types";
+
+export type ResolvedCell = { month: string; categoryId: string };
+
+/**
+ * Resolves a BudgetCellSelection to a flat list of (month, categoryId) pairs.
+ * Uses the positions of anchor/focus months and categories in the provided
+ * ordered arrays to determine the rectangular range.
+ */
+export function resolveSelectionCells(
+  selection: BudgetCellSelection,
+  months: string[],
+  categories: LoadedCategory[]
+): ResolvedCell[] {
+  const anchorMonthIdx = months.indexOf(selection.anchorMonth);
+  const focusMonthIdx = months.indexOf(selection.focusMonth);
+  const anchorCatIdx = categories.findIndex(
+    (c) => c.id === selection.anchorCategoryId
+  );
+  const focusCatIdx = categories.findIndex(
+    (c) => c.id === selection.focusCategoryId
+  );
+
+  if (
+    anchorMonthIdx === -1 ||
+    focusMonthIdx === -1 ||
+    anchorCatIdx === -1 ||
+    focusCatIdx === -1
+  ) {
+    return [];
+  }
+
+  const minMonthIdx = Math.min(anchorMonthIdx, focusMonthIdx);
+  const maxMonthIdx = Math.max(anchorMonthIdx, focusMonthIdx);
+  const minCatIdx = Math.min(anchorCatIdx, focusCatIdx);
+  const maxCatIdx = Math.max(anchorCatIdx, focusCatIdx);
+
+  const cells: ResolvedCell[] = [];
+  for (let mi = minMonthIdx; mi <= maxMonthIdx; mi++) {
+    for (let ci = minCatIdx; ci <= maxCatIdx; ci++) {
+      const month = months[mi];
+      const cat = categories[ci];
+      if (month && cat) {
+        cells.push({ month, categoryId: cat.id });
+      }
+    }
+  }
+  return cells;
+}
+
+/**
+ * Parses tab-and-newline-delimited clipboard paste text into a 2D array.
+ * Rows are split on newlines; cells within each row are split on tabs.
+ * Trailing empty rows (from a trailing newline) are discarded.
+ */
+export function parsePastePayload(text: string): string[][] {
+  const rows = text.split(/\r?\n/);
+  // Remove trailing empty row produced by a trailing newline
+  if (rows.length > 0 && rows[rows.length - 1] === "") {
+    rows.pop();
+  }
+  return rows.map((row) => row.split("\t"));
+}

--- a/src/features/budget-management/lib/budgetValidation.ts
+++ b/src/features/budget-management/lib/budgetValidation.ts
@@ -1,0 +1,30 @@
+/**
+ * Budget cell validation helpers.
+ *
+ * LARGE_CHANGE_THRESHOLD: edits that exceed this absolute delta are flagged
+ * as suspiciously large in the pre-save review panel (FR-021).
+ * Value: 500,000 minor units = $5,000 at 100¢/$.
+ */
+
+import type { BudgetMode, LoadedCategory } from "../types";
+
+export const LARGE_CHANGE_THRESHOLD = 500_000;
+
+/**
+ * Returns true when the absolute difference between prev and next exceeds the
+ * large-change threshold. Used to surface pre-save warnings.
+ */
+export function isLargeChange(prev: number, next: number): boolean {
+  return Math.abs(next - prev) > LARGE_CHANGE_THRESHOLD;
+}
+
+/**
+ * Returns true when the category is an income category AND the active budget
+ * mode is envelope. In that case, the cell must be hard-blocked from editing.
+ */
+export function isIncomeBlocked(
+  category: LoadedCategory,
+  mode: BudgetMode
+): boolean {
+  return category.isIncome && mode === "envelope";
+}

--- a/src/features/budget-management/types.ts
+++ b/src/features/budget-management/types.ts
@@ -1,0 +1,185 @@
+/**
+ * Domain types for the Budget Management Workspace feature.
+ *
+ * All types are sourced from specs/001-budget-management-workspace/data-model.md.
+ * Amounts are in minor units (integer, 100ths of currency unit).
+ */
+
+// ─── Core domain ─────────────────────────────────────────────────────────────
+
+/**
+ * Lowercase canonical form for the feature.
+ * Mapped from overview's "Envelope" | "Tracking" | "Unidentified" at the hook boundary.
+ */
+export type BudgetMode = "envelope" | "tracking" | "unidentified";
+
+/** Composite key uniquely identifying a category-month intersection. */
+export type BudgetCellKey = `${string}:${string}`; // `${month}:${categoryId}`
+
+// ─── Loaded server data ───────────────────────────────────────────────────────
+
+/** Month-level summary totals — top-level fields from GET /months/{month}. */
+export type BudgetMonthSummary = {
+  month: string;
+  incomeAvailable: number;
+  lastMonthOverspent: number;
+  forNextMonth: number;
+  totalBudgeted: number;
+  toBudget: number;
+  fromLastMonth: number;
+  totalIncome: number;
+  totalSpent: number;
+  totalBalance: number;
+};
+
+/**
+ * A normalized category group.
+ * `categoryIds` preserves the API-returned category order within the group.
+ * `isIncome` is the authoritative flag — present at both group and category level in the API.
+ */
+export type LoadedGroup = {
+  id: string;
+  name: string;
+  isIncome: boolean;
+  hidden: boolean;
+  categoryIds: string[];  // ordered list — use with LoadedMonthState.categoriesById
+  budgeted: number;
+  /** Actual money flow for the month: `spent` (expense groups) or `received` (income groups). */
+  actuals: number;
+  balance: number;
+};
+
+/**
+ * A normalized budget category.
+ * `isIncome` is inherited from the parent group at parse time.
+ * `groupName` is denormalized at parse time.
+ */
+export type LoadedCategory = {
+  id: string;
+  name: string;
+  groupId: string;
+  groupName: string;
+  isIncome: boolean;
+  hidden: boolean;
+  budgeted: number;
+  /** Actual money flow for the month: `spent` (expense categories) or `received` (income categories). */
+  actuals: number;
+  balance: number;
+  carryover: boolean;
+};
+
+/**
+ * Normalized in-memory month state produced by useMonthData.
+ * `groupOrder` preserves the API-returned group order.
+ * Use groupOrder + groupsById to iterate groups in order.
+ */
+export type LoadedMonthState = {
+  summary: BudgetMonthSummary;
+  groupsById: Record<string, LoadedGroup>;
+  categoriesById: Record<string, LoadedCategory>;
+  groupOrder: string[];
+};
+
+// ─── Staged edits ─────────────────────────────────────────────────────────────
+
+/** Stored in budgetEditsStore as Record<BudgetCellKey, StagedBudgetEdit>. */
+export type StagedBudgetEdit = {
+  month: string;
+  categoryId: string;
+  nextBudgeted: number;
+  previousBudgeted: number;
+  source: "manual" | "paste" | "bulk-action" | "import";
+  saveError?: string;
+};
+
+/** Used by undo/redo in budgetEditsStore. */
+export type BudgetEditSnapshot = Record<BudgetCellKey, StagedBudgetEdit>;
+
+// ─── Navigation ───────────────────────────────────────────────────────────────
+
+export type NavDirection =
+  | "up" | "down" | "left" | "right"
+  | "shift-up" | "shift-down" | "shift-left" | "shift-right"
+  | "tab" | "shift-tab";
+
+/** What value the grid cells display. Only "budgeted" allows editing. */
+export type CellView = "budgeted" | "spent" | "balance";
+
+// ─── Selection ────────────────────────────────────────────────────────────────
+
+/** Local state within the workspace — not persisted. */
+export type BudgetCellSelection = {
+  anchorMonth: string;
+  anchorCategoryId: string;
+  focusMonth: string;
+  focusCategoryId: string;
+};
+
+/** Derived from BudgetCellSelection + StagedBudgetEdit map. */
+export type BudgetSelectionSummary = {
+  selectedMonths: string[];
+  selectedCategoryIds: string[];
+  totalCellsInSelection: number;
+  affectedCellCount: number;
+  totalStagedDelta: number;
+};
+
+// ─── Save ─────────────────────────────────────────────────────────────────────
+
+/** Returned by useBudgetSave after a save attempt. */
+export type BudgetSaveResult = {
+  month: string;
+  categoryId: string;
+  status: "success" | "error";
+  message?: string;
+};
+
+// ─── Envelope immediate actions ───────────────────────────────────────────────
+
+/** Input for POST /months/{month}/categorytransfers */
+export type CategoryTransferInput = {
+  fromCategoryId: string;
+  toCategoryId: string;
+  amount: number;
+};
+
+/** Input for POST /months/{month}/nextmonthbudgethold */
+export type NextMonthHoldInput = {
+  amount: number;
+};
+
+// ─── Store shape ──────────────────────────────────────────────────────────────
+
+/** Flat navigation item for the interleaved keyboard-nav list in BudgetWorkspace. */
+export type NavItem =
+  | { type: "category"; id: string }
+  | { type: "group"; id: string };
+
+export type BudgetEditsState = {
+  edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  undoStack: BudgetEditSnapshot[];
+  redoStack: BudgetEditSnapshot[];
+  /** Currently focused cell or group — synced by BudgetWorkspace so BudgetDraftPanel can read it. */
+  uiSelection: { month: string | null; categoryId: string | null; groupId: string | null };
+  /** The 12 months currently visible in the grid window — synced by BudgetManagementView. */
+  displayMonths: string[];
+};
+
+export type BudgetEditsActions = {
+  stageEdit: (edit: StagedBudgetEdit) => void;
+  stageBulkEdits: (edits: StagedBudgetEdit[]) => void;
+  removeEdit: (key: BudgetCellKey) => void;
+  discardAll: () => void;
+  clearEditsForMonths: (months: string[]) => void;
+  clearEditsForKeys: (keys: BudgetCellKey[]) => void;
+  setSaveError: (key: BudgetCellKey, message: string) => void;
+  clearSaveError: (key: BudgetCellKey) => void;
+  pushUndo: () => void;
+  undo: () => void;
+  redo: () => void;
+  hasPendingEdits: () => boolean;
+  /** Pass groupId to indicate a group row is selected; pass categoryId for a category cell.
+   *  The two are mutually exclusive — whichever is non-null takes precedence. */
+  setUiSelection: (month: string | null, categoryId: string | null, groupId?: string | null) => void;
+  setDisplayMonths: (months: string[]) => void;
+};

--- a/src/features/overview/lib/overviewQueries.ts
+++ b/src/features/overview/lib/overviewQueries.ts
@@ -1,4 +1,5 @@
 import { runQuery } from "@/lib/api/query";
+import { deriveBudgetMode } from "@/lib/budget/deriveBudgetMode";
 import type { ConnectionInstance } from "@/store/connection";
 import type { BudgetMode, BudgetOverviewSnapshot, OverviewStatKey } from "../types";
 
@@ -124,20 +125,7 @@ function formatBudgetingSince(dateString: string): string {
   });
 }
 
-function deriveBudgetMode(
-  zeroBudgetCount: number,
-  reflectBudgetCount: number
-): BudgetMode {
-  if (zeroBudgetCount > reflectBudgetCount) {
-    return "Envelope";
-  }
-
-  if (reflectBudgetCount > zeroBudgetCount) {
-    return "Tracking";
-  }
-
-  return "Unidentified";
-}
+// deriveBudgetMode is now shared from src/lib/budget/deriveBudgetMode.ts
 
 async function fetchOverviewCountWithRetry(
   connection: ConnectionInstance,

--- a/src/lib/budget/deriveBudgetMode.ts
+++ b/src/lib/budget/deriveBudgetMode.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared budget mode derivation utility.
+ *
+ * Returns the uppercase BudgetMode from overview/types.ts so that the overview
+ * feature requires zero changes after extraction. The budget-management feature
+ * normalizes to lowercase at the useBudgetMode hook boundary.
+ */
+
+import type { BudgetMode } from "@/features/overview/types";
+
+export function deriveBudgetMode(
+  zeroBudgetCount: number,
+  reflectBudgetCount: number
+): BudgetMode {
+  if (zeroBudgetCount > reflectBudgetCount) {
+    return "Envelope";
+  }
+
+  if (reflectBudgetCount > zeroBudgetCount) {
+    return "Tracking";
+  }
+
+  return "Unidentified";
+}

--- a/src/store/budgetEdits.ts
+++ b/src/store/budgetEdits.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { create } from "zustand";
+import type {
+  BudgetCellKey,
+  BudgetEditSnapshot,
+  BudgetEditsActions,
+  BudgetEditsState,
+  StagedBudgetEdit,
+} from "@/features/budget-management/types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeKey(edit: StagedBudgetEdit): BudgetCellKey {
+  return `${edit.month}:${edit.categoryId}`;
+}
+
+function snapshotEdits(
+  edits: Record<BudgetCellKey, StagedBudgetEdit>
+): BudgetEditSnapshot {
+  return { ...edits };
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+type BudgetEditsStore = BudgetEditsState & BudgetEditsActions;
+
+const MAX_UNDO_DEPTH = 50;
+
+export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
+  edits: {},
+  undoStack: [],
+  redoStack: [],
+  uiSelection: { month: null, categoryId: null, groupId: null },
+  displayMonths: [],
+
+  pushUndo() {
+    const { edits, undoStack } = get();
+    set({
+      undoStack: [...undoStack, snapshotEdits(edits)].slice(-MAX_UNDO_DEPTH),
+      redoStack: [],
+    });
+  },
+
+  stageEdit(edit) {
+    const { edits, undoStack } = get();
+    const key = makeKey(edit);
+    set({
+      undoStack: [...undoStack, snapshotEdits(edits)].slice(-MAX_UNDO_DEPTH),
+      redoStack: [],
+      edits: { ...edits, [key]: edit },
+    });
+  },
+
+  stageBulkEdits(newEdits) {
+    const { edits, undoStack } = get();
+    const patch: Record<BudgetCellKey, StagedBudgetEdit> = {};
+    for (const edit of newEdits) {
+      patch[makeKey(edit)] = edit;
+    }
+    set({
+      undoStack: [...undoStack, snapshotEdits(edits)].slice(-MAX_UNDO_DEPTH),
+      redoStack: [],
+      edits: { ...edits, ...patch },
+    });
+  },
+
+  removeEdit(key) {
+    const { edits, undoStack } = get();
+    if (!(key in edits)) return;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [key]: _removed, ...rest } = edits;
+    set({
+      undoStack: [...undoStack, { ...edits }].slice(-MAX_UNDO_DEPTH),
+      redoStack: [],
+      edits: rest as Record<BudgetCellKey, StagedBudgetEdit>,
+    });
+  },
+
+  discardAll() {
+    set({ edits: {}, undoStack: [], redoStack: [] });
+  },
+
+  clearEditsForMonths(months) {
+    const { edits } = get();
+    const monthSet = new Set(months);
+    const next: Record<BudgetCellKey, StagedBudgetEdit> = {};
+    for (const [key, edit] of Object.entries(edits)) {
+      if (!monthSet.has(edit.month)) {
+        next[key as BudgetCellKey] = edit;
+      }
+    }
+    set({ edits: next });
+  },
+
+  clearEditsForKeys(keys) {
+    const { edits } = get();
+    const keySet = new Set(keys);
+    const next: Record<BudgetCellKey, StagedBudgetEdit> = {};
+    for (const [key, edit] of Object.entries(edits)) {
+      if (!keySet.has(key as BudgetCellKey)) {
+        next[key as BudgetCellKey] = edit;
+      }
+    }
+    set({ edits: next });
+  },
+
+  setSaveError(key, message) {
+    const { edits } = get();
+    const existing = edits[key];
+    if (!existing) return;
+    set({ edits: { ...edits, [key]: { ...existing, saveError: message } } });
+  },
+
+  clearSaveError(key) {
+    const { edits } = get();
+    const existing = edits[key];
+    if (!existing) return;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { saveError: _saveError, ...rest } = existing;
+    set({ edits: { ...edits, [key]: rest as StagedBudgetEdit } });
+  },
+
+  undo() {
+    const { edits, undoStack, redoStack } = get();
+    if (undoStack.length === 0) return;
+    const previous = undoStack[undoStack.length - 1]!;
+    set({
+      edits: previous,
+      undoStack: undoStack.slice(0, -1),
+      redoStack: [...redoStack, snapshotEdits(edits)],
+    });
+  },
+
+  redo() {
+    const { edits, undoStack, redoStack } = get();
+    if (redoStack.length === 0) return;
+    const next = redoStack[redoStack.length - 1]!;
+    set({
+      edits: next,
+      undoStack: [...undoStack, snapshotEdits(edits)],
+      redoStack: redoStack.slice(0, -1),
+    });
+  },
+
+  hasPendingEdits() {
+    return Object.keys(get().edits).length > 0;
+  },
+
+  setUiSelection(month, categoryId, groupId = null) {
+    set({ uiSelection: { month, categoryId, groupId } });
+  },
+
+  setDisplayMonths(months) {
+    set({ displayMonths: months });
+  },
+}));


### PR DESCRIPTION
## Summary

Implements **RD-027** by adding `/budget-management`, a multi-month budget editing workspace built around the Budget Months API.

- add the budget management page, toolbar, 12-month grid, selection summary, and right-side draft panel
- mode-aware behavior for envelope and tracking budgets
- support staged cell editing, arithmetic input, keyboard navigation, clipboard paste, undo/redo, and save progress feedback
- add right-click bulk actions and year summary / selection details in the draft panel
- add CSV import/export with UTF-8 BOM plus import review and preview
- add envelope-mode immediate actions for next-month hold and category transfer
- derive and surface budget mode in overview and budget management flows
- wire the workspace into app shell, top bar, and sidebar navigation
- document the feature in FEATURES.md

<img width="1920" height="1065" alt="image" src="https://github.com/user-attachments/assets/a630ebc3-ab62-4a53-a977-709a8b51f9b4" />

<img width="1920" height="1065" alt="image" src="https://github.com/user-attachments/assets/fdf990a7-a1b5-4a28-82e7-af4eb8cbaf44" />

<img width="1920" height="1065" alt="image" src="https://github.com/user-attachments/assets/cdf8449e-4714-456c-b54a-ca4f3c881bb9" />



Closes #68 

## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser

## Notes

- Reviewers should pay particular attention to the distinction between **staged** budget edits and **immediate** envelope-mode actions. Cell edits, imports, paste, and bulk actions stay local until Save, while **Next Month Hold** and **Category Transfer** execute immediately in envelope mode and bypass the staged save flow.
- The default right-side panel state is the **Year summary** when no cell or group is selected; selected cells and groups switch the panel into contextual detail mode, while staged changes remain visible separately when edits exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Budget Management Workspace: 12-month interactive grid, toolbar, draft panel, dialogs (import/export/transfer/hold), selection/keyboard/clipboard support, expression editing, bulk actions, and staged multi-cell save with progress/retry.
* **Components & Hooks**
  * New UI panels, grid/cell components, dialogs, utility hooks, validation/math/CSV helpers, and typed domain types for budget flows.
* **Tests**
  * Added save-progress dialog test.
* **Documentation**
  * Clarified store responsibilities and feature docs for Budget Management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->