### PR TITLE
docs/add fly.toml for Fly.io deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,34 @@
+# fly.toml — Fly.io deployment config for actual-bench
+#
+# Quick start:
+#   fly launch --no-deploy   # create the app and import this config
+#   fly deploy               # deploy using the pre-built Docker Hub image
+#
+# No secrets are required — the actual-http-api URL and API key are entered
+# in the browser UI and stored in session storage (cleared on tab close).
+#
+# To pin to a specific version instead of always pulling latest, change
+# the image tag below, e.g. xrous/actual-bench:1.1.6
+
+app = "actual-bench"
+primary_region = "iad"
+
+[build]
+  image = "xrous/actual-bench:latest"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 200
+    soft_limit = 150
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds a `fly.toml` so users can deploy Actual Bench to Fly.io with `fly launch --no-deploy` + `fly deploy`.

Uses the pre-built `xrous/actual-bench:latest` Docker Hub image - no build step required on Fly.io's infrastructure. No secrets needed; the actual-http-api URL and API key are entered in the browser UI.

Fixes #101