### PR TITLE
feat/Add budget save review and category jump search

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -228,6 +228,7 @@ Spreadsheet-grade keyboard support — every shortcut is data-driven from a sing
 
 **View & visibility:**
 - `V` — cycle Budget → Actuals → Balance
+- `F` — open Jump to Category search; selecting a match scrolls and focuses that category in the current month, including hidden categories and collapsed groups
 - `H` — toggle hidden categories
 - `E` / `Shift+E` — expand all / collapse all groups
 - `[` / `]` — pan the visible 12-month window backward / forward by one month
@@ -243,7 +244,7 @@ Spreadsheet-grade keyboard support — every shortcut is data-driven from a sing
 **Help:**
 - `?` (or `F1`, `Ctrl/Cmd+/`, or the toolbar Shortcuts button) opens a two-column cheatsheet modal generated directly from the keymap — adding a future shortcut surfaces it here automatically. Renders `⌘`/`⌥`/`⇧` glyphs on macOS and `Ctrl`/`Alt`/`Shift` text elsewhere
 
-Bare-letter shortcuts (`V`, `H`, `E`, `[`, `]`) are scoped so they never fire while typing in a cell input.
+Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fire while typing in a cell input or modal search field.
 
 ### Right-Click Context Menu
 - Right-clicking any category budget cell opens a compact context menu with two sections:
@@ -263,8 +264,8 @@ Bare-letter shortcuts (`V`, `H`, `E`, `[`, `]`) are scoped so they never fire wh
 - Paste tab-delimited data from spreadsheets into the grid starting from the top-left selected cell; fills the corresponding rectangle without requiring pre-selection of exact dimensions
 
 ### Save Flow
-- **Single edit**: clicking Save in the top bar sends one `PATCH /months/{month}/categories/{id}` and shows a toast with the result
-- **Multiple edits**: clicking Save opens a non-dismissable progress dialog that sends one `PATCH` per cell sequentially (never in parallel) to avoid server race conditions
+- Clicking Save first opens a compact review summary grouped by month with total change count, affected month count, and net budget delta; users can skip this review on future saves
+- Confirming the review opens a non-dismissable progress dialog that sends one `PATCH` per cell sequentially (never in parallel) to avoid server race conditions
   - In-progress state: "Saving budget changes — N of M cells saved…" with a live progress bar
   - All-success state: cell count and affected months; dialog auto-closes after 3 seconds (manual close also available)
   - Partial or full failure state: amber header with a scrollable list of failed cells (month / category ID / error message); "Retry Failed" button re-reads only the still-failed keys from the store and re-sends them

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -82,6 +82,9 @@ export function TopBar() {
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [budgetSaveReviewSkipped, setBudgetSaveReviewSkipped] = useState(
+    () => readBudgetSaveReviewSkip()
+  );
   const [budgetSaveReviewEdits, setBudgetSaveReviewEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
 
@@ -173,7 +176,7 @@ export function TopBar() {
       const editSnapshot = { ...edits };
       if (Object.keys(editSnapshot).length === 0) return;
 
-      if (readBudgetSaveReviewSkip()) {
+      if (budgetSaveReviewSkipped) {
         setBudgetSaveEdits(editSnapshot);
         return;
       }
@@ -224,6 +227,12 @@ export function TopBar() {
     }
     setIsRefreshing(true);
     queryClient.invalidateQueries().then(() => setIsRefreshing(false));
+  }
+
+  function handleResetBudgetSaveReview() {
+    writeBudgetSaveReviewSkip(false);
+    setBudgetSaveReviewSkipped(false);
+    toast.success("Budget save review re-enabled.");
   }
 
   return (
@@ -345,6 +354,18 @@ export function TopBar() {
             Discard
           </Button>
 
+          {isBudgetPage && budgetSaveReviewSkipped && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={handleResetBudgetSaveReview}
+              title="Show the budget save review dialog before saving again"
+            >
+              Reset review
+            </Button>
+          )}
+
           <Button
             size="sm"
             className={cn(
@@ -367,7 +388,10 @@ export function TopBar() {
             setBudgetSaveReviewEdits(null);
           }}
           onConfirm={(skipReviewNextTime) => {
-            if (skipReviewNextTime) writeBudgetSaveReviewSkip(true);
+            if (skipReviewNextTime) {
+              writeBudgetSaveReviewSkip(true);
+              setBudgetSaveReviewSkipped(true);
+            }
             setBudgetSaveEdits(budgetSaveReviewEdits);
             setBudgetSaveReviewEdits(null);
           }}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -39,6 +39,11 @@ import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useBudgetSavePipeline } from "./useBudgetSavePipeline";
 import { useBudgetSave } from "@/features/budget-management/hooks/useBudgetSave";
 import { BudgetSaveProgressDialog } from "@/features/budget-management/components/BudgetSaveProgressDialog";
+import { BudgetSaveReviewDialog } from "@/features/budget-management/components/BudgetSaveReviewDialog";
+import {
+  readBudgetSaveReviewSkip,
+  writeBudgetSaveReviewSkip,
+} from "@/features/budget-management/lib/budgetSaveReview";
 import type { BudgetCellKey, StagedBudgetEdit } from "@/features/budget-management/types";
 
 type PendingAction =
@@ -77,6 +82,7 @@ export function TopBar() {
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [budgetSaveReviewEdits, setBudgetSaveReviewEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
 
   const activeInstance = useConnectionStore(selectActiveInstance);
@@ -104,7 +110,7 @@ export function TopBar() {
   const budgetUndo = useBudgetEditsStore((s) => s.undo);
   const budgetRedo = useBudgetEditsStore((s) => s.redo);
   const budgetDiscardAll = useBudgetEditsStore((s) => s.discardAll);
-  const { save: saveBudgetCells, isSaving: isBudgetSaving } = useBudgetSave();
+  const { isSaving: isBudgetSaving } = useBudgetSave();
 
   // Route-aware resolution
   const isBudgetPage = pathname?.startsWith("/budget-management") ?? false;
@@ -112,6 +118,8 @@ export function TopBar() {
   const canUndo = isBudgetPage ? budgetCanUndo : stagedCanUndo;
   const canRedo = isBudgetPage ? budgetCanRedo : stagedCanRedo;
   const isSaving = isBudgetPage ? (isBudgetSaving || budgetSaveEdits !== null) : isEntitySaving;
+  const saveDisabled =
+    !hasChanges || isSaving || (isBudgetPage && budgetSaveReviewEdits !== null);
 
   function handleDiscardAll() {
     if (isBudgetPage) {
@@ -162,28 +170,15 @@ export function TopBar() {
   async function handleSave() {
     if (isBudgetPage) {
       const edits = useBudgetEditsStore.getState().edits;
-      const editCount = Object.keys(edits).length;
-      if (editCount > 1) {
-        // Multi-edit: open progress dialog — it handles save internally
-        setBudgetSaveEdits({ ...edits });
+      const editSnapshot = { ...edits };
+      if (Object.keys(editSnapshot).length === 0) return;
+
+      if (readBudgetSaveReviewSkip()) {
+        setBudgetSaveEdits(editSnapshot);
         return;
       }
-      // Single edit: inline save with toast
-      try {
-        const results = await saveBudgetCells(edits);
-        const succeeded = results.filter((r) => r.status === "success").length;
-        const failed = results.filter((r) => r.status === "error").length;
-        if (failed === 0) {
-          toast.success(
-            `Saved ${succeeded} budget cell${succeeded !== 1 ? "s" : ""} successfully.`
-          );
-        } else {
-          toast.error(`${succeeded} saved, ${failed} failed.`);
-        }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Budget save failed.";
-        toast.error(msg);
-      }
+
+      setBudgetSaveReviewEdits(editSnapshot);
     } else {
       try {
         const { totalSucceeded, totalFailed } = await saveAll();
@@ -356,7 +351,7 @@ export function TopBar() {
               "h-7 text-xs bg-action text-action-foreground hover:bg-action-hover",
               hasChanges && !isSaving && "ring-2 ring-offset-1 ring-action/50"
             )}
-            disabled={!hasChanges || isSaving}
+            disabled={saveDisabled}
             onClick={handleSave}
           >
             <Save className="mr-1 h-3.5 w-3.5" />
@@ -364,6 +359,20 @@ export function TopBar() {
           </Button>
         </div>
       </header>
+
+      {budgetSaveReviewEdits !== null && (
+        <BudgetSaveReviewDialog
+          edits={budgetSaveReviewEdits}
+          onCancel={() => {
+            setBudgetSaveReviewEdits(null);
+          }}
+          onConfirm={(skipReviewNextTime) => {
+            if (skipReviewNextTime) writeBudgetSaveReviewSkip(true);
+            setBudgetSaveEdits(budgetSaveReviewEdits);
+            setBudgetSaveReviewEdits(null);
+          }}
+        />
+      )}
 
       {budgetSaveEdits !== null && (
         <BudgetSaveProgressDialog

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer flex size-4 shrink-0 items-center justify-center rounded-sm border border-input bg-background text-primary-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center"
+      >
+        <CheckIcon className="size-3" aria-hidden="true" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.test.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BudgetSaveReviewDialog } from "./BudgetSaveReviewDialog";
+import { LARGE_CHANGE_THRESHOLD } from "../lib/budgetValidation";
+import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+
+const edits: Record<BudgetCellKey, StagedBudgetEdit> = {
+  "2026-04:cat-1": {
+    month: "2026-04",
+    categoryId: "cat-1",
+    nextBudgeted: LARGE_CHANGE_THRESHOLD + 1,
+    previousBudgeted: 0,
+    source: "manual",
+  },
+  "2026-05:cat-2": {
+    month: "2026-05",
+    categoryId: "cat-2",
+    nextBudgeted: 5000,
+    previousBudgeted: 7000,
+    source: "paste",
+  },
+};
+
+describe("BudgetSaveReviewDialog", () => {
+  it("shows a compact month summary before confirmation", () => {
+    render(
+      <BudgetSaveReviewDialog
+        edits={edits}
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Review save summary")).toBeInTheDocument();
+    expect(screen.getByText("Changes")).toBeInTheDocument();
+    expect(screen.getByText("Months")).toBeInTheDocument();
+    expect(screen.getAllByText("Net")).toHaveLength(2);
+    expect(screen.getByText("Apr 2026")).toBeInTheDocument();
+    expect(screen.getByText("May 2026")).toBeInTheDocument();
+    expect(screen.queryByText("Large")).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
+    expect(screen.queryByText("cat-1")).not.toBeInTheDocument();
+  });
+
+  it("passes the skip-review checkbox value on confirm", () => {
+    const onConfirm = jest.fn();
+    render(
+      <BudgetSaveReviewDialog
+        edits={edits}
+        onCancel={jest.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Skip review next time"));
+    fireEvent.click(screen.getByRole("button", { name: "Save 2 changes" }));
+
+    expect(onConfirm).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.test.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.test.tsx
@@ -51,7 +51,7 @@ describe("BudgetSaveReviewDialog", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText("Skip review next time"));
+    fireEvent.click(screen.getByText("Skip review next time"));
     fireEvent.click(screen.getByRole("button", { name: "Save 2 changes" }));
 
     expect(onConfirm).toHaveBeenCalledWith(true);

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { formatMinor } from "../lib/format";
+import { buildBudgetSaveReviewSummary } from "../lib/budgetSaveReview";
+import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+
+type Props = {
+  edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  onCancel: () => void;
+  onConfirm: (skipReviewNextTime: boolean) => void;
+};
+
+function formatDeltaAmount(delta: number): string {
+  if (delta === 0) return "0.00";
+  const sign = delta > 0 ? "+" : "-";
+  return `${sign}${formatMinor(Math.abs(delta))}`;
+}
+
+export function BudgetSaveReviewDialog({
+  edits,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const [skipReviewNextTime, setSkipReviewNextTime] = useState(false);
+  const summary = useMemo(
+    () => buildBudgetSaveReviewSummary(edits),
+    [edits]
+  );
+  const monthRows = useMemo(
+    () =>
+      summary.months.map((month) => ({
+        month: month.month,
+        label: month.label,
+        changeCount: month.entries.length,
+        totalDelta: month.totalDelta,
+      })),
+    [summary.months]
+  );
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-lg gap-3 p-0 sm:max-w-lg max-h-[92vh]"
+      >
+        <DialogHeader className="gap-1 px-4 pt-4">
+          <DialogTitle>Review save summary</DialogTitle>
+          <DialogDescription className="text-xs">
+            Confirm the staged budget totals before sending changes to the server.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-4">
+          <div className="grid grid-cols-3 overflow-hidden rounded-md border border-border text-xs">
+            <div className="border-r border-border px-2 py-2">
+              <p className="text-[10px] uppercase text-muted-foreground">Changes</p>
+              <p className="font-semibold text-foreground tabular-nums">
+                {summary.editCount}
+              </p>
+            </div>
+            <div className="border-r border-border px-2 py-2">
+              <p className="text-[10px] uppercase text-muted-foreground">Months</p>
+              <p className="font-semibold text-foreground tabular-nums">
+                {summary.monthCount}
+              </p>
+            </div>
+            <div className="border-r border-border px-2 py-2">
+              <p className="text-[10px] uppercase text-muted-foreground">Net</p>
+              <p
+                className={`font-semibold tabular-nums ${
+                  summary.totalDelta >= 0
+                    ? "text-emerald-700 dark:text-emerald-400"
+                    : "text-destructive"
+                }`}
+              >
+                {formatDeltaAmount(summary.totalDelta)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mx-4 rounded-md border border-border">
+          <table className="w-full table-fixed text-xs">
+            <thead className="bg-muted text-[10px] uppercase text-muted-foreground">
+              <tr>
+                <th className="px-2 py-1.5 text-left font-medium">Month</th>
+                <th className="w-16 px-2 py-1.5 text-right font-medium">Edits</th>
+                <th className="w-24 px-2 py-1.5 text-right font-medium">Net</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {monthRows.map((row) => (
+                <tr key={row.month}>
+                  <td className="truncate px-2 py-1.5 font-medium text-foreground">
+                    {row.label}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
+                    {row.changeCount}
+                  </td>
+                  <td
+                    className={`px-2 py-1.5 text-right font-medium tabular-nums ${
+                      row.totalDelta >= 0
+                        ? "text-emerald-700 dark:text-emerald-400"
+                        : "text-destructive"
+                    }`}
+                  >
+                    {formatDeltaAmount(row.totalDelta)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex items-center gap-3 border-t border-border px-4 py-3">
+          <label className="flex min-w-0 flex-1 items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={skipReviewNextTime}
+              onChange={(e) => setSkipReviewNextTime(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border"
+            />
+            Skip review next time
+          </label>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => onConfirm(skipReviewNextTime)}
+              disabled={summary.editCount === 0}
+            >
+              Save {summary.editCount} change{summary.editCount !== 1 ? "s" : ""}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -122,15 +123,20 @@ export function BudgetSaveReviewDialog({
         </div>
 
         <div className="flex items-center gap-3 border-t border-border px-4 py-3">
-          <label className="flex min-w-0 flex-1 items-center gap-2 text-xs text-muted-foreground">
-            <input
-              type="checkbox"
+          <div className="flex min-w-0 flex-1 items-center gap-2 text-xs text-muted-foreground">
+            <Checkbox
+              aria-labelledby="skip-budget-save-review-label"
               checked={skipReviewNextTime}
-              onChange={(e) => setSkipReviewNextTime(e.target.checked)}
-              className="h-3.5 w-3.5 rounded border-border"
+              onCheckedChange={(checked) => setSkipReviewNextTime(Boolean(checked))}
             />
-            Skip review next time
-          </label>
+            <label
+              id="skip-budget-save-review-label"
+              className="cursor-pointer"
+              onClick={() => setSkipReviewNextTime((checked) => !checked)}
+            >
+              Skip review next time
+            </label>
+          </div>
           <div className="flex shrink-0 items-center gap-2">
             <Button variant="outline" onClick={onCancel}>
               Cancel

--- a/src/features/budget-management/components/BudgetWorkspace.tsx
+++ b/src/features/budget-management/components/BudgetWorkspace.tsx
@@ -29,6 +29,11 @@ import { BudgetSelectionSummary } from "./BudgetSelectionSummary";
 import { BulkActionDialog } from "./BulkActionDialog";
 import { BudgetCellContextMenu } from "./BudgetCellContextMenu";
 import { BudgetCarryoverProgressDialog } from "./BudgetCarryoverProgressDialog";
+import { CategoryJumpDialog } from "./CategoryJumpDialog";
+import {
+  buildCategorySearchOptions,
+  type CategorySearchOption,
+} from "../lib/categorySearch";
 import {
   MonthsDataProvider,
   useMonthsData,
@@ -61,6 +66,15 @@ type ContextMenuState = {
   categoryId: string;
   month: string;
   carryover: boolean;
+} | null;
+
+type PendingCategoryJump = {
+  categoryId: string;
+  groupId: string;
+  month: string;
+  hidden: boolean;
+  groupHidden: boolean;
+  attempts: number;
 } | null;
 
 type Props = {
@@ -131,6 +145,8 @@ function BudgetWorkspaceInner({
   const [rowSelection, setRowSelectionLocal] = useState<RowSelection | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [pendingBulkAction, setPendingBulkAction] = useState<BulkActionType | null>(null);
+  const [categorySearchOpen, setCategorySearchOpen] = useState(false);
+  const [pendingCategoryJump, setPendingCategoryJump] = useState<PendingCategoryJump>(null);
   const [carryoverRequest, setCarryoverRequest] = useState<{
     input: CarryoverToggleInput;
     categoryLabel?: string;
@@ -205,6 +221,11 @@ function BudgetWorkspaceInner({
     }
     return items;
   }, [merged, showHidden, collapsedGroups]);
+
+  const categorySearchOptions = useMemo<CategorySearchOption[]>(() => {
+    if (!merged) return [];
+    return buildCategorySearchOptions(merged);
+  }, [merged]);
 
   const handleCellFocus = useCallback(
     (categoryId: string, month: string) => {
@@ -391,6 +412,92 @@ function BudgetWorkspaceInner({
     },
     [navigateFrom]
   );
+
+  const selectedMonth =
+    selection?.focusMonth ??
+    groupSelection?.month ??
+    activeMonths[0] ??
+    null;
+
+  const handleCategoryJumpSelect = useCallback(
+    (option: CategorySearchOption) => {
+      const month = selectedMonth;
+      if (!month) return;
+
+      setContextMenu(null);
+      setGroupSelection(null);
+      setRowSelectionLocal(null);
+      setSelection({
+        anchorCategoryId: option.categoryId,
+        anchorMonth: month,
+        focusCategoryId: option.categoryId,
+        focusMonth: month,
+      });
+
+      if (!showHidden && (option.hidden || option.groupHidden)) {
+        onToggleShowHidden();
+      }
+      if (collapsedGroups.has(option.groupId)) {
+        onToggleCollapse(option.groupId);
+      }
+
+      setPendingCategoryJump({
+        categoryId: option.categoryId,
+        groupId: option.groupId,
+        month,
+        hidden: option.hidden,
+        groupHidden: option.groupHidden,
+        attempts: 0,
+      });
+    },
+    [
+      selectedMonth,
+      showHidden,
+      collapsedGroups,
+      onToggleShowHidden,
+      onToggleCollapse,
+      setSelection,
+    ]
+  );
+
+  useEffect(() => {
+    if (!pendingCategoryJump) return;
+    if (
+      (!showHidden && (pendingCategoryJump.hidden || pendingCategoryJump.groupHidden)) ||
+      collapsedGroups.has(pendingCategoryJump.groupId)
+    ) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLElement>(
+        `[data-month="${CSS.escape(pendingCategoryJump.month)}"][data-category-id="${CSS.escape(pendingCategoryJump.categoryId)}"]`
+      );
+      if (!el) {
+        setPendingCategoryJump((current) => {
+          if (
+            !current ||
+            current.month !== pendingCategoryJump.month ||
+            current.categoryId !== pendingCategoryJump.categoryId
+          ) {
+            return current;
+          }
+          if (current.attempts >= 6) return null;
+          return { ...current, attempts: current.attempts + 1 };
+        });
+        return;
+      }
+      el.scrollIntoView({ block: "center", inline: "nearest" });
+      el.focus();
+      setSelection({
+        anchorCategoryId: pendingCategoryJump.categoryId,
+        anchorMonth: pendingCategoryJump.month,
+        focusCategoryId: pendingCategoryJump.categoryId,
+        focusMonth: pendingCategoryJump.month,
+      });
+      setPendingCategoryJump(null);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [pendingCategoryJump, showHidden, collapsedGroups, setSelection]);
 
   /** Copy selected cell values as tab-delimited text (dollar amounts). */
   const handleCopySelection = useCallback(() => {
@@ -642,9 +749,24 @@ function BudgetWorkspaceInner({
     collapseAll: onCollapseAll,
     panMonthsPrev: onPanMonthsPrev,
     panMonthsNext: onPanMonthsNext,
+    openCategorySearch: () => setCategorySearchOpen(true),
     toggleCarryoverForSelection,
     openShortcutsHelp: onOpenShortcutsHelp,
   });
+
+  const handleWorkspaceKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.closest("[role=dialog]") ||
+        target.matches("input, textarea, select, [contenteditable='true']")
+      ) {
+        return;
+      }
+      handleKeyDown(e);
+    },
+    [handleKeyDown]
+  );
 
   // Clipboard paste: parse tab-delimited text and stage bulk edits
   const handlePaste = useCallback(
@@ -720,7 +842,7 @@ function BudgetWorkspaceInner({
     <div
       ref={workspaceRef}
       className="flex flex-col flex-1 min-h-0"
-      onKeyDown={handleKeyDown}
+      onKeyDown={handleWorkspaceKeyDown}
       onPaste={handlePaste}
       tabIndex={-1}
       aria-label="Budget workspace"
@@ -780,6 +902,15 @@ function BudgetWorkspaceInner({
         />
       )}
 
+      {categorySearchOpen && (
+        <CategoryJumpDialog
+          open={categorySearchOpen}
+          options={categorySearchOptions}
+          onOpenChange={setCategorySearchOpen}
+          onSelect={handleCategoryJumpSelect}
+        />
+      )}
+
       {contextMenu && (
         <BudgetCellContextMenu
           x={contextMenu.x}
@@ -803,4 +934,3 @@ function BudgetWorkspaceInner({
     </div>
   );
 }
-

--- a/src/features/budget-management/components/CategoryJumpDialog.tsx
+++ b/src/features/budget-management/components/CategoryJumpDialog.tsx
@@ -56,8 +56,17 @@ export function CategoryJumpDialog({
     : `${options.length} categories`;
 
   useEffect(() => {
-    if (!open) return;
-    requestAnimationFrame(() => inputRef.current?.focus());
+    const frame = requestAnimationFrame(() => {
+      if (open) {
+        inputRef.current?.focus();
+        return;
+      }
+      inputRef.current?.blur();
+      resultRefs.current = [];
+      setQuery("");
+      setActiveIndex(0);
+    });
+    return () => cancelAnimationFrame(frame);
   }, [open]);
 
   useEffect(() => {

--- a/src/features/budget-management/components/CategoryJumpDialog.tsx
+++ b/src/features/budget-management/components/CategoryJumpDialog.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { EyeOff, Search, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  filterCategorySearchOptions,
+  type CategorySearchOption,
+} from "../lib/categorySearch";
+
+const MAX_VISIBLE_RESULTS = 80;
+
+type Props = {
+  open: boolean;
+  options: CategorySearchOption[];
+  onOpenChange: (open: boolean) => void;
+  onSelect: (option: CategorySearchOption) => void;
+};
+
+export function CategoryJumpDialog({
+  open,
+  options,
+  onOpenChange,
+  onSelect,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultRefs = useRef<Array<HTMLLIElement | null>>([]);
+
+  const matches = useMemo(
+    () => filterCategorySearchOptions(options, query),
+    [options, query]
+  );
+  const visibleResults = useMemo(
+    () => matches.slice(0, MAX_VISIBLE_RESULTS),
+    [matches]
+  );
+  const activeResultIndex =
+    visibleResults.length === 0
+      ? -1
+      : Math.min(activeIndex, visibleResults.length - 1);
+  const activeResultId =
+    activeResultIndex >= 0 ? `category-jump-option-${activeResultIndex}` : undefined;
+  const hasQuery = query.trim().length > 0;
+  const resultSummary = hasQuery
+    ? matches.length > MAX_VISIBLE_RESULTS
+      ? `Showing first ${MAX_VISIBLE_RESULTS} of ${matches.length} matches`
+      : `${visibleResults.length} ${visibleResults.length === 1 ? "match" : "matches"}`
+    : `${options.length} categories`;
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [open]);
+
+  useEffect(() => {
+    if (activeResultIndex < 0) return;
+    resultRefs.current[activeResultIndex]?.scrollIntoView({ block: "nearest" });
+  }, [activeResultIndex]);
+
+  function choose(option: CategorySearchOption) {
+    onSelect(option);
+    onOpenChange(false);
+  }
+
+  function handleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (visibleResults.length === 0) return;
+      setActiveIndex((idx) => Math.min(visibleResults.length - 1, idx + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (visibleResults.length === 0) return;
+      setActiveIndex((idx) => Math.max(0, idx - 1));
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveIndex(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveIndex(Math.max(0, visibleResults.length - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const option = visibleResults[activeResultIndex];
+      if (option) choose(option);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-xl gap-0 overflow-hidden p-0 sm:max-w-xl"
+        finalFocus={false}
+        initialFocus={inputRef}
+      >
+        <DialogHeader className="gap-1 border-b border-border px-4 py-3">
+          <DialogTitle>Jump to Category</DialogTitle>
+          <DialogDescription className="sr-only">
+            Search categories by category or group name.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="border-b border-border px-4 py-3">
+          <div className="flex h-9 items-center gap-2 rounded-md border border-input bg-background px-2 focus-within:ring-2 focus-within:ring-ring/40">
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={handleInputKeyDown}
+              role="combobox"
+              aria-expanded="true"
+              aria-controls="category-jump-results"
+              aria-activedescendant={activeResultId}
+              aria-autocomplete="list"
+              aria-haspopup="listbox"
+              placeholder="Category or group"
+              className="min-w-0 flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => {
+                  setQuery("");
+                  setActiveIndex(0);
+                  inputRef.current?.focus();
+                }}
+                className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+          <p className="mt-1.5 text-[11px] text-muted-foreground">
+            {resultSummary}
+          </p>
+        </div>
+
+        <div className="max-h-[min(24rem,60vh)] overflow-y-auto">
+          {visibleResults.length === 0 ? (
+            <p className="px-4 py-8 text-center text-xs text-muted-foreground">
+              No categories found
+            </p>
+          ) : (
+            <ul id="category-jump-results" role="listbox" className="py-1">
+              {visibleResults.map((option, idx) => {
+                const hidden = option.hidden || option.groupHidden;
+                const active = idx === activeResultIndex;
+                return (
+                  <li
+                    id={`category-jump-option-${idx}`}
+                    key={option.categoryId}
+                    ref={(node) => {
+                      resultRefs.current[idx] = node;
+                    }}
+                    role="option"
+                    aria-selected={active}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => choose(option)}
+                    className={`grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2 text-left text-xs ${
+                      active ? "bg-accent text-accent-foreground" : "hover:bg-muted/60"
+                    }`}
+                  >
+                    <span className="min-w-0">
+                      <span
+                        className={`block truncate font-medium ${
+                          active ? "text-accent-foreground" : "text-foreground"
+                        }`}
+                      >
+                        {option.name}
+                      </span>
+                      <span
+                        className={`block truncate text-[11px] ${
+                          active ? "text-accent-foreground/70" : "text-muted-foreground"
+                        }`}
+                      >
+                        {option.groupName} · {option.isIncome ? "Income" : "Expense"}
+                      </span>
+                    </span>
+                    {hidden && (
+                      <span
+                        className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] ${
+                          active
+                            ? "border-accent-foreground/25 text-accent-foreground/75"
+                            : "border-border text-muted-foreground"
+                        }`}
+                      >
+                        <EyeOff className="h-3 w-3" aria-hidden="true" />
+                        Hidden
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/budget-management/keyboard/__tests__/keymap.test.ts
+++ b/src/features/budget-management/keyboard/__tests__/keymap.test.ts
@@ -252,8 +252,14 @@ describe("Tier 3 view & visibility bindings", () => {
     expect(matchAction(ev({ key: "]" }), "workspace")).toBe("view.pan-months-next");
   });
 
+  it("F opens category search in workspace scope only", () => {
+    expect(matchAction(ev({ key: "f" }), "workspace")).toBe("view.open-category-search");
+    expect(matchAction(ev({ key: "f" }), "cell")).toBeNull();
+    expect(matchAction(ev({ key: "f" }), "cell-edit")).toBeNull();
+  });
+
   it("Tier-3 bare-alpha bindings never fire while typing in a cell input", () => {
-    for (const k of ["v", "h", "e", "[", "]"]) {
+    for (const k of ["v", "h", "e", "f", "[", "]"]) {
       expect(matchAction(ev({ key: k }), "cell-edit")).toBeNull();
     }
     expect(matchAction(ev({ key: "E", shiftKey: true }), "cell-edit")).toBeNull();

--- a/src/features/budget-management/keyboard/actions.ts
+++ b/src/features/budget-management/keyboard/actions.ts
@@ -63,6 +63,7 @@ export type ActionId =
   | "view.collapse-all"
   | "view.pan-months-prev"
   | "view.pan-months-next"
+  | "view.open-category-search"
   // ─── Tier 4 selection actions (workspace) ───────────────────────────────
   | "selection.toggle-carryover"
   // ─── Discoverability ────────────────────────────────────────────────────
@@ -158,6 +159,11 @@ export const ACTION_META: Record<ActionId, ActionMeta> = {
   "view.collapse-all": { id: "view.collapse-all", label: "Collapse all groups", category: "view" },
   "view.pan-months-prev": { id: "view.pan-months-prev", label: "Pan visible months one earlier", category: "view" },
   "view.pan-months-next": { id: "view.pan-months-next", label: "Pan visible months one later",   category: "view" },
+  "view.open-category-search": {
+    id: "view.open-category-search",
+    label: "Jump to category",
+    category: "navigation",
+  },
 
   "selection.toggle-carryover": {
     id: "selection.toggle-carryover",

--- a/src/features/budget-management/keyboard/context.ts
+++ b/src/features/budget-management/keyboard/context.ts
@@ -72,6 +72,7 @@ export type WorkspaceContext = {
   collapseAll: () => void;
   panMonthsPrev: () => void;
   panMonthsNext: () => void;
+  openCategorySearch: () => void;
   // ── Tier 4 selection actions ───────────────────────────────────────────
   /**
    * Toggle carryover for the anchor cell's category across the selected

--- a/src/features/budget-management/keyboard/handlers.ts
+++ b/src/features/budget-management/keyboard/handlers.ts
@@ -147,6 +147,7 @@ export const WORKSPACE_HANDLERS: Partial<Record<ActionId, ActionHandler<Workspac
   "view.collapse-all":        (_e, ctx) => ctx.collapseAll(),
   "view.pan-months-prev":     (_e, ctx) => ctx.panMonthsPrev(),
   "view.pan-months-next":     (_e, ctx) => ctx.panMonthsNext(),
+  "view.open-category-search":(_e, ctx) => ctx.openCategorySearch(),
   "selection.toggle-carryover": (_e, ctx) => ctx.toggleCarryoverForSelection(),
   "help.open-shortcuts":        (_e, ctx) => ctx.openShortcutsHelp(),
 };

--- a/src/features/budget-management/keyboard/keymap.ts
+++ b/src/features/budget-management/keyboard/keymap.ts
@@ -105,6 +105,7 @@ export const DEFAULT_KEYMAP: KeymapBinding[] = [
   // Pan visible months one month back / forward. Bare brackets on US layout.
   { action: "view.pan-months-prev",    chord: { key: "[" },                   scopes: ["workspace"] },
   { action: "view.pan-months-next",    chord: { key: "]" },                   scopes: ["workspace"] },
+  { action: "view.open-category-search", chord: { key: "f" },                 scopes: ["workspace"] },
 
   // ── Tier 4 selection actions ───────────────────────────────────────────
   { action: "selection.toggle-carryover", chord: { key: "c", alt: true },     scopes: ["workspace"] },

--- a/src/features/budget-management/lib/budgetSaveReview.test.ts
+++ b/src/features/budget-management/lib/budgetSaveReview.test.ts
@@ -1,0 +1,84 @@
+import {
+  BUDGET_SAVE_REVIEW_SKIP_KEY,
+  buildBudgetSaveReviewSummary,
+  readBudgetSaveReviewSkip,
+  writeBudgetSaveReviewSkip,
+} from "./budgetSaveReview";
+import { LARGE_CHANGE_THRESHOLD } from "./budgetValidation";
+import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+
+const edits: Record<BudgetCellKey, StagedBudgetEdit> = {
+  "2026-05:cat-b": {
+    month: "2026-05",
+    categoryId: "cat-b",
+    previousBudgeted: 1000,
+    nextBudgeted: 2500,
+    source: "manual",
+  },
+  "2026-04:cat-a": {
+    month: "2026-04",
+    categoryId: "cat-a",
+    previousBudgeted: 0,
+    nextBudgeted: LARGE_CHANGE_THRESHOLD + 1,
+    source: "paste",
+  },
+  "2026-04:cat-c": {
+    month: "2026-04",
+    categoryId: "cat-c",
+    previousBudgeted: 5000,
+    nextBudgeted: 3000,
+    source: "bulk-action",
+  },
+};
+
+describe("buildBudgetSaveReviewSummary", () => {
+  it("groups edits by month and computes totals", () => {
+    const summary = buildBudgetSaveReviewSummary(edits, {
+      "cat-a": { name: "Rent", groupName: "Housing" },
+      "cat-b": { name: "Groceries", groupName: "Food" },
+      "cat-c": { name: "Utilities", groupName: "Housing" },
+    });
+
+    expect(summary.editCount).toBe(3);
+    expect(summary.monthCount).toBe(2);
+    expect(summary.totalDelta).toBe(LARGE_CHANGE_THRESHOLD - 499);
+    expect(summary.largeChangeCount).toBe(1);
+    expect(summary.months.map((m) => m.month)).toEqual(["2026-04", "2026-05"]);
+    expect(summary.months[0]?.totalDelta).toBe(LARGE_CHANGE_THRESHOLD - 1999);
+    expect(summary.months[0]?.entries.map((e) => e.categoryName)).toEqual([
+      "Rent",
+      "Utilities",
+    ]);
+  });
+
+  it("falls back to category IDs when names are unavailable", () => {
+    const summary = buildBudgetSaveReviewSummary({
+      "2026-04:unknown": {
+        month: "2026-04",
+        categoryId: "unknown",
+        previousBudgeted: 100,
+        nextBudgeted: 200,
+        source: "manual",
+      },
+    });
+
+    expect(summary.months[0]?.entries[0]?.categoryName).toBe("unknown");
+  });
+});
+
+describe("budget save review preference", () => {
+  afterEach(() => {
+    window.localStorage.removeItem(BUDGET_SAVE_REVIEW_SKIP_KEY);
+  });
+
+  it("reads and writes the skip-review preference", () => {
+    expect(readBudgetSaveReviewSkip()).toBe(false);
+
+    writeBudgetSaveReviewSkip(true);
+    expect(window.localStorage.getItem(BUDGET_SAVE_REVIEW_SKIP_KEY)).toBe("1");
+    expect(readBudgetSaveReviewSkip()).toBe(true);
+
+    writeBudgetSaveReviewSkip(false);
+    expect(readBudgetSaveReviewSkip()).toBe(false);
+  });
+});

--- a/src/features/budget-management/lib/budgetSaveReview.ts
+++ b/src/features/budget-management/lib/budgetSaveReview.ts
@@ -1,0 +1,113 @@
+import { formatMonthLabel } from "@/lib/budget/monthMath";
+import { isLargeChange } from "./budgetValidation";
+import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+
+export const BUDGET_SAVE_REVIEW_SKIP_KEY =
+  "actual-bench:budget-save-review:skip";
+
+export type BudgetSaveReviewCategory = {
+  name: string;
+  groupName?: string;
+};
+
+export type BudgetSaveReviewCategoryLookup = Record<
+  string,
+  BudgetSaveReviewCategory
+>;
+
+export type BudgetSaveReviewEntry = {
+  key: BudgetCellKey;
+  edit: StagedBudgetEdit;
+  categoryName: string;
+  groupName?: string;
+  delta: number;
+  largeChange: boolean;
+};
+
+export type BudgetSaveReviewMonth = {
+  month: string;
+  label: string;
+  totalDelta: number;
+  entries: BudgetSaveReviewEntry[];
+};
+
+export type BudgetSaveReviewSummary = {
+  editCount: number;
+  monthCount: number;
+  totalDelta: number;
+  largeChangeCount: number;
+  months: BudgetSaveReviewMonth[];
+};
+
+export function buildBudgetSaveReviewSummary(
+  edits: Record<BudgetCellKey, StagedBudgetEdit>,
+  categoryLookup: BudgetSaveReviewCategoryLookup = {}
+): BudgetSaveReviewSummary {
+  const grouped = new Map<string, BudgetSaveReviewEntry[]>();
+
+  for (const [key, edit] of Object.entries(edits) as [
+    BudgetCellKey,
+    StagedBudgetEdit,
+  ][]) {
+    const category = categoryLookup[edit.categoryId];
+    const entry: BudgetSaveReviewEntry = {
+      key,
+      edit,
+      categoryName: category?.name ?? edit.categoryId,
+      groupName: category?.groupName,
+      delta: edit.nextBudgeted - edit.previousBudgeted,
+      largeChange: isLargeChange(edit.previousBudgeted, edit.nextBudgeted),
+    };
+    const entries = grouped.get(edit.month) ?? [];
+    entries.push(entry);
+    grouped.set(edit.month, entries);
+  }
+
+  const months = [...grouped.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, entries]) => {
+      const sortedEntries = entries.slice().sort((a, b) => {
+        const nameCompare = a.categoryName.localeCompare(b.categoryName);
+        return nameCompare !== 0 ? nameCompare : a.key.localeCompare(b.key);
+      });
+      return {
+        month,
+        label: formatMonthLabel(month, "long"),
+        totalDelta: sortedEntries.reduce((sum, e) => sum + e.delta, 0),
+        entries: sortedEntries,
+      };
+    });
+
+  return {
+    editCount: months.reduce((sum, m) => sum + m.entries.length, 0),
+    monthCount: months.length,
+    totalDelta: months.reduce((sum, m) => sum + m.totalDelta, 0),
+    largeChangeCount: months.reduce(
+      (sum, m) => sum + m.entries.filter((e) => e.largeChange).length,
+      0
+    ),
+    months,
+  };
+}
+
+export function readBudgetSaveReviewSkip(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(BUDGET_SAVE_REVIEW_SKIP_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeBudgetSaveReviewSkip(skip: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (skip) {
+      window.localStorage.setItem(BUDGET_SAVE_REVIEW_SKIP_KEY, "1");
+    } else {
+      window.localStorage.removeItem(BUDGET_SAVE_REVIEW_SKIP_KEY);
+    }
+  } catch {
+    // Preference writes are best-effort; saving must still work.
+  }
+}

--- a/src/features/budget-management/lib/categorySearch.test.ts
+++ b/src/features/budget-management/lib/categorySearch.test.ts
@@ -1,0 +1,157 @@
+import {
+  buildCategorySearchOptions,
+  filterCategorySearchOptions,
+} from "./categorySearch";
+import type { LoadedCategory, LoadedGroup } from "../types";
+
+const groupsById: Record<string, LoadedGroup> = {
+  food: {
+    id: "food",
+    name: "Food",
+    isIncome: false,
+    hidden: false,
+    categoryIds: ["groceries", "restaurants"],
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+  },
+  archived: {
+    id: "archived",
+    name: "Archived",
+    isIncome: false,
+    hidden: true,
+    categoryIds: ["old-cat"],
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+  },
+  income: {
+    id: "income",
+    name: "Income",
+    isIncome: true,
+    hidden: false,
+    categoryIds: ["paycheck"],
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+  },
+};
+
+const categoriesById: Record<string, LoadedCategory> = {
+  groceries: {
+    id: "groceries",
+    name: "Groceries",
+    groupId: "food",
+    groupName: "Food",
+    isIncome: false,
+    hidden: false,
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+    carryover: false,
+  },
+  restaurants: {
+    id: "restaurants",
+    name: "Restaurants",
+    groupId: "food",
+    groupName: "Food",
+    isIncome: false,
+    hidden: true,
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+    carryover: false,
+  },
+  "old-cat": {
+    id: "old-cat",
+    name: "Old Category",
+    groupId: "archived",
+    groupName: "Archived",
+    isIncome: false,
+    hidden: false,
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+    carryover: false,
+  },
+  paycheck: {
+    id: "paycheck",
+    name: "Paycheck",
+    groupId: "income",
+    groupName: "Income",
+    isIncome: true,
+    hidden: false,
+    budgeted: 0,
+    actuals: 0,
+    balance: 0,
+    carryover: false,
+  },
+};
+
+describe("buildCategorySearchOptions", () => {
+  it("includes visible, hidden, and hidden-group categories in visual section order", () => {
+    const options = buildCategorySearchOptions({
+      groupOrder: ["income", "food", "archived"],
+      groupsById,
+      categoriesById,
+    });
+
+    expect(options.map((option) => option.categoryId)).toEqual([
+      "groceries",
+      "restaurants",
+      "old-cat",
+      "paycheck",
+    ]);
+    expect(options.find((option) => option.categoryId === "restaurants")?.hidden).toBe(true);
+    expect(options.find((option) => option.categoryId === "old-cat")?.groupHidden).toBe(true);
+  });
+});
+
+describe("filterCategorySearchOptions", () => {
+  it("matches by category name or group name", () => {
+    const options = buildCategorySearchOptions({
+      groupOrder: ["income", "food", "archived"],
+      groupsById,
+      categoriesById,
+    });
+
+    expect(filterCategorySearchOptions(options, "gro").map((o) => o.categoryId)).toEqual(["groceries"]);
+    expect(filterCategorySearchOptions(options, "food").map((o) => o.categoryId)).toEqual([
+      "groceries",
+      "restaurants",
+    ]);
+  });
+
+  it("ranks category name matches before group name matches", () => {
+    const options = buildCategorySearchOptions({
+      groupOrder: ["income", "food", "archived"],
+      groupsById,
+      categoriesById,
+    });
+
+    expect(filterCategorySearchOptions(options, "pay").map((o) => o.categoryId)).toEqual(["paycheck"]);
+  });
+
+  it("supports fuzzy subsequence matches", () => {
+    const options = buildCategorySearchOptions({
+      groupOrder: ["income", "food", "archived"],
+      groupsById,
+      categoriesById,
+    });
+
+    expect(filterCategorySearchOptions(options, "grcr").map((o) => o.categoryId)).toEqual(["groceries"]);
+  });
+
+  it("preserves visual order for equal-rank matches", () => {
+    const options = buildCategorySearchOptions({
+      groupOrder: ["income", "food", "archived"],
+      groupsById,
+      categoriesById,
+    });
+
+    expect(filterCategorySearchOptions(options, "food").map((o) => o.categoryId)).toEqual([
+      "groceries",
+      "restaurants",
+    ]);
+  });
+});

--- a/src/features/budget-management/lib/categorySearch.ts
+++ b/src/features/budget-management/lib/categorySearch.ts
@@ -1,0 +1,135 @@
+import type { LoadedCategory, LoadedGroup } from "../types";
+
+export type CategorySearchOption = {
+  categoryId: string;
+  name: string;
+  groupId: string;
+  groupName: string;
+  isIncome: boolean;
+  hidden: boolean;
+  groupHidden: boolean;
+};
+
+type BuildCategorySearchOptionsInput = {
+  groupOrder: string[];
+  groupsById: Record<string, LoadedGroup>;
+  categoriesById: Record<string, LoadedCategory>;
+};
+
+export function buildCategorySearchOptions({
+  groupOrder,
+  groupsById,
+  categoriesById,
+}: BuildCategorySearchOptionsInput): CategorySearchOption[] {
+  const expenseIds = groupOrder.filter((id) => !groupsById[id]?.isIncome);
+  const incomeIds = groupOrder.filter((id) => groupsById[id]?.isIncome);
+  const options: CategorySearchOption[] = [];
+
+  for (const groupId of [...expenseIds, ...incomeIds]) {
+    const group = groupsById[groupId];
+    if (!group) continue;
+    for (const categoryId of group.categoryIds) {
+      const category = categoriesById[categoryId];
+      if (!category) continue;
+      options.push({
+        categoryId: category.id,
+        name: category.name,
+        groupId: group.id,
+        groupName: group.name,
+        isIncome: category.isIncome,
+        hidden: category.hidden,
+        groupHidden: group.hidden,
+      });
+    }
+  }
+
+  return options;
+}
+
+export function filterCategorySearchOptions(
+  options: CategorySearchOption[],
+  query: string
+): CategorySearchOption[] {
+  const term = normalizeSearchText(query);
+  if (!term) return options;
+  const tokens = term.split(" ");
+  return options
+    .map((option, index) => {
+      const rank = scoreCategorySearchOption(option, term, tokens);
+      return rank === null ? null : { option, rank, index };
+    })
+    .filter(
+      (match): match is { option: CategorySearchOption; rank: number; index: number } =>
+        match !== null
+    )
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      return a.index - b.index;
+    })
+    .map((match) => match.option);
+}
+
+function scoreCategorySearchOption(
+  option: CategorySearchOption,
+  term: string,
+  tokens: string[]
+): number | null {
+  const name = normalizeSearchText(option.name);
+  const groupName = normalizeSearchText(option.groupName);
+  const combined = `${name} ${groupName} ${option.isIncome ? "income" : "expense"}`;
+
+  const exactName = scoreText(name, term);
+  if (exactName !== null) return exactName;
+
+  const exactGroup = scoreText(groupName, term);
+  if (exactGroup !== null) return exactGroup + 30;
+
+  const tokenScore = scoreTokens(combined, tokens);
+  if (tokenScore !== null) return tokenScore + 60;
+
+  const fuzzyName = scoreSubsequence(name, term);
+  if (fuzzyName !== null) return fuzzyName + 90;
+
+  const fuzzyCombined = scoreSubsequence(combined, term);
+  if (fuzzyCombined !== null) return fuzzyCombined + 130;
+
+  return null;
+}
+
+function normalizeSearchText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function scoreText(text: string, term: string): number | null {
+  if (text === term) return 0;
+  if (text.startsWith(term)) return 10;
+  if (text.split(" ").some((word) => word.startsWith(term))) return 20;
+  if (text.includes(term)) return 30;
+  return null;
+}
+
+function scoreTokens(text: string, tokens: string[]): number | null {
+  let total = 0;
+  for (const token of tokens) {
+    const score = scoreText(text, token) ?? scoreSubsequence(text, token);
+    if (score === null) return null;
+    total += score;
+  }
+  return total;
+}
+
+function scoreSubsequence(text: string, term: string): number | null {
+  if (!term) return 0;
+  let lastIndex = -1;
+  let firstIndex = -1;
+
+  for (const char of term) {
+    const nextIndex = text.indexOf(char, lastIndex + 1);
+    if (nextIndex === -1) return null;
+    if (firstIndex === -1) firstIndex = nextIndex;
+    lastIndex = nextIndex;
+  }
+
+  const spread = lastIndex - firstIndex - term.length + 1;
+  return 40 + Math.max(0, spread);
+}


### PR DESCRIPTION
## Summary

  - Add a compact pre-save review dialog for budget edits before the existing save progress flow
  - Add an optional “skip review next time” preference for budget saves
  - Add `F` keyboard shortcut to open Jump to Category search
  - Support fuzzy category/group matching, hidden categories, collapsed-group expansion, and automatic scroll/focus to the selected budget cell
  - 
## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jump to Category search feature enabling rapid navigation to specific budget categories within the budget management interface
  * Budget save flow now includes an interactive review screen that displays month-grouped edit summaries with calculated totals before processing any saves
  * Users can opt to skip the review confirmation screen permanently to streamline future save operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->