### PR TITLE
 fix/skip transfer payees and schedule rules during bundle import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",

--- a/src/features/payees/csv/payeesCsvImport.test.ts
+++ b/src/features/payees/csv/payeesCsvImport.test.ts
@@ -57,4 +57,25 @@ describe("importPayeesFromCsv", () => {
     expect(result.payees).toHaveLength(2);
     expect(result.payees[0]).toEqual({ name: "Amazon" });
   });
+
+  it("skips transfer payees and counts them as skipped", () => {
+    const csv = "id,name,type\n1,Amazon,regular\n2,Transfer: Savings,transfer\n3,Netflix,regular";
+    const result = importPayeesFromCsv(csv);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.payees).toHaveLength(2);
+    expect(result.payees.map((p) => p.name)).toEqual(["Amazon", "Netflix"]);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("skips transfer payees case-insensitively", () => {
+    const csv = "name,type\nAmazon,TRANSFER";
+    const result = importPayeesFromCsv(csv);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.payees).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
 });

--- a/src/features/payees/csv/payeesCsvImport.ts
+++ b/src/features/payees/csv/payeesCsvImport.ts
@@ -22,6 +22,7 @@ export function importPayeesFromCsv(text: string): PayeesImportResult | PayeesIm
   const headers = parseCsvLine(nonEmpty[0]).map((h) => h.trim().toLowerCase());
   const nameIdx = headers.indexOf("name");
   if (nameIdx === -1) return { error: 'CSV must have a "name" column.' };
+  const typeIdx = headers.indexOf("type");
 
   const payees: Pick<Payee, "name">[] = [];
   let skipped = 0;
@@ -30,6 +31,8 @@ export function importPayeesFromCsv(text: string): PayeesImportResult | PayeesIm
     const fields = parseCsvLine(allLines[i]);
     const name = fields[nameIdx]?.trim() ?? "";
     if (!name) { skipped++; continue; }
+    const type = typeIdx !== -1 ? (fields[typeIdx]?.trim().toLowerCase() ?? "") : "";
+    if (type === "transfer") { skipped++; continue; }
     payees.push({ name });
   }
 

--- a/src/features/rules/csv/rulesCsvImport.test.ts
+++ b/src/features/rules/csv/rulesCsvImport.test.ts
@@ -286,6 +286,25 @@ describe("importRulesFromCsv", () => {
     expect(result.rules[1].actions[0].value).toBe(false);
   });
 
+  it("skips rules with a link-schedule action and counts them as skipped", () => {
+    const csv = [
+      "rule_id,stage,conditions_op,row_type,field,op,value",
+      "r1,default,and,condition,notes,contains,grocery",
+      "r1,,,action,category,set,Food",
+      "r2,default,and,condition,notes,contains,schedule",
+      "r2,,,action,,link-schedule,some-schedule-id",
+      "r3,default,and,action,category,set,Transport",
+    ].join("\n");
+
+    const result = importRulesFromCsv(csv, emptyMaps);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+    expect(result.rules).toHaveLength(2);
+    expect(result.rules.map((r) => r.conditions[0]?.value ?? r.actions[0]?.value)).not.toContain("some-schedule-id");
+    expect(result.skipped).toBe(1);
+  });
+
   it("resolves category_group names to IDs", () => {
     const maps = makeMaps([], [], [], [{ id: "grp-1", name: "Food & Dining" }]);
     const csv = [

--- a/src/features/rules/csv/rulesCsvImport.ts
+++ b/src/features/rules/csv/rulesCsvImport.ts
@@ -177,7 +177,7 @@ export function importRulesFromCsv(
 
     if (stage && !group.stage)               group.stage        = stage;
     if (conditionsOp && !group.conditionsOp) group.conditionsOp = conditionsOp;
-    if (op === "link-schedule")              group.isScheduleRule = true;
+    if (rowType === "action" && op === "link-schedule") group.isScheduleRule = true;
 
     // Accept: conditions with a field, or actions with a field or delete-transaction op
     const isValidRow =

--- a/src/features/rules/csv/rulesCsvImport.ts
+++ b/src/features/rules/csv/rulesCsvImport.ts
@@ -153,6 +153,7 @@ export function importRulesFromCsv(
   type RuleGroup = {
     stage: string;
     conditionsOp: string;
+    isScheduleRule: boolean;
     rows: { rowType: string; field: string; op: string; rawValue: string }[];
   };
 
@@ -164,7 +165,7 @@ export function importRulesFromCsv(
     const ruleId = cellAt(row, ruleIdIdx);
     if (!ruleId) { parseSkipped++; continue; }
 
-    if (!groups.has(ruleId)) groups.set(ruleId, { stage: "", conditionsOp: "", rows: [] });
+    if (!groups.has(ruleId)) groups.set(ruleId, { stage: "", conditionsOp: "", isScheduleRule: false, rows: [] });
 
     const group        = groups.get(ruleId)!;
     const stage        = cellAt(row, stageIdx);
@@ -176,6 +177,7 @@ export function importRulesFromCsv(
 
     if (stage && !group.stage)               group.stage        = stage;
     if (conditionsOp && !group.conditionsOp) group.conditionsOp = conditionsOp;
+    if (op === "link-schedule")              group.isScheduleRule = true;
 
     // Accept: conditions with a field, or actions with a field or delete-transaction op
     const isValidRow =
@@ -197,6 +199,8 @@ export function importRulesFromCsv(
   let skipped = parseSkipped;
 
   for (const [, group] of groups) {
+    if (group.isScheduleRule) { skipped++; continue; }
+
     const conditions: ConditionOrAction[] = [];
     const actions:    ConditionOrAction[] = [];
 


### PR DESCRIPTION
## Summary

- importPayeesFromCsv: skip rows where type="transfer" (case-insensitive); these payees are auto-created when accounts are imported
  - importRulesFromCsv: skip rule groups that contain a link-schedule action; these rules are auto-created when schedules are imported Both skipped entries are counted in the result's skipped field.
  - bump version to 1.1.4

## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV import now excludes transfer payees from being imported.
  * CSV import now excludes rules with schedule link actions from being imported.

* **Tests**
  * Added test coverage for transfer payee exclusion handling.
  * Added test coverage for schedule-linked rule exclusion handling.

* **Chores**
  * Version bumped to 1.1.4.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x-rous/actual-bench/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->