### PR TITLE
feat/add entity quick-create dialog with keyboard shortcuts and discoverability

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,6 +9,18 @@
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed
 
+## Quick Create
+
+- `N` (bare key, when no input or dialog is focused) or `Ctrl/Cmd+Shift+N` (from anywhere, including inside inputs) opens a global Quick Create dialog to stage a new entity without leaving the current page
+- Supports four entity types: **Payee**, **Category**, **Account**, and **Tag** — switchable via pill buttons inside the dialog
+- Conditional secondary fields per type: Category requires a group selection (searchable combobox of existing groups); Account has an on-budget / off-budget toggle; Tag has an optional color picker with a clear action
+- Name field auto-focuses on open; `Enter` submits when the form is valid, `Escape` closes without staging anything
+- Non-blocking amber duplicate warning when a name already exists in the staged store — submission is still allowed
+- Hard blocks: empty name, or Category selected with no group chosen
+- On submit, the entity is staged immediately (one undo step) and a toast confirms the action; the dialog closes and the user stays on the current page
+- **Inline "Create" prompt** in the Rule Drawer: typing in a payee or category combobox and finding no match shows a `+ Create [type] "[name]"` footer button — clicking it opens the Quick Create dialog pre-seeded with the typed name; the new entity appears in the combobox options as soon as the dialog closes
+- **Global keyboard shortcuts modal** accessible from a standalone "Keyboard shortcuts" button in the sidebar footer; lists app-wide shortcuts (Quick Create, Global Search, Undo, Redo) with keyboard badge styling; references the budget workspace `?` shortcut for workspace-specific bindings
+
 ## Global Search
 
 - `Ctrl/Cmd+K` or the top-bar Search button opens a global search modal across accounts, payees, categories, rules, schedules, and tags
@@ -235,6 +247,7 @@ Spreadsheet-grade keyboard support — every shortcut is data-driven from a sing
 
 **View & visibility:**
 - `V` — cycle Budget → Actuals → Balance
+- `D` — open the spending details panel for the currently selected category or group in the focused month
 - `F` — open Jump to Category search; selecting a match scrolls and focuses that category in the current month, including hidden categories and collapsed groups
 - `H` — toggle hidden categories
 - `E` / `Shift+E` — expand all / collapse all groups
@@ -474,7 +487,7 @@ budget-bundle-<label>-<date>.zip
 - Top bar shows the active connection with a switcher dropdown, undo/redo, discard, save, and a refresh button — refresh prompts for confirmation when unsaved changes exist
 - Toast notifications for all success, error, and warning states
 - Entity counts shown in page headers
-- Help menu in the sidebar with links to the GitHub repository, issue tracker, and changelog
+- Help menu in the sidebar with links to the GitHub repository, issue tracker, and changelog; a separate standalone "Keyboard shortcuts" button below it opens an app-wide shortcuts cheatsheet
 - Top bar shows a compact version cluster beside the active connection with `API` and `Actual` version badges when available
 - **Dark mode toggle** in the sidebar footer: cycles System → Light → Dark; preference persists in `localStorage`; icon reflects the resolved appearance (Moon when OS is dark in System mode, Sun when OS is light)
 - **Connection health indicator**: a coloured dot inside the connection dropdown trigger in the top bar actively polls `GET /actualhttpapiversion` every 30 seconds. Green = healthy (with round-trip latency in the tooltip), pulsing amber = checking, solid amber = degraded (>3 s response), red = offline. When the server is unreachable for two consecutive checks, a non-blocking red strip appears below the top bar and the Save button is disabled with an explanatory tooltip. The banner and disabled state clear automatically as soon as a check succeeds. Polling pauses when the browser tab is hidden and resumes immediately on tab focus.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -13,6 +13,7 @@ import { usePreloadEntities } from "@/hooks/useAllEntities";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { GlobalSearchModal } from "@/features/global-search/components/GlobalSearchModal";
+import { QuickCreateDialog } from "@/features/quick-create/components/QuickCreateDialog";
 import { useConnectionHealth, ConnectionHealthContext } from "@/hooks/useConnectionHealth";
 import { useVersionCheck, VersionCheckContext } from "@/hooks/useVersionCheck";
 
@@ -83,6 +84,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <ConnectionOfflineBanner />
         <NewVersionBanner />
         <GlobalSearchModal />
+        <QuickCreateDialog />
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <Sidebar />
           <main className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/src/components/layout/GlobalShortcutsHelp.tsx
+++ b/src/components/layout/GlobalShortcutsHelp.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+type ShortcutRow = {
+  label: string;
+  keys: string[];
+};
+
+type ShortcutSection = {
+  title: string;
+  rows: ShortcutRow[];
+};
+
+const SECTIONS: ShortcutSection[] = [
+  {
+    title: "Global",
+    rows: [
+      { label: "Quick Create",   keys: ["N", "Ctrl+Shift+N"] },
+      { label: "Global Search",  keys: ["Ctrl+K"] },
+    ],
+  },
+  {
+    title: "History",
+    rows: [
+      { label: "Undo",  keys: ["Ctrl+Z"] },
+      { label: "Redo",  keys: ["Ctrl+Shift+Z", "Ctrl+Y"] },
+    ],
+  },
+];
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">
+      {children}
+    </kbd>
+  );
+}
+
+export function GlobalShortcutsHelp({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xs" aria-describedby="shortcuts-desc">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription id="shortcuts-desc" className="text-[11px]">
+            App-wide shortcuts. The Budget workspace has additional shortcuts — press{" "}
+            <Kbd>?</Kbd> there to see them.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {SECTIONS.map((section) => (
+            <section key={section.title}>
+              <h3 className="mb-1 px-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {section.title}
+              </h3>
+              <ul className="overflow-hidden rounded-md border border-border/40 divide-y divide-border/40">
+                {section.rows.map((row) => (
+                  <li
+                    key={row.label}
+                    className="flex items-center justify-between gap-2 px-2 py-1.5 text-xs hover:bg-muted/30"
+                  >
+                    <span className="text-foreground">{row.label}</span>
+                    <span className="flex items-center gap-1 shrink-0">
+                      {row.keys.map((key, i) => (
+                        <span key={key} className="flex items-center gap-1">
+                          {i > 0 && (
+                            <span className="text-[10px] text-muted-foreground">or</span>
+                          )}
+                          <Kbd>{key}</Kbd>
+                        </span>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   Sun,
   Moon,
   ArrowUpCircle,
+  Keyboard,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -41,6 +42,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { GlobalShortcutsHelp } from "./GlobalShortcutsHelp";
 
 const GITHUB_URL = "https://github.com/x-rous/actual-bench";
 const LS_KEY = "sidebar-collapsed";
@@ -160,6 +162,7 @@ export function Sidebar() {
   const version = process.env.NEXT_PUBLIC_APP_VERSION;
   const { updateAvailable, latestVersion } = useVersionCheckContext();
 
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     return localStorage.getItem(LS_KEY) === "1";
@@ -287,6 +290,19 @@ export function Sidebar() {
 
         <button
           type="button"
+          onClick={() => setShortcutsOpen(true)}
+          title="Keyboard shortcuts"
+          className={cn(
+            "flex w-full items-center rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground",
+            collapsed ? "justify-center" : "gap-2"
+          )}
+        >
+          <Keyboard className="h-4 w-4 shrink-0" />
+          {!collapsed && <span>Keyboard shortcuts</span>}
+        </button>
+
+        <button
+          type="button"
           onClick={handleClearAll}
           title="Clear all connections and cached data"
           className={cn(
@@ -328,6 +344,8 @@ export function Sidebar() {
           )}
         </button>
       </div>
+
+      <GlobalShortcutsHelp open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
     </aside>
   );
 }

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -96,11 +96,13 @@ export function SearchableCombobox({
   value,
   onChange,
   placeholder = "— select —",
+  footer,
 }: {
   options: ComboboxOption[];
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
+  footer?: (search: string) => React.ReactNode;
 }) {
   const { open, openDropdown, closeDropdown, search, setSearch, containerRef, searchRef } =
     useComboboxState();
@@ -184,6 +186,11 @@ export function SearchableCombobox({
               )
             )}
           </ul>
+          {footer && (
+            <div className="border-t border-border">
+              {footer(search)}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/features/budget-management/keyboard/actions.ts
+++ b/src/features/budget-management/keyboard/actions.ts
@@ -64,6 +64,7 @@ export type ActionId =
   | "view.pan-months-prev"
   | "view.pan-months-next"
   | "view.open-category-search"
+  | "view.open-spending-details"
   // ─── Tier 4 selection actions (workspace) ───────────────────────────────
   | "selection.toggle-carryover"
   // ─── Discoverability ────────────────────────────────────────────────────
@@ -163,6 +164,11 @@ export const ACTION_META: Record<ActionId, ActionMeta> = {
     id: "view.open-category-search",
     label: "Jump to category",
     category: "navigation",
+  },
+  "view.open-spending-details": {
+    id: "view.open-spending-details",
+    label: "Open spending details",
+    category: "view",
   },
 
   "selection.toggle-carryover": {

--- a/src/features/budget-management/keyboard/keymap.ts
+++ b/src/features/budget-management/keyboard/keymap.ts
@@ -105,7 +105,8 @@ export const DEFAULT_KEYMAP: KeymapBinding[] = [
   // Pan visible months one month back / forward. Bare brackets on US layout.
   { action: "view.pan-months-prev",    chord: { key: "[" },                   scopes: ["workspace"] },
   { action: "view.pan-months-next",    chord: { key: "]" },                   scopes: ["workspace"] },
-  { action: "view.open-category-search", chord: { key: "f" },                 scopes: ["workspace"] },
+  { action: "view.open-category-search",  chord: { key: "f" },                 scopes: ["workspace"] },
+  { action: "view.open-spending-details", chord: { key: "d" },                 scopes: ["workspace"] },
 
   // ── Tier 4 selection actions ───────────────────────────────────────────
   { action: "selection.toggle-carryover", chord: { key: "c", alt: true },     scopes: ["workspace"] },

--- a/src/features/quick-create/components/QuickCreateDialog.tsx
+++ b/src/features/quick-create/components/QuickCreateDialog.tsx
@@ -115,7 +115,7 @@ function QuickCreateForm({
     close();
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter" && isValid) {
       e.preventDefault();
       handleCreate();
@@ -123,7 +123,7 @@ function QuickCreateForm({
   }
 
   return (
-    <div className="flex flex-col gap-4" onKeyDown={handleKeyDown}>
+    <div className="flex flex-col gap-4">
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <Plus className="h-4 w-4" />
@@ -160,6 +160,7 @@ function QuickCreateForm({
           maxLength={100}
           value={name}
           onChange={(e) => setName(e.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder={`${ENTITY_LABELS[selectedType]} name…`}
           className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
         />

--- a/src/features/quick-create/components/QuickCreateDialog.tsx
+++ b/src/features/quick-create/components/QuickCreateDialog.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Plus, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { SearchableCombobox } from "@/components/ui/combobox";
+import { cn } from "@/lib/utils";
+import { generateId } from "@/lib/uuid";
+import { useStagedStore } from "@/store/staged";
+import { useQuickCreateStore } from "../store/useQuickCreateStore";
+import type { QuickCreateEntityType } from "../store/useQuickCreateStore";
+
+const DEFAULT_TAG_COLOR = "#E4D4FF";
+
+const ENTITY_LABELS: Record<QuickCreateEntityType, string> = {
+  payee: "Payee",
+  category: "Category",
+  account: "Account",
+  tag: "Tag",
+};
+
+const ENTITY_TYPES: QuickCreateEntityType[] = ["payee", "category", "account", "tag"];
+
+// ─── Inner form — keyed so it remounts fresh on each open/preselect change ────
+
+function QuickCreateForm({
+  preselectedType,
+  prefillName,
+  close,
+}: {
+  preselectedType: QuickCreateEntityType | null;
+  prefillName: string;
+  close: () => void;
+}) {
+  const stageNew             = useStagedStore((s) => s.stageNew);
+  const pushUndo             = useStagedStore((s) => s.pushUndo);
+  const stagedPayees         = useStagedStore((s) => s.payees);
+  const stagedCategories     = useStagedStore((s) => s.categories);
+  const stagedAccounts       = useStagedStore((s) => s.accounts);
+  const stagedTags           = useStagedStore((s) => s.tags);
+  const stagedCategoryGroups = useStagedStore((s) => s.categoryGroups);
+
+  // Initial values come from props — no effect needed (component is re-keyed on each open)
+  const [selectedType, setSelectedType] = useState<QuickCreateEntityType>(preselectedType ?? "payee");
+  const [name, setName]                 = useState(prefillName);
+  const [groupId, setGroupId]           = useState("");
+  const [offBudget, setOffBudget]       = useState(false);
+  const [color, setColor]               = useState<string | undefined>(undefined);
+
+  function handleTypeChange(type: QuickCreateEntityType) {
+    setSelectedType(type);
+    setGroupId("");
+    setOffBudget(false);
+    setColor(undefined);
+  }
+
+  const groupOptions = useMemo(
+    () =>
+      Object.values(stagedCategoryGroups)
+        .filter((s) => !s.isDeleted)
+        .sort((a, b) => a.entity.name.localeCompare(b.entity.name))
+        .map((s) => ({ id: s.entity.id, name: s.entity.name })),
+    [stagedCategoryGroups]
+  );
+
+  const isDuplicate = useMemo(() => {
+    const lower = name.trim().toLowerCase();
+    if (!lower) return false;
+    const map =
+      selectedType === "payee"    ? stagedPayees
+      : selectedType === "category" ? stagedCategories
+      : selectedType === "account"  ? stagedAccounts
+      : stagedTags;
+    return Object.values(map).some(
+      (s) => !s.isDeleted && s.entity.name.trim().toLowerCase() === lower
+    );
+  }, [name, selectedType, stagedPayees, stagedCategories, stagedAccounts, stagedTags]);
+
+  const trimmedName = name.trim();
+  const isValid =
+    trimmedName.length > 0 &&
+    trimmedName.length <= 100 &&
+    !(selectedType === "category" && !groupId);
+
+  function handleCreate() {
+    if (!isValid) return;
+    pushUndo();
+    const id = generateId();
+    const label = ENTITY_LABELS[selectedType];
+
+    switch (selectedType) {
+      case "payee":
+        stageNew("payees", { id, name: trimmedName });
+        break;
+      case "category":
+        stageNew("categories", { id, name: trimmedName, groupId, hidden: false, isIncome: false });
+        break;
+      case "account":
+        stageNew("accounts", { id, name: trimmedName, offBudget, closed: false });
+        break;
+      case "tag":
+        stageNew("tags", { id, name: trimmedName, ...(color ? { color } : {}) });
+        break;
+    }
+
+    toast.success(`${label} staged — save to persist.`);
+    close();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && isValid) {
+      e.preventDefault();
+      handleCreate();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4" onKeyDown={handleKeyDown}>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <Plus className="h-4 w-4" />
+          Quick Create
+        </DialogTitle>
+      </DialogHeader>
+
+      {/* Type selector */}
+      <div className="flex gap-1.5">
+        {ENTITY_TYPES.map((type) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => handleTypeChange(type)}
+            className={cn(
+              "flex-1 rounded-md border px-2 py-1 text-xs font-medium transition-colors",
+              selectedType === type
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-background text-muted-foreground hover:border-foreground/30 hover:text-foreground"
+            )}
+          >
+            {ENTITY_LABELS[type]}
+          </button>
+        ))}
+      </div>
+
+      {/* Name field */}
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-foreground">
+          Name <span className="text-destructive">*</span>
+        </label>
+        <input
+          autoFocus
+          maxLength={100}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={`${ENTITY_LABELS[selectedType]} name…`}
+          className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
+        />
+        {isDuplicate && (
+          <p className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="h-3 w-3 shrink-0" />
+            A {ENTITY_LABELS[selectedType].toLowerCase()} named &ldquo;{trimmedName}&rdquo; already exists — it will still be staged.
+          </p>
+        )}
+      </div>
+
+      {/* Secondary field — Category group */}
+      {selectedType === "category" && (
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-foreground">
+            Group <span className="text-destructive">*</span>
+          </label>
+          <SearchableCombobox
+            options={groupOptions}
+            value={groupId}
+            onChange={setGroupId}
+            placeholder="Select group…"
+          />
+          {groupOptions.length === 0 && (
+            <p className="text-xs text-muted-foreground italic">
+              No category groups exist yet — create one on the Categories page first.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Secondary field — Account budget type */}
+      {selectedType === "account" && (
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-foreground">Budget type</label>
+          <div className="flex gap-1.5">
+            {(["on-budget", "off-budget"] as const).map((opt) => {
+              const isOffBudget = opt === "off-budget";
+              const active = offBudget === isOffBudget;
+              return (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => setOffBudget(isOffBudget)}
+                  className={cn(
+                    "flex-1 rounded-md border px-2 py-1 text-xs font-medium transition-colors",
+                    active
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background text-muted-foreground hover:border-foreground/30 hover:text-foreground"
+                  )}
+                >
+                  {opt === "on-budget" ? "On-budget" : "Off-budget"}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Secondary field — Tag color */}
+      {selectedType === "tag" && (
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-foreground">Color (optional)</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="color"
+              value={color ?? DEFAULT_TAG_COLOR}
+              onChange={(e) => setColor(e.target.value)}
+              aria-label="Tag color"
+              className="h-7 w-10 cursor-pointer rounded border border-border bg-transparent p-0.5"
+            />
+            {color && (
+              <button
+                type="button"
+                onClick={() => setColor(undefined)}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      <DialogFooter>
+        <Button variant="outline" size="sm" onClick={close}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleCreate} disabled={!isValid}>
+          Create {ENTITY_LABELS[selectedType]}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}
+
+// ─── Dialog shell — owns open state; re-keys form on each open ────────────────
+
+export function QuickCreateDialog() {
+  const { isOpen, preselectedType, prefillName, close } = useQuickCreateStore();
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) close(); }}>
+      <DialogContent className="max-w-sm" aria-describedby={undefined}>
+        <QuickCreateForm
+          key={`${String(isOpen)}-${preselectedType ?? "payee"}-${prefillName}`}
+          preselectedType={preselectedType}
+          prefillName={prefillName}
+          close={close}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/quick-create/store/useQuickCreateStore.ts
+++ b/src/features/quick-create/store/useQuickCreateStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+export type QuickCreateEntityType = "payee" | "category" | "account" | "tag";
+
+type QuickCreateState = {
+  isOpen: boolean;
+  preselectedType: QuickCreateEntityType | null;
+  prefillName: string;
+  open: (type?: QuickCreateEntityType, name?: string) => void;
+  close: () => void;
+};
+
+export const useQuickCreateStore = create<QuickCreateState>((set) => ({
+  isOpen: false,
+  preselectedType: null,
+  prefillName: "",
+  open: (type, name = "") =>
+    set({ isOpen: true, preselectedType: type ?? null, prefillName: name }),
+  close: () => set({ isOpen: false, preselectedType: null, prefillName: "" }),
+}));

--- a/src/features/rules/components/ActionRow.tsx
+++ b/src/features/rules/components/ActionRow.tsx
@@ -9,6 +9,8 @@ import { selectCls, inputCls } from "./ConditionRow";
 import { valueToString } from "../utils/rulePreview";
 import { ACTION_FIELDS, ACTION_OPS } from "../utils/ruleFields";
 import { useStagedStore } from "@/store/staged";
+import { useQuickCreateStore } from "@/features/quick-create/store/useQuickCreateStore";
+import type { QuickCreateEntityType } from "@/features/quick-create/store/useQuickCreateStore";
 import type { ConditionOrAction } from "@/types/entities";
 import type { RuleEntityOptionsMap } from "../lib/ruleEditor";
 
@@ -33,6 +35,7 @@ export function ActionRow({
   const isTemplate = op === "set" && action.options?.template !== undefined;
   const supportsTemplate = op === "set" && fieldDef?.supportsTemplate === true;
   const stagedSchedules = useStagedStore((s) => s.schedules);
+  const openQuickCreate = useQuickCreateStore((s) => s.open);
 
   const handleOpChange = useCallback(
     (newOp: string) => {
@@ -233,6 +236,7 @@ export function ActionRow({
             options={entityOptions[fieldDef.entity]}
             value={valueToString(action.value)}
             onChange={(v) => onChange({ ...action, value: v })}
+            onQuickCreate={(name) => openQuickCreate(fieldDef.entity as QuickCreateEntityType, name)}
           />
         ) : (
           <input

--- a/src/features/rules/components/ConditionRow.tsx
+++ b/src/features/rules/components/ConditionRow.tsx
@@ -108,13 +108,17 @@ function ConditionValueInput({
 
   if (fieldDef?.entity) {
     const scalar = valueToString(condition.value);
+    const QUICK_CREATE_ENTITIES: QuickCreateEntityType[] = ["payee", "category", "account", "tag"];
+    const quickCreateEntity = QUICK_CREATE_ENTITIES.includes(fieldDef.entity as QuickCreateEntityType)
+      ? (fieldDef.entity as QuickCreateEntityType)
+      : null;
     return (
       <EntityCombobox
         entity={fieldDef.entity}
         options={entityOptions[fieldDef.entity]}
         value={scalar}
         onChange={(v) => onChange({ ...condition, value: v })}
-        onQuickCreate={(name) => onQuickCreate(fieldDef.entity as QuickCreateEntityType, name)}
+        onQuickCreate={quickCreateEntity ? (name) => onQuickCreate(quickCreateEntity, name) : undefined}
       />
     );
   }

--- a/src/features/rules/components/ConditionRow.tsx
+++ b/src/features/rules/components/ConditionRow.tsx
@@ -9,6 +9,8 @@ import { EntityCombobox, MultiEntityCombobox } from "./EntityCombobox";
 import { valueToString, isRecurConfig } from "../utils/rulePreview";
 import { CONDITION_FIELDS, getConditionOps } from "../utils/ruleFields";
 import { recurSummary } from "@/features/schedules/lib/recurSummary";
+import { useQuickCreateStore } from "@/features/quick-create/store/useQuickCreateStore";
+import type { QuickCreateEntityType } from "@/features/quick-create/store/useQuickCreateStore";
 import type { ConditionOrAction, AmountRange, RecurConfig } from "@/types/entities";
 import type { RuleEntityOptionsMap } from "../lib/ruleEditor";
 
@@ -26,10 +28,12 @@ function ConditionValueInput({
   condition,
   entityOptions,
   onChange,
+  onQuickCreate,
 }: {
   condition: ConditionOrAction;
   entityOptions: RuleEntityOptionsMap;
   onChange: (c: ConditionOrAction) => void;
+  onQuickCreate: (entity: QuickCreateEntityType, name: string) => void;
 }) {
   const fieldDef = CONDITION_FIELDS[condition.field ?? ""];
   const ops = getConditionOps(condition.field ?? "");
@@ -110,6 +114,7 @@ function ConditionValueInput({
         options={entityOptions[fieldDef.entity]}
         value={scalar}
         onChange={(v) => onChange({ ...condition, value: v })}
+        onQuickCreate={(name) => onQuickCreate(fieldDef.entity as QuickCreateEntityType, name)}
       />
     );
   }
@@ -172,6 +177,7 @@ export function ConditionRow({
   onChange: (c: ConditionOrAction) => void;
   onDelete: () => void;
 }) {
+  const openQuickCreate = useQuickCreateStore((s) => s.open);
   const field = condition.field ?? "";
   const ops = getConditionOps(field);
   const isScheduleDate = field === "date" && isRecurConfig(condition.value);
@@ -258,7 +264,7 @@ export function ConditionRow({
           </div>
 
           <div className="flex-1">
-            <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} />
+            <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} onQuickCreate={openQuickCreate} />
           </div>
 
           <span className="mt-2 shrink-0 text-[10px] italic text-muted-foreground/60">
@@ -297,7 +303,7 @@ export function ConditionRow({
           ))}
         </select>
 
-        <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} />
+        <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} onQuickCreate={openQuickCreate} />
 
         <Button
           variant="ghost"

--- a/src/features/rules/components/EntityCombobox.tsx
+++ b/src/features/rules/components/EntityCombobox.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Plus } from "lucide-react";
 import { SearchableCombobox, MultiSearchableCombobox } from "@/components/ui/combobox";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import type { RuleEntityType } from "../lib/ruleEditor";
@@ -9,11 +10,13 @@ export function EntityCombobox({
   options,
   value,
   onChange,
+  onQuickCreate,
 }: {
   entity: RuleEntityType;
   options: ComboboxOption[];
   value: string;
   onChange: (v: string) => void;
+  onQuickCreate?: (name: string) => void;
 }) {
   const placeholder =
     entity === "payee"
@@ -23,8 +26,32 @@ export function EntityCombobox({
       : entity === "categoryGroup"
       ? "Select category group…"
       : "Select account…";
+
+  const canQuickCreate = onQuickCreate && (entity === "payee" || entity === "category");
+  const entityLabel = entity === "payee" ? "payee" : "category";
+
   return (
-    <SearchableCombobox options={options} value={value} onChange={onChange} placeholder={placeholder} />
+    <SearchableCombobox
+      options={options}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      footer={
+        canQuickCreate
+          ? (search) =>
+              search.trim() ? (
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-1.5 px-3 py-2 text-xs text-primary hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => onQuickCreate!(search.trim())}
+                >
+                  <Plus className="h-3 w-3 shrink-0" />
+                  Create {entityLabel} &ldquo;{search.trim()}&rdquo;
+                </button>
+              ) : null
+          : undefined
+      }
+    />
   );
 }
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useStagedStore } from "@/store/staged";
 import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSearchStore";
+import { useQuickCreateStore } from "@/features/quick-create/store/useQuickCreateStore";
 
 /**
  * Wires global keyboard shortcuts for the staged store and app-wide actions.
@@ -12,21 +13,44 @@ import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSe
  * Ctrl/Cmd+Shift+Z  → redo
  * Ctrl/Cmd+Y        → redo (Windows convention)
  * Ctrl/Cmd+K        → open global search modal
+ * Ctrl/Cmd+Shift+N  → open quick-create dialog (fires from anywhere)
+ * N                 → open quick-create dialog (only when no input/dialog is focused)
  *
  * Undo/redo are suppressed inside text inputs so native browser undo is not
- * broken. Ctrl/Cmd+K intentionally fires from anywhere, including text inputs,
- * consistent with standard search-modal conventions.
+ * broken. Ctrl/Cmd+K and Ctrl/Cmd+Shift+N intentionally fire from anywhere,
+ * including text inputs, consistent with standard modal-trigger conventions.
  */
 export function useKeyboardShortcuts() {
   const undo = useStagedStore((s) => s.undo);
   const redo = useStagedStore((s) => s.redo);
   const openSearch = useGlobalSearchStore((s) => s.open);
+  const openQuickCreate = useQuickCreateStore((s) => s.open);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const mod = e.ctrlKey || e.metaKey;
-      if (!mod) return;
       const key = e.key.toLowerCase();
+
+      // Bare "N" — open quick-create only when no input/dialog is focused
+      if (!mod && !e.shiftKey && !e.altKey && key === "n") {
+        const target = e.target as HTMLElement;
+        const tag = target.tagName;
+        const dialogOpen = !!document.querySelector('[role="dialog"]');
+        if (!dialogOpen && tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT" && !target.isContentEditable) {
+          e.preventDefault();
+          openQuickCreate();
+          return;
+        }
+      }
+
+      if (!mod) return;
+
+      // Ctrl/Cmd+Shift+N — open quick-create from anywhere, including inside inputs
+      if (e.shiftKey && key === "n") {
+        e.preventDefault();
+        openQuickCreate();
+        return;
+      }
 
       // Ctrl/Cmd+K — open global search (fires from anywhere, including inputs)
       if (key === "k") {
@@ -54,5 +78,5 @@ export function useKeyboardShortcuts() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [undo, redo, openSearch]);
+  }, [undo, redo, openSearch, openQuickCreate]);
 }


### PR DESCRIPTION
 ## Summary

  - Adds a global **Quick Create** dialog (`N` bare key or `Ctrl/Cmd+Shift+N`) to stage a new Payee, Category, Account, or Tag without leaving the current page
  - Inline **"+ Create [type] …"** footer prompt in the Rule Drawer's payee/category comboboxes — clicking it opens the dialog pre-seeded with the typed search term; the new
  entity appears in the combobox options immediately after the dialog closes
  - **Global keyboard shortcuts modal** added as a standalone sidebar button (separate from Help & feedback); lists app-wide shortcuts with `<kbd>` badge styling and references
   the budget workspace `?` cheatsheet for workspace-specific bindings
  - **D shortcut** in the budget workspace registered in `ACTION_META` and `DEFAULT_KEYMAP` so it now appears in the `?` cheatsheet under "View & visibility" (shortcut was
  already functional via `useSpendingDetailsShortcut` but was invisible in the help modal)

  ## Implementation notes

  - `useQuickCreateStore` (Zustand) owns open state with optional type pre-selection and name prefill — same pattern as `useGlobalSearchStore`
  - Inner `QuickCreateForm` is re-keyed on each open (`key={isOpen-type-prefill}`) to reset `useState` without `useEffect`, avoiding the `react-hooks/set-state-in-effect` lint
  rule
  - `SearchableCombobox` gains an optional `footer: (search: string) => ReactNode` render prop; all existing callers are unaffected
  - `view.open-spending-details` is registered in the keymap with no entry in `WORKSPACE_HANDLERS` — the dispatcher early-exits without calling `preventDefault`, so the
  
  ## Test plan
  
  - [x] `N` opens dialog when body is focused; does nothing inside an input or when another dialog is open
  - [x] `Ctrl/Cmd+Shift+N` opens dialog from anywhere, including inside inputs 
  - [x] Create Payee / Category (with group) / Account (on/off-budget) / Tag (with color) — each appears staged in the respective entity table
  - [x] Duplicate name shows amber warning but does not block submission
  - [x] Category with no group selected keeps Create button disabled
  - [x] `Enter` submits valid form; `Escape` closes without staging
  - [x] Type in a payee combobox in the Rule Drawer with no match → "+ Create payee …" footer appears; clicking it opens dialog pre-seeded with the typed name
  - [x] After Quick Create closes from Rule Drawer, new entity appears in combobox options
  - [x] Sidebar "Keyboard shortcuts" button opens the app-wide shortcuts modal
  - [x] Press `?` in the budget workspace → `D` (Open spending details) appears under "View & visibility"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added global keyboard shortcuts reference modal accessible via sidebar button
  * Introduced Quick Create dialog for rapidly creating payees, categories, accounts, and tags with duplicate detection
  * Added inline "Create" prompts in rule editor fields for quick entity creation
  * Added "D" keyboard shortcut for opening spending details in Budget Management workspace
  * Added "N" and "Ctrl/Cmd+Shift+N" global shortcuts for Quick Create

* **Documentation**
  * Updated feature documentation with Quick Create workflow details and comprehensive keyboard shortcuts reference

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x-rous/actual-bench/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->