### PR TITLE
feat: add connection health indicator and persist entity filter state

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -63,7 +63,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
+          build-args: |
+                QEMU_CPU=cortex-a72
+                
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
         with:

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -466,6 +466,7 @@ budget-bundle-<label>-<date>.zip
 - Bulk-add: add multiple empty rows at once with a configurable count
 - Global undo/redo keyboard shortcuts: Ctrl/Cmd+Z to undo, Ctrl/Cmd+Shift+Z or Ctrl+Y to redo; suppressed inside text inputs so native browser undo is not interrupted
 - Filter bars stay pinned to the top of each table when scrolling long lists (Payees, Accounts, Categories, Tags)
+- **Filter state persistence**: search text and active filter pills on all six entity pages (Accounts, Payees, Categories, Tags, Schedules, Rules) are persisted to `sessionStorage` and restored on navigation. Filters reset to defaults when the active connection changes. Inline "Clear filters" links appear in the empty state when filters are active.
 
 ## Navigation & Layout
 
@@ -476,6 +477,7 @@ budget-bundle-<label>-<date>.zip
 - Help menu in the sidebar with links to the GitHub repository, issue tracker, and changelog
 - Top bar shows a compact version cluster beside the active connection with `API` and `Actual` version badges when available
 - **Dark mode toggle** in the sidebar footer: cycles System → Light → Dark; preference persists in `localStorage`; icon reflects the resolved appearance (Moon when OS is dark in System mode, Sun when OS is light)
+- **Connection health indicator**: a coloured dot inside the connection dropdown trigger in the top bar actively polls `GET /actualhttpapiversion` every 30 seconds. Green = healthy (with round-trip latency in the tooltip), pulsing amber = checking, solid amber = degraded (>3 s response), red = offline. When the server is unreachable for two consecutive checks, a non-blocking red strip appears below the top bar and the Save button is disabled with an explanatory tooltip. The banner and disabled state clear automatically as soon as a check succeeds. Polling pauses when the browser tab is hidden and resumes immediately on tab focus.
 
 ---
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { TopBar } from "./TopBar";
 import { Sidebar } from "./Sidebar";
 import { DraftPanel } from "./DraftPanel";
 import { BudgetDraftPanel } from "@/features/budget-management/components/BudgetDraftPanel";
+import { ConnectionOfflineBanner } from "./ConnectionOfflineBanner";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { usePreloadEntities } from "@/hooks/useAllEntities";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { GlobalSearchModal } from "@/features/global-search/components/GlobalSearchModal";
+import { useConnectionHealth, ConnectionHealthContext } from "@/hooks/useConnectionHealth";
 
 /**
  * The four-panel app shell:
@@ -38,12 +40,27 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   useKeyboardShortcuts();
 
   const hydrated = useIsHydrated();
+  const health = useConnectionHealth();
 
   useEffect(() => {
     if (hydrated && !activeInstance) {
       router.replace("/connect");
     }
   }, [hydrated, activeInstance, router]);
+
+  // Clear persisted filter state when the active connection changes so that
+  // stale entity IDs stored in filter values don't carry over to a new budget.
+  const prevConnectionIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const currentId = activeInstance?.id;
+    if (prevConnectionIdRef.current !== undefined && prevConnectionIdRef.current !== currentId) {
+      for (let i = sessionStorage.length - 1; i >= 0; i--) {
+        const k = sessionStorage.key(i);
+        if (k?.startsWith("filters:")) sessionStorage.removeItem(k);
+      }
+    }
+    prevConnectionIdRef.current = currentId;
+  }, [activeInstance?.id]);
 
   if (!hydrated) {
     return null;
@@ -56,16 +73,19 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const isBudgetPage = pathname?.startsWith("/budget-management") ?? false;
 
   return (
-    <div className="flex h-full flex-col">
-      <TopBar />
-      <GlobalSearchModal />
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <Sidebar />
-        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          {children}
-        </main>
-        {isBudgetPage ? <BudgetDraftPanel /> : <DraftPanel />}
+    <ConnectionHealthContext.Provider value={health}>
+      <div className="flex h-full flex-col">
+        <TopBar />
+        <ConnectionOfflineBanner />
+        <GlobalSearchModal />
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <Sidebar />
+          <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            {children}
+          </main>
+          {isBudgetPage ? <BudgetDraftPanel /> : <DraftPanel />}
+        </div>
       </div>
-    </div>
+    </ConnectionHealthContext.Provider>
   );
 }

--- a/src/components/layout/ConnectionHealthDot.tsx
+++ b/src/components/layout/ConnectionHealthDot.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useConnectionHealthContext, type HealthStatus } from "@/hooks/useConnectionHealth";
+
+function statusLabel(status: HealthStatus, latencyMs: number | null): string {
+  const latency = latencyMs !== null ? ` · ${Math.round(latencyMs)}ms` : "";
+  switch (status) {
+    case "healthy":  return `Connected${latency}`;
+    case "checking": return "Checking…";
+    case "degraded": return `Slow${latency}`;
+    case "offline":  return "Offline";
+    case "unknown":  return "Unknown";
+  }
+}
+
+export function ConnectionHealthDot() {
+  const { status, latencyMs } = useConnectionHealthContext();
+
+  if (status === "unknown") return null;
+
+  const label = statusLabel(status, latencyMs);
+
+  return (
+    <span
+      title={`Connection: ${label}`}
+      aria-label={`Connection status: ${label}`}
+      className={cn(
+        "inline-block h-2 w-2 shrink-0 rounded-full",
+        status === "healthy"  && "bg-green-500",
+        status === "checking" && "animate-pulse bg-amber-400",
+        status === "degraded" && "bg-amber-400",
+        status === "offline"  && "bg-red-500",
+      )}
+    />
+  );
+}

--- a/src/components/layout/ConnectionOfflineBanner.tsx
+++ b/src/components/layout/ConnectionOfflineBanner.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { useConnectionHealthContext } from "@/hooks/useConnectionHealth";
+
+export function ConnectionOfflineBanner() {
+  const { showBanner } = useConnectionHealthContext();
+
+  if (!showBanner) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-center gap-2 border-b border-red-200 bg-red-50 px-4 py-1.5 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400"
+    >
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+      <span>Lost connection to server — save disabled until reconnected.</span>
+    </div>
+  );
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -29,6 +29,8 @@ import {
   selectActiveInstance,
 } from "@/store/connection";
 import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSearchStore";
+import { useConnectionHealthContext } from "@/hooks/useConnectionHealth";
+import { ConnectionHealthDot } from "./ConnectionHealthDot";
 import { useSavedServersStore } from "@/store/savedServers";
 import {
   useStagedStore,
@@ -92,6 +94,9 @@ export function TopBar() {
   const openSearch = useGlobalSearchStore((s) => s.open);
   const searchShortcutLabel = "Ctrl+k";
 
+  const { status: healthStatus } = useConnectionHealthContext();
+  const isOffline = healthStatus === "offline";
+
   const activeInstance = useConnectionStore(selectActiveInstance);
   const instances = useConnectionStore((s) => s.instances);
   const setActive = useConnectionStore((s) => s.setActiveInstance);
@@ -126,7 +131,7 @@ export function TopBar() {
   const canRedo = isBudgetPage ? budgetCanRedo : stagedCanRedo;
   const isSaving = isBudgetPage ? (isBudgetSaving || budgetSaveEdits !== null) : isEntitySaving;
   const saveDisabled =
-    !hasChanges || isSaving || (isBudgetPage && budgetSaveReviewEdits !== null);
+    !hasChanges || isSaving || isOffline || (isBudgetPage && budgetSaveReviewEdits !== null);
 
   function handleDiscardAll() {
     if (isBudgetPage) {
@@ -252,6 +257,7 @@ export function TopBar() {
           {activeInstance && (
             <DropdownMenu>
               <DropdownMenuTrigger className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground">
+                <ConnectionHealthDot />
                 <span className="max-w-40 truncate text-muted-foreground">
                   {activeInstance.label}
                 </span>
@@ -393,6 +399,7 @@ export function TopBar() {
             )}
             disabled={saveDisabled}
             onClick={handleSave}
+            title={isOffline ? "Cannot save — server is unreachable" : undefined}
           >
             <Save className="mr-1 h-3.5 w-3.5" />
             {isSaving ? "Saving…" : "Save"}

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useEditableGrid } from "@/hooks/useEditableGrid";
@@ -52,10 +53,17 @@ export function AccountsTable({
   const router = useRouter();
 
   // ── Filter / sort state ──────────────────────────────────────────────────────
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [budgetFilter, setBudgetFilter] = useState<BudgetFilter>("all");
-  const [rulesFilter, setRulesFilter] = useState<RulesFilter>("all");
+  const [filters, setFilters, clearFilters] = usePersistedFilters("filters:accounts", {
+    search: "",
+    statusFilter: "all" as StatusFilter,
+    budgetFilter: "all" as BudgetFilter,
+    rulesFilter: "all" as RulesFilter,
+  });
+  const { search, statusFilter, budgetFilter, rulesFilter } = filters;
+  const setSearch       = (v: string)       => setFilters((f) => ({ ...f, search: v }));
+  const setStatusFilter = (v: StatusFilter) => setFilters((f) => ({ ...f, statusFilter: v }));
+  const setBudgetFilter = (v: BudgetFilter) => setFilters((f) => ({ ...f, budgetFilter: v }));
+  const setRulesFilter  = (v: RulesFilter)  => setFilters((f) => ({ ...f, rulesFilter: v }));
   const [sortCol, setSortCol] = useState<SortCol | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -397,7 +405,7 @@ export function AccountsTable({
             {(search || statusFilter !== "all" || budgetFilter !== "all" || rulesFilter !== "all") && (
               <button
                 className="text-xs underline hover:text-foreground"
-                onClick={() => { setSearch(""); setStatusFilter("all"); setBudgetFilter("all"); setRulesFilter("all"); }}
+                onClick={clearFilters}
               >
                 Clear filters
               </button>

--- a/src/features/categories/components/CategoriesTable.tsx
+++ b/src/features/categories/components/CategoriesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useDeferredValue, useMemo, useState, startTransition } from "react";
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useEditableGrid } from "@/hooks/useEditableGrid";
@@ -67,10 +68,17 @@ export function CategoriesTable({
   onInspectTargetChange: (target: CategoryInspectTarget | null) => void;
 }) {
   // ── Filter / sort state ──────────────────────────────────────────────────────
-  const [search, setSearch] = useState("");
-  const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>("all");
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
-  const [rulesFilter, setRulesFilter] = useState<RulesFilter>("all");
+  const [filters, setFilters, clearFilters] = usePersistedFilters("filters:categories", {
+    search: "",
+    visibilityFilter: "all" as VisibilityFilter,
+    typeFilter: "all" as TypeFilter,
+    rulesFilter: "all" as RulesFilter,
+  });
+  const { search, visibilityFilter, typeFilter, rulesFilter } = filters;
+  const setSearch          = (v: string)           => setFilters((f) => ({ ...f, search: v }));
+  const setVisibilityFilter = (v: VisibilityFilter) => setFilters((f) => ({ ...f, visibilityFilter: v }));
+  const setTypeFilter      = (v: TypeFilter)        => setFilters((f) => ({ ...f, typeFilter: v }));
+  const setRulesFilter     = (v: RulesFilter)       => setFilters((f) => ({ ...f, rulesFilter: v }));
   const [sortNameDir, setSortNameDir] = useState<SortDir | null>(null);
   const deferredSearch = useDeferredValue(search);
 
@@ -344,6 +352,10 @@ export function CategoriesTable({
 
   function handleRulesFilterChange(value: RulesFilter) {
     startTransition(() => setRulesFilter(value));
+  }
+
+  function handleClearFilters() {
+    startTransition(() => clearFilters());
   }
 
   function handleToggleCollapseAll() {
@@ -673,7 +685,7 @@ export function CategoriesTable({
                       <td colSpan={8} className="px-4 py-3 text-xs text-muted-foreground">
                         <span>No income groups{search || visibilityFilter !== "all" || rulesFilter !== "all" ? " matching the current filters" : ""}.</span>
                         {(search || visibilityFilter !== "all" || rulesFilter !== "all") && (
-                          <button className="ml-2 underline hover:text-foreground" onClick={() => { setSearch(""); setVisibilityFilter("all"); setRulesFilter("all"); }}>
+                          <button className="ml-2 underline hover:text-foreground" onClick={handleClearFilters}>
                             Clear filters
                           </button>
                         )}
@@ -729,7 +741,7 @@ export function CategoriesTable({
                       <td colSpan={8} className="px-4 py-3 text-xs text-muted-foreground">
                         <span>No expense groups{search || visibilityFilter !== "all" || rulesFilter !== "all" ? " matching the current filters" : ""}.</span>
                         {(search || visibilityFilter !== "all" || rulesFilter !== "all") && (
-                          <button className="ml-2 underline hover:text-foreground" onClick={() => { setSearch(""); setVisibilityFilter("all"); setRulesFilter("all"); }}>
+                          <button className="ml-2 underline hover:text-foreground" onClick={handleClearFilters}>
                             Clear filters
                           </button>
                         )}

--- a/src/features/payees/components/PayeesTable.tsx
+++ b/src/features/payees/components/PayeesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useEditableGrid } from "@/hooks/useEditableGrid";
@@ -50,9 +51,15 @@ export function PayeesTable({
   onMergeDialogChange: (state: PayeeMergeState | null) => void;
 }) {
   // ── Filter / sort state ──────────────────────────────────────────────────────
-  const [search, setSearch] = useState("");
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
-  const [rulesFilter, setRulesFilter] = useState<RulesFilter>("all");
+  const [filters, setFilters, clearFilters] = usePersistedFilters("filters:payees", {
+    search: "",
+    typeFilter: "all" as TypeFilter,
+    rulesFilter: "all" as RulesFilter,
+  });
+  const { search, typeFilter, rulesFilter } = filters;
+  const setSearch      = (v: string)      => setFilters((f) => ({ ...f, search: v }));
+  const setTypeFilter  = (v: TypeFilter)  => setFilters((f) => ({ ...f, typeFilter: v }));
+  const setRulesFilter = (v: RulesFilter) => setFilters((f) => ({ ...f, rulesFilter: v }));
   const [sortCol, setSortCol] = useState<SortCol | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -368,7 +375,7 @@ export function PayeesTable({
             {(search || typeFilter !== "all" || rulesFilter !== "all") && (
               <button
                 className="text-xs underline hover:text-foreground"
-                onClick={() => { setSearch(""); setTypeFilter("all"); setRulesFilter("all"); }}
+                onClick={clearFilters}
               >
                 Clear filters
               </button>

--- a/src/features/rules/components/RulesTable.tsx
+++ b/src/features/rules/components/RulesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { useRouter } from "next/navigation";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useTableSelection } from "@/hooks/useTableSelection";
@@ -71,9 +72,15 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
   const router        = useRouter();
   const highlightedId = useHighlight();
 
-  const [stageFilter, setStageFilter] = useState<StageFilter>("all");
-  const [actionTypeFilter, setActionTypeFilter] = useState<ActionTypeFilter>("all");
-  const [search, setSearch] = useState("");
+  const [filters, setFilters, clearFilters] = usePersistedFilters("filters:rules", {
+    search: "",
+    stageFilter: "all" as StageFilter,
+    actionTypeFilter: "all" as ActionTypeFilter,
+  });
+  const { search, stageFilter, actionTypeFilter } = filters;
+  const setSearch          = (v: string)           => setFilters((f) => ({ ...f, search: v }));
+  const setStageFilter     = (v: StageFilter)      => setFilters((f) => ({ ...f, stageFilter: v }));
+  const setActionTypeFilter = (v: ActionTypeFilter) => setFilters((f) => ({ ...f, actionTypeFilter: v }));
   const { selectedIds, toggleSelect, toggleSelectAll: _toggleSelectAll, clearSelection } = useTableSelection();
 
   const entityMaps = useMemo<EntityMaps>(
@@ -237,9 +244,7 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
               <button
                 className="text-xs underline hover:text-foreground"
                 onClick={() => {
-                  setSearch("");
-                  setStageFilter("all");
-                  setActionTypeFilter("all");
+                  clearFilters();
                   if (payeeId || categoryId || accountId) router.push("/rules");
                 }}
               >

--- a/src/features/schedules/components/SchedulesTable.tsx
+++ b/src/features/schedules/components/SchedulesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useTableSelection } from "@/hooks/useTableSelection";
 import { Pencil, Trash2, RotateCcw, Copy, Braces, AlertTriangle, Info, RefreshCw, Check } from "lucide-react";
@@ -76,11 +77,19 @@ export function SchedulesTable({
 
   const highlightedId = useHighlight();
 
-  const [search, setSearch]                       = useState("");
-  const [autoAddFilter, setAutoAddFilter]         = useState<AutoAddFilter>("all");
-  const [frequencyFilter, setFrequencyFilter]     = useState<FrequencyFilter>("all");
-  const [payeeFilter, setPayeeFilter]             = useState("");
-  const [accountFilter, setAccountFilter]         = useState("");
+  const [filters, setFilters, clearFilters] = usePersistedFilters("filters:schedules", {
+    search: "",
+    autoAddFilter: "all" as AutoAddFilter,
+    frequencyFilter: "all" as FrequencyFilter,
+    payeeFilter: "",
+    accountFilter: "",
+  });
+  const { search, autoAddFilter, frequencyFilter, payeeFilter, accountFilter } = filters;
+  const setSearch          = (v: string)          => setFilters((f) => ({ ...f, search: v }));
+  const setAutoAddFilter   = (v: AutoAddFilter)   => setFilters((f) => ({ ...f, autoAddFilter: v }));
+  const setFrequencyFilter = (v: FrequencyFilter) => setFilters((f) => ({ ...f, frequencyFilter: v }));
+  const setPayeeFilter     = (v: string)          => setFilters((f) => ({ ...f, payeeFilter: v }));
+  const setAccountFilter   = (v: string)          => setFilters((f) => ({ ...f, accountFilter: v }));
 
   const { selectedIds, toggleSelect, toggleSelectAll: _toggleSelectAll, clearSelection } =
     useTableSelection();
@@ -208,7 +217,7 @@ export function SchedulesTable({
             {(search || autoAddFilter !== "all" || frequencyFilter !== "all" || payeeFilter || accountFilter) && (
               <button
                 className="text-xs underline hover:text-foreground"
-                onClick={() => { setSearch(""); setAutoAddFilter("all"); setFrequencyFilter("all"); setPayeeFilter(""); setAccountFilter(""); }}
+                onClick={clearFilters}
               >
                 Clear filters
               </button>

--- a/src/features/tags/components/TagsTable.tsx
+++ b/src/features/tags/components/TagsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import { toast } from "sonner";
 import type { ConfirmState } from "@/components/ui/confirm-dialog";
@@ -42,8 +43,13 @@ export function TagsTable({
   const pushUndo       = useStagedStore((s) => s.pushUndo);
 
   // ── Filter + bulk-add state ───────────────────────────────────────────────
-  const [search, setSearch]           = useState("");
-  const [colorFilter, setColorFilter] = useState<ColorFilter>("all");
+  const [filters, setFilters] = usePersistedFilters("filters:tags", {
+    search: "",
+    colorFilter: "all" as ColorFilter,
+  });
+  const { search, colorFilter } = filters;
+  const setSearch      = (v: string)      => setFilters((f) => ({ ...f, search: v }));
+  const setColorFilter = (v: ColorFilter) => setFilters((f) => ({ ...f, colorFilter: v }));
   const [sortNameDir, setSortNameDir] = useState<"asc" | "desc" | null>(null);
   const [bulkCount, setBulkCount]     = useState(5);
 

--- a/src/hooks/useConnectionHealth.ts
+++ b/src/hooks/useConnectionHealth.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback, createContext, useContext } from "react";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+
+export type HealthStatus = "unknown" | "checking" | "healthy" | "degraded" | "offline";
+
+export type ConnectionHealthState = {
+  status: HealthStatus;
+  latencyMs: number | null;
+  /** True only after 2+ consecutive offline checks — triggers the banner. */
+  showBanner: boolean;
+};
+
+const POLL_INTERVAL_MS = 30_000;
+const DEGRADED_THRESHOLD_MS = 3_000;
+const OFFLINE_BANNER_THRESHOLD = 2;
+
+export const ConnectionHealthContext = createContext<ConnectionHealthState>({
+  status: "unknown",
+  latencyMs: null,
+  showBanner: false,
+});
+
+export function useConnectionHealthContext(): ConnectionHealthState {
+  return useContext(ConnectionHealthContext);
+}
+
+async function pingServer(baseUrl: string, apiKey: string): Promise<number> {
+  const start = performance.now();
+  const response = await fetch("/api/proxy", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      connection: { baseUrl, apiKey },
+      path: "/v1/actualhttpapiversion",
+      method: "GET",
+    }),
+  });
+  const latencyMs = performance.now() - start;
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return latencyMs;
+}
+
+export function useConnectionHealth(): ConnectionHealthState {
+  const activeInstance = useConnectionStore(selectActiveInstance);
+  const [status, setStatus] = useState<HealthStatus>("unknown");
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [showBanner, setShowBanner] = useState(false);
+  const consecutiveFailures = useRef(0);
+  const isChecking = useRef(false);
+
+  const runCheck = useCallback(async (baseUrl: string, apiKey: string) => {
+    if (isChecking.current) return;
+    isChecking.current = true;
+    setStatus("checking");
+
+    try {
+      const ms = await pingServer(baseUrl, apiKey);
+      consecutiveFailures.current = 0;
+      setShowBanner(false);
+      setLatencyMs(ms);
+      setStatus(ms > DEGRADED_THRESHOLD_MS ? "degraded" : "healthy");
+    } catch {
+      consecutiveFailures.current += 1;
+      setLatencyMs(null);
+      setStatus("offline");
+      if (consecutiveFailures.current >= OFFLINE_BANNER_THRESHOLD) {
+        setShowBanner(true);
+      }
+    } finally {
+      isChecking.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    // Reset guards on connection change so a stale check doesn't block the new one.
+    consecutiveFailures.current = 0;
+    isChecking.current = false;
+
+    if (!activeInstance) {
+      setStatus("unknown");
+      setLatencyMs(null);
+      setShowBanner(false);
+      return;
+    }
+
+    const { baseUrl, apiKey } = activeInstance;
+    void runCheck(baseUrl, apiKey);
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    function scheduleNext() {
+      timeoutId = setTimeout(() => {
+        if (document.visibilityState === "visible") {
+          void runCheck(baseUrl, apiKey);
+        }
+        scheduleNext();
+      }, POLL_INTERVAL_MS);
+    }
+
+    scheduleNext();
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible") {
+        clearTimeout(timeoutId);
+        void runCheck(baseUrl, apiKey);
+        scheduleNext();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [activeInstance, runCheck]);
+
+  return { status, latencyMs, showBanner };
+}

--- a/src/hooks/useConnectionHealth.ts
+++ b/src/hooks/useConnectionHealth.ts
@@ -26,20 +26,25 @@ export function useConnectionHealthContext(): ConnectionHealthState {
   return useContext(ConnectionHealthContext);
 }
 
-async function pingServer(baseUrl: string, apiKey: string): Promise<number> {
+async function pingServer(
+  baseUrl: string,
+  apiKey: string
+): Promise<{ latencyMs: number; ok: boolean }> {
   const start = performance.now();
-  const response = await fetch("/api/proxy", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      connection: { baseUrl, apiKey },
-      path: "/v1/actualhttpapiversion",
-      method: "GET",
+  const [result] = await Promise.allSettled([
+    fetch("/api/proxy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        connection: { baseUrl, apiKey },
+        path: "/v1/actualhttpapiversion",
+        method: "GET",
+      }),
     }),
-  });
+  ]);
   const latencyMs = performance.now() - start;
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  return latencyMs;
+  if (result.status === "rejected") return { latencyMs, ok: false };
+  return { latencyMs, ok: result.value.ok };
 }
 
 export function useConnectionHealth(): ConnectionHealthState {
@@ -55,22 +60,23 @@ export function useConnectionHealth(): ConnectionHealthState {
     isChecking.current = true;
     setStatus("checking");
 
-    try {
-      const ms = await pingServer(baseUrl, apiKey);
+    const { latencyMs: ms, ok } = await pingServer(baseUrl, apiKey);
+
+    if (ok) {
       consecutiveFailures.current = 0;
       setShowBanner(false);
       setLatencyMs(ms);
       setStatus(ms > DEGRADED_THRESHOLD_MS ? "degraded" : "healthy");
-    } catch {
+    } else {
       consecutiveFailures.current += 1;
       setLatencyMs(null);
       setStatus("offline");
       if (consecutiveFailures.current >= OFFLINE_BANNER_THRESHOLD) {
         setShowBanner(true);
       }
-    } finally {
-      isChecking.current = false;
     }
+
+    isChecking.current = false;
   }, []);
 
   useEffect(() => {

--- a/src/hooks/useConnectionHealth.ts
+++ b/src/hooks/useConnectionHealth.ts
@@ -84,17 +84,14 @@ export function useConnectionHealth(): ConnectionHealthState {
     consecutiveFailures.current = 0;
     isChecking.current = false;
 
-    if (!activeInstance) {
-      setStatus("unknown");
-      setLatencyMs(null);
-      setShowBanner(false);
-      return;
-    }
+    if (!activeInstance) return;
 
     const { baseUrl, apiKey } = activeInstance;
-    void runCheck(baseUrl, apiKey);
-
     let timeoutId: ReturnType<typeof setTimeout>;
+
+    // runCheck calls setStatus("checking") before its first await; deferring
+    // keeps it out of the synchronous effect body to satisfy the lint rule.
+    const initialId = setTimeout(() => void runCheck(baseUrl, apiKey), 0);
 
     function scheduleNext() {
       timeoutId = setTimeout(() => {
@@ -118,10 +115,14 @@ export function useConnectionHealth(): ConnectionHealthState {
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
+      clearTimeout(initialId);
       clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [activeInstance, runCheck]);
 
+  // When no connection is active derive the reset values during render rather
+  // than calling setState in the effect body (which triggers cascading renders).
+  if (!activeInstance) return { status: "unknown", latencyMs: null, showBanner: false };
   return { status, latencyMs, showBanner };
 }

--- a/src/hooks/usePersistedFilters.ts
+++ b/src/hooks/usePersistedFilters.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef, type Dispatch, type SetStateAction } from "react";
+
+/**
+ * Like useState, but the value is serialised to sessionStorage so it survives
+ * client-side navigation within the same tab.
+ *
+ * - Reads the stored value on mount and merges it with defaults (missing keys
+ *   fall back to the default value, so adding new filter fields is safe).
+ * - Writes the full state object to storage on every state change.
+ * - Returns a stable clearFilters callback that resets to defaults and removes
+ *   the storage key.
+ *
+ * sessionStorage lifetime matches connection and staged data — cleared on tab
+ * close. Clear all "filters:*" keys from sessionStorage in AppShell when the
+ * active connection changes so stale entity IDs don't carry over.
+ */
+export function usePersistedFilters<T extends Record<string, unknown>>(
+  key: string,
+  defaults: T
+): [T, Dispatch<SetStateAction<T>>, () => void] {
+  // Capture defaults once so clearFilters doesn't depend on the caller's
+  // object reference (which may change on every render).
+  const defaultsRef = useRef(defaults);
+
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") return defaults;
+    try {
+      const stored = sessionStorage.getItem(key);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<T>;
+        // Spread defaults first so new filter fields added later still get
+        // their default value even if the stored object predates them.
+        return { ...defaults, ...parsed };
+      }
+    } catch {
+      // Ignore parse errors — fall back to defaults.
+    }
+    return defaults;
+  });
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // Ignore storage errors (private mode, quota exceeded).
+    }
+  }, [key, state]);
+
+  const clearFilters = useCallback(() => {
+    setState(defaultsRef.current);
+    try {
+      sessionStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }, [key]);
+
+  return [state, setState, clearFilters];
+}


### PR DESCRIPTION
## Summary

Implements improvements roadmap.

  RConnection Health Indicator
  - useConnectionHealth hook polls GET /actualhttpapiversion every 30s, pauses when the tab is hidden, resumes immediately on focus
  - ConnectionHealthDot renders a coloured dot inside the connection dropdown trigger (green / pulsing amber / solid amber / red)
  - ConnectionOfflineBanner renders a non-modal red strip below the TopBar after 2 consecutive failed checks
  - Save button is disabled with a tooltip on the first failed check
  - State shared via ConnectionHealthContext from AppShell; no prop drilling Filter State Persistence
  - usePersistedFilters<T>(key, defaults) hook serialises filter state to sessionStorage and restores it on navigation; returns clearFilters to reset to defaults and remove the storage key
  - AccountsTable, PayeesTable, CategoriesTable, TagsTable, SchedulesTable, and RulesTable each replace their individual filter useState calls with one usePersistedFilters call; FilterBar interface is unchanged
  - AppShell clears all filters:* sessionStorage keys when the active connection changes so stale entity IDs don't carry over
  - RulesTable persists only {search, stageFilter, actionTypeFilter}; URL-driven payeeId/categoryId/accountId props are not persisted


  ## Test plan

  - [x] Connect to a budget — health dot appears green beside the connection label
  - [x] Stop the server — dot turns red on first failure, banner appears on second; Save is disabled throughout
  - [x] Restart the server — banner dismisses automatically, dot turns green, Save re-enables
  - [x] On any entity page, set filters and navigate away then back — filters are restored
  - [x] Switch to a different connection — all entity page filters reset to defaults
  - [x] Open a new tab — filters are reset (sessionStorage is tab-scoped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection health indicator in the top bar displaying server status and latency information
  * Filters now persist within sessions across all entity pages and reset when switching connections
  * Offline banner alerts users when server connection is lost; Save button is disabled during outages

* **Documentation**
  * Updated feature documentation for connection health monitoring and session filter persistence

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x-rous/actual-bench/pull/91)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->