### PR TITLE
fix/add formula mode for rule actions and fix CSV formula round-trip (v1.1.6)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -64,6 +64,7 @@
 - Operators include `is`, `is not`, `contains`, `matches`, `lt`, `lte`, `gt`, `gte`, `oneOf`, and others; the `matches` operator shows a regex syntax hint
 - Actions include set payee, set category, set account, set amount, set notes, link schedule, and more
 - Action template mode: toggle the `{}` button on any action to enter a Handlebars expression (e.g. `{{regex imported_payee 'foo' 'bar'}}`); templates are displayed in an amber monospace chip in the rules table
+- Action formula mode: toggle the `ƒ` button on `notes` or `payee_name` actions to enter an Excel-style formula evaluated by HyperFormula (e.g. `=IF(ISBLANK(notes), imported_payee, notes)`); formulas must start with `=` and are displayed in an amber monospace chip in the rules table; template and formula modes are mutually exclusive per action row
 - Merge multiple selected rules into one via a dedicated merge dialog
 - Merge dialog now shares the same editor sections, row identity model, and validation behavior as the main rule drawer, avoiding combobox state jumps when rows are added or removed
 - Duplicate a rule with one click
@@ -436,8 +437,8 @@ Transaction counts are fetched lazily when the drawer opens, gated by the same `
 | `conditions_op` | `and` or `or` |
 | `row_type` | `condition` or `action` |
 | `field` | Field name (e.g. `imported_payee`, `payee`, `category`, `amount`) |
-| `op` | Operator (e.g. `is`, `contains`, `lt`, `oneOf`) |
-| `value` | Value — use `\|` as separator for multi-value `oneOf` operators |
+| `op` | Operator (e.g. `is`, `contains`, `lt`, `oneOf`); use synthetic op `set-template` for Handlebars template actions or `set-formula` for formula actions |
+| `value` | Value — use `\|` as separator for multi-value `oneOf` operators; formula values starting with `=` are exported with a leading `'` (e.g. `'=IF(...)`) to prevent Excel from evaluating them and the prefix is stripped on re-import |
 
 ## Bundle Export / Import
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Manage the core Actual Budget entities from dedicated admin pages with support f
 | **Categories** | Manage income/expense groups, categories, visibility, hierarchy, notes, and import/export CSV |
 | **Schedules** | Create one-time or recurring schedules with amount modes, recurrence controls, weekend adjustment, auto-add, linked rules, and CSV import/export |
 | **Tags** | Create, rename, color-code, describe, filter, bulk-delete, and import/export tags |
-| **Rules** | Build rules with conditions/actions, stages, AND/OR logic, templates, entity chips, filtering, search, duplication, merge, and CSV import/export |
+| **Rules** | Build rules with conditions/actions, stages, AND/OR logic, templates, HyperFormula formulas, entity chips, filtering, search, duplication, merge, and CSV import/export |
 
 ### Rule Diagnostics
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -97,12 +97,14 @@ export function SearchableCombobox({
   onChange,
   placeholder = "— select —",
   footer,
+  triggerClassName,
 }: {
   options: ComboboxOption[];
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
   footer?: (search: string) => React.ReactNode;
+  triggerClassName?: string;
 }) {
   const { open, openDropdown, closeDropdown, search, setSearch, containerRef, searchRef } =
     useComboboxState();
@@ -122,7 +124,8 @@ export function SearchableCombobox({
         onClick={() => (open ? closeDropdown() : openDropdown())}
         className={cn(
           "flex h-8 w-full items-center justify-between rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring/50",
-          !selectedLabel && "text-muted-foreground"
+          !selectedLabel && "text-muted-foreground",
+          triggerClassName
         )}
       >
         <span className="truncate">{selectedLabel || placeholder}</span>
@@ -204,11 +207,13 @@ export function MultiSearchableCombobox({
   values,
   onChange,
   placeholder = "— select —",
+  triggerClassName,
 }: {
   options: ComboboxOption[];
   values: string[];
   onChange: (v: string[]) => void;
   placeholder?: string;
+  triggerClassName?: string;
 }) {
   const { open, openDropdown, closeDropdown, search, setSearch, containerRef, searchRef } =
     useComboboxState();
@@ -233,7 +238,10 @@ export function MultiSearchableCombobox({
         tabIndex={0}
         onClick={() => (open ? closeDropdown() : openDropdown())}
         onKeyDown={(e) => e.key === "Enter" && (open ? closeDropdown() : openDropdown())}
-        className="flex min-h-8 w-full cursor-pointer flex-wrap items-center gap-1 rounded-md border border-input bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring/50"
+        className={cn(
+          "flex min-h-8 w-full cursor-pointer flex-wrap items-center gap-1 rounded-md border border-input bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring/50",
+          triggerClassName
+        )}
       >
         {selectedOptions.length === 0 ? (
           <span className="text-muted-foreground">{placeholder}</span>

--- a/src/features/rules/components/ActionRow.tsx
+++ b/src/features/rules/components/ActionRow.tsx
@@ -5,7 +5,7 @@ import { Trash2, Braces } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { EntityCombobox } from "./EntityCombobox";
-import { selectCls, inputCls } from "./ConditionRow";
+import { selectCls, fieldSelectCls, inputCls } from "./ConditionRow";
 import { valueToString } from "../utils/rulePreview";
 import { ACTION_FIELDS, ACTION_OPS } from "../utils/ruleFields";
 import { useStagedStore } from "@/store/staged";
@@ -191,7 +191,7 @@ export function ActionRow({
         </select>
 
         <select
-          className={cn(selectCls, "w-32 shrink-0")}
+          className={cn(fieldSelectCls, "w-32 shrink-0")}
           value={field}
           onChange={(e) => handleFieldChange(e.target.value)}
         >
@@ -276,6 +276,8 @@ export function ActionRow({
             variant="ghost"
             size="icon"
             title={isFormula ? "Switch to text mode" : "Switch to formula mode"}
+            aria-label={isFormula ? "Switch to text mode" : "Switch to formula mode"}
+            aria-pressed={isFormula}
             className={cn(
               "mt-0.5 h-7 w-7 shrink-0 font-mono text-base leading-none",
               isFormula
@@ -293,6 +295,8 @@ export function ActionRow({
             variant="ghost"
             size="icon"
             title={isTemplate ? "Switch to text mode" : "Switch to template mode"}
+            aria-label={isTemplate ? "Switch to text mode" : "Switch to template mode"}
+            aria-pressed={isTemplate}
             className={cn(
               "mt-0.5 h-7 w-7 shrink-0",
               isTemplate

--- a/src/features/rules/components/ActionRow.tsx
+++ b/src/features/rules/components/ActionRow.tsx
@@ -33,7 +33,9 @@ export function ActionRow({
   const field = action.field ?? "";
   const fieldDef = ACTION_FIELDS[field];
   const isTemplate = op === "set" && action.options?.template !== undefined;
+  const isFormula = op === "set" && action.options?.formula !== undefined;
   const supportsTemplate = op === "set" && fieldDef?.supportsTemplate === true;
+  const supportsFormula = op === "set" && fieldDef?.supportsFormula === true;
   const stagedSchedules = useStagedStore((s) => s.schedules);
   const openQuickCreate = useQuickCreateStore((s) => s.open);
 
@@ -72,9 +74,19 @@ export function ActionRow({
       const restoredValue = action.options?.template ?? valueToString(action.value);
       onChange({ ...action, value: restoredValue, options: undefined });
     } else {
-      // Enter template mode: zero value type-aware
+      // Enter template mode (exits formula mode if active)
       const zeroValue = fieldDef?.type === "number" || fieldDef?.type === "boolean" ? null : "";
       onChange({ ...action, value: zeroValue, options: { template: valueToString(action.value) } });
+    }
+  }
+
+  function toggleFormulaMode() {
+    if (isFormula) {
+      const restoredValue = action.options?.formula ?? valueToString(action.value);
+      onChange({ ...action, value: restoredValue, options: undefined });
+    } else {
+      // Enter formula mode (exits template mode if active)
+      onChange({ ...action, value: "", options: { formula: valueToString(action.value) } });
     }
   }
 
@@ -190,7 +202,19 @@ export function ActionRow({
             ))}
         </select>
 
-        {isTemplate ? (
+        {isFormula ? (
+          <div className="flex flex-1 flex-col gap-0.5">
+            <input
+              className={inputCls}
+              value={action.options?.formula ?? ""}
+              onChange={(e) => onChange({ ...action, options: { formula: e.target.value } })}
+              placeholder="=IF(ISBLANK(notes), …)"
+            />
+            <span className="text-[10px] text-muted-foreground">
+              Excel formula — e.g. <code>{"=IF(ISBLANK(notes), imported_payee, notes)"}</code>
+            </span>
+          </div>
+        ) : isTemplate ? (
           <div className="flex flex-1 flex-col gap-0.5">
             <input
               className={inputCls}
@@ -247,7 +271,24 @@ export function ActionRow({
           />
         )}
 
-        {supportsTemplate && (
+        {supportsFormula && !isTemplate && (
+          <Button
+            variant="ghost"
+            size="icon"
+            title={isFormula ? "Switch to text mode" : "Switch to formula mode"}
+            className={cn(
+              "mt-0.5 h-7 w-7 shrink-0 font-mono text-base leading-none",
+              isFormula
+                ? "text-amber-600 hover:text-amber-700"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+            onClick={toggleFormulaMode}
+          >
+            ƒ
+          </Button>
+        )}
+
+        {supportsTemplate && !isFormula && (
           <Button
             variant="ghost"
             size="icon"

--- a/src/features/rules/components/ConditionRow.tsx
+++ b/src/features/rules/components/ConditionRow.tsx
@@ -19,6 +19,12 @@ import type { RuleEntityOptionsMap } from "../lib/ruleEditor";
 export const selectCls =
   "h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50";
 
+export const conditionFieldSelectCls =
+  "h-8 rounded-md border border-indigo-200 bg-indigo-50 px-2 text-xs font-medium text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400/50 dark:border-indigo-800 dark:bg-indigo-950/30 dark:text-indigo-300";
+
+export const fieldSelectCls =
+  "h-8 rounded-md border border-violet-200 bg-violet-50 px-2 text-xs font-medium text-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-400/50 dark:border-violet-800 dark:bg-violet-950/30 dark:text-violet-300";
+
 export const inputCls =
   "h-8 w-full rounded-md border border-input bg-background px-2 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-ring/50";
 
@@ -284,7 +290,7 @@ export function ConditionRow({
     <div className="space-y-1">
       <div className="flex items-start gap-1.5">
         <select
-          className={cn(selectCls, "w-32 shrink-0")}
+          className={cn(conditionFieldSelectCls, "w-32 shrink-0")}
           value={field ?? ""}
           onChange={(e) => setField(e.target.value)}
         >

--- a/src/features/rules/components/EntityCombobox.tsx
+++ b/src/features/rules/components/EntityCombobox.tsx
@@ -36,6 +36,7 @@ export function EntityCombobox({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
+      triggerClassName="bg-sky-50 border-sky-200 dark:bg-sky-950/20 dark:border-sky-800"
       footer={
         canQuickCreate
           ? (search) =>
@@ -80,6 +81,7 @@ export function MultiEntityCombobox({
       values={values}
       onChange={onChange}
       placeholder={placeholder}
+      triggerClassName="bg-sky-50 border-sky-200 dark:bg-sky-950/20 dark:border-sky-800"
     />
   );
 }

--- a/src/features/rules/components/RuleChips.tsx
+++ b/src/features/rules/components/RuleChips.tsx
@@ -159,6 +159,7 @@ export function ActionChip({
 
   const fieldLabel = ACTION_FIELDS[field]?.label ?? field;
   const template = action.options?.template;
+  const formula = action.options?.formula;
   const fieldDef = ACTION_FIELDS[field];
 
   // Template mode
@@ -174,6 +175,24 @@ export function ActionChip({
         <span className="text-[11px] text-muted-foreground">template:</span>
         <span className="rounded px-1 py-0.5 text-[11px] font-mono bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
           {template || <span className="italic opacity-60">empty template</span>}
+        </span>
+      </div>
+    );
+  }
+
+  // Formula mode
+  if (formula !== undefined) {
+    return (
+      <div className="flex items-center gap-1 flex-wrap">
+        <span className="rounded px-1 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+          set
+        </span>
+        <span className="rounded px-1 py-0.5 text-[11px] font-semibold bg-violet-50 text-violet-700 dark:bg-violet-950/30 dark:text-violet-400">
+          {fieldLabel}
+        </span>
+        <span className="text-[11px] text-muted-foreground">formula:</span>
+        <span className="rounded px-1 py-0.5 text-[11px] font-mono bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
+          {formula || <span className="italic opacity-60">empty formula</span>}
         </span>
       </div>
     );

--- a/src/features/rules/components/RuleEditorFields.tsx
+++ b/src/features/rules/components/RuleEditorFields.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ConditionRow, selectCls } from "./ConditionRow";
+import { cn } from "@/lib/utils";
+import { ConditionRow } from "./ConditionRow";
 import { ActionRow } from "./ActionRow";
-import { STAGE_OPTIONS, CONDITIONS_OP_OPTIONS } from "../utils/ruleFields";
+import { STAGE_OPTIONS } from "../utils/ruleFields";
 import type { EditorPart, RuleDraftValidation, RuleEntityOptionsMap } from "../lib/ruleEditor";
 import type { ConditionOrAction, ConditionsOp, RuleStage } from "@/types/entities";
 
@@ -60,36 +61,25 @@ export function RuleEditorFields({
 
   return (
     <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
-      <div className="flex items-end gap-4">
-        <div className="flex flex-col gap-1">
-          <label htmlFor="stage-select" className="text-xs font-medium text-muted-foreground">Stage</label>
-          <select
-            id="stage-select"
-            className={selectCls}
-            value={stage}
-            onChange={(e) => onStageChange(e.target.value as RuleStage)}
-          >
-            {STAGE_OPTIONS.map((option) => (
-              <option key={option} value={option}>
-                {option.charAt(0).toUpperCase() + option.slice(1)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="flex flex-1 flex-col gap-1">
-          <label htmlFor="conditionsop-select" className="text-xs font-medium text-muted-foreground">Match</label>
-          <select
-            id="conditionsop-select"
-            className={selectCls}
-            value={conditionsOp}
-            onChange={(e) => onConditionsOpChange(e.target.value as ConditionsOp)}
-          >
-            {CONDITIONS_OP_OPTIONS.map((option) => (
-              <option key={option} value={option}>
-                {option === "and" ? "ALL conditions (and)" : "ANY condition (or)"}
-              </option>
-            ))}
-          </select>
+      {/* Stage — inline label + compact segmented toggle */}
+      <div className="flex items-center gap-3">
+        <span className="whitespace-nowrap text-xs font-medium text-muted-foreground">Stage</span>
+        <div className="flex w-fit overflow-hidden rounded-md border border-input">
+          {STAGE_OPTIONS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onStageChange(s)}
+              className={cn(
+                "border-r border-input px-4 py-1.5 text-xs font-medium transition-colors last:border-r-0",
+                stage === s
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              )}
+            >
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -118,49 +108,86 @@ export function RuleEditorFields({
         </div>
       )}
 
+      {/* Conditions section */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Conditions
-          </p>
+          <div className="flex items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Conditions
+            </p>
+            {!scheduleLinked && (
+              <>
+                <span className="text-xs text-muted-foreground">· match</span>
+                <div className="flex overflow-hidden rounded border border-input text-[11px]">
+                  {(["and", "or"] as ConditionsOp[]).map((op, i) => (
+                    <button
+                      key={op}
+                      type="button"
+                      onClick={() => onConditionsOpChange(op)}
+                      className={cn(
+                        "px-2 py-0.5 font-semibold transition-colors",
+                        i > 0 && "border-l border-input",
+                        conditionsOp === op
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-background text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                      )}
+                    >
+                      {op === "and" ? "ALL" : "ANY"}
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
           {!scheduleLinked && (
             <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={onAddCondition}>
               <Plus className="mr-1 h-3 w-3" />
-              Add
+              Add condition
             </Button>
           )}
         </div>
 
         {conditions.length === 0 ? (
           <p className="text-xs italic text-muted-foreground">
-            No conditions yet. This rule will match all transactions unless you add one.
+            No conditions yet. This rule will apply to every transaction.
           </p>
         ) : (
-          <div className="space-y-2">
+          <div>
             {conditions.map((entry, index) => {
               const rowErrors =
                 showValidation || touchedConditionIds.has(entry.clientId)
                   ? validation.conditionErrors[index] ?? []
                   : [];
               return (
-                <ConditionRow
-                  key={entry.clientId}
-                  condition={entry.part}
-                  scheduleLinked={scheduleLinked}
-                  entityOptions={entityOptions}
-                  error={rowErrors[0]}
-                  onChange={(updated) => {
-                    onConditionTouched(entry.clientId);
-                    onConditionChange(entry.clientId, updated);
-                  }}
-                  onDelete={() => onConditionDelete(entry.clientId)}
-                />
+                <Fragment key={entry.clientId}>
+                  {index > 0 && (
+                    <div className="flex items-center gap-2 py-1.5">
+                      <div className="flex-1 border-t border-dashed border-border" />
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">
+                        {conditionsOp}
+                      </span>
+                      <div className="flex-1 border-t border-dashed border-border" />
+                    </div>
+                  )}
+                  <ConditionRow
+                    condition={entry.part}
+                    scheduleLinked={scheduleLinked}
+                    entityOptions={entityOptions}
+                    error={rowErrors[0]}
+                    onChange={(updated) => {
+                      onConditionTouched(entry.clientId);
+                      onConditionChange(entry.clientId, updated);
+                    }}
+                    onDelete={() => onConditionDelete(entry.clientId)}
+                  />
+                </Fragment>
               );
             })}
           </div>
         )}
       </div>
 
+      {/* Actions section */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -168,13 +195,13 @@ export function RuleEditorFields({
           </p>
           <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={onAddAction}>
             <Plus className="mr-1 h-3 w-3" />
-            Add
+            Add action
           </Button>
         </div>
 
         {actions.length === 0 ? (
           <p className="text-xs italic text-muted-foreground">
-            No actions yet. Add at least one action before saving.
+            No actions yet. Add at least one before saving.
           </p>
         ) : (
           <div className="space-y-2">

--- a/src/features/rules/components/RuleEditorFields.tsx
+++ b/src/features/rules/components/RuleEditorFields.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Fragment, type ReactNode } from "react";
-import { Plus } from "lucide-react";
+import { type ReactNode } from "react";
+import { ChevronDown, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ConditionRow } from "./ConditionRow";
@@ -61,20 +61,36 @@ export function RuleEditorFields({
 
   return (
     <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
-      {/* Stage — inline label + compact segmented toggle */}
-      <div className="flex items-center gap-3">
-        <span className="whitespace-nowrap text-xs font-medium text-muted-foreground">Stage</span>
-        <div className="flex w-fit overflow-hidden rounded-md border border-input">
+      {/* Stage — pill-style toggle */}
+      <div className="flex items-center gap-2">
+        <span id="stage-label" className="whitespace-nowrap text-xs font-medium text-muted-foreground">Stage</span>
+        <div
+          role="radiogroup"
+          aria-labelledby="stage-label"
+          className="flex items-center gap-0.5"
+          onKeyDown={(e) => {
+            if (!["ArrowRight", "ArrowLeft", "ArrowDown", "ArrowUp"].includes(e.key)) return;
+            e.preventDefault();
+            const radios = Array.from(e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]'));
+            const currentIndex = STAGE_OPTIONS.indexOf(stage);
+            const delta = e.key === "ArrowRight" || e.key === "ArrowDown" ? 1 : -1;
+            const nextIndex = (currentIndex + delta + STAGE_OPTIONS.length) % STAGE_OPTIONS.length;
+            onStageChange(STAGE_OPTIONS[nextIndex]);
+            radios[nextIndex]?.focus();
+          }}
+        >
           {STAGE_OPTIONS.map((s) => (
             <button
               key={s}
               type="button"
+              role="radio"
+              aria-checked={stage === s}
               onClick={() => onStageChange(s)}
               className={cn(
-                "border-r border-input px-4 py-1.5 text-xs font-medium transition-colors last:border-r-0",
+                "rounded px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
                 stage === s
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-background text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:text-foreground"
               )}
             >
               {s.charAt(0).toUpperCase() + s.slice(1)}
@@ -111,34 +127,9 @@ export function RuleEditorFields({
       {/* Conditions section */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Conditions
-            </p>
-            {!scheduleLinked && (
-              <>
-                <span className="text-xs text-muted-foreground">· match</span>
-                <div className="flex overflow-hidden rounded border border-input text-[11px]">
-                  {(["and", "or"] as ConditionsOp[]).map((op, i) => (
-                    <button
-                      key={op}
-                      type="button"
-                      onClick={() => onConditionsOpChange(op)}
-                      className={cn(
-                        "px-2 py-0.5 font-semibold transition-colors",
-                        i > 0 && "border-l border-input",
-                        conditionsOp === op
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-background text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                      )}
-                    >
-                      {op === "and" ? "ALL" : "ANY"}
-                    </button>
-                  ))}
-                </div>
-              </>
-            )}
-          </div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Conditions
+          </p>
           {!scheduleLinked && (
             <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={onAddCondition}>
               <Plus className="mr-1 h-3 w-3" />
@@ -147,40 +138,47 @@ export function RuleEditorFields({
           )}
         </div>
 
+        {!scheduleLinked && (
+          <p className="text-xs text-muted-foreground">
+            If{" "}
+            <button
+              type="button"
+              onClick={() => onConditionsOpChange(conditionsOp === "and" ? "or" : "and")}
+              className="inline-flex items-center gap-0.5 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              aria-label={`Match logic: currently ${conditionsOp === "and" ? "ALL" : "ANY"}. Click to toggle.`}
+            >
+              {conditionsOp === "and" ? "ALL" : "ANY"}
+              <ChevronDown className="h-2.5 w-2.5" />
+            </button>
+            {" "}of these conditions match:
+          </p>
+        )}
+
         {conditions.length === 0 ? (
           <p className="text-xs italic text-muted-foreground">
             No conditions yet. This rule will apply to every transaction.
           </p>
         ) : (
-          <div>
-            {conditions.map((entry, index) => {
+          <div className="space-y-2">
+            {conditions.map((entry) => {
+              const index = conditions.indexOf(entry);
               const rowErrors =
                 showValidation || touchedConditionIds.has(entry.clientId)
                   ? validation.conditionErrors[index] ?? []
                   : [];
               return (
-                <Fragment key={entry.clientId}>
-                  {index > 0 && (
-                    <div className="flex items-center gap-2 py-1.5">
-                      <div className="flex-1 border-t border-dashed border-border" />
-                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">
-                        {conditionsOp}
-                      </span>
-                      <div className="flex-1 border-t border-dashed border-border" />
-                    </div>
-                  )}
-                  <ConditionRow
-                    condition={entry.part}
-                    scheduleLinked={scheduleLinked}
-                    entityOptions={entityOptions}
-                    error={rowErrors[0]}
-                    onChange={(updated) => {
-                      onConditionTouched(entry.clientId);
-                      onConditionChange(entry.clientId, updated);
-                    }}
-                    onDelete={() => onConditionDelete(entry.clientId)}
-                  />
-                </Fragment>
+                <ConditionRow
+                  key={entry.clientId}
+                  condition={entry.part}
+                  scheduleLinked={scheduleLinked}
+                  entityOptions={entityOptions}
+                  error={rowErrors[0]}
+                  onChange={(updated) => {
+                    onConditionTouched(entry.clientId);
+                    onConditionChange(entry.clientId, updated);
+                  }}
+                  onDelete={() => onConditionDelete(entry.clientId)}
+                />
               );
             })}
           </div>

--- a/src/features/rules/csv/rulesCsvExport.test.ts
+++ b/src/features/rules/csv/rulesCsvExport.test.ts
@@ -170,6 +170,34 @@ describe("exportRulesToCsv", () => {
     expect(result).toContain("true");
   });
 
+  it("exports formula actions with op=set-formula and prefixes '=' formulas with single-quote", () => {
+    const rule = makeRule("r1", {
+      actions: [{ field: "notes", op: "set", value: "", type: "string", options: { formula: "=IF(ISBLANK(notes), x, notes)" } }],
+    });
+    const result = exportRulesToCsv(staged(rule), emptyMaps);
+    expect(result).toContain("set-formula");
+    // The formula is prefixed with ' to prevent spreadsheet apps from evaluating it
+    expect(result).toContain("'=IF(ISBLANK(notes)");
+    expect(result).not.toContain(",set,");
+  });
+
+  it("round-trips: formula action survives export → import", () => {
+    const formula = '=IF(ISBLANK(notes), "(" & imported_payee & ") |", notes & " (" & imported_payee & ") |")';
+    const rule = makeRule("r1", {
+      actions: [{ field: "notes", op: "set", value: "", type: "string", options: { formula } }],
+    });
+    const csv = exportRulesToCsv(staged(rule), emptyMaps);
+    const imported = importRulesFromCsv(csv, emptyMaps);
+
+    expect("error" in imported).toBe(false);
+    if ("error" in imported) return;
+
+    const action = imported.rules[0].actions[0];
+    expect(action.op).toBe("set");
+    expect(action.value).toBe("");
+    expect(action.options).toEqual({ formula });
+  });
+
   it("round-trips: template action survives export → import", () => {
     const rule = makeRule("r1", {
       actions: [{ field: "notes", op: "set", value: "", type: "string", options: { template: "{{regex imported_payee 'foo' 'bar'}}" } }],

--- a/src/features/rules/csv/rulesCsvExport.ts
+++ b/src/features/rules/csv/rulesCsvExport.ts
@@ -59,7 +59,13 @@ export function exportRulesToCsv(stagedRules: StagedMap<Rule>, maps: EntityMaps)
 
     for (const act of rule.actions) {
       const isTemplate = act.options !== undefined && "template" in act.options;
+      const isFormula = act.options !== undefined && "formula" in act.options;
       const isDeleteTxn = act.op === "delete-transaction";
+
+      // Prefix formulas starting with "=" with a single quote so spreadsheet apps
+      // treat the cell as text rather than evaluating it as a formula.
+      const rawFormula = act.options?.formula ?? "";
+      const formulaExportValue = rawFormula.startsWith("=") ? "'" + rawFormula : rawFormula;
 
       lines.push([
         csvField(rule.id),
@@ -67,9 +73,11 @@ export function exportRulesToCsv(stagedRules: StagedMap<Rule>, maps: EntityMaps)
         isFirstRow ? csvField(rule.conditionsOp) : "",
         "action",
         csvField(act.field ?? ""),
-        isTemplate ? "set-template" : csvField(act.op),
+        isTemplate ? "set-template" : isFormula ? "set-formula" : csvField(act.op),
         isTemplate
           ? csvField(act.options!.template ?? "")
+          : isFormula
+          ? csvField(formulaExportValue)
           : isDeleteTxn
           ? ""
           : csvField(exportDisplayValue(act, maps)),

--- a/src/features/rules/csv/rulesCsvImport.test.ts
+++ b/src/features/rules/csv/rulesCsvImport.test.ts
@@ -207,6 +207,40 @@ describe("importRulesFromCsv", () => {
     expect(action.options).toEqual({ template: "{{regex imported_payee 'foo' 'bar'}}" });
   });
 
+  it("imports a formula action (op=set-formula) with options.formula set", () => {
+    const formula = "=IF(ISBLANK(notes), x, notes)";
+    const csv = [
+      "rule_id,stage,conditions_op,row_type,field,op,value",
+      `r1,default,and,action,notes,set-formula,"${formula}"`,
+    ].join("\n");
+
+    const result = importRulesFromCsv(csv, emptyMaps);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+
+    const action = result.rules[0].actions[0];
+    expect(action.op).toBe("set");
+    expect(action.value).toBe("");
+    expect(action.options).toEqual({ formula });
+  });
+
+  it("strips leading single-quote from formula values prefixed by the exporter", () => {
+    const formula = "=IF(ISBLANK(notes), x, notes)";
+    const csv = [
+      "rule_id,stage,conditions_op,row_type,field,op,value",
+      `r1,default,and,action,notes,set-formula,"'${formula}"`,
+    ].join("\n");
+
+    const result = importRulesFromCsv(csv, emptyMaps);
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) return;
+
+    const action = result.rules[0].actions[0];
+    expect(action.options).toEqual({ formula });
+  });
+
   it("imports an empty-string template action (op=set-template, blank value)", () => {
     const csv = [
       "rule_id,stage,conditions_op,row_type,field,op,value",

--- a/src/features/rules/csv/rulesCsvImport.ts
+++ b/src/features/rules/csv/rulesCsvImport.ts
@@ -211,6 +211,11 @@ export function importRulesFromCsv(
       } else {
         if (op === "set-template") {
           actions.push({ field, op: "set", value: "", type: "string", options: { template: rawValue } });
+        } else if (op === "set-formula") {
+          // Strip the leading "'" that the exporter adds to prevent spreadsheet apps
+          // from evaluating "=…" values as formulas.
+          const formula = rawValue.startsWith("'=") ? rawValue.slice(1) : rawValue;
+          actions.push({ field, op: "set", value: "", type: "string", options: { formula } });
         } else if (op === "delete-transaction") {
           actions.push({ op: "delete-transaction", value: "" });
         } else if (op === "prepend-notes" || op === "append-notes") {

--- a/src/features/rules/lib/ruleEditor.test.ts
+++ b/src/features/rules/lib/ruleEditor.test.ts
@@ -63,6 +63,79 @@ describe("validateRuleDraft", () => {
     expect(result.conditionErrors[0]).toContain("Condition 1: enter a valid value.");
   });
 
+  it("accepts a valid formula starting with =", () => {
+    const result = validateRuleDraft(
+      buildDraft({
+        actions: [
+          {
+            clientId: "action-1",
+            part: {
+              field: "notes",
+              op: "set",
+              value: "",
+              type: "string",
+              options: { formula: '=IF(ISBLANK(notes), imported_payee, notes)' },
+            },
+          },
+        ],
+      })
+    );
+
+    expect(result.actionErrors[0]).toEqual([]);
+  });
+
+  it("rejects an empty formula", () => {
+    const result = validateRuleDraft(
+      buildDraft({
+        actions: [
+          {
+            clientId: "action-1",
+            part: { field: "notes", op: "set", value: "", type: "string", options: { formula: "" } },
+          },
+        ],
+      })
+    );
+
+    expect(result.actionErrors[0]).toContain("Action 1: enter a valid value.");
+  });
+
+  it("rejects a formula not starting with =", () => {
+    const result = validateRuleDraft(
+      buildDraft({
+        actions: [
+          {
+            clientId: "action-1",
+            part: { field: "notes", op: "set", value: "", type: "string", options: { formula: "IF(ISBLANK(notes), x, notes)" } },
+          },
+        ],
+      })
+    );
+
+    expect(result.actionErrors[0]).toContain("Action 1: formula must start with =");
+  });
+
+  it("rejects formula mode on ID fields (e.g. category)", () => {
+    const result = validateRuleDraft(
+      buildDraft({
+        actions: [
+          {
+            clientId: "action-1",
+            part: {
+              field: "category",
+              op: "set",
+              value: "",
+              type: "id",
+              options: { formula: "=IF(TRUE, x, y)" },
+            },
+          },
+        ],
+      })
+    );
+
+    // supportsFormula is false for category, so treated as invalid value
+    expect(result.actionErrors[0]).toContain("Action 1: enter a valid value.");
+  });
+
   it("rejects template values for fields that do not support templates", () => {
     const result = validateRuleDraft(
       buildDraft({

--- a/src/features/rules/lib/ruleEditor.ts
+++ b/src/features/rules/lib/ruleEditor.ts
@@ -109,10 +109,14 @@ function isRecurConfigValue(value: ConditionOrAction["value"]): boolean {
 
 function hasValidRequiredValue(
   part: ConditionOrAction,
-  fieldDef: { type: "string" | "id" | "number" | "date" | "boolean"; supportsTemplate?: boolean }
+  fieldDef: { type: "string" | "id" | "number" | "date" | "boolean"; supportsTemplate?: boolean; supportsFormula?: boolean }
 ): boolean {
   if (part.options?.template !== undefined) {
     return fieldDef.supportsTemplate === true && !isBlankString(part.options.template);
+  }
+
+  if (part.options?.formula !== undefined) {
+    return fieldDef.supportsFormula === true && !isBlankString(part.options.formula);
   }
 
   if (Array.isArray(part.value)) {
@@ -184,6 +188,15 @@ function validateActionPart(part: ConditionOrAction, index: number): string[] {
 
   if (opDef.hasValue && !hasValidRequiredValue(part, fieldDef)) {
     errors.push(`Action ${index + 1}: enter a valid value.`);
+  }
+
+  // Formula-specific: must start with "="
+  if (
+    part.options?.formula !== undefined &&
+    !isBlankString(part.options.formula) &&
+    !part.options.formula.trim().startsWith("=")
+  ) {
+    errors.push(`Action ${index + 1}: formula must start with =`);
   }
 
   return errors;

--- a/src/features/rules/schemas/rule.schema.test.ts
+++ b/src/features/rules/schemas/rule.schema.test.ts
@@ -1,0 +1,43 @@
+import { ruleSchema } from "./rule.schema";
+
+const baseRule = {
+  id: "rule-1",
+  stage: "default" as const,
+  conditionsOp: "and" as const,
+  conditions: [],
+  actions: [],
+};
+
+describe("ruleSchema options mutual exclusivity", () => {
+  it("accepts options with only template", () => {
+    const result = ruleSchema.safeParse({
+      ...baseRule,
+      actions: [{ op: "set", field: "notes", value: "", type: "string", options: { template: "{{x}}" } }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts options with only formula", () => {
+    const result = ruleSchema.safeParse({
+      ...baseRule,
+      actions: [{ op: "set", field: "notes", value: "", type: "string", options: { formula: "=IF(1,x,y)" } }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects options with both template and formula", () => {
+    const result = ruleSchema.safeParse({
+      ...baseRule,
+      actions: [
+        {
+          op: "set",
+          field: "notes",
+          value: "",
+          type: "string",
+          options: { template: "{{x}}", formula: "=IF(1,x,y)" },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/rules/schemas/rule.schema.ts
+++ b/src/features/rules/schemas/rule.schema.ts
@@ -30,7 +30,12 @@ const conditionOrActionSchema = z.object({
     recurConfigSchema,
   ]),
   type: z.string().optional(),
-  options: z.object({ template: z.string().optional(), formula: z.string().optional() }).optional(),
+  options: z
+    .object({ template: z.string().optional(), formula: z.string().optional() })
+    .refine((o) => !(o.template !== undefined && o.formula !== undefined), {
+      message: "template and formula are mutually exclusive",
+    })
+    .optional(),
 });
 
 export const ruleSchema = z.object({

--- a/src/features/rules/schemas/rule.schema.ts
+++ b/src/features/rules/schemas/rule.schema.ts
@@ -30,7 +30,7 @@ const conditionOrActionSchema = z.object({
     recurConfigSchema,
   ]),
   type: z.string().optional(),
-  options: z.object({ template: z.string().optional() }).optional(),
+  options: z.object({ template: z.string().optional(), formula: z.string().optional() }).optional(),
 });
 
 export const ruleSchema = z.object({

--- a/src/features/rules/utils/ruleFields.ts
+++ b/src/features/rules/utils/ruleFields.ts
@@ -12,6 +12,8 @@ export type FieldDef = {
   entity?: "payee" | "category" | "account" | "categoryGroup";
   /** Whether this field supports Handlebars template mode */
   supportsTemplate?: boolean;
+  /** Whether this field supports Excel formula mode */
+  supportsFormula?: boolean;
 };
 
 export type OpDef = {
@@ -35,9 +37,9 @@ export const ACTION_FIELDS: Record<string, FieldDef> = {
   payee:           { label: "Payee",          type: "id",      entity: "payee" },
   category:        { label: "Category",       type: "id",      entity: "category" },
   account:         { label: "Account",        type: "id",      entity: "account" },
-  notes:           { label: "Notes",          type: "string",  supportsTemplate: true },
+  notes:           { label: "Notes",          type: "string",  supportsTemplate: true, supportsFormula: true },
   cleared:         { label: "Cleared",        type: "boolean" },
-  payee_name:      { label: "Payee Name",     type: "string",  supportsTemplate: true },
+  payee_name:      { label: "Payee Name",     type: "string",  supportsTemplate: true, supportsFormula: true },
   date:            { label: "Date",           type: "date" },
   amount:          { label: "Amount",         type: "number" },
   // Linked schedule action — created automatically by the schedules API.

--- a/src/features/rules/utils/rulePreview.test.ts
+++ b/src/features/rules/utils/rulePreview.test.ts
@@ -103,6 +103,22 @@ describe("rulePreview", () => {
     expect(result).toContain("unknown-id");
   });
 
+  it("formats a template action", () => {
+    const rule = makeRule({
+      actions: [{ field: "notes", op: "set", value: "", type: "string", options: { template: "{{imported_payee}}" } }],
+    });
+    const result = rulePreview(rule, emptyMaps);
+    expect(result).toContain("template: {{imported_payee}}");
+  });
+
+  it("formats a formula action", () => {
+    const rule = makeRule({
+      actions: [{ field: "notes", op: "set", value: "", type: "string", options: { formula: "=IF(ISBLANK(notes), imported_payee, notes)" } }],
+    });
+    const result = rulePreview(rule, emptyMaps);
+    expect(result).toContain("formula: =IF(ISBLANK(notes)");
+  });
+
   it("formats the full If…→ structure", () => {
     const rule = makeRule({
       conditionsOp: "and",

--- a/src/features/rules/utils/rulePreview.ts
+++ b/src/features/rules/utils/rulePreview.ts
@@ -123,6 +123,10 @@ function summariseAction(a: ConditionOrAction, maps: EntityMaps): string {
     return `set ${fieldLabel} → template: ${a.options.template}`;
   }
 
+  if (a.options !== undefined && "formula" in a.options) {
+    return `set ${fieldLabel} → formula: ${a.options.formula}`;
+  }
+
   const valueLabel = resolveValue(field, a.value, maps, ACTION_FIELDS);
   const wrapped = Array.isArray(a.value) ? valueLabel : `"${valueLabel}"`;
   return `set ${fieldLabel} → ${wrapped}`;

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -63,8 +63,8 @@ export type ConditionOrAction = {
   op: string;
   value: string | number | boolean | null | string[] | AmountRange | RecurConfig;
   type?: string;
-  /** Present on actions when the user has enabled template (Handlebars) mode. */
-  options?: { template?: string };
+  /** Present on actions when the user has enabled template (Handlebars) or formula (Excel) mode. */
+  options?: { template?: string; formula?: string };
 };
 
 export type Rule = BaseEntity & {


### PR DESCRIPTION
## Summary

Fixes #99 

  - Add HyperFormula formula mode to rule actions (notes, payee_name) via a new ƒ toggle button in the rule drawer
  - Fix CSV export/import losing formula mode — introduces a set-formula synthetic op so round-trips preserve the formula correctly
  - Fix #NAME? errors when an exported CSV is opened in Excel by prefixing = formula values with ' on export and stripping it on import
  - Improve rule drawer UI: compact segmented stage toggle, inline CONDITIONS · match [ALL] [ANY] control, dashed AND/OR separator between condition rows
  - Bump version to 1.1.6

  Docs & version

  - FEATURES.md — documented formula mode and updated CSV Rules format
  - README.md — added formulas to the Rules capability row
  - package.json — bumped to 1.1.6

## Tests

  - Open a rule with notes set-action → ƒ button appears; click to enter formula mode → input shows with hint text
  - Enter =IF(ISBLANK(notes), imported_payee, notes) → no validation error; enter IF(...) without = → "formula must start with =" error; clear formula → "enter a valid value"
  error
  - Export rules to CSV → formula row uses set-formula op and value starts with '=
  - Re-import the exported CSV → formula is restored correctly with options.formula set
  - Open exported CSV in Excel → formula cell displays as text (not evaluated as a formula)
  - Template and formula toggles are mutually exclusive — enabling one hides the other
  - Formula action displays as amber monospace chip in the rules table
  - Stage segmented toggle and conditions match toggle work correctly in the rule drawer
  - All 7 ruleEditor.test.ts tests pass: npm test -- --testPathPatterns=ruleEditor