### PR TITLE
feat/add entity bundle export/import (ZIP)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ import { generateId } from "@/lib/uuid";
 ```
 feat/* | fix/* | refactor/* | docs/*  →  main  →  release (tag v1.x.x)
 ```
+CI (`ci.yml`) runs lint, type-check, tests, and build on every push — no need to run these manually before committing.
 
 ---
 
@@ -55,6 +56,7 @@ feat/* | fix/* | refactor/* | docs/*  →  main  →  release (tag v1.x.x)
 | Zustand `connection.ts` | Active connection (`sessionStorage` — do NOT change to `localStorage`) |
 | Zustand `savedServers.ts` | Saved server presets (`sessionStorage`) |
 | Local state | Ephemeral UI only |
+
 
 ---
 
@@ -79,39 +81,50 @@ src/features/<entity>/
   lib/          utils/   # optional, when the feature needs them
 ```
 
-**Proxy responsibilities:**
-- CORS handling
-- Request serialization via `serverQueueTails` (prevents concurrent budget open/close races)
-- Path construction: `/accounts` → `GET /v1/budgets/{budgetSyncId}/accounts`
-- Server-level paths (no `budgetSyncId`) passed as-is: `/v1/budgets/`
-- Logging format: `METHOD STATUS /path (Xms) [reqId]`
+## Proxy Notes
+
+The proxy is responsible for:
+
+- CORS handling.
+- Request serialization using `serverQueueTails`.
+- Adding `/v1/budgets/{budgetSyncId}` for budget-scoped paths.
+- Passing server-level paths as-is.
+
+Do not bypass or duplicate proxy behavior in feature code.
 
 ---
 
-## Reference Documents
+## Reference Docs
 
-Read these **before** implementing anything in the relevant area.
+Read these only when relevant to the task:
 
-| Document | When to Read |
+| Task | Read |
 |---|---|
-| `agents/coding_standards.md` | Before any new component, hook, or utility |
-| `agents/actual_api_docs/api_docs.md` | Before any API integration |
-| `agents/future-roadmap.md` | Before starting any roadmap item |
-| `agents/requirements/` | Before making architectural decisions |
-| `CONTRIBUTING.md` | Before touching git, workflows, or the release process |
-| `FEATURES.md` | Before and after shipping a feature — must be updated |
-| `README.md` | When entry points, setup flow, or product positioning changes |
+| New component, hook, or utility | `agents/coding_standards.md` |
+| API integration | `agents/actual_api_docs/api_docs.md` |
+| Roadmap work | `agents/future-roadmap.md` |
+| Architecture decision | `agents/requirements/` |
+| Git, workflow, or release change | `CONTRIBUTING.md` |
 
-When shipping user-facing work:
-- Update `FEATURES.md` for shipped behavior.
-- Update `README.md` if the main app entry points or product positioning changed.
-- Update `agents/future-roadmap.md` when a roadmap item's status changes.
+Update these only when the change requires it:
+
+| Change | Update |
+|---|---|
+| User-facing feature added or changed | `FEATURES.md` |
+| Setup, entry point, or positioning changed | `README.md` |
 
 ---
 
-## Before Every Commit
+## Validation
+
+GitHub Actions runs lint, typecheck, and tests on push/PR.
+
+Before proposing completion, run only the checks that match the files changed when practical:
+
 ```bash
-npm run lint       # 0 errors
-npx tsc --noEmit   # 0 errors
-npm test           # all suites pass
+npm run lint
+npx tsc --noEmit
+npm test
 ```
+
+Do not spend time running the full suite for documentation-only changes unless requested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
-@AGENTS.md
-
-## Active Technologies
-- TypeScript 5 / Node 20 + Next.js 16 (Turbopack), React 19, TanStack Query 5, Zustand 5, TanStack Table 8, RHF 7 + Zod 4, Tailwind 4 (feat/001-budget-management-workspace)
-- No persistent storage — server state via Budget Months API; client state in Zustand and TanStack Query cache (feat/001-budget-management-workspace)
-- TypeScript 5 / Node 20 + Next.js 16 (Turbopack, app router), React 19, Zustand 5 (existing `staged.ts` store), TanStack Query 5 (existing `useRules` hook), Tailwind 4 (via `globals.css` `@theme`), shadcn/ui primitives already in `src/components/ui/` (002-rule-diagnostics)
-- None — analysis runs entirely in-memory against the staged store and TanStack Query cache that are already loaded for the Rules page. No new API endpoints, no persistence. (002-rule-diagnostics)
-
-## Recent Changes
-- feat/001-budget-management-workspace: Added TypeScript 5 / Node 20 + Next.js 16 (Turbopack), React 19, TanStack Query 5, Zustand 5, TanStack Table 8, RHF 7 + Zod 4, Tailwind 4
-- feat/001-budget-management-workspace: Shipped Budget Management Workspace (`/budget-management`) — staged cell editing, save review panel, bulk actions, CSV import/export, envelope-mode immediate actions. New `src/store/budgetEdits.ts` store for budget-specific undo/redo (separate from `staged.ts`). New `src/lib/budget/deriveBudgetMode.ts` shared utility (returns uppercase; `useBudgetMode` hook normalizes to lowercase).
+Read the rules from AGENTS.md

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -410,6 +410,39 @@ Transaction counts are fetched lazily when the drawer opens, gated by the same `
 | `op` | Operator (e.g. `is`, `contains`, `lt`, `oneOf`) |
 | `value` | Value — use `\|` as separator for multi-value `oneOf` operators |
 
+## Bundle Export / Import
+
+Available from the **Budget Overview** page (`Export` / `Import` buttons in the page header).
+
+### Bundle Export
+
+- Opens a dialog listing all six entity types — Accounts, Payees, Categories & Groups, Tags, Schedules, Rules — with checkboxes pre-selected; live entity counts displayed per type
+- Entity data is loaded on demand when the dialog opens, so exporting from the Overview page (which intentionally skips preloading) always reflects current server state
+- Inline dependency warnings appear dynamically as selections change:
+  - Selecting **Rules** without Payees, Categories, or Accounts produces a portability warning
+  - Selecting **Schedules** without Payees or Accounts produces a portability warning
+- Download produces a single ZIP file named `budget-bundle-<label>-<YYYY-MM-DD>.zip`; each entity type is a separate UTF-8 CSV with BOM using the same format as the per-page exports
+
+**ZIP contents:**
+```
+budget-bundle-<label>-<date>.zip
+  ├── accounts.csv
+  ├── payees.csv
+  ├── category-groups-and-categories.csv
+  ├── tags.csv
+  ├── schedules.csv
+  └── rules.csv
+```
+
+### Bundle Import
+
+- Accepts a `.zip` file produced by Bundle Export (partial bundles with a subset of CSVs are valid)
+- Preview step shows each detected entity type with its row count before any staging occurs
+- Import processes entity types in dependency order — categories first, rules last — so that name→ID resolution for Schedules and Rules picks up Accounts and Payees staged earlier in the same operation
+- All imported rows are staged; nothing is saved until the user clicks Save in the top bar
+- Result summary shows staged count, skipped count, and any parse errors per entity type; quick-navigation links jump directly to each entity page to review the staged rows
+- A single undo step covers the entire bundle import
+
 ## Keyboard & Table UX
 
 - Inline cell editing triggered by double-click, Enter, or F2

--- a/src/features/budget-diagnostics/lib/bundleIsolation.test.ts
+++ b/src/features/budget-diagnostics/lib/bundleIsolation.test.ts
@@ -7,8 +7,10 @@ import { join, relative } from "node:path";
 
 const ROOT = process.cwd();
 const SRC_DIR = join(ROOT, "src");
-const HEAVY_DIAGNOSTICS_IMPORTS = ["@sqlite.org/sqlite-wasm", "fflate"] as const;
-const ALLOWED_PREFIX = "src/features/budget-diagnostics/";
+const SQLITE_IMPORTS = ["@sqlite.org/sqlite-wasm"] as const;
+const FFLATE_IMPORTS = ["fflate"] as const;
+const SQLITE_ALLOWED_PREFIXES = ["src/features/budget-diagnostics/"];
+const FFLATE_ALLOWED_PREFIXES = ["src/features/budget-diagnostics/", "src/features/bundle/"];
 const ALLOWED_TYPE_DECLARATIONS = new Set(["src/types/sqlite-wasm.d.ts"]);
 
 function listSourceFiles(dir: string): string[] {
@@ -25,17 +27,26 @@ describe("budget diagnostics bundle isolation", () => {
     const offenders = listSourceFiles(SRC_DIR).flatMap((file) => {
       const relativePath = relative(ROOT, file);
       const normalizedPath = relativePath.replace(/\\+/g, "/");
-      if (
-        normalizedPath.startsWith(ALLOWED_PREFIX) ||
-        ALLOWED_TYPE_DECLARATIONS.has(normalizedPath)
-      ) {
-        return [];
-      }
+      if (ALLOWED_TYPE_DECLARATIONS.has(normalizedPath)) return [];
 
       const source = readFileSync(file, "utf8");
-      return HEAVY_DIAGNOSTICS_IMPORTS.filter((moduleName) =>
-        source.includes(moduleName)
-      ).map((moduleName) => `${normalizedPath} imports ${moduleName}`);
+      const violations: string[] = [];
+
+      for (const moduleName of SQLITE_IMPORTS) {
+        const allowed = SQLITE_ALLOWED_PREFIXES.some((p) => normalizedPath.startsWith(p));
+        if (!allowed && source.includes(moduleName)) {
+          violations.push(`${normalizedPath} imports ${moduleName}`);
+        }
+      }
+
+      for (const moduleName of FFLATE_IMPORTS) {
+        const allowed = FFLATE_ALLOWED_PREFIXES.some((p) => normalizedPath.startsWith(p));
+        if (!allowed && source.includes(moduleName)) {
+          violations.push(`${normalizedPath} imports ${moduleName}`);
+        }
+      }
+
+      return violations;
     });
 
     expect(offenders).toEqual([]);

--- a/src/features/bundle/components/BundleExportDialog.tsx
+++ b/src/features/bundle/components/BundleExportDialog.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Loader2, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useStagedStore } from "@/store/staged";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { useAccounts } from "@/features/accounts/hooks/useAccounts";
+import { usePayees } from "@/features/payees/hooks/usePayees";
+import { useCategoryGroups } from "@/features/categories/hooks/useCategoryGroups";
+import { useTags } from "@/features/tags/hooks/useTags";
+import { useSchedules } from "@/features/schedules/hooks/useSchedules";
+import { useRules } from "@/features/rules/hooks/useRules";
+import {
+  exportBundle,
+  ALL_BUNDLE_ENTITY_KEYS,
+  BUNDLE_ENTITY_LABELS,
+} from "../lib/bundleExport";
+import type { BundleEntityKey } from "../lib/bundleExport";
+
+// ─── Inner body (only mounted when dialog is open) ────────────────────────────
+
+function ExportDialogBody({
+  onOpenChange,
+}: {
+  onOpenChange: (open: boolean) => void;
+}) {
+  // Calling these hooks here triggers entity loading if not already cached.
+  // Because base-ui's Dialog.Popup is unmounted when closed, these only run
+  // when the dialog is actually open.
+  const { isLoading: accountsLoading } = useAccounts();
+  const { isLoading: payeesLoading } = usePayees();
+  const { isLoading: categoriesLoading } = useCategoryGroups();
+  const { isLoading: tagsLoading } = useTags();
+  const { isLoading: schedulesLoading } = useSchedules();
+  const { isLoading: rulesLoading } = useRules();
+
+  const isLoading =
+    accountsLoading ||
+    payeesLoading ||
+    categoriesLoading ||
+    tagsLoading ||
+    schedulesLoading ||
+    rulesLoading;
+
+  const accounts = useStagedStore((s) => s.accounts);
+  const payees = useStagedStore((s) => s.payees);
+  const categoryGroups = useStagedStore((s) => s.categoryGroups);
+  const categories = useStagedStore((s) => s.categories);
+  const tags = useStagedStore((s) => s.tags);
+  const schedules = useStagedStore((s) => s.schedules);
+  const rules = useStagedStore((s) => s.rules);
+  const connection = useConnectionStore(selectActiveInstance);
+
+  // State initialises fresh every time the dialog opens (component remounts)
+  const [selected, setSelected] = useState<Set<BundleEntityKey>>(
+    new Set(ALL_BUNDLE_ENTITY_KEYS)
+  );
+
+  const counts: Record<BundleEntityKey, number> = {
+    accounts: Object.values(accounts).filter((s) => !s.isDeleted).length,
+    payees: Object.values(payees).filter((s) => !s.isDeleted).length,
+    categories:
+      Object.values(categoryGroups).filter((s) => !s.isDeleted).length +
+      Object.values(categories).filter((s) => !s.isDeleted).length,
+    tags: Object.values(tags).filter((s) => !s.isDeleted).length,
+    schedules: Object.values(schedules).filter((s) => !s.isDeleted).length,
+    rules: Object.values(rules).filter((s) => !s.isDeleted).length,
+  };
+
+  const rulesMissingDeps =
+    selected.has("rules") &&
+    (!selected.has("payees") || !selected.has("categories") || !selected.has("accounts"));
+
+  const schedulesMissingDeps =
+    selected.has("schedules") &&
+    (!selected.has("payees") || !selected.has("accounts"));
+
+  function toggle(key: BundleEntityKey) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function handleDownload() {
+    try {
+      const blob = exportBundle(
+        { accounts, payees, categoryGroups, categories, tags, schedules, rules },
+        selected
+      );
+      const safeLabel = (connection?.label ?? "bundle").replace(/[^a-z0-9_-]/gi, "-");
+      const date = new Date().toISOString().slice(0, 10);
+      const filename = `budget-bundle-${safeLabel}-${date}.zip`;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      try {
+        a.click();
+      } finally {
+        setTimeout(() => URL.revokeObjectURL(url), 100);
+      }
+      onOpenChange(false);
+    } catch {
+      toast.error("Export failed. Please try again.");
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Export Bundle</DialogTitle>
+        <DialogDescription>
+          Select the entity types to include in the ZIP archive. Each type is
+          exported as a separate CSV using the same format as per-page exports.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-3 py-1">
+        {ALL_BUNDLE_ENTITY_KEYS.map((key) => (
+          <div key={key} className="flex items-center justify-between">
+            <div className="flex items-center gap-2.5">
+              <Checkbox
+                id={`export-entity-${key}`}
+                checked={selected.has(key)}
+                onCheckedChange={() => toggle(key)}
+              />
+              <label
+                htmlFor={`export-entity-${key}`}
+                className="cursor-pointer text-sm font-medium leading-none select-none"
+              >
+                {BUNDLE_ENTITY_LABELS[key]}
+              </label>
+            </div>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {isLoading ? "…" : counts[key]}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {(rulesMissingDeps || schedulesMissingDeps) && (
+        <div className="space-y-1.5">
+          {rulesMissingDeps && (
+            <p className="flex items-start gap-1.5 rounded-md bg-amber-50 px-2.5 py-2 text-xs text-amber-700 dark:bg-amber-950/40 dark:text-amber-400">
+              <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
+              Rules reference Payees, Categories, and Accounts — include them
+              for a portable bundle.
+            </p>
+          )}
+          {schedulesMissingDeps && (
+            <p className="flex items-start gap-1.5 rounded-md bg-amber-50 px-2.5 py-2 text-xs text-amber-700 dark:bg-amber-950/40 dark:text-amber-400">
+              <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
+              Schedules reference Payees and Accounts — include them for a
+              portable bundle.
+            </p>
+          )}
+        </div>
+      )}
+
+      <DialogFooter>
+        <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+        <Button
+          onClick={handleDownload}
+          disabled={selected.size === 0 || isLoading}
+        >
+          {isLoading ? (
+            <Loader2 className="animate-spin" />
+          ) : (
+            <Download />
+          )}
+          {isLoading ? "Loading…" : "Download ZIP"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function BundleExportDialog({ open, onOpenChange }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* ExportDialogBody is only mounted when the dialog is open.
+          base-ui's Dialog.Popup unmounts its children when closed,
+          so entity hooks inside only fire while the dialog is visible. */}
+      <DialogContent>
+        <ExportDialogBody onOpenChange={onOpenChange} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/bundle/components/BundleImportDialog.tsx
+++ b/src/features/bundle/components/BundleImportDialog.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ExternalLink,
+  FileArchive,
+  Upload,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useStagedStore } from "@/store/staged";
+import { generateId } from "@/lib/uuid";
+import { importAccountsFromCsv } from "@/features/accounts/csv/accountsCsvImport";
+import { importPayeesFromCsv } from "@/features/payees/csv/payeesCsvImport";
+import { importCategoriesFromCsv } from "@/features/categories/csv/categoriesCsvImport";
+import { importTagsFromCsv } from "@/features/tags/csv/tagsCsvImport";
+import { importSchedulesFromCsv } from "@/features/schedules/csv/schedulesCsvImport";
+import { importRulesFromCsv } from "@/features/rules/csv/rulesCsvImport";
+import { BUNDLE_ENTITY_LABELS } from "../lib/bundleExport";
+import { readBundleZip } from "../lib/bundleImport";
+import type { BundleEntityKey } from "../lib/bundleExport";
+import type { BundleFileEntry } from "../lib/bundleImport";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type EntityResult = {
+  key: BundleEntityKey;
+  staged: number;
+  skipped: number;
+  error: string | null;
+};
+
+type Phase =
+  | { name: "idle" }
+  | { name: "preview"; files: BundleFileEntry[] }
+  | { name: "done"; results: EntityResult[] };
+
+const ENTITY_PAGE: Record<BundleEntityKey, string> = {
+  accounts: "/accounts",
+  payees: "/payees",
+  categories: "/categories",
+  tags: "/tags",
+  schedules: "/schedules",
+  rules: "/rules",
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function BundleImportDialog({ open, onOpenChange }: Props) {
+  const [phase, setPhase] = useState<Phase>({ name: "idle" });
+  const [isParsing, setIsParsing] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  const stageNew = useStagedStore((s) => s.stageNew);
+  const pushUndo = useStagedStore((s) => s.pushUndo);
+
+  function closeAndReset() {
+    onOpenChange(false);
+    setPhase({ name: "idle" });
+    setIsParsing(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    setIsParsing(true);
+    const result = await readBundleZip(file);
+    setIsParsing(false);
+
+    if (!result.ok) {
+      toast.error(result.error);
+      return;
+    }
+    if (result.files.length === 0) {
+      toast.warning("No recognised CSV files found in the ZIP.");
+      return;
+    }
+    setPhase({ name: "preview", files: result.files });
+  }
+
+  function handleImportAll(files: BundleFileEntry[]) {
+    const results: EntityResult[] = [];
+    pushUndo();
+
+    for (const { key, csvText } of files) {
+      try {
+        // Read fresh state each iteration so subsequent entity types
+        // can resolve names from entities staged earlier in this loop.
+        const fresh = useStagedStore.getState();
+
+        switch (key) {
+          case "categories": {
+            const existingGroups = Object.values(fresh.categoryGroups)
+              .filter((s) => !s.isDeleted)
+              .map((s) => ({ name: s.entity.name, id: s.entity.id }));
+            const r = importCategoriesFromCsv(csvText, existingGroups);
+            if ("error" in r) {
+              results.push({ key, staged: 0, skipped: 0, error: r.error });
+              break;
+            }
+            for (const group of r.groups) {
+              stageNew("categoryGroups", { ...group, categoryIds: [] });
+            }
+            for (const cat of r.categories) {
+              stageNew("categories", { id: generateId(), ...cat });
+            }
+            results.push({
+              key,
+              staged: r.groups.length + r.categories.length,
+              skipped: r.skipped,
+              error: null,
+            });
+            break;
+          }
+
+          case "accounts": {
+            const r = importAccountsFromCsv(csvText);
+            if ("error" in r) {
+              results.push({ key, staged: 0, skipped: 0, error: r.error });
+              break;
+            }
+            for (const account of r.accounts) {
+              stageNew("accounts", { id: generateId(), ...account });
+            }
+            results.push({ key, staged: r.accounts.length, skipped: r.skipped, error: null });
+            break;
+          }
+
+          case "payees": {
+            const r = importPayeesFromCsv(csvText);
+            if ("error" in r) {
+              results.push({ key, staged: 0, skipped: 0, error: r.error });
+              break;
+            }
+            for (const payee of r.payees) {
+              stageNew("payees", { id: generateId(), ...payee });
+            }
+            results.push({ key, staged: r.payees.length, skipped: r.skipped, error: null });
+            break;
+          }
+
+          case "tags": {
+            const r = importTagsFromCsv(csvText);
+            if ("error" in r) {
+              results.push({ key, staged: 0, skipped: 0, error: r.error });
+              break;
+            }
+            for (const tag of r.tags) {
+              stageNew("tags", { id: generateId(), ...tag });
+            }
+            results.push({ key, staged: r.tags.length, skipped: r.skipped, error: null });
+            break;
+          }
+
+          case "schedules": {
+            const r = importSchedulesFromCsv(csvText, {
+              payees: fresh.payees,
+              accounts: fresh.accounts,
+            });
+            if ("error" in r) {
+              results.push({ key, staged: 0, skipped: 0, error: r.error });
+              break;
+            }
+            for (const schedule of r.schedules) {
+              stageNew("schedules", schedule);
+            }
+            results.push({ key, staged: r.schedules.length, skipped: r.skipped, error: null });
+            break;
+          }
+
+          case "rules": {
+            const r = importRulesFromCsv(csvText, {
+              payees: fresh.payees,
+              categories: fresh.categories,
+              accounts: fresh.accounts,
+              categoryGroups: fresh.categoryGroups,
+            });
+            if ("error" in r) {
+              results.push({ key, staged: 0, skipped: 0, error: r.error });
+              break;
+            }
+            for (const payee of r.newPayees) stageNew("payees", payee);
+            for (const rule of r.rules) stageNew("rules", rule);
+            results.push({ key, staged: r.rules.length, skipped: r.skipped, error: null });
+            break;
+          }
+        }
+      } catch {
+        results.push({ key, staged: 0, skipped: 0, error: "Unexpected error during import." });
+      }
+    }
+
+    setPhase({ name: "done", results });
+
+    const totalStaged = results.reduce((sum, r) => sum + r.staged, 0);
+    if (totalStaged > 0) {
+      toast.success(`${totalStaged} entities staged — save to persist.`);
+    } else {
+      toast.warning("No entities were staged.");
+    }
+  }
+
+  // ── Idle ──────────────────────────────────────────────────────────────────
+
+  if (phase.name === "idle") {
+    return (
+      <Dialog open={open} onOpenChange={(v) => { if (!v) closeAndReset(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import Bundle</DialogTitle>
+            <DialogDescription>
+              Select a ZIP bundle exported from Actual Bench. Entities will be
+              staged — nothing is saved until you click Save.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col items-center gap-3 py-4">
+            <div className="rounded-full border border-dashed border-border p-4">
+              <FileArchive className="h-8 w-8 text-muted-foreground" />
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isParsing}
+            >
+              <Upload />
+              {isParsing ? "Reading…" : "Select ZIP file"}
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".zip"
+              className="hidden"
+              onChange={(e) => void handleFileChange(e)}
+            />
+          </div>
+
+          <DialogFooter showCloseButton />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // ── Preview ───────────────────────────────────────────────────────────────
+
+  if (phase.name === "preview") {
+    const { files } = phase;
+    return (
+      <Dialog open={open} onOpenChange={(v) => { if (!v) closeAndReset(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import Bundle</DialogTitle>
+            <DialogDescription>
+              {files.length} entity type{files.length !== 1 ? "s" : ""} detected.
+              Review below and click Import All to stage them.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-1.5">
+            {files.map((f) => (
+              <div
+                key={f.key}
+                className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm"
+              >
+                <span className="font-medium">{BUNDLE_ENTITY_LABELS[f.key]}</span>
+                <span className="text-muted-foreground">
+                  {f.rowCount} row{f.rowCount !== 1 ? "s" : ""}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPhase({ name: "idle" })}>
+              Back
+            </Button>
+            <Button onClick={() => handleImportAll(files)}>Import All</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // ── Done ──────────────────────────────────────────────────────────────────
+
+  const { results } = phase;
+  const errorCount = results.filter((r) => r.error !== null).length;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) closeAndReset(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import Complete</DialogTitle>
+          <DialogDescription>
+            {errorCount === 0
+              ? "All entities have been staged. Click Save to persist."
+              : `${errorCount} entity type${errorCount !== 1 ? "s" : ""} had errors. Valid rows were still staged.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-1.5">
+          {results.map((r) => (
+            <div
+              key={r.key}
+              className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm"
+            >
+              <div className="flex items-center gap-2">
+                {r.error ? (
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+                ) : (
+                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-500" />
+                )}
+                <span className="font-medium">{BUNDLE_ENTITY_LABELS[r.key]}</span>
+              </div>
+
+              <div className="flex items-center gap-2 text-muted-foreground">
+                {r.error ? (
+                  <span className="text-xs text-destructive">{r.error}</span>
+                ) : (
+                  <>
+                    <span>{r.staged} staged</span>
+                    {r.skipped > 0 && <span>· {r.skipped} skipped</span>}
+                    <button
+                      onClick={() => {
+                        router.push(ENTITY_PAGE[r.key]);
+                        closeAndReset();
+                      }}
+                      className="ml-1 text-foreground/60 transition-colors hover:text-foreground"
+                      title={`Go to ${BUNDLE_ENTITY_LABELS[r.key]}`}
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter showCloseButton />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/bundle/components/BundleImportDialog.tsx
+++ b/src/features/bundle/components/BundleImportDialog.tsx
@@ -341,12 +341,14 @@ export function BundleImportDialog({ open, onOpenChange }: Props) {
                     <span>{r.staged} staged</span>
                     {r.skipped > 0 && <span>· {r.skipped} skipped</span>}
                     <button
+                      type="button"
                       onClick={() => {
                         router.push(ENTITY_PAGE[r.key]);
                         closeAndReset();
                       }}
                       className="ml-1 text-foreground/60 transition-colors hover:text-foreground"
                       title={`Go to ${BUNDLE_ENTITY_LABELS[r.key]}`}
+                      aria-label={`Go to ${BUNDLE_ENTITY_LABELS[r.key]}`}
                     >
                       <ExternalLink className="h-3.5 w-3.5" />
                     </button>

--- a/src/features/bundle/lib/bundleExport.ts
+++ b/src/features/bundle/lib/bundleExport.ts
@@ -1,0 +1,83 @@
+import { zipSync, strToU8 } from "fflate";
+import { exportAccountsToCsv } from "@/features/accounts/csv/accountsCsvExport";
+import { exportPayeesToCsv } from "@/features/payees/csv/payeesCsvExport";
+import { exportCategoriesToCsv } from "@/features/categories/csv/categoriesCsvExport";
+import { exportTagsToCsv } from "@/features/tags/csv/tagsCsvExport";
+import { exportSchedulesToCsv } from "@/features/schedules/csv/schedulesCsvExport";
+import { exportRulesToCsv } from "@/features/rules/csv/rulesCsvExport";
+import type { StagedMap } from "@/types/staged";
+import type { Account, Payee, CategoryGroup, Category, Tag, Schedule, Rule } from "@/types/entities";
+
+const BOM = "﻿";
+
+export type BundleEntityKey =
+  | "accounts"
+  | "payees"
+  | "categories"
+  | "tags"
+  | "schedules"
+  | "rules";
+
+export const BUNDLE_ENTITY_LABELS: Record<BundleEntityKey, string> = {
+  accounts: "Accounts",
+  payees: "Payees",
+  categories: "Categories & Groups",
+  tags: "Tags",
+  schedules: "Schedules",
+  rules: "Rules",
+};
+
+export const ALL_BUNDLE_ENTITY_KEYS: BundleEntityKey[] = [
+  "accounts",
+  "payees",
+  "categories",
+  "tags",
+  "schedules",
+  "rules",
+];
+
+type BundleExportInput = {
+  accounts: StagedMap<Account>;
+  payees: StagedMap<Payee>;
+  categoryGroups: StagedMap<CategoryGroup>;
+  categories: StagedMap<Category>;
+  tags: StagedMap<Tag>;
+  schedules: StagedMap<Schedule>;
+  rules: StagedMap<Rule>;
+};
+
+export function exportBundle(
+  staged: BundleExportInput,
+  selected: Set<BundleEntityKey>
+): Blob {
+  const { accounts, payees, categoryGroups, categories, tags, schedules, rules } = staged;
+  const files: Record<string, Uint8Array> = {};
+
+  if (selected.has("accounts")) {
+    files["accounts.csv"] = strToU8(BOM + exportAccountsToCsv(accounts));
+  }
+  if (selected.has("payees")) {
+    files["payees.csv"] = strToU8(BOM + exportPayeesToCsv(payees));
+  }
+  if (selected.has("categories")) {
+    files["category-groups-and-categories.csv"] = strToU8(
+      BOM + exportCategoriesToCsv(categoryGroups, categories)
+    );
+  }
+  if (selected.has("tags")) {
+    files["tags.csv"] = strToU8(BOM + exportTagsToCsv(tags));
+  }
+  if (selected.has("schedules")) {
+    files["schedules.csv"] = strToU8(
+      BOM + exportSchedulesToCsv(schedules, { payees, accounts })
+    );
+  }
+  if (selected.has("rules")) {
+    files["rules.csv"] = strToU8(
+      BOM + exportRulesToCsv(rules, { payees, categories, accounts, categoryGroups })
+    );
+  }
+
+  const zipped = zipSync(files);
+  return new Blob([zipped.buffer as ArrayBuffer], { type: "application/zip" });
+}

--- a/src/features/bundle/lib/bundleImport.ts
+++ b/src/features/bundle/lib/bundleImport.ts
@@ -1,0 +1,68 @@
+import { unzipSync, strFromU8 } from "fflate";
+import type { BundleEntityKey } from "./bundleExport";
+
+export type BundleFileEntry = {
+  key: BundleEntityKey;
+  filename: string;
+  csvText: string;
+  rowCount: number;
+};
+
+export type ReadBundleResult =
+  | { ok: true; files: BundleFileEntry[] }
+  | { ok: false; error: string };
+
+const FILENAME_TO_KEY: Record<string, BundleEntityKey> = {
+  "accounts.csv": "accounts",
+  "payees.csv": "payees",
+  "category-groups-and-categories.csv": "categories",
+  "tags.csv": "tags",
+  "schedules.csv": "schedules",
+  "rules.csv": "rules",
+};
+
+// Dependency order for import — each entity may reference earlier ones by name
+const IMPORT_ORDER: BundleEntityKey[] = [
+  "categories",
+  "accounts",
+  "payees",
+  "tags",
+  "schedules",
+  "rules",
+];
+
+function stripBom(text: string): string {
+  return text.startsWith("﻿") ? text.slice(1) : text;
+}
+
+function countDataRows(csvText: string): number {
+  const lines = csvText.split(/\r?\n/).filter((l) => l.trim());
+  return Math.max(0, lines.length - 1);
+}
+
+export async function readBundleZip(file: File): Promise<ReadBundleResult> {
+  try {
+    const buffer = await file.arrayBuffer();
+    const uint8 = new Uint8Array(buffer);
+    const unzipped = unzipSync(uint8);
+
+    const files: BundleFileEntry[] = [];
+    for (const [filename, data] of Object.entries(unzipped)) {
+      const key = FILENAME_TO_KEY[filename];
+      if (!key) continue;
+      const csvText = stripBom(strFromU8(data));
+      files.push({ key, filename, csvText, rowCount: countDataRows(csvText) });
+    }
+
+    files.sort(
+      (a, b) => IMPORT_ORDER.indexOf(a.key) - IMPORT_ORDER.indexOf(b.key)
+    );
+
+    return { ok: true, files };
+  } catch {
+    return {
+      ok: false,
+      error: "Could not read the ZIP file. Please check that it is a valid bundle.",
+    };
+  }
+}

--- a/src/features/overview/components/BudgetOverviewView.test.tsx
+++ b/src/features/overview/components/BudgetOverviewView.test.tsx
@@ -16,6 +16,10 @@ jest.mock("next/link", () => ({
   ),
 }));
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
 jest.mock("../hooks/useBudgetOverview", () => ({
   useBudgetOverview: jest.fn(),
 }));

--- a/src/features/overview/components/BudgetOverviewView.tsx
+++ b/src/features/overview/components/BudgetOverviewView.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { selectActiveInstance, useConnectionStore } from "@/store/connection";
+import { BundleExportDialog } from "@/features/bundle/components/BundleExportDialog";
+import { BundleImportDialog } from "@/features/bundle/components/BundleImportDialog";
 import { useBudgetOverview } from "../hooks/useBudgetOverview";
 import { useOverviewHeaderState } from "../hooks/useOverviewHeaderState";
 import { OverviewHeader } from "./OverviewHeader";
@@ -15,6 +18,8 @@ export function BudgetOverviewView() {
     isLoading,
     refresh,
   });
+  const [exportOpen, setExportOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
   return (
     <div className="min-h-0 flex-1 overflow-auto">
@@ -28,6 +33,8 @@ export function BudgetOverviewView() {
             refreshStatusLabel={headerState.refreshStatusLabel}
             isRefreshing={headerState.isRefreshing}
             onRefresh={headerState.handleRefresh}
+            onExportBundle={() => setExportOpen(true)}
+            onImportBundle={() => setImportOpen(true)}
           />
 
           <OverviewStatsSection
@@ -42,6 +49,9 @@ export function BudgetOverviewView() {
 
         <OverviewNavigationSection />
       </div>
+
+      <BundleExportDialog open={exportOpen} onOpenChange={setExportOpen} />
+      <BundleImportDialog open={importOpen} onOpenChange={setImportOpen} />
     </div>
   );
 }

--- a/src/features/overview/components/OverviewHeader.tsx
+++ b/src/features/overview/components/OverviewHeader.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { RefreshCw } from "lucide-react";
+import { Download, RefreshCw, Upload } from "lucide-react";
 
 type OverviewHeaderProps = {
   budgetLabel: string;
@@ -10,6 +10,8 @@ type OverviewHeaderProps = {
   refreshStatusLabel: string | null;
   isRefreshing: boolean;
   onRefresh: () => void;
+  onExportBundle?: () => void;
+  onImportBundle?: () => void;
 };
 
 export function OverviewHeader({
@@ -20,7 +22,11 @@ export function OverviewHeader({
   refreshStatusLabel,
   isRefreshing,
   onRefresh,
+  onExportBundle,
+  onImportBundle,
 }: OverviewHeaderProps) {
+  const hasConnection = Boolean(budgetLabel);
+
   return (
     <header className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-1">
@@ -38,11 +44,39 @@ export function OverviewHeader({
         </div>
       </div>
 
-      <div className="flex items-center gap-2.5 self-start sm:self-auto sm:ml-auto">
+      <div className="flex flex-wrap items-center gap-2 self-start sm:ml-auto sm:self-auto">
+        {onExportBundle && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onExportBundle}
+            disabled={!hasConnection}
+          >
+            <Upload />
+            Export
+          </Button>
+        )}
+        {onImportBundle && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onImportBundle}
+            disabled={!hasConnection}
+          >
+            <Download />
+            Import
+          </Button>
+        )}
+        <div className="h-4 w-px bg-border/60" aria-hidden />
         <div className="min-h-4 text-xs text-muted-foreground" aria-live="polite">
           {refreshStatusLabel}
         </div>
-        <Button variant="outline" size="sm" onClick={() => void onRefresh()} disabled={isRefreshing}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void onRefresh()}
+          disabled={isRefreshing}
+        >
           <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
           {refreshButtonLabel}
         </Button>


### PR DESCRIPTION
## Summary

Implements a new "bundle" feature lets users export all entity types (accounts, payees, categories, tags, schedules, rules) to a single ZIP archive from the Overview page, and import a previously exported

  Key details:
  - BundleExportDialog: entity checkboxes (all pre-selected), live counts, and inline dependency warnings when Rules or Schedules are selected without their reference types (payees/accounts/categories)
  - Entity hooks are called inside the dialog body so data is loaded on-demand — AppShell intentionally skips preloading on /overview
  - BundleImportDialog: ZIP preview with row counts, sequential import in dependency order (categories → accounts → payees → tags → schedules → rules), per-entity staged/skipped result summary with quick-nav links
  - Export/Import buttons placed in OverviewHeader alongside Refresh for immediate visibility without scrolling
  - Uses fflate (already a dependency) instead of jszip; extended the bundle isolation test to allow fflate in src/features/bundle/
## Test plan

- [X] `npm run lint` passes
- [X] `npx tsc --noEmit` passes
- [X] `npm run build` passes
- [X] `npm test` passes
- [X] Manually tested in browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bundle Export/Import feature accessible from Budget Overview page
  * Users can select and export Accounts, Payees, Categories & Groups, Tags, Schedules, and Rules as ZIP files
  * Import bundles with preview of included entities before confirmation
  * Dependency validation warnings for missing related entities

* **Documentation**
  * Documented Bundle Export/Import workflow and ZIP-based format specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->