### PR TITLE
feat/add global search modal

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,6 +9,12 @@
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed
 
+## Global Search
+
+- `Ctrl/Cmd+K` or the top-bar Search button opens a global search modal across accounts, payees, categories, rules, schedules, and tags
+- Results are grouped by entity type, capped per group, and ranked by exact, prefix, word-boundary, and substring matches
+- Selecting a result navigates to the matching entity page with the row highlighted; search runs against already-loaded in-memory state without server writes
+
 ## Budget Overview
 
 - `/overview` is the default landing page after connecting or reconnecting to a budget

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { usePreloadEntities } from "@/hooks/useAllEntities";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
+import { GlobalSearchModal } from "@/features/global-search/components/GlobalSearchModal";
 
 /**
  * The four-panel app shell:
@@ -57,6 +58,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full flex-col">
       <TopBar />
+      <GlobalSearchModal />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <Sidebar />
         <main className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw } from "lucide-react";
+import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw, Search } from "lucide-react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,7 @@ import {
   useConnectionStore,
   selectActiveInstance,
 } from "@/store/connection";
+import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSearchStore";
 import { useSavedServersStore } from "@/store/savedServers";
 import {
   useStagedStore,
@@ -87,6 +88,8 @@ export function TopBar() {
   );
   const [budgetSaveReviewEdits, setBudgetSaveReviewEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
+
+  const openSearch = useGlobalSearchStore((s) => s.open);
 
   const activeInstance = useConnectionStore(selectActiveInstance);
   const instances = useConnectionStore((s) => s.instances);
@@ -306,8 +309,23 @@ export function TopBar() {
           )}
         </div>
 
-        {/* Right: undo/redo + unsaved indicator + save/discard */}
+        {/* Right: search + undo/redo + unsaved indicator + save/discard */}
         <div className="flex items-center gap-1">
+          {activeInstance && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 text-xs text-muted-foreground"
+              onClick={openSearch}
+              title="Search (Ctrl+K)"
+            >
+              <Search className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Search</span>
+              <kbd className="hidden sm:inline pointer-events-none rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+                ⌘K
+              </kbd>
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -90,6 +90,7 @@ export function TopBar() {
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
 
   const openSearch = useGlobalSearchStore((s) => s.open);
+  const searchShortcutLabel = "Ctrl+k";
 
   const activeInstance = useConnectionStore(selectActiveInstance);
   const instances = useConnectionStore((s) => s.instances);
@@ -317,12 +318,12 @@ export function TopBar() {
               size="sm"
               className="h-7 gap-1.5 text-xs text-muted-foreground"
               onClick={openSearch}
-              title="Search (Ctrl+K)"
+              title={`Search (${searchShortcutLabel})`}
             >
               <Search className="h-3.5 w-3.5" />
               <span className="hidden sm:inline">Search</span>
               <kbd className="hidden sm:inline pointer-events-none rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
-                ⌘K
+                {searchShortcutLabel}
               </kbd>
             </Button>
           )}

--- a/src/features/global-search/components/GlobalSearchModal.tsx
+++ b/src/features/global-search/components/GlobalSearchModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { Search } from "lucide-react";
@@ -11,6 +11,11 @@ import { useGlobalSearchStore } from "../store/useGlobalSearchStore";
 import { searchEntities } from "../lib/searchEntities";
 import { SearchResultGroup } from "./SearchResultGroup";
 import type { SearchResult } from "../types";
+
+function clampFocusedIndex(index: number, resultCount: number): number {
+  if (resultCount === 0) return -1;
+  return Math.min(Math.max(index, 0), resultCount - 1);
+}
 
 export function GlobalSearchModal() {
   const isOpen = useGlobalSearchStore((s) => s.isOpen);
@@ -53,6 +58,18 @@ function GlobalSearchModalContent() {
     () => groups.flatMap((g) => g.results),
     [groups]
   );
+  const activeIndex = clampFocusedIndex(focusedIndex, flatResults.length);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFocusedIndex((index) => {
+        const nextIndex = clampFocusedIndex(index, flatResults.length);
+        return nextIndex === index ? index : nextIndex;
+      });
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [flatResults.length]);
 
   const handleSelect = useCallback(
     (result: SearchResult) => {
@@ -73,17 +90,17 @@ function GlobalSearchModalContent() {
 
       if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
         e.preventDefault();
-        setFocusedIndex((i) => Math.min(i + 1, flatResults.length - 1));
+        setFocusedIndex((i) => clampFocusedIndex(i + 1, flatResults.length));
       } else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
         e.preventDefault();
-        setFocusedIndex((i) => Math.max(i - 1, 0));
+        setFocusedIndex((i) => clampFocusedIndex(i - 1, flatResults.length));
       } else if (e.key === "Enter") {
         e.preventDefault();
-        const result = flatResults[focusedIndex];
+        const result = flatResults[activeIndex];
         if (result) handleSelect(result);
       }
     },
-    [flatResults, focusedIndex, close, handleSelect]
+    [flatResults, activeIndex, close, handleSelect]
   );
 
   const handleBackdropClick = useCallback(
@@ -104,8 +121,8 @@ function GlobalSearchModalContent() {
   }, [groups]);
 
   const activedescendant =
-    focusedIndex >= 0 && flatResults[focusedIndex]
-      ? `search-result-${flatResults[focusedIndex]!.id}`
+    activeIndex >= 0 && flatResults[activeIndex]
+      ? `search-result-${flatResults[activeIndex]!.id}`
       : undefined;
 
   return createPortal(
@@ -173,7 +190,7 @@ function GlobalSearchModalContent() {
             <SearchResultGroup
               key={group.entityType}
               group={group}
-              focusedIndex={focusedIndex}
+              focusedIndex={activeIndex}
               groupStartIndex={groupStartIndices[i] ?? 0}
               onSelect={handleSelect}
             />

--- a/src/features/global-search/components/GlobalSearchModal.tsx
+++ b/src/features/global-search/components/GlobalSearchModal.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { Search } from "lucide-react";
+import { useShallow } from "zustand/shallow";
+import { useStagedStore } from "@/store/staged";
+import { usePreloadEntities } from "@/hooks/useAllEntities";
+import { useGlobalSearchStore } from "../store/useGlobalSearchStore";
+import { searchEntities } from "../lib/searchEntities";
+import { SearchResultGroup } from "./SearchResultGroup";
+import type { SearchResult } from "../types";
+
+export function GlobalSearchModal() {
+  const isOpen = useGlobalSearchStore((s) => s.isOpen);
+
+  // Trigger entity loading when the modal opens. On pages where AppShell skips
+  // preloading (e.g. /overview), this ensures search results are available.
+  // TanStack Query deduplicates the fetches on pages that already loaded entities.
+  usePreloadEntities(isOpen);
+
+  if (!isOpen) return null;
+
+  return <GlobalSearchModalContent />;
+}
+
+function GlobalSearchModalContent() {
+  const close = useGlobalSearchStore((s) => s.close);
+  const router = useRouter();
+
+  const [query, setQuery] = useState("");
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  const slices = useStagedStore(
+    useShallow((s) => ({
+      accounts: s.accounts,
+      payees: s.payees,
+      categoryGroups: s.categoryGroups,
+      categories: s.categories,
+      rules: s.rules,
+      schedules: s.schedules,
+      tags: s.tags,
+    }))
+  );
+
+  const groups = useMemo(
+    () => searchEntities(query, slices),
+    [query, slices]
+  );
+
+  const flatResults = useMemo(
+    () => groups.flatMap((g) => g.results),
+    [groups]
+  );
+
+  const handleSelect = useCallback(
+    (result: SearchResult) => {
+      close();
+      router.push(result.href);
+    },
+    [close, router]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (flatResults.length === 0) return;
+
+      if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
+        e.preventDefault();
+        setFocusedIndex((i) => Math.min(i + 1, flatResults.length - 1));
+      } else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
+        e.preventDefault();
+        setFocusedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const result = flatResults[focusedIndex];
+        if (result) handleSelect(result);
+      }
+    },
+    [flatResults, focusedIndex, close, handleSelect]
+  );
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) close();
+    },
+    [close]
+  );
+
+  const groupStartIndices = useMemo(() => {
+    const indices: number[] = [];
+    let offset = 0;
+    for (const g of groups) {
+      indices.push(offset);
+      offset += g.results.length;
+    }
+    return indices;
+  }, [groups]);
+
+  const activedescendant =
+    focusedIndex >= 0 && flatResults[focusedIndex]
+      ? `search-result-${flatResults[focusedIndex]!.id}`
+      : undefined;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] flex justify-center bg-black/30"
+      style={{ paddingTop: "12vh" }}
+      onClick={handleBackdropClick}
+      aria-hidden="false"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Global search"
+        className="flex h-fit w-full max-w-xl flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl ring-1 ring-foreground/10"
+        style={{ maxHeight: "70vh" }}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            // autoFocus fires when the portal mounts (i.e. when isOpen becomes true).
+            // The component unmounts on close so state and focus reset automatically.
+            autoFocus
+            type="text"
+            role="combobox"
+            aria-expanded={groups.length > 0}
+            aria-haspopup="listbox"
+            aria-autocomplete="list"
+            aria-controls="global-search-results"
+            aria-activedescendant={activedescendant}
+            placeholder="Search payees, categories, accounts, rules…"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setFocusedIndex(0);
+            }}
+            onKeyDown={handleKeyDown}
+          />
+          <kbd className="pointer-events-none rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            Esc
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div
+          id="global-search-results"
+          role="listbox"
+          aria-label="Search results"
+          className="overflow-y-auto"
+        >
+          {query.trim().length === 0 && (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              Type to search across all entities
+            </p>
+          )}
+
+          {query.trim().length > 0 && groups.length === 0 && (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              No results for &ldquo;{query}&rdquo;
+            </p>
+          )}
+
+          {groups.map((group, i) => (
+            <SearchResultGroup
+              key={group.entityType}
+              group={group}
+              focusedIndex={focusedIndex}
+              groupStartIndex={groupStartIndices[i] ?? 0}
+              onSelect={handleSelect}
+            />
+          ))}
+
+          {groups.length > 0 && (
+            <div className="border-t border-border px-3 py-1.5">
+              <p className="text-[10px] text-muted-foreground">
+                ↑↓ navigate · Enter select · Esc close
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/features/global-search/components/SearchResultGroup.tsx
+++ b/src/features/global-search/components/SearchResultGroup.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+  User,
+  Tag,
+  Landmark,
+  ListFilter,
+  CalendarClock,
+  Hash,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SearchResult, SearchResultGroup as SearchResultGroupType, SearchEntityType } from "../types";
+
+const ENTITY_ICONS: Record<SearchEntityType, React.ComponentType<{ className?: string }>> = {
+  payee: User,
+  category: Tag,
+  account: Landmark,
+  rule: ListFilter,
+  schedule: CalendarClock,
+  tag: Hash,
+};
+
+type Props = {
+  group: SearchResultGroupType;
+  focusedIndex: number;
+  groupStartIndex: number;
+  onSelect: (result: SearchResult) => void;
+};
+
+export function SearchResultGroup({
+  group,
+  focusedIndex,
+  groupStartIndex,
+  onSelect,
+}: Props) {
+  const Icon = ENTITY_ICONS[group.entityType];
+
+  return (
+    <div role="group" aria-label={group.groupLabel}>
+      <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground select-none">
+        {group.groupLabel}
+      </div>
+      {group.results.map((result, i) => {
+        const globalIndex = groupStartIndex + i;
+        const isFocused = focusedIndex === globalIndex;
+        return (
+          <button
+            key={result.id}
+            id={`search-result-${result.id}`}
+            role="option"
+            aria-selected={isFocused}
+            type="button"
+            onClick={() => onSelect(result)}
+            className={cn(
+              "flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors",
+              isFocused
+                ? "bg-accent text-accent-foreground"
+                : "hover:bg-accent/50 hover:text-accent-foreground"
+            )}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm">{result.label}</span>
+              {result.sublabel && (
+                <span className="block truncate text-xs text-muted-foreground">
+                  {result.sublabel}
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/global-search/lib/searchEntities.test.ts
+++ b/src/features/global-search/lib/searchEntities.test.ts
@@ -1,0 +1,347 @@
+import { searchEntities } from "./searchEntities";
+import type { SearchSlices } from "./searchEntities";
+import type { StagedMap } from "@/types/staged";
+import type {
+  Account,
+  Payee,
+  Category,
+  CategoryGroup,
+  Rule,
+  Schedule,
+  Tag,
+} from "@/types/entities";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makePayee(id: string, name: string, extra?: Partial<Payee>): StagedMap<Payee> {
+  return {
+    [id]: {
+      entity: { id, name, ...extra },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+function makeAccount(id: string, name: string, offBudget = false): StagedMap<Account> {
+  return {
+    [id]: {
+      entity: { id, name, offBudget, closed: false },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+function makeCategory(
+  id: string,
+  name: string,
+  groupId: string
+): StagedMap<Category> {
+  return {
+    [id]: {
+      entity: { id, name, groupId, isIncome: false, hidden: false },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+function makeCategoryGroup(id: string, name: string): StagedMap<CategoryGroup> {
+  return {
+    [id]: {
+      entity: { id, name, isIncome: false, hidden: false, categoryIds: [] },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+function makeTag(id: string, name: string, description?: string): StagedMap<Tag> {
+  return {
+    [id]: {
+      entity: { id, name, description },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+function makeRule(id: string, stage: Rule["stage"] = "default"): StagedMap<Rule> {
+  return {
+    [id]: {
+      entity: {
+        id,
+        stage,
+        conditionsOp: "and",
+        conditions: [{ field: "payee", op: "is", value: "amazon", type: "id" }],
+        actions: [{ field: "category", op: "set", value: "shopping-id", type: "id" }],
+      },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+function makeSchedule(id: string, name: string, payeeId?: string): StagedMap<Schedule> {
+  return {
+    [id]: {
+      entity: {
+        id,
+        name,
+        completed: false,
+        postsTransaction: false,
+        payeeId: payeeId ?? null,
+      },
+      original: null,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    },
+  };
+}
+
+const emptySlices: SearchSlices = {
+  accounts: {},
+  payees: {},
+  categoryGroups: {},
+  categories: {},
+  rules: {},
+  schedules: {},
+  tags: {},
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("searchEntities", () => {
+  test("empty query returns empty array", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "Amazon"),
+    };
+    expect(searchEntities("", slices)).toEqual([]);
+  });
+
+  test("whitespace-only query returns empty array", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "Amazon"),
+    };
+    expect(searchEntities("   ", slices)).toEqual([]);
+  });
+
+  test("exact match on payee name returns score 100", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "Amazon"),
+    };
+    const groups = searchEntities("Amazon", slices);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.entityType).toBe("payee");
+    expect(groups[0]!.results[0]!.score).toBe(100);
+  });
+
+  test("prefix match returns score 80", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "Amazon Prime"),
+    };
+    const groups = searchEntities("Amazon", slices);
+    expect(groups[0]!.results[0]!.score).toBe(80);
+  });
+
+  test("substring match returns score 40", () => {
+    // "Amazon" appears mid-word (not at a word boundary) → score 40
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "TheAmazonStore"),
+    };
+    const groups = searchEntities("Amazon", slices);
+    expect(groups[0]!.results[0]!.score).toBe(40);
+  });
+
+  test("deleted entries are excluded", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: {
+        p1: {
+          entity: { id: "p1", name: "Amazon" },
+          original: null,
+          isNew: false,
+          isUpdated: false,
+          isDeleted: true,
+          validationErrors: {},
+        },
+      },
+    };
+    expect(searchEntities("Amazon", slices)).toEqual([]);
+  });
+
+  test("results capped at 5 per group", () => {
+    const payees: StagedMap<Payee> = {};
+    for (let i = 1; i <= 10; i++) {
+      payees[`p${i}`] = {
+        entity: { id: `p${i}`, name: `Amazon ${i}` },
+        original: null,
+        isNew: false,
+        isUpdated: false,
+        isDeleted: false,
+        validationErrors: {},
+      };
+    }
+    const groups = searchEntities("Amazon", { ...emptySlices, payees });
+    expect(groups[0]!.results).toHaveLength(5);
+  });
+
+  test("groups with no results are omitted", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "Groceries Store"),
+    };
+    const groups = searchEntities("Groceries", slices);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.entityType).toBe("payee");
+  });
+
+  test("category result includes group name as sublabel", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      categories: makeCategory("c1", "Groceries", "g1"),
+      categoryGroups: makeCategoryGroup("g1", "Food & Dining"),
+    };
+    const groups = searchEntities("Groceries", slices);
+    expect(groups[0]!.entityType).toBe("category");
+    expect(groups[0]!.results[0]!.sublabel).toBe("Food & Dining");
+  });
+
+  test("all entity hrefs include ?highlight=<id>", () => {
+    const slices: SearchSlices = {
+      accounts: makeAccount("a1", "checking"),
+      payees: makePayee("p1", "checking store"),
+      categories: makeCategory("c1", "checking fees", "g1"),
+      categoryGroups: makeCategoryGroup("g1", "Group"),
+      rules: makeRule("rule-1"),
+      schedules: makeSchedule("s1", "checking deposit"),
+      tags: makeTag("t1", "checking"),
+    };
+    const groups = searchEntities("checking", slices);
+    for (const group of groups) {
+      for (const result of group.results) {
+        expect(result.href).toContain(`?highlight=${result.id}`);
+      }
+    }
+  });
+
+  test("empty tags slice omits tags group", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p1", "food"),
+      tags: {},
+    };
+    const groups = searchEntities("food", slices);
+    expect(groups.find((g) => g.entityType === "tag")).toBeUndefined();
+  });
+
+  test("tags group present when tags slice is populated", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      tags: makeTag("t1", "food-expense", "weekly food budget"),
+    };
+    const groups = searchEntities("food", slices);
+    expect(groups.find((g) => g.entityType === "tag")).toBeDefined();
+  });
+
+  test("new entities with placeholder names are excluded", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: {
+        p1: {
+          entity: { id: "p1", name: "New Payee" },
+          original: null,
+          isNew: true,
+          isUpdated: false,
+          isDeleted: false,
+          validationErrors: {},
+        },
+      },
+      tags: {
+        t1: {
+          entity: { id: "t1", name: "NewTag" },
+          original: null,
+          isNew: true,
+          isUpdated: false,
+          isDeleted: false,
+          validationErrors: {},
+        },
+      },
+    };
+    expect(searchEntities("New Payee", slices)).toEqual([]);
+    expect(searchEntities("NewTag", slices)).toEqual([]);
+  });
+
+  test("groups are returned in fixed order: payee, category, account, rule, schedule, tag", () => {
+    const slices: SearchSlices = {
+      accounts: makeAccount("a1", "test account"),
+      payees: makePayee("p1", "test payee"),
+      categories: makeCategory("c1", "test category", "g1"),
+      categoryGroups: makeCategoryGroup("g1", "Group"),
+      rules: makeRule("r1"),
+      schedules: makeSchedule("s1", "test schedule"),
+      tags: makeTag("t1", "test tag"),
+    };
+    const groups = searchEntities("test", slices);
+    const types = groups.map((g) => g.entityType);
+    const expected = ["payee", "category", "account", "schedule", "tag"] as const;
+    // rules may or may not match "test" — just verify relative order of what does match
+    const nonRule = types.filter((t) => t !== "rule");
+    expect(nonRule).toEqual(expected.filter((t) => nonRule.includes(t)));
+  });
+
+  test("schedule sublabel shows resolved payee name", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      schedules: makeSchedule("s1", "Monthly Rent", "p1"),
+      payees: makePayee("p1", "Landlord Co"),
+    };
+    const groups = searchEntities("Rent", slices);
+    const schedGroup = groups.find((g) => g.entityType === "schedule");
+    expect(schedGroup?.results[0]?.sublabel).toBe("Landlord Co");
+  });
+
+  test("account sublabel shows budget type", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      accounts: {
+        a1: {
+          entity: { id: "a1", name: "Savings", offBudget: true, closed: false },
+          original: null,
+          isNew: false,
+          isUpdated: false,
+          isDeleted: false,
+          validationErrors: {},
+        },
+      },
+    };
+    const groups = searchEntities("Savings", slices);
+    expect(groups[0]!.results[0]!.sublabel).toBe("Off budget");
+  });
+});

--- a/src/features/global-search/lib/searchEntities.test.ts
+++ b/src/features/global-search/lib/searchEntities.test.ts
@@ -251,6 +251,15 @@ describe("searchEntities", () => {
     }
   });
 
+  test("entity hrefs encode highlight ids", () => {
+    const slices: SearchSlices = {
+      ...emptySlices,
+      payees: makePayee("p/1?x=#", "Amazon"),
+    };
+    const groups = searchEntities("Amazon", slices);
+    expect(groups[0]!.results[0]!.href).toBe("/payees?highlight=p%2F1%3Fx%3D%23");
+  });
+
   test("empty tags slice omits tags group", () => {
     const slices: SearchSlices = {
       ...emptySlices,

--- a/src/features/global-search/lib/searchEntities.ts
+++ b/src/features/global-search/lib/searchEntities.ts
@@ -66,6 +66,10 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "…" : s;
 }
 
+function entityHref(page: string, id: string): string {
+  return `/${page}?highlight=${encodeURIComponent(id)}`;
+}
+
 function searchPayees(
   slices: SearchSlices,
   needle: string
@@ -80,7 +84,7 @@ function searchPayees(
       entityType: "payee",
       id: entry.entity.id,
       label: entry.entity.name,
-      href: `/payees?highlight=${entry.entity.id}`,
+      href: entityHref("payees", entry.entity.id),
       score: s,
     });
   }
@@ -104,7 +108,7 @@ function searchCategories(
       id: entry.entity.id,
       label: entry.entity.name,
       sublabel: groupName || undefined,
-      href: `/categories?highlight=${entry.entity.id}`,
+      href: entityHref("categories", entry.entity.id),
       score: s,
     });
   }
@@ -126,7 +130,7 @@ function searchAccounts(
       id: entry.entity.id,
       label: entry.entity.name,
       sublabel: entry.entity.offBudget ? "Off budget" : "On budget",
-      href: `/accounts?highlight=${entry.entity.id}`,
+      href: entityHref("accounts", entry.entity.id),
       score: s,
     });
   }
@@ -158,7 +162,7 @@ function searchRules(
       id: rule.id,
       label: preview,
       sublabel: stageLabel,
-      href: `/rules?highlight=${rule.id}`,
+      href: entityHref("rules", rule.id),
       score: s,
     });
   }
@@ -184,7 +188,7 @@ function searchSchedules(
       id: schedule.id,
       label: name,
       sublabel: payeeName || undefined,
-      href: `/schedules?highlight=${schedule.id}`,
+      href: entityHref("schedules", schedule.id),
       score: s,
     });
   }
@@ -207,7 +211,7 @@ function searchTags(
       id: tag.id,
       label: tag.name,
       sublabel: tag.description ? truncate(tag.description, 40) : undefined,
-      href: `/tags?highlight=${tag.id}`,
+      href: entityHref("tags", tag.id),
       score: s,
     });
   }

--- a/src/features/global-search/lib/searchEntities.ts
+++ b/src/features/global-search/lib/searchEntities.ts
@@ -1,0 +1,259 @@
+import type { StagedMap } from "@/types/staged";
+import type {
+  Account,
+  Payee,
+  Category,
+  CategoryGroup,
+  Rule,
+  Schedule,
+  Tag,
+} from "@/types/entities";
+import { rulePreview } from "@/features/rules/utils/rulePreview";
+import type { SearchResult, SearchResultGroup, SearchEntityType } from "../types";
+
+export type SearchSlices = {
+  accounts: StagedMap<Account>;
+  payees: StagedMap<Payee>;
+  categoryGroups: StagedMap<CategoryGroup>;
+  categories: StagedMap<Category>;
+  rules: StagedMap<Rule>;
+  schedules: StagedMap<Schedule>;
+  tags: StagedMap<Tag>;
+};
+
+const MAX_PER_GROUP = 5;
+
+const PLACEHOLDER_NAMES = new Set(["New Account", "New Payee", "New Category", "New Tag", "NewTag"]);
+
+const GROUP_LABELS: Record<SearchEntityType, string> = {
+  payee: "Payees",
+  category: "Categories",
+  account: "Accounts",
+  rule: "Rules",
+  schedule: "Schedules",
+  tag: "Tags",
+};
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function wordBoundaryMatch(haystack: string, needle: string): boolean {
+  const re = new RegExp(`(?:^|[ \\-/(])${escapeRegex(needle)}`);
+  return re.test(haystack);
+}
+
+function scoreMatch(haystack: string, needle: string): number {
+  const h = haystack.toLowerCase();
+  const n = needle.toLowerCase();
+  if (h === n) return 100;
+  if (h.startsWith(n)) return 80;
+  if (wordBoundaryMatch(h, n)) return 60;
+  if (h.includes(n)) return 40;
+  return 0;
+}
+
+function bestScore(fields: string[], needle: string): number {
+  let best = 0;
+  for (const f of fields) {
+    const s = scoreMatch(f, needle);
+    if (s > best) best = s;
+  }
+  return best;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "…" : s;
+}
+
+function searchPayees(
+  slices: SearchSlices,
+  needle: string
+): SearchResult[] {
+  const results: SearchResult[] = [];
+  for (const entry of Object.values(slices.payees)) {
+    if (entry.isDeleted) continue;
+    if (entry.isNew && PLACEHOLDER_NAMES.has(entry.entity.name)) continue;
+    const s = bestScore([entry.entity.name], needle);
+    if (s === 0) continue;
+    results.push({
+      entityType: "payee",
+      id: entry.entity.id,
+      label: entry.entity.name,
+      href: `/payees?highlight=${entry.entity.id}`,
+      score: s,
+    });
+  }
+  return results;
+}
+
+function searchCategories(
+  slices: SearchSlices,
+  needle: string
+): SearchResult[] {
+  const results: SearchResult[] = [];
+  for (const entry of Object.values(slices.categories)) {
+    if (entry.isDeleted) continue;
+    if (entry.isNew && PLACEHOLDER_NAMES.has(entry.entity.name)) continue;
+    const group = slices.categoryGroups[entry.entity.groupId];
+    const groupName = group?.entity.name ?? "";
+    const s = bestScore([entry.entity.name, groupName], needle);
+    if (s === 0) continue;
+    results.push({
+      entityType: "category",
+      id: entry.entity.id,
+      label: entry.entity.name,
+      sublabel: groupName || undefined,
+      href: `/categories?highlight=${entry.entity.id}`,
+      score: s,
+    });
+  }
+  return results;
+}
+
+function searchAccounts(
+  slices: SearchSlices,
+  needle: string
+): SearchResult[] {
+  const results: SearchResult[] = [];
+  for (const entry of Object.values(slices.accounts)) {
+    if (entry.isDeleted) continue;
+    if (entry.isNew && PLACEHOLDER_NAMES.has(entry.entity.name)) continue;
+    const s = bestScore([entry.entity.name], needle);
+    if (s === 0) continue;
+    results.push({
+      entityType: "account",
+      id: entry.entity.id,
+      label: entry.entity.name,
+      sublabel: entry.entity.offBudget ? "Off budget" : "On budget",
+      href: `/accounts?highlight=${entry.entity.id}`,
+      score: s,
+    });
+  }
+  return results;
+}
+
+function searchRules(
+  slices: SearchSlices,
+  needle: string
+): SearchResult[] {
+  const entityMaps = {
+    payees: slices.payees,
+    categories: slices.categories,
+    accounts: slices.accounts,
+    categoryGroups: slices.categoryGroups,
+    schedules: slices.schedules,
+  };
+
+  const results: SearchResult[] = [];
+  for (const entry of Object.values(slices.rules)) {
+    if (entry.isDeleted) continue;
+    const rule = entry.entity;
+    const preview = truncate(rulePreview(rule, entityMaps), 80);
+    const stageLabel = rule.stage ?? "default";
+    const s = bestScore([preview, stageLabel], needle);
+    if (s === 0) continue;
+    results.push({
+      entityType: "rule",
+      id: rule.id,
+      label: preview,
+      sublabel: stageLabel,
+      href: `/rules?highlight=${rule.id}`,
+      score: s,
+    });
+  }
+  return results;
+}
+
+function searchSchedules(
+  slices: SearchSlices,
+  needle: string
+): SearchResult[] {
+  const results: SearchResult[] = [];
+  for (const entry of Object.values(slices.schedules)) {
+    if (entry.isDeleted) continue;
+    const schedule = entry.entity;
+    const name = schedule.name ?? "Unnamed schedule";
+    const payeeName = schedule.payeeId
+      ? (slices.payees[schedule.payeeId]?.entity.name ?? "")
+      : "";
+    const s = bestScore([name, payeeName], needle);
+    if (s === 0) continue;
+    results.push({
+      entityType: "schedule",
+      id: schedule.id,
+      label: name,
+      sublabel: payeeName || undefined,
+      href: `/schedules?highlight=${schedule.id}`,
+      score: s,
+    });
+  }
+  return results;
+}
+
+function searchTags(
+  slices: SearchSlices,
+  needle: string
+): SearchResult[] {
+  const results: SearchResult[] = [];
+  for (const entry of Object.values(slices.tags)) {
+    if (entry.isDeleted) continue;
+    if (entry.isNew && PLACEHOLDER_NAMES.has(entry.entity.name)) continue;
+    const tag = entry.entity;
+    const s = bestScore([tag.name, tag.description ?? ""], needle);
+    if (s === 0) continue;
+    results.push({
+      entityType: "tag",
+      id: tag.id,
+      label: tag.name,
+      sublabel: tag.description ? truncate(tag.description, 40) : undefined,
+      href: `/tags?highlight=${tag.id}`,
+      score: s,
+    });
+  }
+  return results;
+}
+
+function toGroup(
+  entityType: SearchEntityType,
+  results: SearchResult[]
+): SearchResultGroup | null {
+  if (results.length === 0) return null;
+  const sorted = results
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_PER_GROUP);
+  return { entityType, groupLabel: GROUP_LABELS[entityType], results: sorted };
+}
+
+const GROUP_ORDER: SearchEntityType[] = [
+  "payee",
+  "category",
+  "account",
+  "rule",
+  "schedule",
+  "tag",
+];
+
+export function searchEntities(
+  rawQuery: string,
+  slices: SearchSlices
+): SearchResultGroup[] {
+  const needle = rawQuery.trim();
+  if (needle.length === 0) return [];
+
+  const candidates: Record<SearchEntityType, SearchResult[]> = {
+    payee: searchPayees(slices, needle),
+    category: searchCategories(slices, needle),
+    account: searchAccounts(slices, needle),
+    rule: searchRules(slices, needle),
+    schedule: searchSchedules(slices, needle),
+    tag: searchTags(slices, needle),
+  };
+
+  const groups: SearchResultGroup[] = [];
+  for (const type of GROUP_ORDER) {
+    const group = toGroup(type, candidates[type]);
+    if (group) groups.push(group);
+  }
+  return groups;
+}

--- a/src/features/global-search/store/useGlobalSearchStore.ts
+++ b/src/features/global-search/store/useGlobalSearchStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type GlobalSearchState = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+};
+
+export const useGlobalSearchStore = create<GlobalSearchState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+}));

--- a/src/features/global-search/types.ts
+++ b/src/features/global-search/types.ts
@@ -1,0 +1,22 @@
+export type SearchEntityType =
+  | "payee"
+  | "category"
+  | "account"
+  | "rule"
+  | "schedule"
+  | "tag";
+
+export type SearchResult = {
+  entityType: SearchEntityType;
+  id: string;
+  label: string;
+  sublabel?: string;
+  href: string;
+  score: number;
+};
+
+export type SearchResultGroup = {
+  entityType: SearchEntityType;
+  groupLabel: string;
+  results: SearchResult[];
+};

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -6,7 +6,11 @@ import { getTags } from "@/lib/api/tags";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
-export function useTags() {
+type PreloadOptions = {
+  enabled?: boolean;
+};
+
+export function useTags(options: PreloadOptions = {}) {
   const connection = useConnectionStore(selectActiveInstance);
   const loadTags = useStagedStore((s) => s.loadTags);
 
@@ -16,7 +20,7 @@ export function useTags() {
       if (!connection) throw new Error("No active connection");
       return getTags(connection);
     },
-    enabled: !!connection,
+    enabled: !!connection && (options.enabled ?? true),
   });
 
   useEffect(() => {

--- a/src/hooks/useAllEntities.ts
+++ b/src/hooks/useAllEntities.ts
@@ -5,6 +5,7 @@ import { usePayees } from "@/features/payees/hooks/usePayees";
 import { useCategoryGroups } from "@/features/categories/hooks/useCategoryGroups";
 import { useRules } from "@/features/rules/hooks/useRules";
 import { useSchedules } from "@/features/schedules/hooks/useSchedules";
+import { useTags } from "@/features/tags/hooks/useTags";
 
 /**
  * Prefetches all entity types in parallel so that data is available on any
@@ -20,4 +21,5 @@ export function usePreloadEntities(enabled = true) {
   useCategoryGroups({ enabled });
   useRules({ enabled });
   useSchedules({ enabled });
+  useTags({ enabled });
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -26,9 +26,10 @@ export function useKeyboardShortcuts() {
     function handleKeyDown(e: KeyboardEvent) {
       const mod = e.ctrlKey || e.metaKey;
       if (!mod) return;
+      const key = e.key.toLowerCase();
 
       // Ctrl/Cmd+K — open global search (fires from anywhere, including inputs)
-      if (e.key === "k") {
+      if (key === "k") {
         e.preventDefault();
         openSearch();
         return;
@@ -42,10 +43,10 @@ export function useKeyboardShortcuts() {
         target.isContentEditable
       ) return;
 
-      if (e.key === "z" && !e.shiftKey) {
+      if (key === "z" && !e.shiftKey) {
         e.preventDefault();
         undo();
-      } else if ((e.key === "z" && e.shiftKey) || e.key === "y") {
+      } else if ((key === "z" && e.shiftKey) || key === "y") {
         e.preventDefault();
         redo();
       }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -2,26 +2,37 @@
 
 import { useEffect } from "react";
 import { useStagedStore } from "@/store/staged";
+import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSearchStore";
 
 /**
- * Wires global keyboard shortcuts for the staged store.
+ * Wires global keyboard shortcuts for the staged store and app-wide actions.
  * Must be called once, inside a client component (AppShell).
  *
  * Ctrl/Cmd+Z        → undo
  * Ctrl/Cmd+Shift+Z  → redo
  * Ctrl/Cmd+Y        → redo (Windows convention)
+ * Ctrl/Cmd+K        → open global search modal
  *
- * Shortcuts are suppressed when focus is inside an input, textarea, or
- * contentEditable element so native browser text-undo is not broken.
+ * Undo/redo are suppressed inside text inputs so native browser undo is not
+ * broken. Ctrl/Cmd+K intentionally fires from anywhere, including text inputs,
+ * consistent with standard search-modal conventions.
  */
 export function useKeyboardShortcuts() {
   const undo = useStagedStore((s) => s.undo);
   const redo = useStagedStore((s) => s.redo);
+  const openSearch = useGlobalSearchStore((s) => s.open);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const mod = e.ctrlKey || e.metaKey;
       if (!mod) return;
+
+      // Ctrl/Cmd+K — open global search (fires from anywhere, including inputs)
+      if (e.key === "k") {
+        e.preventDefault();
+        openSearch();
+        return;
+      }
 
       // Don't steal Ctrl+Z from text inputs — let the browser handle it.
       const target = e.target as HTMLElement;
@@ -42,5 +53,5 @@ export function useKeyboardShortcuts() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [undo, redo]);
+  }, [undo, redo, openSearch]);
 }


### PR DESCRIPTION
## Summary

  - Add Ctrl/Cmd+K global search across accounts, payees, categories, rules, schedules, and tags
  - Wire the TopBar search trigger, modal state store, keyboard navigation, and highlighted result navigation
  - Preload tags through the shared entity preload hook so search works before visiting /tags
  - Reset modal query/focus state on close and reopen

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Manually tested in browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global Search added — search across accounts, payees, categories, rules, schedules, and tags
  * Open via new Search button in the header or Ctrl/Cmd+K
  * Results grouped by entity type with keyboard navigation (Arrow keys, Enter) and clear empty/no-results states
  * Results show contextual sublabels and highlightable matches; searches preload data for faster response
<!-- end of auto-generated comment: release notes by coderabbit.ai -->