### PR TITLE
Add initial balance on account creation + refresh balances action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,12 @@ Read these only when relevant to the task:
 |---|---|
 | New component, hook, or utility | `agents/coding_standards.md` |
 | API integration | `agents/actual_api_docs/api_docs.md` |
-| Roadmap work | `agents/future-roadmap.md` |
+| Roadmap work (master list of features) | `agents/roadmap.md` |
+| Reviewing existing features / improvements | `agents/findings.md` |
+| Context behind rejected/deferred items, constraints | `agents/knowledge.md` |
 | Architecture decision | `agents/requirements/` |
 | Git, workflow, or release change | `CONTRIBUTING.md` |
+| Overall agents/ folder framework | `agents/FRAMEWORK.md` |
 
 Update these only when the change requires it:
 
@@ -112,6 +115,8 @@ Update these only when the change requires it:
 |---|---|
 | User-facing feature added or changed | `FEATURES.md` |
 | Setup, entry point, or positioning changed | `README.md` |
+| RD-### item shipped or status changed | `agents/roadmap.md` |
+| F-### finding resolved | `agents/findings.md` |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,12 +102,11 @@ Read these only when relevant to the task:
 |---|---|
 | New component, hook, or utility | `agents/coding_standards.md` |
 | API integration | `agents/actual_api_docs/api_docs.md` |
-| Roadmap work (master list of features) | `agents/roadmap.md` |
-| Reviewing existing features / improvements | `agents/findings.md` |
-| Context behind rejected/deferred items, constraints | `agents/knowledge.md` |
-| Architecture decision | `agents/requirements/` |
+| Roadmap work (master list of features - internal) | `agents/roadmap.md` |
+| Reviewing existing features / improvements - internal| `agents/findings.md` |
+| Context behind rejected/deferred items, constraints - internal | `agents/knowledge.md` |
 | Git, workflow, or release change | `CONTRIBUTING.md` |
-| Overall agents/ folder framework | `agents/FRAMEWORK.md` |
+| Overall agents/ folder framework -internal | `agents/FRAMEWORK.md` |
 
 Update these only when the change requires it:
 
@@ -115,8 +114,8 @@ Update these only when the change requires it:
 |---|---|
 | User-facing feature added or changed | `FEATURES.md` |
 | Setup, entry point, or positioning changed | `README.md` |
-| RD-### item shipped or status changed | `agents/roadmap.md` |
-| F-### finding resolved | `agents/findings.md` |
+| RD-### item shipped or status changed - internal | `agents/roadmap.md` |
+| F-### finding resolved - internal | `agents/findings.md` |
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ For user-facing changes:
 
 Check issues labelled [`good first issue`](https://github.com/x-rous/actual-bench/issues?q=is%3Aissue+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/x-rous/actual-bench/issues?q=is%3Aissue+label%3A%22help+wanted%22).
 
-Planned roadmap items with effort estimates are tracked in [`agents/future-roadmap.md`](agents/future-roadmap.md). If you want to pick up a `pending` item, open an issue first to claim it and avoid duplicate work.
+Planned roadmap items with effort estimates are tracked in [`agents/roadmap.md`](agents/roadmap.md). If you want to pick up a `pending` item, open an issue first to claim it and avoid duplicate work.
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ For user-facing changes:
 
 Check issues labelled [`good first issue`](https://github.com/x-rous/actual-bench/issues?q=is%3Aissue+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/x-rous/actual-bench/issues?q=is%3Aissue+label%3A%22help+wanted%22).
 
-Planned roadmap items with effort estimates are tracked in [`agents/roadmap.md`](agents/roadmap.md). If you want to pick up a `pending` item, open an issue first to claim it and avoid duplicate work.
+If you want to pick up a new feature, open an issue first to claim it and avoid duplicate work.
 
 ## Project structure
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -501,5 +501,4 @@ budget-bundle-<label>-<date>.zip
 
 ---
 
-> Planned features and improvements are tracked in [`agents/roadmap.md`](agents/roadmap.md) (new features) and [`agents/findings.md`](agents/findings.md) (fixes/improvements to existing features).
-> When a roadmap item ships, add it to the relevant section above and let the merged PR title feed the next GitHub Release draft.
+> When a feature ships, add it to the relevant section above and let the merged PR title feed the next GitHub Release draft.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -93,8 +93,10 @@
 ## Accounts
 
 - Create, rename, and delete accounts
+- "Add Account" opens a form drawer with Name, an optional Initial Balance (seeds the account's starting balance on creation), and Budget Type
 - Budget type (on-budget / off-budget) is set at creation time via a toggle switch and displayed as a read-only badge thereafter — reflecting Actual Budget's constraint that account type cannot be changed after creation
-- Current balance column shows the live account balance fetched via ActualQL aggregation, refreshed every 60 seconds; negative balances are highlighted in red
+- Current balance column shows the live account balance fetched via ActualQL aggregation, refreshed every 60 seconds, or via the toolbar "Refresh" action; negative balances are highlighted in red
+- For staged (new) accounts created via the bottom Add Rows / paste flow, the Balance column is editable to set the initial balance
 - Open and close accounts
 - Inline editing: double-click, Enter, or F2 to edit; Escape to cancel
 - Bulk select with bulk close, reopen, and delete
@@ -499,5 +501,5 @@ budget-bundle-<label>-<date>.zip
 
 ---
 
-> Planned features and improvements are tracked in [`agents/future-roadmap.md`](agents/future-roadmap.md).
+> Planned features and improvements are tracked in [`agents/roadmap.md`](agents/roadmap.md) (new features) and [`agents/findings.md`](agents/findings.md) (fixes/improvements to existing features).
 > When a roadmap item ships, add it to the relevant section above and let the merged PR title feed the next GitHub Release draft.

--- a/src/features/accounts/components/AccountFormDrawer.tsx
+++ b/src/features/accounts/components/AccountFormDrawer.tsx
@@ -37,11 +37,12 @@ export function AccountFormDrawer({ open, onOpenChange, onSubmit }: Props) {
     defaultValues: {
       name: "",
       offBudget: false,
+      initialBalance: undefined,
     },
   });
 
   useEffect(() => {
-    if (open) reset({ name: "", offBudget: false });
+    if (open) reset({ name: "", offBudget: false, initialBalance: undefined });
   }, [open, reset]);
 
   function handleFormSubmit(values: AccountFormValues) {
@@ -79,6 +80,26 @@ export function AccountFormDrawer({ open, onOpenChange, onSubmit }: Props) {
             {errors.name && (
               <p className="text-xs text-destructive">{errors.name.message}</p>
             )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="account-initial-balance">Initial Balance</Label>
+            <Input
+              id="account-initial-balance"
+              type="number"
+              step="0.01"
+              placeholder="0.00"
+              aria-invalid={!!errors.initialBalance}
+              {...register("initialBalance", {
+                setValueAs: (v) => (v === "" || v === null || v === undefined ? undefined : Number(v)),
+              })}
+            />
+            {errors.initialBalance && (
+              <p className="text-xs text-destructive">{errors.initialBalance.message}</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Optional starting balance for this account. Leave blank for $0.00.
+            </p>
           </div>
 
           <div className="flex flex-col gap-1.5">

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -338,6 +338,11 @@ export function AccountsTable({
     stageUpdate("accounts", accountId, { offBudget: nextOffBudget });
   }
 
+  function handleSetInitialBalance(accountId: string, value: number | undefined) {
+    pushUndo();
+    stageUpdate("accounts", accountId, { initialBalance: value });
+  }
+
   function handleReopen(accountId: string) {
     pushUndo();
     stageUpdate("accounts", accountId, { closed: false });
@@ -494,6 +499,7 @@ export function AccountsTable({
                       onStartEditingName={handleStartEditingName}
                       onDoneName={handleNameDone}
                       onToggleNewBudgetType={handleToggleNewBudgetType}
+                      onSetInitialBalance={handleSetInitialBalance}
                       onOpenRules={handleOpenRules}
                       onClearSaveError={handleClearSaveError}
                       onRevert={handleRevert}

--- a/src/features/accounts/components/AccountsTable.tsx
+++ b/src/features/accounts/components/AccountsTable.tsx
@@ -339,6 +339,7 @@ export function AccountsTable({
   }
 
   function handleSetInitialBalance(accountId: string, value: number | undefined) {
+    if (value === staged[accountId]?.entity.initialBalance) return;
     pushUndo();
     stageUpdate("accounts", accountId, { initialBalance: value });
   }

--- a/src/features/accounts/components/AccountsTableRow.tsx
+++ b/src/features/accounts/components/AccountsTableRow.tsx
@@ -37,6 +37,7 @@ type AccountsTableRowProps = {
   onStartEditingName: (id: string) => void;
   onDoneName: (id: string, value: string, action: DoneAction) => void;
   onToggleNewBudgetType: (id: string, nextOffBudget: boolean) => void;
+  onSetInitialBalance: (id: string, value: number | undefined) => void;
   onOpenRules: (accountId: string, accountName: string, ruleCount: number) => void;
   onClearSaveError: (id: string) => void;
   onRevert: (id: string) => void;
@@ -55,6 +56,42 @@ function formatBalance(balance?: number) {
   });
 }
 
+function InitialBalanceInput({
+  accountId,
+  accountName,
+  value,
+  disabled,
+  onChange,
+}: {
+  accountId: string;
+  accountName: string;
+  value: number | undefined;
+  disabled: boolean;
+  onChange: (id: string, value: number | undefined) => void;
+}) {
+  return (
+    <input
+      key={value ?? "empty"}
+      type="text"
+      inputMode="decimal"
+      disabled={disabled}
+      defaultValue={formatBalance(value) ?? ""}
+      placeholder="0.00"
+      aria-label={`Initial balance for ${accountName || "new account"}`}
+      onKeyDown={(e) => e.stopPropagation()}
+      onFocus={(e) => e.target.select()}
+      onBlur={(e) => {
+        const raw = e.target.value.replace(/,/g, "").trim();
+        const parsed = raw === "" ? undefined : parseFloat(raw);
+        const next = parsed === undefined || Number.isNaN(parsed) ? undefined : parsed;
+        onChange(accountId, next);
+        e.target.value = formatBalance(next) ?? "";
+      }}
+      className="w-full rounded border border-input bg-background px-1 py-0.5 text-right text-xs tabular-nums outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+    />
+  );
+}
+
 function AccountsTableRowComponent({
   row,
   highlightedId,
@@ -71,6 +108,7 @@ function AccountsTableRowComponent({
   onStartEditingName,
   onDoneName,
   onToggleNewBudgetType,
+  onSetInitialBalance,
   onOpenRules,
   onClearSaveError,
   onRevert,
@@ -180,7 +218,15 @@ function AccountsTableRowComponent({
       </td>
 
       <td className="w-32 px-4 py-0.5 text-right tabular-nums">
-        {isNew || formattedBalance === null ? (
+        {isNew ? (
+          <InitialBalanceInput
+            accountId={entity.id}
+            accountName={entity.name}
+            value={entity.initialBalance}
+            disabled={isDeleted}
+            onChange={onSetInitialBalance}
+          />
+        ) : formattedBalance === null ? (
           <span className="text-xs text-muted-foreground/50">-</span>
         ) : (
           <span

--- a/src/features/accounts/components/AccountsView.tsx
+++ b/src/features/accounts/components/AccountsView.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Plus, Download, Upload } from "lucide-react";
+import { Plus, Download, Upload, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { CSV_MAX_BYTES } from "@/lib/csv";
+import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { useAccounts } from "../hooks/useAccounts";
+import { useAccountBalances } from "../hooks/useAccountBalances";
 import { AccountsTable } from "./AccountsTable";
+import { AccountFormDrawer } from "./AccountFormDrawer";
+import type { AccountFormValues } from "../schemas/account.schema";
 import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
 import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { AccountsTableOverlays } from "./AccountsTableOverlays";
@@ -20,24 +24,40 @@ import { importAccountsFromCsv } from "../csv/accountsCsvImport";
 export function AccountsView() {
   const [ruleDrawerOpen, setRuleDrawerOpen] = useState(false);
   const [ruleSeed, setRuleSeed] = useState<RuleSeed | undefined>(undefined);
+  const [formDrawerOpen, setFormDrawerOpen] = useState(false);
   const [deleteIntent, setDeleteIntent] = useState<AccountDeleteIntent | null>(null);
   const [inspectId, setInspectId] = useState<string | null>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
 
   const { isLoading, isError, error, refetch } = useAccounts();
+  const { refetch: refetchBalances, isFetching: isRefreshingBalances } = useAccountBalances();
 
   const staged = useStagedStore((s) => s.accounts);
   const stageNew = useStagedStore((s) => s.stageNew);
   const pushUndo = useStagedStore((s) => s.pushUndo);
 
   function handleAddAccount() {
+    setFormDrawerOpen(true);
+  }
+
+  function handleCreateAccount(values: AccountFormValues) {
     pushUndo();
     stageNew("accounts", {
       id: generateId(),
-      name: "New Account",
-      offBudget: false,
+      name: values.name,
+      offBudget: values.offBudget,
       closed: false,
+      initialBalance: values.initialBalance,
     });
+  }
+
+  async function handleRefreshBalances() {
+    const result = await refetchBalances();
+    if (result.error) {
+      toast.error("Failed to refresh balances.");
+    } else {
+      toast.success("Balances refreshed.");
+    }
   }
 
   function handleCreateRule(accountId: string, accountName: string) {
@@ -119,6 +139,16 @@ export function AccountsView() {
             className="hidden"
             onChange={handleImportCsv}
           />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefreshBalances}
+            disabled={isRefreshingBalances}
+            title="Refresh balances"
+          >
+            <RefreshCw className={cn(isRefreshingBalances && "animate-spin")} />
+            Refresh
+          </Button>
           <Button variant="outline" size="sm" onClick={() => importInputRef.current?.click()} title="Import CSV">
             <Download />
             Import
@@ -145,6 +175,12 @@ export function AccountsView() {
         onOpenChange={setRuleDrawerOpen}
         ruleId={null}
         seed={ruleSeed}
+      />
+
+      <AccountFormDrawer
+        open={formDrawerOpen}
+        onOpenChange={setFormDrawerOpen}
+        onSubmit={handleCreateAccount}
       />
 
       <AccountsTableOverlays

--- a/src/features/accounts/hooks/useAccountsSave.ts
+++ b/src/features/accounts/hooks/useAccountsSave.ts
@@ -40,7 +40,7 @@ export function useAccountsSave() {
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
         toCreate.map((a) =>
-          createAccount(connection, { name: a.name, offBudget: a.offBudget, closed: a.closed })
+          createAccount(connection, { name: a.name, offBudget: a.offBudget, closed: a.closed, initialBalance: a.initialBalance })
         )
       );
       for (let i = 0; i < toCreate.length; i++) {

--- a/src/features/accounts/schemas/account.schema.ts
+++ b/src/features/accounts/schemas/account.schema.ts
@@ -5,12 +5,14 @@ export const accountSchema = z.object({
   name: z.string().min(1, "Name is required").max(100, "Name cannot exceed 100 characters"),
   offBudget: z.boolean(),
   closed: z.boolean(),
+  initialBalance: z.number().optional(),
 });
 
 /** Used for the create/edit form — id is not included */
 export const accountFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(100, "Name cannot exceed 100 characters"),
   offBudget: z.boolean(),
+  initialBalance: z.number().optional(),
 });
 
 export type AccountFormValues = z.infer<typeof accountFormSchema>;

--- a/src/features/budget-diagnostics/lib/expectedSchema.ts
+++ b/src/features/budget-diagnostics/lib/expectedSchema.ts
@@ -1,10 +1,3 @@
-/**
- * Expected Actual Budget snapshot schema.
- *
- * Source: agents/rd-specs/rd-006-budget-diagnostics-ddl.md
- * Source snapshot date: 2026-04-20
- */
-
 export const DDL_SOURCE_DATE = "2026-04-20";
 
 export const EXPECTED_TABLES = [

--- a/src/features/budget-diagnostics/lib/expectedSchema.ts
+++ b/src/features/budget-diagnostics/lib/expectedSchema.ts
@@ -1,7 +1,7 @@
 /**
  * Expected Actual Budget snapshot schema.
  *
- * Source: agents/rd-006-budget-diagnostics-ddl.md
+ * Source: agents/rd-specs/rd-006-budget-diagnostics-ddl.md
  * Source snapshot date: 2026-04-20
  */
 

--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -40,7 +40,7 @@ function denormalizeAccountCreate(
 ): ApiAccountCreateInput {
   return {
     ...denormalizeAccount(account),
-    ...(account.initialBalance ? { initialBalance: Math.round(account.initialBalance * 100) } : {}),
+    ...(account.initialBalance !== undefined ? { initialBalance: Math.round(account.initialBalance * 100) } : {}),
   };
 }
 

--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -9,6 +9,7 @@ import type { ConnectionInstance } from "@/store/connection";
 import type {
   ApiAccount,
   ApiAccountInput,
+  ApiAccountCreateInput,
   ApiListResponse,
   ApiSingleResponse,
 } from "@/types/api";
@@ -34,6 +35,15 @@ function denormalizeAccount(
   };
 }
 
+function denormalizeAccountCreate(
+  account: Pick<Account, "name" | "offBudget" | "initialBalance">
+): ApiAccountCreateInput {
+  return {
+    ...denormalizeAccount(account),
+    ...(account.initialBalance ? { initialBalance: Math.round(account.initialBalance * 100) } : {}),
+  };
+}
+
 // ─── API functions ────────────────────────────────────────────────────────────
 
 export async function getAccounts(connection: ConnectionInstance): Promise<Account[]> {
@@ -52,7 +62,7 @@ export async function createAccount(
   const response = await apiRequest<ApiSingleResponse<ApiAccount>>(
     connection,
     "/accounts",
-    { method: "POST", body: { account: denormalizeAccount(input) } }
+    { method: "POST", body: { account: denormalizeAccountCreate(input) } }
   );
   return normalizeAccount(response.data);
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -25,6 +25,11 @@ export type ApiAccount = {
 
 export type ApiAccountInput = Omit<ApiAccount, "id">;
 
+/** POST /accounts body shape — initialBalance is a one-time creation param, in cents. */
+export type ApiAccountCreateInput = Pick<ApiAccountInput, "name" | "offbudget"> & {
+  initialBalance?: number;
+};
+
 // ─── Payee ───────────────────────────────────────────────────────────────────
 
 export type ApiPayee = {

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -15,6 +15,8 @@ export type Account = BaseEntity & {
   name: string;
   offBudget: boolean;
   closed: boolean;
+  /** Whole-currency-unit balance to seed on creation. Create-time only — never returned by the API. */
+  initialBalance?: number;
 };
 
 // ─── Payee ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- "Add Account" now opens a form drawer (Name, optional Initial Balance, Budget Type) instead of inserting a blank row directly.
- Initial Balance is staged with the new account and sent to Actual's `/accounts` API on save (converted to cents).
- The bottom "Add Rows" quick-create flow is retained, with a formatted, editable Balance column for newly staged accounts.
- New "Refresh balances" toolbar action re-fetches account balances on demand.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `npx jest`
- [x] Manual: create account via "Add Account" drawer with an initial balance, save, verify balance in Actual
- [x] Manual: create account via bottom Add Rows, enter formatted balance, save, verify
- [x] Manual: click "Refresh" and verify balances update