### PR TITLE
feat/ budget prefetch adjacent months and invalidate on save/carryover

### DIFF
--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
+import { Loader2 } from "lucide-react";
 import { useMonthsData } from "../context/MonthsDataContext";
 import { MonthColumnHeader } from "./grid/MonthColumnHeader";
 import {
@@ -186,11 +187,12 @@ export function BudgetGrid({
   if (isLoading && !hasAnyData) {
     return (
       <div
-        className="flex-1 flex items-center justify-center"
+        className="min-h-full flex flex-col items-center justify-center gap-3"
         aria-busy="true"
         aria-label="Loading budget data…"
       >
-        <div className="text-sm text-muted-foreground">Loading budget data…</div>
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Loading budget data…</p>
       </div>
     );
   }

--- a/src/features/budget-management/components/BudgetManagementView.tsx
+++ b/src/features/budget-management/components/BudgetManagementView.tsx
@@ -8,6 +8,7 @@ import { useAvailableMonths } from "../hooks/useAvailableMonths";
 import { useMonthData } from "../hooks/useMonthData";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useStagedStore, selectHasChanges } from "@/store/staged";
+import { usePrefetchAdjacentMonths } from "../hooks/usePrefetchAdjacentMonths";
 import { BudgetToolbar } from "./BudgetToolbar";
 import { BudgetWorkspace } from "./BudgetWorkspace";
 import { BudgetExportDialog } from "./BudgetExportDialog";
@@ -57,6 +58,10 @@ export function BudgetManagementView() {
   useEffect(() => {
     setDisplayMonths(activeMonths);
   }, [activeMonths, setDisplayMonths]);
+
+  // Warm the adjacent ±12 months in the TanStack Query cache so «/» navigation
+  // renders from cache without a loading state.
+  usePrefetchAdjacentMonths({ windowStart, availableMonths });
 
   const [cellView, setCellView] = useState<CellView>("budgeted");
   const [exportDialogOpen, setExportDialogOpen] = useState(false);

--- a/src/features/budget-management/hooks/useBudgetSave.ts
+++ b/src/features/budget-management/hooks/useBudgetSave.ts
@@ -6,6 +6,7 @@ import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { apiRequest } from "@/lib/api/client";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { budgetMonthDataQueryOptions } from "./useMonthData";
+import { addMonths } from "@/lib/budget/monthMath";
 import type {
   BudgetCellKey,
   BudgetSaveResult,
@@ -416,6 +417,24 @@ export function useBudgetSave(): UseBudgetSaveReturn {
             })
           )
         );
+
+        // RD-038: Invalidate the two adjacent 12-month windows so any prefetched
+        // months get fresh server cascade values (incomeAvailable / toBudget)
+        // after saves propagate through the server.
+        const displayMonths = useBudgetEditsStore.getState().displayMonths;
+        if (displayMonths.length > 0) {
+          const firstVisible = displayMonths[0]!;
+          const adjacentMonths: string[] = [];
+          for (let i = -12; i <= -1; i++) adjacentMonths.push(addMonths(firstVisible, i));
+          for (let i = 12; i <= 23; i++) adjacentMonths.push(addMonths(firstVisible, i));
+          await Promise.all(
+            adjacentMonths.map((month) =>
+              queryClient.invalidateQueries({
+                queryKey: ["budget-month-data", connection.id, month],
+              })
+            )
+          );
+        }
       }
 
       setIsSaving(false);

--- a/src/features/budget-management/hooks/useCarryoverToggle.ts
+++ b/src/features/budget-management/hooks/useCarryoverToggle.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { apiRequest } from "@/lib/api/client";
+import { addMonths } from "@/lib/budget/monthMath";
 
 export type CarryoverToggleInput = {
   categoryId: string;
@@ -85,6 +86,22 @@ export function useCarryoverToggle(): UseCarryoverToggleReturn {
           successMonths.map((m) =>
             queryClient.invalidateQueries({
               queryKey: ["budget-month-data", connection.id, m],
+            })
+          )
+        );
+
+        // RD-038: Invalidate adjacent prefetched windows so any pre-warmed months
+        // reflect the updated carryover flag and compute the correct per-category
+        // balance cascade in tracking mode.
+        const firstMonth = input.months[0]!;
+        const lastMonth = input.months[input.months.length - 1]!;
+        const adjacentMonths: string[] = [];
+        for (let i = -12; i <= -1; i++) adjacentMonths.push(addMonths(firstMonth, i));
+        for (let i = 1; i <= 12; i++) adjacentMonths.push(addMonths(lastMonth, i));
+        await Promise.all(
+          adjacentMonths.map((month) =>
+            queryClient.invalidateQueries({
+              queryKey: ["budget-month-data", connection.id, month],
             })
           )
         );

--- a/src/features/budget-management/hooks/usePrefetchAdjacentMonths.ts
+++ b/src/features/budget-management/hooks/usePrefetchAdjacentMonths.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { addMonths } from "@/lib/budget/monthMath";
+import { budgetMonthDataQueryOptions } from "./useMonthData";
+
+type Props = {
+  windowStart: string;
+  availableMonths: string[] | undefined;
+};
+
+/**
+ * Warms the TanStack Query cache for the 12 months immediately before and
+ * after the current 12-month window. Fires as a background side-effect so
+ * that «/» navigation renders from cache without a loading state.
+ *
+ * prefetchQuery is a no-op if the data is already cached or a fetch is in
+ * flight — safe to call on every windowStart change.
+ *
+ * staleTime is intentionally kept at 0 (the query default) so TanStack Query
+ * fires a background refetch when the prefetched months become visible. Any
+ * staleness from save or carryover toggle self-corrects within ~200–400ms.
+ */
+export function usePrefetchAdjacentMonths({ windowStart, availableMonths }: Props) {
+  const connection = useConnectionStore(selectActiveInstance);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!connection || !availableMonths || availableMonths.length === 0) return;
+
+    const availableSet = new Set(availableMonths);
+
+    // prev window: windowStart − 12 to windowStart − 1
+    // next window: windowStart + 12 to windowStart + 23
+    const monthsToPrefetch: string[] = [];
+    for (let i = -12; i <= -1; i++) {
+      monthsToPrefetch.push(addMonths(windowStart, i));
+    }
+    for (let i = 12; i <= 23; i++) {
+      monthsToPrefetch.push(addMonths(windowStart, i));
+    }
+
+    for (const month of monthsToPrefetch) {
+      if (!availableSet.has(month)) continue;
+      queryClient.prefetchQuery(budgetMonthDataQueryOptions(connection, month));
+    }
+  }, [windowStart, availableMonths, connection, queryClient]);
+}

--- a/src/features/budget-management/hooks/usePrefetchAdjacentMonths.ts
+++ b/src/features/budget-management/hooks/usePrefetchAdjacentMonths.ts
@@ -16,12 +16,12 @@ type Props = {
  * after the current 12-month window. Fires as a background side-effect so
  * that «/» navigation renders from cache without a loading state.
  *
- * prefetchQuery is a no-op if the data is already cached or a fetch is in
- * flight — safe to call on every windowStart change.
- *
- * staleTime is intentionally kept at 0 (the query default) so TanStack Query
- * fires a background refetch when the prefetched months become visible. Any
- * staleness from save or carryover toggle self-corrects within ~200–400ms.
+ * prefetchQuery is a no-op if the data is already fresh — safe to call on
+ * every windowStart change. staleTime of 2 minutes keeps prefetched months
+ * fresh across typical month-by-month navigation so repeated adjacent-window
+ * shifts don't trigger redundant network requests. Saves and carryover toggles
+ * explicitly invalidate affected query keys, so stale data is never silently
+ * retained after a write.
  */
 export function usePrefetchAdjacentMonths({ windowStart, availableMonths }: Props) {
   const connection = useConnectionStore(selectActiveInstance);
@@ -44,7 +44,10 @@ export function usePrefetchAdjacentMonths({ windowStart, availableMonths }: Prop
 
     for (const month of monthsToPrefetch) {
       if (!availableSet.has(month)) continue;
-      queryClient.prefetchQuery(budgetMonthDataQueryOptions(connection, month));
+      queryClient.prefetchQuery({
+        ...budgetMonthDataQueryOptions(connection, month),
+        staleTime: 2 * 60 * 1000, // 2 min — keeps prefetched months fresh across navigation
+      });
     }
   }, [windowStart, availableMonths, connection, queryClient]);
 }


### PR DESCRIPTION
## Summary

Introduces usePrefetchAdjacentMonths hook that warms the ±12 month windows around the current view in the background, so month navigation renders from cache without a loading state. Invalidates those same windows after any save or carryover toggle so prefetched data reflects server-side cascade values. Also improves the loading spinner to a centered Loader2 icon.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser
