### PR TITLE
fix: tighten rule diagnostics shadow + impossible-range semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/src/features/rule-diagnostics/lib/checks/impossibleConditions.test.ts
+++ b/src/features/rule-diagnostics/lib/checks/impossibleConditions.test.ts
@@ -58,6 +58,35 @@ describe("impossibleConditions", () => {
     expect(impossibleConditions(ws([r]), ctx)).toHaveLength(1);
   });
 
+  it("flags `gt 5` + `gt 100` + `lt 50` (effective lower bound is the max)", () => {
+    // Effective: x > 100 AND x < 50 → empty. The earlier code returned the
+    // first matching gt (gt 5) and missed the contradiction.
+    const r = rule({
+      id: "r1",
+      conditions: [
+        { field: "amount", op: "gt", value: 5 },
+        { field: "amount", op: "gt", value: 100 },
+        { field: "amount", op: "lt", value: 50 },
+      ],
+    });
+    expect(impossibleConditions(ws([r]), ctx)).toHaveLength(1);
+  });
+
+  it("flags `gt 5` + `gte 5` + `lte 5` (tighter `gt` wins the tie-break)", () => {
+    // Effective: x > 5 AND x ≤ 5 → empty. The picked-first code would have
+    // chosen `gte 5` and `lte 5`, leaving the singleton {5} and missing the
+    // contradiction introduced by the additional `gt 5`.
+    const r = rule({
+      id: "r1",
+      conditions: [
+        { field: "amount", op: "gt", value: 5 },
+        { field: "amount", op: "gte", value: 5 },
+        { field: "amount", op: "lte", value: 5 },
+      ],
+    });
+    expect(impossibleConditions(ws([r]), ctx)).toHaveLength(1);
+  });
+
   it("flags `is \"X\"` + `isNot \"X\"`", () => {
     const r = rule({
       id: "r1",

--- a/src/features/rule-diagnostics/lib/checks/impossibleConditions.ts
+++ b/src/features/rule-diagnostics/lib/checks/impossibleConditions.ts
@@ -9,6 +9,48 @@ function asNumber(v: ConditionOrAction["value"]): number | null {
   return null;
 }
 
+/** Tightest lower bound across all gt/gte conditions on the same field.
+ *  At equal values, "gt" wins over "gte" (stricter narrows the range further). */
+function effectiveLowerBound(
+  conds: ConditionOrAction[]
+): { op: "gt" | "gte"; value: number } | null {
+  let best: { op: "gt" | "gte"; value: number } | null = null;
+  for (const c of conds) {
+    if (c.op !== "gt" && c.op !== "gte") continue;
+    const n = asNumber(c.value);
+    if (n === null) continue;
+    if (
+      best === null ||
+      n > best.value ||
+      (n === best.value && c.op === "gt" && best.op === "gte")
+    ) {
+      best = { op: c.op, value: n };
+    }
+  }
+  return best;
+}
+
+/** Tightest upper bound across all lt/lte conditions on the same field.
+ *  At equal values, "lt" wins over "lte". */
+function effectiveUpperBound(
+  conds: ConditionOrAction[]
+): { op: "lt" | "lte"; value: number } | null {
+  let best: { op: "lt" | "lte"; value: number } | null = null;
+  for (const c of conds) {
+    if (c.op !== "lt" && c.op !== "lte") continue;
+    const n = asNumber(c.value);
+    if (n === null) continue;
+    if (
+      best === null ||
+      n < best.value ||
+      (n === best.value && c.op === "lt" && best.op === "lte")
+    ) {
+      best = { op: c.op, value: n };
+    }
+  }
+  return best;
+}
+
 /** Find contradictory pairs within an `and`-combined rule's conditions on the same field. */
 function findContradictions(rule: Rule): string[] {
   if (rule.conditionsOp !== "and") return [];
@@ -70,9 +112,10 @@ function findContradictions(rule: Rule): string[] {
       }
     }
 
-    // Numeric range contradictions: gt X with lt Y when Y <= X, etc.
-    const gt = numericBound(conds, ["gt", "gte"]);
-    const lt = numericBound(conds, ["lt", "lte"]);
+    // Numeric range contradictions: collapse multiple gt/gte and lt/lte
+    // bounds into the tightest pair before checking for an empty range.
+    const gt = effectiveLowerBound(conds);
+    const lt = effectiveUpperBound(conds);
     if (gt !== null && lt !== null) {
       // gt 10 with lt 5 → 10 < 5 false: range is empty when lt-bound <= gt-bound.
       const invalid =
@@ -118,18 +161,6 @@ function findContradictions(rule: Rule): string[] {
     seen.add(c);
     return true;
   });
-
-  function numericBound(
-    conds: ConditionOrAction[],
-    ops: ("gt" | "gte" | "lt" | "lte")[]
-  ): { op: string; value: number } | null {
-    for (const c of conds) {
-      if (!ops.includes(c.op as "gt" | "gte" | "lt" | "lte")) continue;
-      const n = asNumber(c.value);
-      if (n !== null) return { op: c.op, value: n };
-    }
-    return null;
-  }
 }
 
 export const impossibleConditions: CheckFn = (ws, ctx) => {

--- a/src/features/rule-diagnostics/lib/checks/shadowedRules.test.ts
+++ b/src/features/rule-diagnostics/lib/checks/shadowedRules.test.ts
@@ -46,7 +46,7 @@ describe("shadowedRules check", () => {
         { field: "imported_payee", op: "contains", value: "Amazon" },
         { field: "amount", op: "gt", value: 100 },
       ],
-      actions: [{ field: "payee", op: "set", value: "p-amazon-big" }],
+      actions: [{ field: "payee", op: "set", value: "p-amazon" }],
     });
     const findings = shadowedRules(ws([earlier, later]), emptyCtx);
     expect(findings).toHaveLength(1);
@@ -66,7 +66,7 @@ describe("shadowedRules check", () => {
       id: "r2",
       stage: "post",
       conditions: [{ field: "imported_payee", op: "contains", value: "Amazon" }],
-      actions: [{ field: "payee", op: "set", value: "p-other" }],
+      actions: [{ field: "payee", op: "set", value: "p-amazon" }],
     });
     const findings = shadowedRules(ws([earlier, later]), emptyCtx);
     expect(findings).toHaveLength(0);

--- a/src/features/rule-diagnostics/lib/shadowDetection.test.ts
+++ b/src/features/rule-diagnostics/lib/shadowDetection.test.ts
@@ -24,7 +24,7 @@ describe("findShadowedPairs", () => {
         { field: "imported_payee", op: "contains", value: "Amazon" },
         { field: "amount", op: "gt", value: 100 },
       ],
-      actions: [{ field: "payee", op: "set", value: "p-amazon-big" }],
+      actions: [{ field: "payee", op: "set", value: "p-amazon" }],
     });
     const pairs = findShadowedPairs([earlier, later]);
     expect(pairs).toHaveLength(1);
@@ -131,7 +131,7 @@ describe("findShadowedPairs", () => {
     const later = rule({
       id: "r2",
       conditions: [{ field: "notes", op: "doesNotContain", value: "foo" }],
-      actions: [{ field: "category", op: "set", value: "c-2" }],
+      actions: [{ field: "category", op: "set", value: "c-1" }],
     });
     const pairs = findShadowedPairs([earlier, later]);
     expect(pairs).toHaveLength(1);
@@ -148,8 +148,42 @@ describe("findShadowedPairs", () => {
     const later = rule({
       id: "r2",
       conditions: [{ field: "payee", op: "is", value: "b" }],
-      actions: [{ field: "category", op: "set", value: "c-2" }],
+      actions: [{ field: "category", op: "set", value: "c-1" }],
     });
     expect(findShadowedPairs([earlier, later])).toHaveLength(1);
+  });
+
+  it("does NOT flag when later uses a different op on the same field (set vs prepend-notes)", () => {
+    // Earlier `set notes="X"` and later `prepend-notes "Y"` are distinct
+    // operations: the later one still has an effect (prepending Y), so it
+    // is not redundant.
+    const earlier = rule({
+      id: "r1",
+      conditions: [{ field: "imported_payee", op: "contains", value: "Amazon" }],
+      actions: [{ field: "notes", op: "set", value: "X" }],
+    });
+    const later = rule({
+      id: "r2",
+      conditions: [{ field: "imported_payee", op: "contains", value: "Amazon" }],
+      actions: [{ field: "notes", op: "prepend-notes", value: "Y" }],
+    });
+    expect(findShadowedPairs([earlier, later])).toHaveLength(0);
+  });
+
+  it("does NOT flag when later sets a different value than earlier on the same field", () => {
+    // Earlier `set category="A"` and later `set category="B"` write different
+    // values; the later rule overrides the earlier and is therefore not
+    // redundant — it must not be flagged as shadowed.
+    const earlier = rule({
+      id: "r1",
+      conditions: [{ field: "imported_payee", op: "contains", value: "Amazon" }],
+      actions: [{ field: "category", op: "set", value: "A" }],
+    });
+    const later = rule({
+      id: "r2",
+      conditions: [{ field: "imported_payee", op: "contains", value: "Amazon" }],
+      actions: [{ field: "category", op: "set", value: "B" }],
+    });
+    expect(findShadowedPairs([earlier, later])).toHaveLength(0);
   });
 });

--- a/src/features/rule-diagnostics/lib/shadowDetection.ts
+++ b/src/features/rule-diagnostics/lib/shadowDetection.ts
@@ -86,20 +86,23 @@ function actionsDominate(earlier: Rule, later: Rule): boolean {
   // Delete-transaction is always dominant.
   if (earlier.actions.some(isDeleteTransaction)) return true;
 
-  // Every field the later rule writes must also be written by the earlier rule.
+  // For every action the later rule performs, the earlier rule must perform
+  // an equivalent one — same op, same field, same value. A different op
+  // (e.g. set vs prepend-notes) or a different value (e.g. set category="A"
+  // vs set category="B") means the later rule is NOT redundant: it changes
+  // the result in a way the earlier rule does not.
   for (const la of later.actions) {
     if (la.op === "link-schedule") continue;
     if (la.op === "delete-transaction") {
-      // Later tries to delete, but we are checking if earlier shadows it. Earlier
-      // must also be a delete-transaction to dominate a delete.
       if (!earlier.actions.some(isDeleteTransaction)) return false;
       continue;
     }
     if (!la.field) return false;
     const writtenByEarlier = earlier.actions.some(
       (ea) =>
-        (ea.op === "set" || ea.op === la.op) &&
-        ea.field === la.field
+        ea.op === la.op &&
+        ea.field === la.field &&
+        jsonEqual(ea.value, la.value)
     );
     if (!writtenByEarlier) return false;
   }


### PR DESCRIPTION
## Summary

Fix issues with rule diagnostics.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser