### PR TITLE
 feat/staged hold for next month with undo/redo and full save pipeline

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,119 @@
+language: "en-US"
+early_access: false
+
+tone_instructions: "Be concise, practical, and focus on real defects, regressions, security, maintainability, and user-facing impact. Avoid nitpicks unless they prevent bugs."
+
 reviews:
+  profile: "chill"
+  request_changes_workflow: true
+
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
   review_status: true
+  review_details: false
+  commit_status: true
+  fail_commit_status: false
+
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+
   auto_review:
     enabled: true
     drafts: false
-    base_branches:
-      - "main"
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+
+  path_filters:
+    - "!**/.next/**"
+    - "!**/.next-build/**"
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/coverage/**"
+    - "!**/*.lock"
+    - "!**/package-lock.json"
+    - "!**/pnpm-lock.yaml"
+    - "!**/yarn.lock"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.gif"
+    - "!**/*.svg"
+    - "!**/*.webp"
+
+  labeling_instructions:
+    - label: "frontend"
+      instructions: "Suggest when the PR changes React components, UI layout, styling, accessibility, or client-side behavior."
+    - label: "api"
+      instructions: "Suggest when the PR changes Next.js API routes, proxy behavior, request validation, server-side logic, or actual-http-api integration."
+    - label: "budget-management"
+      instructions: "Suggest when the PR changes budget-management logic, month summaries, staged changes, Tracking/Envelope behavior, or transaction analysis."
+    - label: "docs"
+      instructions: "Suggest when the PR mainly changes README, AGENTS.md, tutorials, or documentation."
+    - label: "ci"
+      instructions: "Suggest when the PR changes GitHub Actions, Docker, release workflows, build configuration, or deployment behavior."
+    - label: "tests"
+      instructions: "Suggest when the PR adds or changes Jest, React Testing Library, or regression tests."
+
+  path_instructions:
+    - path: "src/app/api/**"
+      instructions: |
+        Review as server-side API/proxy code. Focus on input validation, error handling, response consistency, authentication/secret leakage risks, binary response handling, and avoiding unsafe assumptions when calling actual-http-api.
+
+    - path: "src/features/budget-management/**"
+      instructions: |
+        This is one of the most sensitive areas of actual-bench. Pay close attention to Actual Budget mode differences:
+        - Tracking and Envelope budgets must not be treated the same unless intentionally documented.
+        - Hidden category behavior, rollover/carryover behavior, available funds, budgeted values, spent values, and To Budget / Overbudget summaries must remain mode-aware.
+        - Staged edits should remain local until Save and should not silently mutate server state.
+        - Review user-facing regressions carefully, especially table totals, month summaries, dialogs, and selection behavior.
+
+    - path: "src/features/**"
+      instructions: |
+        Review for React state consistency, TypeScript correctness, accessibility, keyboard behavior, loading/error states, and whether the feature adds useful behavior without unnecessary complexity.
+
+    - path: "src/lib/**"
+      instructions: |
+        Review utilities for edge cases, predictable behavior, type safety, and whether shared logic can break existing callers.
+
+    - path: "src/**/*.test.*"
+      instructions: |
+        Review whether tests cover meaningful behavior, edge cases, regressions, and user-visible outcomes. Avoid suggesting tests that only lock implementation details.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Review GitHub Actions for reliable CI/CD, correct permissions, cache safety, Docker build behavior, multi-arch build concerns, tag/release logic, and avoiding accidental secret exposure.
+
+    - path: "Dockerfile"
+      instructions: |
+        Review Docker changes for production readiness, image size, runtime user safety, environment variables, Next.js build/start behavior, and self-hosted deployment reliability.
+
+    - path: "docs/**"
+      instructions: |
+        Review documentation for clarity, beginner-friendliness, accuracy, and practical value for self-hosted Actual Budget users.
+
+    - path: "README.md"
+      instructions: |
+        Review the README as open-source onboarding material. Focus on whether a new user quickly understands what actual-bench does, who it is for, how to run it, and how it relates to Actual Budget and actual-http-api.
+
+    - path: "AGENTS.md"
+      instructions: |
+        Review agent instructions for clarity and usefulness. Keep them lightweight; avoid duplicating tasks already handled by CI unless the instruction changes how an AI coding agent should work.
+
+chat:
+  auto_reply: true

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -289,7 +289,7 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
 
 ### Save Flow
 - Clicking Save first opens a compact review summary grouped by month with total change count (cell edits + holds), affected month count, and net budget delta; individual months show a sub-line for any staged hold; users can skip this review on future saves
-- Confirming the review opens a non-dismissable progress dialog that processes changes sequentially (never in parallel) to avoid server race conditions: complete transfer pairs are sent first via the atomic `POST /months/{month}/categorytransfers` endpoint (one request per pair); remaining standalone edits and any incomplete transfer legs are sent as individual `PATCH /months/{month}/categories/{id}` requests; holds are processed last — DELETE-before-POST when replacing an existing server hold, or DELETE alone when freeing
+- Confirming the review opens a non-dismissible progress dialog that processes changes sequentially (never in parallel) to avoid server race conditions: complete transfer pairs are sent first via the atomic `POST /months/{month}/categorytransfers` endpoint (one request per pair); remaining standalone edits and any incomplete transfer legs are sent as individual `PATCH /months/{month}/categories/{id}` requests; holds are processed last — DELETE-before-POST when replacing an existing server hold, or DELETE alone when freeing
   - In-progress state: "Saving budget changes — N of M changes saved…" with a live progress bar
   - All-success state: change count and affected months; dialog auto-closes after 3 seconds (manual close also available)
   - Partial or full failure state: amber header with a scrollable list of failed changes (month / category ID / error message); "Retry Failed" button re-reads only the still-failed keys and hold months from the store and re-sends them
@@ -313,7 +313,7 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
 
 ### Envelope-Mode Hold (Staged)
 - **Hold toggle**: each "To Budget" cell in the summary section shows the currently held amount as a negative value (e.g. `-$350.00`) with a free-hold icon to its left. Clicking the toggle when no hold is active opens the "Hold for next month - YYYY-MM" dialog; the amount input auto-focuses with the existing value fully selected so the user can type immediately. Pressing `Enter` or clicking "Stage Hold" stages the hold; `Escape` closes without staging.
-- Clicking the toggle when a hold is already staged or active stages a free (sets the hold amount to zero and removes the entry from the draft panel).
++- Clicking the toggle stages a free (hold amount = 0). If the hold was only staged locally, the staged hold entry is removed; if a server hold exists, a staged clear remains in the draft panel until Save so the delete can be persisted.
 - Staged holds appear in the draft panel alongside cell edits and are saved in the same batch when the user clicks Save. Undo/redo applies to hold staging on the same history stack as cell edits (up to 50 steps).
 - The staged hold is immediately overlaid on the effective month state — `To Budget` and `Hold for next month` in the summary row update without writing to the server.
 - Hold is only available in envelope mode; it does not appear in tracking mode.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -180,7 +180,7 @@
 
 URL: `/budget-management`
 
-A multi-month budget editing workspace with staged cell editing, a draft review panel, right-click bulk actions, CSV import/export, and envelope-mode immediate actions.
+A multi-month budget editing workspace with staged cell editing, a draft review panel, right-click bulk actions, CSV import/export, and envelope-mode staged hold and transfer actions.
 
 ### Toolbar
 - Budget mode badge (`Envelope`, `Tracking`, or `Unknown`) always visible at the left
@@ -281,19 +281,20 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
 - **Period Summary** (default, when no category or group is selected): shows the active 12-month range, budget mode, coverage split between actualized/current/future months, one mode-aware primary status, and one compact trend. Tracking mode separates Actuals to date, Budget to date, and Full 12-month plan; future months are muted as plan-only and never counted as zero-actual savings. Envelope mode shows current/ending To Budget or Overbudget status, end-of-visible-plan To Budget when future months exist, and period values such as Assigned / Budgeted, Spent to date, Income received to date, and Hold for next month.
 - **Category or group label selected**: the panel switches to the selected row across the visible 12-month period. Tracking mode uses planning language (over/under plan, actual vs budget to date, full-period budget, averages to date) and does not use Balance as the primary group/category concept. If rollover/carryover applies, Tracking adds Current, Ending, or Planned Rollover Balance without summing balances across months. Tracking also shows a **Monthly average** (full 12-month budgeted ÷ 12) beneath the full-period budget figure. Envelope mode uses allocation language (Current Balance, Planned Balance, Assigned / Budgeted, Spent to date, Carryover where available) and never sums balances across months. If a note exists for the selected category or group, a **Note** section is shown at the bottom of the panel.
 - **Category or group month cell selected**: the panel switches to compact selected-month details. Tracking shows month status, budgeted, actuals, variance, rollover balance when applicable, and previous month budget when available; future months are plan-only and do not show fake under-plan results. Envelope shows Current Balance for actualized/current months, Planned Balance for future months, selected-month assigned/spent/balance, and carryover where available. If a note exists for the selected category × month combination, a **Note** section is shown at the bottom of the panel.
-- **Staged Changes** appears only when staged edits affect the visible period and current selection. Month-cell selections scope staged impact to the selected month and row. Tracking shows budget plan impact; Envelope shows Estimated To Budget impact and notes that final balances recalculate after save.
+- **Staged Changes** appears only when staged edits affect the visible period and current selection. Month-cell selections scope staged impact to the selected month and row. Tracking shows budget plan impact; Envelope shows Estimated To Budget impact and notes that final balances recalculate after save. The staged changes overlay (accessible from the "N changes" badge) includes hold entries alongside cell edits and transfer pairs.
 - All notes are fetched in a single bulk ActualQL `SELECT *` from the `notes` table and cached for 5 minutes — no per-entity network calls are made when selecting cells or row labels.
 
 ### Clipboard Paste
 - Paste tab-delimited data from spreadsheets into the grid starting from the top-left selected cell; fills the corresponding rectangle without requiring pre-selection of exact dimensions
 
 ### Save Flow
-- Clicking Save first opens a compact review summary grouped by month with total change count, affected month count, and net budget delta; users can skip this review on future saves
-- Confirming the review opens a non-dismissable progress dialog that processes edits sequentially (never in parallel) to avoid server race conditions: complete transfer pairs are sent first via the atomic `POST /months/{month}/categorytransfers` endpoint (one request per pair); remaining standalone edits and any incomplete transfer legs are sent as individual `PATCH /months/{month}/categories/{id}` requests
-  - In-progress state: "Saving budget changes — N of M cells saved…" with a live progress bar
-  - All-success state: cell count and affected months; dialog auto-closes after 3 seconds (manual close also available)
-  - Partial or full failure state: amber header with a scrollable list of failed cells (month / category ID / error message); "Retry Failed" button re-reads only the still-failed keys from the store and re-sends them
-- Failed cells always remain in the store with their `saveError` set — only cells that received a 200 response are cleared; TanStack Query cache is invalidated per succeeded month
+- Clicking Save first opens a compact review summary grouped by month with total change count (cell edits + holds), affected month count, and net budget delta; individual months show a sub-line for any staged hold; users can skip this review on future saves
+- Confirming the review opens a non-dismissable progress dialog that processes changes sequentially (never in parallel) to avoid server race conditions: complete transfer pairs are sent first via the atomic `POST /months/{month}/categorytransfers` endpoint (one request per pair); remaining standalone edits and any incomplete transfer legs are sent as individual `PATCH /months/{month}/categories/{id}` requests; holds are processed last — DELETE-before-POST when replacing an existing server hold, or DELETE alone when freeing
+  - In-progress state: "Saving budget changes — N of M changes saved…" with a live progress bar
+  - All-success state: change count and affected months; dialog auto-closes after 3 seconds (manual close also available)
+  - Partial or full failure state: amber header with a scrollable list of failed changes (month / category ID / error message); "Retry Failed" button re-reads only the still-failed keys and hold months from the store and re-sends them
+- Failed changes (cell edits and holds) always remain in the store with their `saveError` set — only changes that received a 200 response are cleared; TanStack Query cache is invalidated per succeeded month; for hold saves, M+1 is also invalidated because the server updates `fromLastMonth` on the following month
+- Undo/redo history is cleared after a fully or partially successful save so stale undo steps from before the save cannot be replayed
 
 ### CSV Export
 - Three month-selection modes in the export dialog:
@@ -310,9 +311,12 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
 - Levenshtein-distance fuzzy matching (distance ≤ 2) offers suggestions for near-miss category names
 - Out-of-range months (exist in budget but outside the current 12-month window) shown with an "Extend visible range" option; absent months (not in `GET /months`) rejected with a clear error
 
-### Envelope-Mode Immediate Actions
-- **Hold toggle**: each "To Budget" cell in the summary section has a hold toggle button (arrow icon, left of the amount). Clicking it when no hold is active opens the "Next Month Hold for YYYY-MM" dialog to set an amount; the dialog closes immediately on save. Clicking it when a hold is active shows a confirmation dialog ("Free the hold for YYYY-MM?") before clearing. Both actions are immediate and bypass the staged save panel
-- Hold is only available in envelope mode; it does not appear in tracking mode
+### Envelope-Mode Hold (Staged)
+- **Hold toggle**: each "To Budget" cell in the summary section shows the currently held amount as a negative value (e.g. `-$350.00`) with a free-hold icon to its left. Clicking the toggle when no hold is active opens the "Hold for next month - YYYY-MM" dialog; the amount input auto-focuses with the existing value fully selected so the user can type immediately. Pressing `Enter` or clicking "Stage Hold" stages the hold; `Escape` closes without staging.
+- Clicking the toggle when a hold is already staged or active stages a free (sets the hold amount to zero and removes the entry from the draft panel).
+- Staged holds appear in the draft panel alongside cell edits and are saved in the same batch when the user clicks Save. Undo/redo applies to hold staging on the same history stack as cell edits (up to 50 steps).
+- The staged hold is immediately overlaid on the effective month state — `To Budget` and `Hold for next month` in the summary row update without writing to the server.
+- Hold is only available in envelope mode; it does not appear in tracking mode.
 
 ### Envelope-Mode Staged Transfers
 - Right-click any spending category cell → **Cover Overspending** (negative balance) or **Transfer to Another Category** (positive balance) → opens the staged transfer dialog

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A full-width 12-month budget editor for envelope and tracking budgets.
 - Multi-cell selection, copy/paste from Excel or Google Sheets, fill down/right, previous-month fill, and average-based fill
 - Right-click bulk actions such as copy previous month, set to zero, set fixed amount, apply percentage change, and average calculations
 - Draft panel with selected-cell details, group totals, year summary, staged deltas, and save errors
-- Envelope-mode actions for next-month hold and category transfer
+- Envelope-mode staged hold for next month (with undo support) and staged category transfer
 - Keyboard shortcut cheatsheet
 
 ### Advanced Data Management

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -47,7 +47,7 @@ import {
   readBudgetSaveReviewSkip,
   writeBudgetSaveReviewSkip,
 } from "@/features/budget-management/lib/budgetSaveReview";
-import type { BudgetCellKey, StagedBudgetEdit } from "@/features/budget-management/types";
+import type { BudgetCellKey, StagedBudgetEdit, StagedHold } from "@/features/budget-management/types";
 
 type PendingAction =
   | { kind: "switch"; id: string }
@@ -89,7 +89,9 @@ export function TopBar() {
     () => readBudgetSaveReviewSkip()
   );
   const [budgetSaveReviewEdits, setBudgetSaveReviewEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
+  const [budgetSaveReviewHolds, setBudgetSaveReviewHolds] = useState<Record<string, StagedHold>>({});
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
+  const [budgetSaveHolds, setBudgetSaveHolds] = useState<Record<string, StagedHold>>({});
 
   const openSearch = useGlobalSearchStore((s) => s.open);
   const searchShortcutLabel = "Ctrl+k";
@@ -115,7 +117,7 @@ export function TopBar() {
 
   // Budget page store (always called — hooks cannot be conditional)
   const budgetHasChanges = useBudgetEditsStore(
-    (s) => Object.keys(s.edits).length > 0
+    (s) => Object.keys(s.edits).length > 0 || Object.keys(s.holds).length > 0
   );
   const budgetCanUndo = useBudgetEditsStore((s) => s.undoStack.length > 0);
   const budgetCanRedo = useBudgetEditsStore((s) => s.redoStack.length > 0);
@@ -181,16 +183,19 @@ export function TopBar() {
 
   async function handleSave() {
     if (isBudgetPage) {
-      const edits = useBudgetEditsStore.getState().edits;
+      const { edits, holds } = useBudgetEditsStore.getState();
       const editSnapshot = { ...edits };
-      if (Object.keys(editSnapshot).length === 0) return;
+      const holdSnapshot = { ...holds };
+      if (Object.keys(editSnapshot).length === 0 && Object.keys(holdSnapshot).length === 0) return;
 
       if (budgetSaveReviewSkipped) {
         setBudgetSaveEdits(editSnapshot);
+        setBudgetSaveHolds(holdSnapshot);
         return;
       }
 
       setBudgetSaveReviewEdits(editSnapshot);
+      setBudgetSaveReviewHolds(holdSnapshot);
     } else {
       try {
         const { totalSucceeded, totalFailed } = await saveAll();
@@ -410,8 +415,10 @@ export function TopBar() {
       {budgetSaveReviewEdits !== null && (
         <BudgetSaveReviewDialog
           edits={budgetSaveReviewEdits}
+          holds={budgetSaveReviewHolds}
           onCancel={() => {
             setBudgetSaveReviewEdits(null);
+            setBudgetSaveReviewHolds({});
           }}
           onConfirm={(skipReviewNextTime) => {
             if (skipReviewNextTime) {
@@ -419,7 +426,9 @@ export function TopBar() {
               setBudgetSaveReviewSkipped(true);
             }
             setBudgetSaveEdits(budgetSaveReviewEdits);
+            setBudgetSaveHolds(budgetSaveReviewHolds);
             setBudgetSaveReviewEdits(null);
+            setBudgetSaveReviewHolds({});
           }}
         />
       )}
@@ -427,7 +436,11 @@ export function TopBar() {
       {budgetSaveEdits !== null && (
         <BudgetSaveProgressDialog
           edits={budgetSaveEdits}
-          onClose={() => setBudgetSaveEdits(null)}
+          holds={budgetSaveHolds}
+          onClose={() => {
+            setBudgetSaveEdits(null);
+            setBudgetSaveHolds({});
+          }}
         />
       )}
 

--- a/src/features/budget-management/components/BudgetDraftPanel.tsx
+++ b/src/features/budget-management/components/BudgetDraftPanel.tsx
@@ -16,9 +16,10 @@ import { BudgetDetailsPanel } from "./details/BudgetDetailsPanel";
  */
 export function BudgetDraftPanel() {
   const edits = useBudgetEditsStore((s) => s.edits);
+  const holds = useBudgetEditsStore((s) => s.holds);
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const changeCount = countLogicalEdits(edits);
+  const changeCount = countLogicalEdits(edits, holds);
 
   return (
     <aside

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.test.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.test.tsx
@@ -48,7 +48,7 @@ describe("BudgetSaveProgressDialog", () => {
     );
 
     expect(await screen.findByText("Save failed")).toBeInTheDocument();
-    expect(screen.getByText("2 cells could not be saved.")).toBeInTheDocument();
+    expect(screen.getByText("2 changes could not be saved.")).toBeInTheDocument();
     expect(screen.getAllByText("No active connection")).toHaveLength(2);
     expect(consoleError).toHaveBeenCalledWith("Budget save failed", error);
 

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
@@ -4,10 +4,11 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import { useBudgetSave } from "../hooks/useBudgetSave";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
-import type { BudgetCellKey, BudgetSaveResult, StagedBudgetEdit } from "../types";
+import type { BudgetCellKey, BudgetSaveResult, StagedBudgetEdit, StagedHold } from "../types";
 
 type Props = {
   edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  holds?: Record<string, StagedHold>;
   onClose: () => void;
 };
 
@@ -33,7 +34,7 @@ function buildRejectedSaveResults(
   }));
 }
 
-export function BudgetSaveProgressDialog({ edits, onClose }: Props) {
+export function BudgetSaveProgressDialog({ edits, holds = {}, onClose }: Props) {
   const { save, isSaving, progress } = useBudgetSave();
   const [results, setResults] = useState<BudgetSaveResult[]>([]);
   const [dialogState, setDialogState] = useState<DialogState>("saving");
@@ -62,7 +63,7 @@ export function BudgetSaveProgressDialog({ edits, onClose }: Props) {
   useEffect(() => {
     if (hasStarted.current) return;
     hasStarted.current = true;
-    void save(edits)
+    void save(edits, holds)
       .then(applyResults)
       .catch((error: unknown) => {
         console.error("Budget save failed", error);
@@ -89,10 +90,20 @@ export function BudgetSaveProgressDialog({ edits, onClose }: Props) {
         retryEdits[key as BudgetCellKey] = edit;
       }
     }
+    // Retry failed hold months too.
+    const failedHoldMonths = new Set(
+      failedResults.filter((r) => r.categoryId === "").map((r) => r.month)
+    );
+    const currentHolds = useBudgetEditsStore.getState().holds;
+    const retryHolds: Record<string, StagedHold> = {};
+    for (const [month, hold] of Object.entries(currentHolds)) {
+      if (failedHoldMonths.has(month)) retryHolds[month] = hold;
+    }
+
     setDialogState("saving");
     setResults([]);
     try {
-      const retryResults = await save(retryEdits);
+      const retryResults = await save(retryEdits, retryHolds);
       applyResults(retryResults);
     } catch (error) {
       console.error("Budget save retry failed", error);

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
@@ -69,7 +69,7 @@ export function BudgetSaveProgressDialog({ edits, holds = {}, onClose }: Props) 
         console.error("Budget save failed", error);
         applyResults(buildRejectedSaveResults(edits, error));
       });
-  }, [edits, save, applyResults]);
+  }, [edits, holds, save, applyResults]);
 
   // Auto-close countdown for success state
   useEffect(() => {

--- a/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveProgressDialog.tsx
@@ -128,7 +128,7 @@ export function BudgetSaveProgressDialog({ edits, holds = {}, onClose }: Props) 
             </div>
             <p className="text-sm text-muted-foreground mb-3">
               {progress.total > 0
-                ? `${progress.completed} of ${progress.total} cells saved…`
+                ? `${progress.completed} of ${progress.total} changes saved…`
                 : "Preparing…"}
             </p>
             {progress.total > 0 && (
@@ -149,7 +149,7 @@ export function BudgetSaveProgressDialog({ edits, holds = {}, onClose }: Props) 
               <h2 className="text-base font-semibold text-foreground">All changes saved</h2>
             </div>
             <p className="text-sm text-muted-foreground mb-1">
-              {succeededResults.length} cell{succeededResults.length !== 1 ? "s" : ""} saved
+              {succeededResults.length} change{succeededResults.length !== 1 ? "s" : ""} saved
               {successMonths.length > 0 && ` across ${successMonths.length} month${successMonths.length !== 1 ? "s" : ""}`}.
             </p>
             {successMonths.length > 0 && (
@@ -177,8 +177,8 @@ export function BudgetSaveProgressDialog({ edits, holds = {}, onClose }: Props) 
             </div>
             <p className="text-sm text-muted-foreground mb-3">
               {dialogState === "partial-failure"
-                ? `${succeededResults.length} cell${succeededResults.length !== 1 ? "s" : ""} saved, ${failedResults.length} failed.`
-                : `${failedResults.length} cell${failedResults.length !== 1 ? "s" : ""} could not be saved.`}
+                ? `${succeededResults.length} change${succeededResults.length !== 1 ? "s" : ""} saved, ${failedResults.length} failed.`
+                : `${failedResults.length} change${failedResults.length !== 1 ? "s" : ""} could not be saved.`}
             </p>
             <div className="mb-4 max-h-44 overflow-y-auto rounded border border-border divide-y divide-border">
               {failedResults.map((r) => (

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.test.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.test.tsx
@@ -31,7 +31,7 @@ describe("BudgetSaveReviewDialog", () => {
     );
 
     expect(screen.getByText("Review save summary")).toBeInTheDocument();
-    expect(screen.getByText("Changes")).toBeInTheDocument();
+    expect(screen.getAllByText("Changes")).toHaveLength(2); // summary card + table column header
     expect(screen.getByText("Months")).toBeInTheDocument();
     expect(screen.getAllByText("Net")).toHaveLength(2);
     expect(screen.getByText("Apr 2026")).toBeInTheDocument();

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
@@ -99,7 +99,7 @@ export function BudgetSaveReviewDialog({
             <thead className="bg-muted text-[10px] uppercase text-muted-foreground">
               <tr>
                 <th className="px-2 py-1.5 text-left font-medium">Month</th>
-                <th className="w-16 px-2 py-1.5 text-right font-medium">Edits</th>
+                <th className="w-16 px-2 py-1.5 text-right font-medium">Changes</th>
                 <th className="w-24 px-2 py-1.5 text-right font-medium">Net</th>
               </tr>
             </thead>

--- a/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
+++ b/src/features/budget-management/components/BudgetSaveReviewDialog.tsx
@@ -12,10 +12,11 @@ import {
 } from "@/components/ui/dialog";
 import { formatMinor } from "../lib/format";
 import { buildBudgetSaveReviewSummary } from "../lib/budgetSaveReview";
-import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+import type { BudgetCellKey, StagedBudgetEdit, StagedHold } from "../types";
 
 type Props = {
   edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  holds?: Record<string, StagedHold>;
   onCancel: () => void;
   onConfirm: (skipReviewNextTime: boolean) => void;
 };
@@ -28,21 +29,25 @@ function formatDeltaAmount(delta: number): string {
 
 export function BudgetSaveReviewDialog({
   edits,
+  holds = {},
   onCancel,
   onConfirm,
 }: Props) {
   const [skipReviewNextTime, setSkipReviewNextTime] = useState(false);
   const summary = useMemo(
-    () => buildBudgetSaveReviewSummary(edits),
-    [edits]
+    () => buildBudgetSaveReviewSummary(edits, {}, holds),
+    [edits, holds]
   );
+  const totalCount = summary.editCount + summary.holdCount;
+
   const monthRows = useMemo(
     () =>
       summary.months.map((month) => ({
         month: month.month,
         label: month.label,
-        changeCount: month.entries.length,
+        changeCount: month.entries.length + (month.hold ? 1 : 0),
         totalDelta: month.totalDelta,
+        hold: month.hold,
       })),
     [summary.months]
   );
@@ -65,7 +70,7 @@ export function BudgetSaveReviewDialog({
             <div className="border-r border-border px-2 py-2">
               <p className="text-[10px] uppercase text-muted-foreground">Changes</p>
               <p className="font-semibold text-foreground tabular-nums">
-                {summary.editCount}
+                {totalCount}
               </p>
             </div>
             <div className="border-r border-border px-2 py-2">
@@ -101,8 +106,18 @@ export function BudgetSaveReviewDialog({
             <tbody className="divide-y divide-border">
               {monthRows.map((row) => (
                 <tr key={row.month}>
-                  <td className="truncate px-2 py-1.5 font-medium text-foreground">
-                    {row.label}
+                  <td className="px-2 py-1.5 font-medium text-foreground">
+                    <div className="truncate">{row.label}</div>
+                    {row.hold && (
+                      <div className="text-[10px] font-normal text-muted-foreground mt-0.5">
+                        Hold:{" "}
+                        {row.hold.nextAmount === 0 ? (
+                          <span className="line-through">{formatMinor(row.hold.previousAmount)}</span>
+                        ) : (
+                          formatMinor(row.hold.nextAmount)
+                        )}
+                      </div>
+                    )}
                   </td>
                   <td className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
                     {row.changeCount}
@@ -143,9 +158,9 @@ export function BudgetSaveReviewDialog({
             </Button>
             <Button
               onClick={() => onConfirm(skipReviewNextTime)}
-              disabled={summary.editCount === 0}
+              disabled={totalCount === 0}
             >
-              Save {summary.editCount} change{summary.editCount !== 1 ? "s" : ""}
+              Save {totalCount} change{totalCount !== 1 ? "s" : ""}
             </Button>
           </div>
         </div>

--- a/src/features/budget-management/components/NextMonthHoldDialog.tsx
+++ b/src/features/budget-management/components/NextMonthHoldDialog.tsx
@@ -53,7 +53,7 @@ export function NextMonthHoldDialog({
 
   const handleSet = () => {
     const amount = Math.round(parseFloat(amountStr) * 100);
-    if (isNaN(amount) || amount < 0) {
+    if (!Number.isFinite(amount) || !Number.isSafeInteger(amount) || amount < 0) {
       setValidationError("Please enter a valid amount (0 or greater).");
       return;
     }

--- a/src/features/budget-management/components/NextMonthHoldDialog.tsx
+++ b/src/features/budget-management/components/NextMonthHoldDialog.tsx
@@ -1,26 +1,37 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { formatMonthLabel } from "@/lib/budget/monthMath";
-import { useNextMonthHold } from "../hooks/useNextMonthHold";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
 
 type Props = {
   month: string;
   onClose: () => void;
-  /** Pre-fill the amount input (minor units). */
+  /** Pre-fill the amount input (positive minor units). */
   defaultAmount?: number;
+  /**
+   * Server's current forNextMonth for this month (positive minor units, as
+   * returned by the API). Used to build previousAmount in the staged hold.
+   */
+  currentForNextMonth: number;
   /** When true, hides the Clear Hold button — the caller handles clearing separately. */
   setOnly?: boolean;
 };
 
 /**
- * Envelope-mode: immediate next-month budget hold dialog.
+ * Envelope-mode: staged next-month budget hold dialog.
  *
- * Lets users set or clear the hold for a given month.
- * Displays a disclaimer that the action is immediate and bypasses the save panel.
+ * Stages a hold (holdBudgetForNextMonth) or a hold clear (resetBudgetHold)
+ * into the draft pipeline. The change is flushed to the server on Save.
  */
-export function NextMonthHoldDialog({ month, onClose, defaultAmount, setOnly }: Props) {
-  const { setHold, clearHold, isPending, error } = useNextMonthHold();
+export function NextMonthHoldDialog({
+  month,
+  onClose,
+  defaultAmount,
+  currentForNextMonth,
+  setOnly,
+}: Props) {
+  const stageHold = useBudgetEditsStore((s) => s.stageHold);
   const monthLabel = formatMonthLabel(month, "long");
 
   const [amountStr, setAmountStr] = useState(
@@ -28,33 +39,32 @@ export function NextMonthHoldDialog({ month, onClose, defaultAmount, setOnly }: 
       ? (defaultAmount / 100).toFixed(2)
       : ""
   );
-  const [done, setDone] = useState(false);
-  const [lastAction, setLastAction] = useState<"clear" | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleSet = async () => {
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, []);
+
+  const previousAmount = currentForNextMonth;
+
+  const handleSet = () => {
     const amount = Math.round(parseFloat(amountStr) * 100);
     if (isNaN(amount) || amount < 0) {
       setValidationError("Please enter a valid amount (0 or greater).");
       return;
     }
     setValidationError(null);
-    try {
-      await setHold(month, { amount });
-      onClose();
-    } catch {
-      // error is set by the hook
-    }
+    stageHold({ month, nextAmount: amount, previousAmount });
+    onClose();
   };
 
-  const handleClear = async () => {
-    try {
-      await clearHold(month);
-      setLastAction("clear");
-      setDone(true);
-    } catch {
-      // error is set by the hook
-    }
+  const handleClear = () => {
+    stageHold({ month, nextAmount: 0, previousAmount });
+    onClose();
   };
 
   return (
@@ -65,92 +75,61 @@ export function NextMonthHoldDialog({ month, onClose, defaultAmount, setOnly }: 
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
     >
       <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-sm mx-4 p-5">
-        {!done ? (
-          <>
-            <h2 className="text-base font-semibold mb-4">
-              Hold for next month — {monthLabel}
-            </h2>
+        <h2 className="text-base font-semibold mb-4">
+          Hold for next month - {monthLabel}
+        </h2>
 
-            <div className="mb-4">
-              <label htmlFor="hold-amount" className="block text-sm font-medium mb-1">
-                Amount to hold
-              </label>
-              <input
-                id="hold-amount"
-                type="number"
-                min="0"
-                step="0.01"
-                value={amountStr}
-                onChange={(e) => setAmountStr(e.target.value)}
-                disabled={isPending}
-                placeholder="0.00"
-                className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
-                aria-label="Hold amount in dollars"
-              />
-            </div>
+        <div className="mb-4">
+          <label htmlFor="hold-amount" className="block text-sm font-medium mb-1">
+            Amount to hold
+          </label>
+          <input
+            ref={inputRef}
+            id="hold-amount"
+            type="number"
+            min="0"
+            step="0.01"
+            value={amountStr}
+            onChange={(e) => setAmountStr(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter" && amountStr !== "") handleSet(); }}
+            placeholder="0.00"
+            className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+            aria-label="Hold amount in dollars"
+          />
+        </div>
 
-            <div
-              className="mb-4 p-2 rounded bg-orange-50 dark:bg-orange-950/20 text-xs text-orange-700 dark:text-orange-400"
-              role="note"
-            >
-              This action applies immediately and does not go through the save panel.
-            </div>
-
-            {validationError && (
-              <p className="text-xs text-destructive mb-3" role="alert">{validationError}</p>
-            )}
-            {error && (
-              <p className="text-xs text-destructive mb-3" role="alert">{error}</p>
-            )}
-
-            <div className="flex gap-2 justify-end">
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={isPending}
-                className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
-              >
-                Cancel
-              </button>
-              {!setOnly && (
-                <button
-                  type="button"
-                  onClick={() => void handleClear()}
-                  disabled={isPending}
-                  aria-label="Clear the next month hold immediately"
-                  className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
-                >
-                  {isPending && lastAction === "clear" ? "Clearing…" : "Clear Hold"}
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => void handleSet()}
-                disabled={isPending || amountStr === ""}
-                aria-label="Set the next month hold amount immediately"
-                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                {isPending ? "Saving…" : "Set Hold"}
-              </button>
-            </div>
-          </>
-        ) : (
-          <>
-            <h2 className="text-base font-semibold mb-3">Hold Cleared</h2>
-            <p className="text-sm text-muted-foreground mb-4">
-              The next-month hold has been cleared. The grid has been updated.
-            </p>
-            <div className="flex justify-end">
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-              >
-                Done
-              </button>
-            </div>
-          </>
+        {validationError && (
+          <p className="text-xs text-destructive mb-3" role="alert">{validationError}</p>
         )}
+
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors"
+          >
+            Cancel
+          </button>
+          {!setOnly && (
+            <button
+              type="button"
+              onClick={handleClear}
+              aria-label="Stage a hold clear for next month"
+              className="px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors"
+            >
+              Clear Hold
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleSet}
+            disabled={amountStr === ""}
+            aria-label="Stage the next month hold amount"
+            className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Stage Hold
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/budget-management/components/StagedChangesDialog.tsx
+++ b/src/features/budget-management/components/StagedChangesDialog.tsx
@@ -18,6 +18,7 @@ import type { LoadedCategory, LoadedMonthState } from "../types";
  */
 export function StagedChangesDialog({ onClose }: { onClose: () => void }) {
   const edits = useBudgetEditsStore((s) => s.edits);
+  const holds = useBudgetEditsStore((s) => s.holds);
   const displayMonths = useBudgetEditsStore((s) => s.displayMonths);
   const connection = useConnectionStore(selectActiveInstance);
   const queryClient = useQueryClient();
@@ -84,7 +85,7 @@ export function StagedChangesDialog({ onClose }: { onClose: () => void }) {
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
-          <StagedChangesSection edits={edits} allCategories={allCategories} />
+          <StagedChangesSection edits={edits} holds={holds} allCategories={allCategories} />
         </div>
       </div>
     </div>

--- a/src/features/budget-management/components/StagedChangesDialog.tsx
+++ b/src/features/budget-management/components/StagedChangesDialog.tsx
@@ -24,7 +24,7 @@ export function StagedChangesDialog({ onClose }: { onClose: () => void }) {
   const queryClient = useQueryClient();
   const overlayRef = useRef<HTMLDivElement>(null);
 
-  const totalChanges = countLogicalEdits(edits);
+  const totalChanges = countLogicalEdits(edits, holds);
 
   // Resolve category metadata from the cache. We only need one loaded month —
   // the category set is the same across all months in a budget.

--- a/src/features/budget-management/components/draft-panel/StagedChangesSection.tsx
+++ b/src/features/budget-management/components/draft-panel/StagedChangesSection.tsx
@@ -2,19 +2,21 @@
 
 import { useMemo } from "react";
 import { formatMonthLabel } from "@/lib/budget/monthMath";
-import { formatSigned as fmt, formatCurrency } from "../../lib/format";
+import { formatSigned as fmt, formatCurrency, formatMinor } from "../../lib/format";
 import type {
   BudgetCellKey,
   LoadedCategory,
   StagedBudgetEdit,
+  StagedHold,
 } from "../../types";
 
 /**
  * Counts logical staged changes: transfer pairs count as 1, standalone edits
- * count as 1 each. Matches the count shown in the section header.
+ * count as 1 each, holds count as 1 each.
  */
 export function countLogicalEdits(
-  edits: Record<BudgetCellKey, StagedBudgetEdit>
+  edits: Record<BudgetCellKey, StagedBudgetEdit>,
+  holds: Record<string, StagedHold> = {}
 ): number {
   const groupIds = new Set<string>();
   let standalone = 0;
@@ -25,7 +27,7 @@ export function countLogicalEdits(
       standalone++;
     }
   }
-  return standalone + groupIds.size;
+  return standalone + groupIds.size + Object.keys(holds).length;
 }
 
 /**
@@ -39,9 +41,11 @@ export function countLogicalEdits(
  */
 export function StagedChangesSection({
   edits,
+  holds = {},
   allCategories,
 }: {
   edits: Record<BudgetCellKey, StagedBudgetEdit>;
+  holds?: Record<string, StagedHold>;
   allCategories: LoadedCategory[];
 }) {
   const editList = Object.values(edits);
@@ -67,29 +71,34 @@ export function StagedChangesSection({
     return { standaloneEdits: standalone, transferGroups: groups };
   }, [editList]);
 
-  const totalChanges = standaloneEdits.length + transferGroups.size;
+  const totalChanges = standaloneEdits.length + transferGroups.size + Object.keys(holds).length;
 
   const byMonth = useMemo(() => {
-    const grouped: Record<string, { standalone: StagedBudgetEdit[]; transferGroupIds: string[] }> = {};
+    const grouped: Record<string, { standalone: StagedBudgetEdit[]; transferGroupIds: string[]; hold: StagedHold | null }> = {};
 
     for (const edit of standaloneEdits) {
-      if (!grouped[edit.month]) grouped[edit.month] = { standalone: [], transferGroupIds: [] };
+      if (!grouped[edit.month]) grouped[edit.month] = { standalone: [], transferGroupIds: [], hold: null };
       grouped[edit.month]!.standalone.push(edit);
     }
 
     for (const [groupId, legs] of transferGroups) {
       const month = legs[0]?.month;
       if (!month) continue;
-      if (!grouped[month]) grouped[month] = { standalone: [], transferGroupIds: [] };
+      if (!grouped[month]) grouped[month] = { standalone: [], transferGroupIds: [], hold: null };
       grouped[month]!.transferGroupIds.push(groupId);
     }
 
+    for (const [month, hold] of Object.entries(holds)) {
+      if (!grouped[month]) grouped[month] = { standalone: [], transferGroupIds: [], hold: null };
+      grouped[month]!.hold = hold;
+    }
+
     return grouped;
-  }, [standaloneEdits, transferGroups]);
+  }, [standaloneEdits, transferGroups, holds]);
 
   const months = useMemo(() => Object.keys(byMonth).sort(), [byMonth]);
 
-  if (editList.length === 0) {
+  if (editList.length === 0 && Object.keys(holds).length === 0) {
     return (
       <div className="px-3 py-4 text-[11px] text-muted-foreground text-center">
         No staged changes
@@ -105,9 +114,10 @@ export function StagedChangesSection({
       </p>
 
       {months.map((month) => {
-        const { standalone, transferGroupIds } = byMonth[month] ?? {
+        const { standalone, transferGroupIds, hold } = byMonth[month] ?? {
           standalone: [],
           transferGroupIds: [],
+          hold: null,
         };
 
         const sortedStandalone = standalone.slice().sort((a, b) => {
@@ -121,6 +131,27 @@ export function StagedChangesSection({
             <p className="text-[11px] font-semibold text-foreground/80 mb-1">
               {formatMonthLabel(month, "long")}
             </p>
+
+            {/* Hold row */}
+            {hold && (
+              <div className="flex items-baseline justify-between gap-1 py-0.5">
+                <span className="text-[10px] text-muted-foreground shrink-0">Hold for next month</span>
+                <span
+                  className={`font-sans tabular-nums text-[10px] shrink-0 ${
+                    hold.nextAmount === 0
+                      ? "text-muted-foreground line-through"
+                      : "text-amber-600 dark:text-amber-400"
+                  }`}
+                >
+                  {hold.nextAmount === 0
+                    ? formatMinor(hold.previousAmount)
+                    : formatMinor(hold.nextAmount)}
+                </span>
+                {hold.saveError && (
+                  <span className="text-[9px] text-destructive shrink-0" title={hold.saveError}>!</span>
+                )}
+              </div>
+            )}
 
             {/* Transfer group rows */}
             {transferGroupIds.map((groupId) => {

--- a/src/features/budget-management/components/grid/HoldToggle.tsx
+++ b/src/features/budget-management/components/grid/HoldToggle.tsx
@@ -2,79 +2,8 @@
 
 import { useState } from "react";
 import { ArrowRight, Undo2 } from "lucide-react";
-import { formatMonthLabel } from "@/lib/budget/monthMath";
-import { useNextMonthHold } from "../../hooks/useNextMonthHold";
-import { formatMinor } from "../../lib/format";
+import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { NextMonthHoldDialog } from "../NextMonthHoldDialog";
-
-/**
- * Confirmation dialog before clearing an active "next-month hold". Lifted
- * here from `BudgetGrid` so the envelope-mode hold flow is in one place.
- */
-function HoldClearConfirmDialog({
-  month,
-  forNextMonth,
-  onConfirm,
-  onCancel,
-  isPending,
-  error,
-}: {
-  month: string;
-  forNextMonth: number;
-  onConfirm: () => void;
-  onCancel: () => void;
-  isPending: boolean;
-  error: string | null;
-}) {
-  const monthLabel = formatMonthLabel(month, "long");
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="Confirm free hold"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-    >
-      <div className="bg-background border border-border rounded-lg shadow-xl w-full max-w-xs mx-4 p-4">
-        <p className="text-sm font-medium text-foreground mb-0.5">
-          Free held amount for {monthLabel}?
-        </p>
-        <p className="text-xs text-muted-foreground mb-3">
-          Currently held:{" "}
-          <span className="font-semibold tabular-nums text-foreground">
-            {formatMinor(Math.abs(forNextMonth))}
-          </span>
-        </p>
-        <p className="text-xs bg-amber-50 dark:bg-amber-950/20 text-amber-700 dark:text-amber-400 rounded px-2.5 py-1.5 mb-4">
-          This action applies immediately and does not go through the save panel.
-        </p>
-        {error && (
-          <p className="text-xs text-destructive mb-3" role="alert">
-            {error}
-          </p>
-        )}
-        <div className="flex gap-2 justify-end">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isPending}
-            className="px-3 py-1.5 text-sm text-foreground rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={isPending}
-            className="px-3 py-1.5 text-sm text-foreground rounded border border-border hover:bg-muted disabled:opacity-40 transition-colors"
-          >
-            {isPending ? "Clearing…" : "Free Hold"}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 /**
  * Gray hold action rendered beside the envelope "To Budget" value when money
@@ -116,6 +45,7 @@ export function HoldMoneyButton({
         <NextMonthHoldDialog
           month={month}
           defaultAmount={toBudget > 0 ? toBudget : undefined}
+          currentForNextMonth={forNextMonth}
           setOnly
           onClose={() => setShowSetDialog(false)}
         />
@@ -126,7 +56,8 @@ export function HoldMoneyButton({
 
 /**
  * Amber free action rendered beside the envelope "Hold for next month" value
- * whenever a hold is active for that month.
+ * whenever a hold is active for that month. Staging a clear is reversible via
+ * undo, so no confirmation dialog is needed.
  */
 export function FreeHeldAmountButton({
   month,
@@ -135,48 +66,29 @@ export function FreeHeldAmountButton({
   month: string;
   forNextMonth: number;
 }) {
-  const { clearHold, isPending, error } = useNextMonthHold();
-  const [showConfirm, setShowConfirm] = useState(false);
+  const stageHold = useBudgetEditsStore((s) => s.stageHold);
+  const holds = useBudgetEditsStore((s) => s.holds);
 
   if (forNextMonth === 0) return null;
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setShowConfirm(true);
-  };
-
-  const handleConfirmClear = async () => {
-    try {
-      await clearHold(month);
-      setShowConfirm(false);
-    } catch {
-      // error is set by the hook and shown in the confirmation dialog.
-    }
+    // previousAmount: use the server's original value. If a staged hold exists,
+    // its previousAmount IS the server's original. Otherwise the effective
+    // forNextMonth equals the server value directly (no hold staged yet).
+    const previousAmount = holds[month]?.previousAmount ?? forNextMonth;
+    stageHold({ month, nextAmount: 0, previousAmount });
   };
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={isPending}
-        title="Free held amount"
-        aria-label="Free held amount"
-        className="flex items-center justify-center w-5 h-5 rounded text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 disabled:opacity-40 transition-colors shrink-0"
-      >
-        <Undo2 className="h-3 w-3" aria-hidden="true" />
-      </button>
-
-      {showConfirm && (
-        <HoldClearConfirmDialog
-          month={month}
-          forNextMonth={forNextMonth}
-          onConfirm={() => void handleConfirmClear()}
-          onCancel={() => setShowConfirm(false)}
-          isPending={isPending}
-          error={error}
-        />
-      )}
-    </>
+    <button
+      type="button"
+      onClick={handleClick}
+      title="Free held amount"
+      aria-label="Free held amount"
+      className="flex items-center justify-center w-5 h-5 rounded text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 transition-colors shrink-0"
+    >
+      <Undo2 className="h-3 w-3" aria-hidden="true" />
+    </button>
   );
 }

--- a/src/features/budget-management/components/grid/SummaryRows.tsx
+++ b/src/features/budget-management/components/grid/SummaryRows.tsx
@@ -142,7 +142,7 @@ export const ENVELOPE_SUMMARY_ROWS: SummaryRowConfig[] = [
   },
   {
     label: "Hold for next month",
-    getValue: (s) => (s.forNextMonth <= 0 ? 0 : Math.abs(s.forNextMonth)),
+    getValue: (s) => (s.forNextMonth > 0 ? -s.forNextMonth : 0),
     colorClass: () => "text-foreground/75",
     isSubRow: true,
     operator: "−",
@@ -265,6 +265,12 @@ function SummaryHeaderCell({
         className={`${rowH} px-1.5 ${marginTopClass} flex items-center justify-end gap-1 bg-transparent font-sans tabular-nums leading-tight text-[11px] ${borderClass} ${colorClass}`}
         title={tooltip}
       >
+        {config.holdAction === "free" && (
+          <FreeHeldAmountButton
+            month={month}
+            forNextMonth={data.summary.forNextMonth}
+          />
+        )}
         <div className="flex flex-col items-end flex-1 min-w-0">
           {dynamicLabel && (
             <span className="max-w-full truncate text-[9px] font-medium leading-none mb-0.5">
@@ -277,16 +283,11 @@ function SummaryHeaderCell({
               : formatSummary(numericValue)}
           </span>
         </div>
-        {config.holdAction === "set" ? (
+        {config.holdAction === "set" && (
           <HoldMoneyButton
             month={month}
             forNextMonth={data.summary.forNextMonth}
             toBudget={data.summary.toBudget}
-          />
-        ) : (
-          <FreeHeldAmountButton
-            month={month}
-            forNextMonth={data.summary.forNextMonth}
           />
         )}
       </div>

--- a/src/features/budget-management/context/MonthsDataContext.tsx
+++ b/src/features/budget-management/context/MonthsDataContext.tsx
@@ -110,9 +110,10 @@ export function MonthsDataProvider({
 
   const { data: incomeBudgets } = useIncomeBudgets(incomeCategoryIds, isTracking);
 
-  // Single subscription to the entire edits map happens here, ONCE for the
-  // whole grid — instead of once per cell as in the pre-BM-02 implementation.
+  // Single subscription to the entire edits map and holds map happens here,
+  // ONCE for the whole grid — instead of once per cell as in pre-BM-02.
   const allEdits = useBudgetEditsStore((s) => s.edits);
+  const allHolds = useBudgetEditsStore((s) => s.holds);
 
   const value = useMemo<MonthsDataContextValue>(() => {
     const raw = new Map<string, LoadedMonthState>();
@@ -133,6 +134,7 @@ export function MonthsDataProvider({
           isTracking,
           incomeBudgets,
           month: m,
+          stagedHolds: allHolds,
         });
         if (eff) effective.set(m, eff);
       }
@@ -144,7 +146,7 @@ export function MonthsDataProvider({
     // Spread data and error arrays so the memo recomputes only when an
     // underlying query result reference changes, not on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [months, loadableMonthSet, allEdits, isTracking, incomeBudgets, isLoading, ...dataArr, ...errorArr]);
+  }, [months, loadableMonthSet, allEdits, allHolds, isTracking, incomeBudgets, isLoading, ...dataArr, ...errorArr]);
 
   return (
     <MonthsDataContext.Provider value={value}>

--- a/src/features/budget-management/hooks/useBudgetSave.ts
+++ b/src/features/budget-management/hooks/useBudgetSave.ts
@@ -11,6 +11,7 @@ import type {
   BudgetSaveResult,
   LoadedMonthState,
   StagedBudgetEdit,
+  StagedHold,
 } from "../types";
 
 /**
@@ -58,7 +59,8 @@ type SaveProgress = {
 
 type UseBudgetSaveReturn = {
   save: (
-    edits: Record<BudgetCellKey, StagedBudgetEdit>
+    edits: Record<BudgetCellKey, StagedBudgetEdit>,
+    holds?: Record<string, StagedHold>
   ) => Promise<BudgetSaveResult[]>;
   isSaving: boolean;
   progress: SaveProgress;
@@ -84,19 +86,24 @@ export function useBudgetSave(): UseBudgetSaveReturn {
   const connection = useConnectionStore(selectActiveInstance);
   const queryClient = useQueryClient();
   const clearEditsForKeys = useBudgetEditsStore((s) => s.clearEditsForKeys);
+  const clearHoldsForMonths = useBudgetEditsStore((s) => s.clearHoldsForMonths);
+  const clearHistory = useBudgetEditsStore((s) => s.clearHistory);
   const setSaveError = useBudgetEditsStore((s) => s.setSaveError);
+  const setHoldSaveError = useBudgetEditsStore((s) => s.setHoldSaveError);
 
   const [isSaving, setIsSaving] = useState(false);
   const [progress, setProgress] = useState<SaveProgress>({ completed: 0, total: 0 });
 
   const save = useCallback(
     async (
-      edits: Record<BudgetCellKey, StagedBudgetEdit>
+      edits: Record<BudgetCellKey, StagedBudgetEdit>,
+      holds: Record<string, StagedHold> = {}
     ): Promise<BudgetSaveResult[]> => {
       if (!connection) throw new Error("No active connection");
 
       const entries = Object.entries(edits) as [BudgetCellKey, StagedBudgetEdit][];
-      if (entries.length === 0) return [];
+      const holdEntries = Object.entries(holds) as [string, StagedHold][];
+      if (entries.length === 0 && holdEntries.length === 0) return [];
 
       // Pre-save guard: verify all target months still exist in GET /months.
       const monthsResult = await apiRequest<{ data: string[] }>(connection, "/months");
@@ -194,14 +201,86 @@ export function useBudgetSave(): UseBudgetSaveReturn {
         }
       }
 
-      const totalCalls = completePairs.length + incompleteLegs.length + nonTransferEntries.length;
+      const totalCalls =
+        holdEntries.filter(([m]) => availableSet.has(m)).length +
+        completePairs.length +
+        incompleteLegs.length +
+        nonTransferEntries.length;
 
       setIsSaving(true);
       setProgress({ completed: 0, total: totalCalls });
 
       const succeededKeys: BudgetCellKey[] = [];
+      const succeededHoldMonths: string[] = [];
       const successMonths = new Set<string>();
       let completedCalls = 0;
+
+      // ── 0. Staged holds ───────────────────────────────────────────────────────
+      for (const [month, hold] of holdEntries) {
+        if (!availableSet.has(month)) {
+          results.push({
+            month,
+            categoryId: "",
+            status: "error",
+            message: `Month ${month} is no longer available in this budget`,
+          });
+          continue;
+        }
+
+        try {
+          if (hold.nextAmount === 0) {
+            // resetBudgetHold — DELETE /months/{month}/nextmonthbudgethold
+            await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
+              method: "DELETE",
+            });
+          } else {
+            // When the server already has a hold (previousAmount > 0), DELETE it
+            // first so the subsequent POST sets an absolute value rather than
+            // adding on top of whatever the server currently holds.
+            if (hold.previousAmount > 0) {
+              await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
+                method: "DELETE",
+              });
+            }
+            // holdBudgetForNextMonth — POST /months/{month}/nextmonthbudgethold
+            await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
+              method: "POST",
+              body: { amount: hold.nextAmount },
+            });
+          }
+
+          // Optimistic cache update: apply the hold to the cached month state.
+          queryClient.setQueryData(
+            ["budget-month-data", connection.id, month],
+            (prev: LoadedMonthState | undefined) => {
+              if (!prev) return prev;
+              const holdDelta = hold.nextAmount - prev.summary.forNextMonth;
+              return {
+                ...prev,
+                summary: {
+                  ...prev.summary,
+                  forNextMonth: hold.nextAmount,
+                  toBudget: prev.summary.toBudget - holdDelta,
+                },
+              };
+            }
+          );
+
+          succeededHoldMonths.push(month);
+          successMonths.add(month);
+          results.push({ month, categoryId: "", status: "success" });
+        } catch (err) {
+          const message =
+            err instanceof Error
+              ? err.message
+              : (err as { message?: string }).message ?? "Save failed";
+          setHoldSaveError(month, message);
+          results.push({ month, categoryId: "", status: "error", message });
+        }
+
+        completedCalls++;
+        setProgress({ completed: completedCalls, total: totalCalls });
+      }
 
       // ── 1. Complete transfer pairs via atomic POST ────────────────────────────
       for (const { src, dst } of completePairs) {
@@ -300,7 +379,12 @@ export function useBudgetSave(): UseBudgetSaveReturn {
         setProgress({ completed: completedCalls, total: totalCalls });
       }
 
-      // Clear only the keys that actually succeeded AND whose stored value
+      // Clear succeeded hold months from the store.
+      if (succeededHoldMonths.length > 0) {
+        clearHoldsForMonths(succeededHoldMonths);
+      }
+
+      // Clear only the edit keys that actually succeeded AND whose stored value
       // still matches the snapshot taken at save-enqueue time. Anything the
       // user re-edited mid-save stays in the store with the newer value.
       if (succeededKeys.length > 0) {
@@ -313,9 +397,18 @@ export function useBudgetSave(): UseBudgetSaveReturn {
         if (safeToClear.length > 0) {
           clearEditsForKeys(safeToClear);
         }
-        // BM-11: Invalidate in parallel — invalidations are read-side and
-        // independent. The optimistic updates above already cleared the UI;
-        // these refetches reconcile against the server.
+      }
+
+      // Clear undo/redo history after any successful save so the user cannot
+      // undo back to a state that has already been persisted to the server.
+      if (succeededKeys.length > 0 || succeededHoldMonths.length > 0) {
+        clearHistory();
+      }
+
+      // BM-11: Invalidate in parallel — invalidations are read-side and
+      // independent. The optimistic updates above already cleared the UI;
+      // these refetches reconcile against the server.
+      if (successMonths.size > 0) {
         await Promise.all(
           Array.from(successMonths).map((month) =>
             queryClient.invalidateQueries({
@@ -330,7 +423,7 @@ export function useBudgetSave(): UseBudgetSaveReturn {
 
       return results;
     },
-    [connection, queryClient, clearEditsForKeys, setSaveError]
+    [connection, queryClient, clearEditsForKeys, clearHoldsForMonths, setSaveError, setHoldSaveError]
   );
 
   return { save, isSaving, progress };

--- a/src/features/budget-management/hooks/useBudgetSave.ts
+++ b/src/features/budget-management/hooks/useBudgetSave.ts
@@ -423,7 +423,7 @@ export function useBudgetSave(): UseBudgetSaveReturn {
 
       return results;
     },
-    [connection, queryClient, clearEditsForKeys, clearHoldsForMonths, setSaveError, setHoldSaveError]
+    [connection, queryClient, clearEditsForKeys, clearHoldsForMonths, clearHistory, setSaveError, setHoldSaveError]
   );
 
   return { save, isSaving, progress };

--- a/src/features/budget-management/lib/budgetSaveReview.ts
+++ b/src/features/budget-management/lib/budgetSaveReview.ts
@@ -1,6 +1,6 @@
 import { formatMonthLabel } from "@/lib/budget/monthMath";
 import { isLargeChange } from "./budgetValidation";
-import type { BudgetCellKey, StagedBudgetEdit } from "../types";
+import type { BudgetCellKey, StagedBudgetEdit, StagedHold } from "../types";
 
 export const BUDGET_SAVE_REVIEW_SKIP_KEY =
   "actual-bench:budget-save-review:skip";
@@ -29,10 +29,12 @@ export type BudgetSaveReviewMonth = {
   label: string;
   totalDelta: number;
   entries: BudgetSaveReviewEntry[];
+  hold?: StagedHold;
 };
 
 export type BudgetSaveReviewSummary = {
   editCount: number;
+  holdCount: number;
   monthCount: number;
   totalDelta: number;
   largeChangeCount: number;
@@ -41,7 +43,8 @@ export type BudgetSaveReviewSummary = {
 
 export function buildBudgetSaveReviewSummary(
   edits: Record<BudgetCellKey, StagedBudgetEdit>,
-  categoryLookup: BudgetSaveReviewCategoryLookup = {}
+  categoryLookup: BudgetSaveReviewCategoryLookup = {},
+  holds: Record<string, StagedHold> = {}
 ): BudgetSaveReviewSummary {
   const grouped = new Map<string, BudgetSaveReviewEntry[]>();
 
@@ -63,6 +66,11 @@ export function buildBudgetSaveReviewSummary(
     grouped.set(edit.month, entries);
   }
 
+  // Ensure months that only have a hold (no cell edits) appear in the list.
+  for (const month of Object.keys(holds)) {
+    if (!grouped.has(month)) grouped.set(month, []);
+  }
+
   const months = [...grouped.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([month, entries]) => {
@@ -75,11 +83,13 @@ export function buildBudgetSaveReviewSummary(
         label: formatMonthLabel(month, "long"),
         totalDelta: sortedEntries.reduce((sum, e) => sum + e.delta, 0),
         entries: sortedEntries,
+        hold: holds[month],
       };
     });
 
   return {
     editCount: months.reduce((sum, m) => sum + m.entries.length, 0),
+    holdCount: Object.keys(holds).length,
     monthCount: months.length,
     totalDelta: months.reduce((sum, m) => sum + m.totalDelta, 0),
     largeChangeCount: months.reduce(

--- a/src/features/budget-management/lib/effectiveMonth.ts
+++ b/src/features/budget-management/lib/effectiveMonth.ts
@@ -13,6 +13,7 @@ import type {
   LoadedGroup,
   LoadedMonthState,
   StagedBudgetEdit,
+  StagedHold,
 } from "../types";
 
 export type ComputeEffectiveMonthStateInput = {
@@ -22,6 +23,8 @@ export type ComputeEffectiveMonthStateInput = {
   /** Map<month, Map<categoryId, budgeted>> from useIncomeBudgets. Tracking mode only. */
   incomeBudgets: Map<string, Map<string, number>> | undefined;
   month: string;
+  /** Staged holds keyed by month — from the budgetEdits store. */
+  stagedHolds?: Record<string, StagedHold>;
 };
 
 /**
@@ -59,7 +62,7 @@ export type ComputeEffectiveMonthStateInput = {
 export function computeEffectiveMonthState(
   input: ComputeEffectiveMonthStateInput
 ): LoadedMonthState | undefined {
-  const { serverState, allEdits, isTracking, incomeBudgets, month } = input;
+  const { serverState, allEdits, isTracking, incomeBudgets, month, stagedHolds } = input;
   if (!serverState || !month) return serverState;
 
   const incomeBudgetForMonth = isTracking ? incomeBudgets?.get(month) : undefined;
@@ -101,7 +104,9 @@ export function computeEffectiveMonthState(
 
   const hasCatCascade = priorCatDeltas.size > 0;
 
-  if (!incomeBudgetForMonth && editEntries.length === 0 && priorDelta === 0 && !hasCatCascade) {
+  const stagedHold = stagedHolds?.[month];
+
+  if (!incomeBudgetForMonth && editEntries.length === 0 && priorDelta === 0 && !hasCatCascade && !stagedHold) {
     return serverState;
   }
 
@@ -222,6 +227,17 @@ export function computeEffectiveMonthState(
       if (!(isTracking && effectivelyHidden)) {
         summary.totalBalance += cascadeDelta;
       }
+    }
+  }
+
+  // ── Hold overlay: staged hold for month M only ─────────────────────────────
+  // forNextMonth on the server is a positive integer (0 = no hold).
+  // nextAmount/previousAmount use the same convention.
+  if (stagedHold) {
+    const holdDelta = stagedHold.nextAmount - serverState.summary.forNextMonth;
+    if (holdDelta !== 0) {
+      summary.forNextMonth = stagedHold.nextAmount;
+      summary.toBudget -= holdDelta;
     }
   }
 

--- a/src/features/budget-management/types.ts
+++ b/src/features/budget-management/types.ts
@@ -82,6 +82,20 @@ export type LoadedMonthState = {
 
 // ─── Staged edits ─────────────────────────────────────────────────────────────
 
+/**
+ * Staged "hold for next month" — keyed by month string in the store.
+ * `nextAmount` and `previousAmount` are positive minor units (0 = no hold /
+ * clear hold), matching the server's forNextMonth convention.
+ */
+export type StagedHold = {
+  month: string;
+  /** New hold amount in positive minor units. 0 = stage a hold clear. */
+  nextAmount: number;
+  /** Server's forNextMonth at the time of first staging (positive minor units, 0 = no hold). For undo. */
+  previousAmount: number;
+  saveError?: string;
+};
+
 /** Stored in budgetEditsStore as Record<BudgetCellKey, StagedBudgetEdit>. */
 export type StagedBudgetEdit = {
   month: string;
@@ -106,6 +120,23 @@ export type BudgetEditPatch = {
   key: BudgetCellKey;
   prev: StagedBudgetEdit | undefined;
 };
+
+/** Tagged patch for a single cell edit — part of the unified ActionPatch union. */
+export type EditPatch = {
+  type: "edit";
+  key: BudgetCellKey;
+  prev: StagedBudgetEdit | undefined;
+};
+
+/** Tagged patch for a hold action — part of the unified ActionPatch union. */
+export type HoldPatch = {
+  type: "hold";
+  month: string;
+  prev: StagedHold | undefined;
+};
+
+/** Union of all reversible action patch types for the undo/redo stack. */
+export type ActionPatch = EditPatch | HoldPatch;
 
 // ─── Navigation ───────────────────────────────────────────────────────────────
 
@@ -186,9 +217,11 @@ export type RowSelection = { kind: "category" | "group"; id: string };
 
 export type BudgetEditsState = {
   edits: Record<BudgetCellKey, StagedBudgetEdit>;
-  /** BM-19: stack of inverse-patch lists. Each list reverses one user action. */
-  undoStack: BudgetEditPatch[][];
-  redoStack: BudgetEditPatch[][];
+  /** Staged holds keyed by month string. At most one hold per month. */
+  holds: Record<string, StagedHold>;
+  /** Unified undo/redo stack covering both cell edits and holds. */
+  undoStack: ActionPatch[][];
+  redoStack: ActionPatch[][];
   /** Currently focused cell or group — synced by BudgetWorkspace so BudgetDraftPanel can read it. */
   uiSelection: { month: string | null; categoryId: string | null; groupId: string | null };
   /** Currently selected row label, mutually exclusive with uiSelection. */
@@ -201,11 +234,17 @@ export type BudgetEditsActions = {
   stageEdit: (edit: StagedBudgetEdit) => void;
   stageBulkEdits: (edits: StagedBudgetEdit[]) => void;
   removeEdit: (key: BudgetCellKey) => void;
+  stageHold: (hold: StagedHold) => void;
+  removeHold: (month: string) => void;
+  clearHoldsForMonths: (months: string[]) => void;
+  setHoldSaveError: (month: string, message: string) => void;
+  clearHoldSaveError: (month: string) => void;
   discardAll: () => void;
   clearEditsForMonths: (months: string[]) => void;
   clearEditsForKeys: (keys: BudgetCellKey[]) => void;
   setSaveError: (key: BudgetCellKey, message: string) => void;
   clearSaveError: (key: BudgetCellKey) => void;
+  clearHistory: () => void;
   pushUndo: () => void;
   undo: () => void;
   redo: () => void;

--- a/src/store/budgetEdits.ts
+++ b/src/store/budgetEdits.ts
@@ -2,10 +2,12 @@
 
 import { create } from "zustand";
 import type {
+  ActionPatch,
   BudgetCellKey,
   BudgetEditsActions,
   BudgetEditsState,
   StagedBudgetEdit,
+  StagedHold,
 } from "@/features/budget-management/types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -37,59 +39,59 @@ function sameEdit(
  * that's 2,500 redundant edit objects retained.
  *
  * A patch records exactly what changed:
- *   { key, prev: undefined } — key did not exist before; undo deletes it
- *   { key, prev: <edit> }    — key existed; undo restores `prev`
+ *   { type: "edit", key, prev: undefined } — key did not exist; undo deletes it
+ *   { type: "edit", key, prev: <edit> }    — key existed; undo restores `prev`
+ *   { type: "hold", month, prev: undefined } — no hold existed; undo deletes it
+ *   { type: "hold", month, prev: <hold> }    — hold existed; undo restores `prev`
  *
- * Each patch holds at most O(changed-keys) state. For a single-cell edit,
- * one patch entry. For a bulk paste/import, one entry per cell — but only
- * for the cells the operation actually touched.
- *
- * `undo()` applies the patch in reverse to recover the prior `edits` state,
- * while pushing the inverse onto `redoStack`. `redo()` is symmetric.
+ * `undo()` applies the patch in reverse to recover the prior state, while
+ * pushing the inverse onto `redoStack`. `redo()` is symmetric.
  */
-type EditPatch = {
-  key: BudgetCellKey;
-  prev: StagedBudgetEdit | undefined;
-};
 
-function applyPatches(
+function applyActionPatches(
   edits: Record<BudgetCellKey, StagedBudgetEdit>,
-  patches: EditPatch[]
+  holds: Record<string, StagedHold>,
+  patches: ActionPatch[]
 ): {
-  next: Record<BudgetCellKey, StagedBudgetEdit>;
-  inverse: EditPatch[];
+  nextEdits: Record<BudgetCellKey, StagedBudgetEdit>;
+  nextHolds: Record<string, StagedHold>;
+  inverse: ActionPatch[];
 } {
-  const next: Record<BudgetCellKey, StagedBudgetEdit> = { ...edits };
-  const inverse: EditPatch[] = [];
+  const nextEdits: Record<BudgetCellKey, StagedBudgetEdit> = { ...edits };
+  const nextHolds: Record<string, StagedHold> = { ...holds };
+  const inverse: ActionPatch[] = [];
   // Apply newest-first so the inverse runs back to original order.
   for (let i = patches.length - 1; i >= 0; i--) {
     const p = patches[i]!;
-    inverse.push({ key: p.key, prev: edits[p.key] });
-    if (p.prev === undefined) {
-      delete next[p.key];
+    if (p.type === "edit") {
+      inverse.push({ type: "edit", key: p.key, prev: edits[p.key] });
+      if (p.prev === undefined) delete nextEdits[p.key];
+      else nextEdits[p.key] = p.prev;
     } else {
-      next[p.key] = p.prev;
+      inverse.push({ type: "hold", month: p.month, prev: holds[p.month] });
+      if (p.prev === undefined) delete nextHolds[p.month];
+      else nextHolds[p.month] = p.prev;
     }
   }
   // Inverse was built newest-first; reverse so callers can apply it directly.
   inverse.reverse();
-  return { next, inverse };
+  return { nextEdits, nextHolds, inverse };
 }
 
 /**
- * Build a patch list capturing the prior values of every key that's about to
- * be added or replaced. Keys absent from `edits` get `prev: undefined`.
+ * Build a patch list capturing the prior values of every edit key that's
+ * about to be added or replaced. Keys absent from `edits` get `prev: undefined`.
  */
-function buildPatchForChanges(
+function buildEditPatchForChanges(
   edits: Record<BudgetCellKey, StagedBudgetEdit>,
   keysAffected: Iterable<BudgetCellKey>
-): EditPatch[] {
+): ActionPatch[] {
   const seen = new Set<BudgetCellKey>();
-  const patches: EditPatch[] = [];
+  const patches: ActionPatch[] = [];
   for (const key of keysAffected) {
     if (seen.has(key)) continue;
     seen.add(key);
-    patches.push({ key, prev: edits[key] });
+    patches.push({ type: "edit", key, prev: edits[key] });
   }
   return patches;
 }
@@ -100,13 +102,14 @@ type BudgetEditsStore = BudgetEditsState & BudgetEditsActions;
 
 const MAX_UNDO_DEPTH = 50;
 
-function pushPatch(stack: EditPatch[][], patch: EditPatch[]): EditPatch[][] {
+function pushPatch(stack: ActionPatch[][], patch: ActionPatch[]): ActionPatch[][] {
   if (patch.length === 0) return stack;
   return [...stack, patch].slice(-MAX_UNDO_DEPTH);
 }
 
 export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
   edits: {},
+  holds: {},
   undoStack: [],
   redoStack: [],
   uiSelection: { month: null, categoryId: null, groupId: null },
@@ -132,7 +135,7 @@ export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
       }
       return;
     }
-    const patch = buildPatchForChanges(edits, [key]);
+    const patch = buildEditPatchForChanges(edits, [key]);
     set({
       undoStack: pushPatch(undoStack, patch),
       redoStack: [],
@@ -166,7 +169,7 @@ export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
       if (clearedSaveError) set({ edits: next });
       return;
     }
-    const patch = buildPatchForChanges(edits, changedKeys);
+    const patch = buildEditPatchForChanges(edits, changedKeys);
     set({
       undoStack: pushPatch(undoStack, patch),
       redoStack: [],
@@ -177,7 +180,7 @@ export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
   removeEdit(key) {
     const { edits, undoStack } = get();
     if (!(key in edits)) return;
-    const patch = buildPatchForChanges(edits, [key]);
+    const patch = buildEditPatchForChanges(edits, [key]);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [key]: _removed, ...rest } = edits;
     set({
@@ -187,8 +190,85 @@ export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
     });
   },
 
+  stageHold(hold) {
+    const { holds, undoStack } = get();
+    const existing = holds[hold.month];
+    if (existing && existing.nextAmount === hold.nextAmount) return;
+
+    // Always preserve the server-baseline previousAmount from the first staging
+    // for this month. When the user stages a FREE then re-opens the Hold dialog,
+    // the dialog receives currentForNextMonth=0 (effective after overlay) so it
+    // passes previousAmount=0 — but the real server value is in existing.previousAmount.
+    // Inheriting it here keeps undo, the draft panel, and the save-pipeline reset
+    // guard all anchored to the actual server state.
+    const previousAmount =
+      existing !== undefined ? existing.previousAmount : hold.previousAmount;
+    const normalizedHold: StagedHold = { ...hold, previousAmount };
+
+    // If the staged amount equals the server's hold it is a net no-op — remove
+    // the entry so it does not pollute the draft panel or trigger a redundant save.
+    if (normalizedHold.nextAmount === previousAmount) {
+      if (existing !== undefined) {
+        const patch: ActionPatch[] = [{ type: "hold", month: hold.month, prev: existing }];
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { [hold.month]: _removed, ...rest } = holds;
+        set({
+          undoStack: pushPatch(undoStack, patch),
+          redoStack: [],
+          holds: rest as Record<string, StagedHold>,
+        });
+      }
+      return;
+    }
+
+    const patch: ActionPatch[] = [{ type: "hold", month: hold.month, prev: existing }];
+    set({
+      undoStack: pushPatch(undoStack, patch),
+      redoStack: [],
+      holds: { ...holds, [hold.month]: normalizedHold },
+    });
+  },
+
+  removeHold(month) {
+    const { holds } = get();
+    if (!(month in holds)) return;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [month]: _removed, ...rest } = holds;
+    set({ holds: rest as Record<string, StagedHold> });
+  },
+
+  clearHoldsForMonths(months) {
+    const { holds } = get();
+    const monthSet = new Set(months);
+    const next: Record<string, StagedHold> = {};
+    for (const [m, hold] of Object.entries(holds)) {
+      if (!monthSet.has(m)) next[m] = hold;
+    }
+    set({ holds: next });
+  },
+
+  setHoldSaveError(month, message) {
+    const { holds } = get();
+    const existing = holds[month];
+    if (!existing) return;
+    set({ holds: { ...holds, [month]: { ...existing, saveError: message } } });
+  },
+
+  clearHoldSaveError(month) {
+    const { holds } = get();
+    const existing = holds[month];
+    if (!existing) return;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { saveError: _saveError, ...rest } = existing;
+    set({ holds: { ...holds, [month]: rest as StagedHold } });
+  },
+
   discardAll() {
-    set({ edits: {}, undoStack: [], redoStack: [] });
+    set({ edits: {}, holds: {}, undoStack: [], redoStack: [] });
+  },
+
+  clearHistory() {
+    set({ undoStack: [], redoStack: [] });
   },
 
   clearEditsForMonths(months) {
@@ -234,31 +314,34 @@ export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
   },
 
   undo() {
-    const { edits, undoStack, redoStack } = get();
+    const { edits, holds, undoStack, redoStack } = get();
     if (undoStack.length === 0) return;
     const patch = undoStack[undoStack.length - 1]!;
-    const { next, inverse } = applyPatches(edits, patch);
+    const { nextEdits, nextHolds, inverse } = applyActionPatches(edits, holds, patch);
     set({
-      edits: next,
+      edits: nextEdits,
+      holds: nextHolds,
       undoStack: undoStack.slice(0, -1),
       redoStack: pushPatch(redoStack, inverse),
     });
   },
 
   redo() {
-    const { edits, undoStack, redoStack } = get();
+    const { edits, holds, undoStack, redoStack } = get();
     if (redoStack.length === 0) return;
     const patch = redoStack[redoStack.length - 1]!;
-    const { next, inverse } = applyPatches(edits, patch);
+    const { nextEdits, nextHolds, inverse } = applyActionPatches(edits, holds, patch);
     set({
-      edits: next,
+      edits: nextEdits,
+      holds: nextHolds,
       undoStack: pushPatch(undoStack, inverse),
       redoStack: redoStack.slice(0, -1),
     });
   },
 
   hasPendingEdits() {
-    return Object.keys(get().edits).length > 0;
+    const { edits, holds } = get();
+    return Object.keys(edits).length > 0 || Object.keys(holds).length > 0;
   },
 
   setUiSelection(month, categoryId, groupId = null) {

--- a/src/store/budgetEdits.ts
+++ b/src/store/budgetEdits.ts
@@ -193,7 +193,14 @@ export const useBudgetEditsStore = create<BudgetEditsStore>()((set, get) => ({
   stageHold(hold) {
     const { holds, undoStack } = get();
     const existing = holds[hold.month];
-    if (existing && existing.nextAmount === hold.nextAmount) return;
+    if (existing && existing.nextAmount === hold.nextAmount) {
+      if (existing.saveError) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { saveError: _saveError, ...rest } = existing;
+        set({ holds: { ...holds, [hold.month]: rest as StagedHold } });
+      }
+      return;
+    }
 
     // Always preserve the server-baseline previousAmount from the first staging
     // for this month. When the user stages a FREE then re-opens the Hold dialog,


### PR DESCRIPTION
 ## Summary

  - Hold amounts now flow through the draft pipeline (stage → review → save) instead of applying immediately, giving users full undo/redo support and the ability to review
  holds alongside cell edits before committing
  - `stageHold` preserves the server-baseline `previousAmount` across FREE → HOLD cycles so the save pipeline always knows whether a DELETE is needed before POST
  - Undo/redo stacks are cleared after any successful save and on discard/refresh

  ## Changes

  **Store (`budgetEdits`)**
  - Added `stageHold`, `removeHold`, `clearHoldsForMonths`, `setHoldSaveError`, `clearHoldSaveError`, `clearHistory`
  - Extended `ActionPatch` to a tagged union (`type: "edit" | "hold"`) so undo/redo covers both cell edits and holds

  **Save pipeline (`useBudgetSave`)**
  - Saves staged holds: DELETE for a clear, DELETE + POST when replacing an existing server hold
  - Optimistic cache update for `forNextMonth` after a hold save
  - Calls `clearHistory()` after any successful save

  **Display / UX**
  - Held amount displayed with a `−` sign to match the formula layout
  - Free (return) button moved to the left of the held value
  - Hold dialog: auto-focuses and selects the input on open; Enter confirms the amount
  - `forNextMonth` sign convention corrected throughout (always a positive integer); redundant `Math.abs()` guards removed

  ## Test plan

  - [ ] Stage a hold → verify draft panel and `toBudget` update correctly
  - [ ] Stage FREE then re-open Hold dialog → enter a new amount → verify held amount and `toBudget` are correct after staging and after saving
  - [ ] Undo / redo a hold staging and a hold clear
  - [ ] Save with a mix of cell edits and holds → verify all succeed and undo/redo stack is cleared
  - [ ] Partial save failure → verify failed holds remain staged and undo stack is preserved
  - [ ] Discard all / Discard & Refresh → verify undo/redo stack is cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staged "hold for next month" entries are now part of the draft pipeline, count toward pending changes, support undo/redo, and are saved alongside edits in a unified save flow.
  * Hold actions moved to envelope-mode staging with updated dialogs, immediate staging for “free” clears, and retry handling for failed holds.

* **Documentation**
  * Budget workspace docs updated to describe staged holds, save sequencing, and envelope-mode behavior.

* **Tests**
  * UI copy and tests updated to use "changes" wording and verify combined counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/x-rous/actual-bench/pull/96)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->