### PR TITLE
feat/add dark mode toggle

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -475,6 +475,7 @@ budget-bundle-<label>-<date>.zip
 - Entity counts shown in page headers
 - Help menu in the sidebar with links to the GitHub repository, issue tracker, and changelog
 - Top bar shows a compact version cluster beside the active connection with `API` and `Actual` version badges when available
+- **Dark mode toggle** in the sidebar footer: cycles System → Light → Dark; preference persists in `localStorage`; icon reflects the resolved appearance (Moon when OS is dark in System mode, Sun when OS is light)
 
 ---
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
       <body className="h-full overflow-hidden font-sans">
         <Providers>{children}</Providers>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { ComponentType } from "react";
+import { useTheme } from "next-themes";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -23,6 +24,9 @@ import {
   BookOpen,
   LayoutDashboard,
   Wallet,
+  Monitor,
+  Sun,
+  Moon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -158,6 +162,16 @@ export function Sidebar() {
     return localStorage.getItem(LS_KEY) === "1";
   });
 
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const themeOrder = ["system", "light", "dark"] as const;
+  const themeLabels: Record<string, string> = { system: "System", light: "Light", dark: "Dark" };
+  // Icon reflects the resolved appearance (so system+dark OS shows Moon); label reflects the stored mode.
+  const ThemeIcon = resolvedTheme === "light" ? Sun : resolvedTheme === "dark" ? Moon : Monitor;
+  const cycleTheme = () => {
+    const idx = themeOrder.indexOf((theme ?? "system") as typeof themeOrder[number]);
+    setTheme(themeOrder[(idx + 1) % themeOrder.length]);
+  };
+
   function handleClearAll() {
     if (!window.confirm("Clear all connections and cached data? This cannot be undone.")) return;
     discardAll();
@@ -268,6 +282,18 @@ export function Sidebar() {
         >
           <Trash2 className="h-4 w-4 shrink-0" />
           {!collapsed && <span>Clear all data</span>}
+        </button>
+        <button
+          type="button"
+          onClick={cycleTheme}
+          title={`Theme: ${themeLabels[theme ?? "system"]} — click to cycle`}
+          className={cn(
+            "flex w-full items-center rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground",
+            collapsed ? "justify-center" : "gap-2"
+          )}
+        >
+          <ThemeIcon className="h-4 w-4 shrink-0" />
+          {!collapsed && <span>{themeLabels[theme ?? "system"]}</span>}
         </button>
         <button
           type="button"

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ThemeProvider } from "next-themes";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/sonner";
 import { createQueryClient } from "@/lib/queryClient";
@@ -10,9 +11,16 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => createQueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <Toaster richColors position="bottom-right" />
-    </QueryClientProvider>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <Toaster richColors position="bottom-right" />
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -5,11 +5,11 @@ import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { resolvedTheme } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={(resolvedTheme ?? "system") as ToasterProps["theme"]}
       className="toaster group"
       icons={{
         success: (

--- a/src/features/budget-management/components/BudgetDraftPanel.tsx
+++ b/src/features/budget-management/components/BudgetDraftPanel.tsx
@@ -22,7 +22,7 @@ export function BudgetDraftPanel() {
 
   return (
     <aside
-      className="flex w-[17rem] shrink-0 flex-col border-l border-border bg-background"
+      className="flex w-68 shrink-0 flex-col border-l border-border bg-background"
       data-budget-details-panel>
       <div className="flex items-center justify-between px-3 shrink-0 h-[2.7rem]">
         <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">

--- a/src/features/budget-management/components/StagedChangesDialog.tsx
+++ b/src/features/budget-management/components/StagedChangesDialog.tsx
@@ -60,7 +60,7 @@ export function StagedChangesDialog({ onClose }: { onClose: () => void }) {
         role="dialog"
         aria-modal="true"
         aria-label="Staged changes"
-        className="relative flex flex-col bg-background border-l border-border shadow-xl h-full w-[17rem] shrink-0"
+        className="relative flex flex-col bg-background border-l border-border shadow-xl h-full w-68 shrink-0"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-3 shrink-0 h-[2.7rem] border-b border-border">

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -129,7 +129,7 @@ function GroupMonthAggregate({
     >
       {stagedChildCount > 0 && (
         <span
-          className="absolute top-1 left-1 h-1.5 w-1.5 rounded-full bg-amber-400"
+          className="absolute top-1 left-1 h-1.5 w-1.5 rounded-full bg-amber-400 dark:bg-amber-500"
           aria-hidden="true"
           title={`${stagedChildCount} staged change${stagedChildCount !== 1 ? "s" : ""} in this group for ${month}`}
         />

--- a/src/features/budget-management/components/grid/MonthColumnHeader.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.tsx
@@ -32,7 +32,7 @@ export function MonthColumnHeader({
   const dotColor = !isAvailable
     ? "bg-muted-foreground/40"
     : hasStagedEdits
-    ? "bg-amber-400"
+    ? "bg-amber-400 dark:bg-amber-500"
     : "bg-transparent";
 
   const dotTitle = !isAvailable


### PR DESCRIPTION
## Summary

Wire next-themes ThemeProvider (system/light/dark) and add a cycling toggle in the sidebar footer. The .dark CSS token set and next-themes were already in place; this connects them.

  - providers.tsx: ThemeProvider wrapping the full tree, attribute="class", defaultTheme="system", disableTransitionOnChange
  - layout.tsx: suppressHydrationWarning on <html>
  - Sidebar: toggle button cycles system→light→dark; icon uses resolvedTheme so system+dark OS shows Moon rather than Monitor
  - sonner.tsx: pass resolvedTheme (never "system") to the Toaster
  - MonthColumnHeader, GroupRows: dark:bg-amber-500 on staged-edit indicator dots for better contrast on dark backgrounds


## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark Mode Toggle: Added a theme switcher in the sidebar footer. Easily cycle between System, Light, and Dark modes with automatic preference persistence across sessions.

* **Style**
  * Enhanced dark mode color contrast for UI indicators and optimized layout spacing in dialogs and panels for improved visual consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x-rous/actual-bench/pull/90)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->