### PR TITLE
feat/notify users when a new version is available

### DIFF
--- a/src/app/api/version-check/route.ts
+++ b/src/app/api/version-check/route.ts
@@ -4,6 +4,19 @@ const RELEASES_URL = "https://api.github.com/repos/x-rous/actual-bench/releases/
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 let cached: { latestVersion: string; fetchedAt: number } | null = null;
+let fetchInFlight: Promise<string> | null = null;
+
+async function fetchLatestVersion(): Promise<string> {
+  const res = await fetch(RELEASES_URL, {
+    headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+  const data = (await res.json()) as { tag_name?: string };
+  const latestVersion = (data.tag_name ?? "").replace(/^v/, "");
+  if (!latestVersion) throw new Error("Empty tag_name");
+  return latestVersion;
+}
 
 export async function GET() {
   const currentVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
@@ -13,16 +26,10 @@ export async function GET() {
   }
 
   try {
-    const res = await fetch(RELEASES_URL, {
-      headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
-
-    const data = (await res.json()) as { tag_name?: string };
-    const latestVersion = (data.tag_name ?? "").replace(/^v/, "");
-    if (!latestVersion) throw new Error("Empty tag_name");
-
+    if (!fetchInFlight) {
+      fetchInFlight = fetchLatestVersion().finally(() => { fetchInFlight = null; });
+    }
+    const latestVersion = await fetchInFlight;
     cached = { latestVersion, fetchedAt: Date.now() };
     return NextResponse.json({ currentVersion, latestVersion });
   } catch {

--- a/src/app/api/version-check/route.ts
+++ b/src/app/api/version-check/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+const RELEASES_URL = "https://api.github.com/repos/x-rous/actual-bench/releases/latest";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+let cached: { latestVersion: string; fetchedAt: number } | null = null;
+
+export async function GET() {
+  const currentVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
+
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return NextResponse.json({ currentVersion, latestVersion: cached.latestVersion });
+  }
+
+  try {
+    const res = await fetch(RELEASES_URL, {
+      headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+
+    const data = (await res.json()) as { tag_name?: string };
+    const latestVersion = (data.tag_name ?? "").replace(/^v/, "");
+    if (!latestVersion) throw new Error("Empty tag_name");
+
+    cached = { latestVersion, fetchedAt: Date.now() };
+    return NextResponse.json({ currentVersion, latestVersion });
+  } catch {
+    // Return current version as latest so the client doesn't show a false alert.
+    return NextResponse.json({ currentVersion, latestVersion: currentVersion });
+  }
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -7,12 +7,14 @@ import { Sidebar } from "./Sidebar";
 import { DraftPanel } from "./DraftPanel";
 import { BudgetDraftPanel } from "@/features/budget-management/components/BudgetDraftPanel";
 import { ConnectionOfflineBanner } from "./ConnectionOfflineBanner";
+import { NewVersionBanner } from "./NewVersionBanner";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { usePreloadEntities } from "@/hooks/useAllEntities";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { GlobalSearchModal } from "@/features/global-search/components/GlobalSearchModal";
 import { useConnectionHealth, ConnectionHealthContext } from "@/hooks/useConnectionHealth";
+import { useVersionCheck, VersionCheckContext } from "@/hooks/useVersionCheck";
 
 /**
  * The four-panel app shell:
@@ -41,6 +43,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   const hydrated = useIsHydrated();
   const health = useConnectionHealth();
+  const versionCheck = useVersionCheck();
 
   useEffect(() => {
     if (hydrated && !activeInstance) {
@@ -74,9 +77,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <ConnectionHealthContext.Provider value={health}>
+    <VersionCheckContext.Provider value={versionCheck}>
       <div className="flex h-full flex-col">
         <TopBar />
         <ConnectionOfflineBanner />
+        <NewVersionBanner />
         <GlobalSearchModal />
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <Sidebar />
@@ -86,6 +91,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           {isBudgetPage ? <BudgetDraftPanel /> : <DraftPanel />}
         </div>
       </div>
+    </VersionCheckContext.Provider>
     </ConnectionHealthContext.Provider>
   );
 }

--- a/src/components/layout/NewVersionBanner.tsx
+++ b/src/components/layout/NewVersionBanner.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ArrowUpCircle, X } from "lucide-react";
+import { useVersionCheckContext } from "@/hooks/useVersionCheck";
+
+const RELEASES_URL = "https://github.com/x-rous/actual-bench/releases";
+
+export function NewVersionBanner() {
+  const { updateAvailable, latestVersion, dismissed, dismiss } = useVersionCheckContext();
+
+  if (!updateAvailable || dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-center gap-2 border-b border-blue-200 bg-blue-50 px-4 py-1.5 text-xs text-blue-700 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-400"
+    >
+      <ArrowUpCircle className="h-3.5 w-3.5 shrink-0" />
+      <span>
+        Version <strong>{latestVersion}</strong> is available.{" "}
+        <a
+          href={RELEASES_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:opacity-80"
+        >
+          View release notes
+        </a>{" "}
+        to update, pull the latest image and restart.
+      </span>
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss update notification"
+        className="ml-auto shrink-0 opacity-60 hover:opacity-100"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -27,11 +27,13 @@ import {
   Monitor,
   Sun,
   Moon,
+  ArrowUpCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
 import { useSavedServersStore } from "@/store/savedServers";
 import { useStagedStore } from "@/store/staged";
+import { useVersionCheckContext } from "@/hooks/useVersionCheck";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -156,6 +158,7 @@ export function Sidebar() {
   const clearServers = useSavedServersStore((s) => s.clearServers);
   const discardAll = useStagedStore((s) => s.discardAll);
   const version = process.env.NEXT_PUBLIC_APP_VERSION;
+  const { updateAvailable, latestVersion } = useVersionCheckContext();
 
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
@@ -236,9 +239,20 @@ export function Sidebar() {
         })}
 
         {!collapsed && version && (
-          <span className="mt-auto px-3 pt-4 text-xs text-muted-foreground/55">
-            v{version}
-          </span>
+          <div className="mt-auto px-3 pt-4 flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground/55">v{version}</span>
+            {updateAvailable && latestVersion && (
+              <a
+                href="https://github.com/x-rous/actual-bench/releases"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                <ArrowUpCircle className="h-3 w-3 shrink-0" />
+                v{latestVersion} available
+              </a>
+            )}
+          </div>
         )}
       </nav>
 

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect, createContext, useContext } from "react";
+
+export type VersionCheckState = {
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  dismissed: boolean;
+  dismiss: () => void;
+};
+
+export const VersionCheckContext = createContext<VersionCheckState>({
+  latestVersion: null,
+  updateAvailable: false,
+  dismissed: false,
+  dismiss: () => {},
+});
+
+export function useVersionCheckContext(): VersionCheckState {
+  return useContext(VersionCheckContext);
+}
+
+function compareSemver(a: string, b: string): number {
+  const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+  const [aMaj, aMin, aPat] = parse(a);
+  const [bMaj, bMin, bPat] = parse(b);
+  return bMaj - aMaj || bMin - aMin || bPat - aPat;
+}
+
+function dismissKey(version: string) {
+  return `version-update-dismissed:${version}`;
+}
+
+export function useVersionCheck(): VersionCheckState {
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/version-check")
+      .then((r) => r.json())
+      .then((data: { currentVersion: string; latestVersion: string }) => {
+        if (cancelled) return;
+        const { latestVersion: latest } = data;
+        setLatestVersion(latest);
+        setDismissed(localStorage.getItem(dismissKey(latest)) === "1");
+      })
+      .catch(() => { /* silently ignore — version check is non-critical */ });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  const currentVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
+  const updateAvailable =
+    latestVersion !== null && compareSemver(currentVersion, latestVersion) > 0;
+
+  function dismiss() {
+    if (!latestVersion) return;
+    localStorage.setItem(dismissKey(latestVersion), "1");
+    setDismissed(true);
+  }
+
+  return { latestVersion, updateAvailable, dismissed, dismiss };
+}

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -21,7 +21,12 @@ export function useVersionCheckContext(): VersionCheckState {
 }
 
 function compareSemver(a: string, b: string): number {
-  const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+  const parse = (v: string): [number, number, number] => {
+    const core = v.replace(/^v/, "").split(/[-+]/)[0];
+    const parts = (core ?? "").split(".").slice(0, 3);
+    const [maj, min, pat] = [0, 1, 2].map((i) => Number(parts[i]) || 0);
+    return [maj, min, pat];
+  };
   const [aMaj, aMin, aPat] = parse(a);
   const [bMaj, bMin, bPat] = parse(b);
   return bMaj - aMaj || bMin - aMin || bPat - aPat;


### PR DESCRIPTION
## Summary

Adds an in-app update notification for self-hosted deployments:

  - /api/version-check: server-side proxy to GitHub Releases API with a 1-hour in-memory cache; returns current version on any failure so no false alerts are shown
  - useVersionCheck: fetches the proxy once on mount, compares semver, and exposes VersionCheckContext so banner and sidebar share one fetch
  - NewVersionBanner: dismissible blue banner (below the offline banner) with the new version number and a link to release notes; dismiss state is stored in localStorage keyed by version so it reappears on the next release
  - Sidebar: persistent "↑ vX.Y.Z available" link below the current version label, visible even after the banner is dismissed

## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added in-app version update notifications that automatically check for new releases and alert users when updates are available. The notification appears as a prominent banner and sidebar indicator, providing convenient access to release notes on GitHub. Users can dismiss the notification, with dismissal preferences saved locally to prevent duplicate alerts for the same update.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x-rous/actual-bench/pull/93)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->