### PR TITLE
feat(payees): merge impact preview — transaction & rule counts

### DIFF
--- a/src/features/payees/components/PayeesMergeDialog.tsx
+++ b/src/features/payees/components/PayeesMergeDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,6 +11,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { useStagedStore } from "@/store/staged";
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
 
 export type PayeeMergeCandidate = { id: string; name: string };
 export type PayeeMergeState = {
@@ -27,6 +31,24 @@ export function PayeesMergeDialog({
   mergeDialog,
   onMergeDialogChange,
 }: Props) {
+  const stagedRules = useStagedStore((s) => s.rules);
+
+  const payeeRuleCount = useMemo(
+    () => buildRuleReferenceMap(stagedRules, ["payee", "imported_payee"]),
+    [stagedRules]
+  );
+
+  const candidateIds = useMemo(
+    () => mergeDialog?.candidates.map((c) => c.id) ?? [],
+    [mergeDialog]
+  );
+
+  const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
+    "payee",
+    candidateIds,
+    { enabled: mergeDialog !== null }
+  );
+
   return (
     <Dialog
       open={mergeDialog !== null}
@@ -48,6 +70,9 @@ export function PayeesMergeDialog({
           <div className="flex flex-col gap-1 py-1">
             {mergeDialog.candidates.map((candidate, index) => {
               const isTarget = candidate.id === mergeDialog.targetId;
+              const txCount = txCounts?.get(candidate.id) ?? 0;
+              const ruleCount = payeeRuleCount.get(candidate.id) ?? 0;
+
               return (
                 <label
                   key={candidate.id}
@@ -66,14 +91,21 @@ export function PayeesMergeDialog({
                     onChange={() => onMergeDialogChange({ ...mergeDialog, targetId: candidate.id })}
                     className="accent-primary"
                   />
-                  <span className="flex-1 truncate">
-                    {candidate.name || <em className="text-muted-foreground">empty name</em>}
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">
+                      {candidate.name || <em className="text-muted-foreground">empty name</em>}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {txLoading
+                        ? "loading…"
+                        : `${txCount} transaction${txCount !== 1 ? "s" : ""} · ${ruleCount} rule${ruleCount !== 1 ? "s" : ""}`}
+                    </span>
                   </span>
                   {index === 0 && !isTarget && (
-                    <span className="text-[10px] text-muted-foreground">first selected</span>
+                    <span className="shrink-0 text-[10px] text-muted-foreground">first selected</span>
                   )}
                   {isTarget && (
-                    <span className="text-[10px] font-medium text-primary">keep</span>
+                    <span className="shrink-0 text-[10px] font-medium text-primary">keep</span>
                   )}
                 </label>
               );


### PR DESCRIPTION
## Summary
- Merge dialog now shows transaction count and rule reference count per
  candidate payee, so the user can make an informed keep/discard choice
- Transaction counts are fetched lazily (only when the dialog opens) via
  the existing `useTransactionCountsForIds` hook with 30s cache
- Rule counts are derived synchronously from staged rules via
  `buildRuleReferenceMap` — no extra fetch needed
- Counts display as "N transactions · M rules" under each candidate name;
  shows "loading…" while the query is in-flight

## Test plan
- [ ] Select 2+ regular payees, open merge dialog — counts appear for each
- [ ] "loading…" shows briefly then resolves to real numbers
- [ ] Changing the "keep" selection works correctly
- [ ] Confirming the merge still behaves as before (no regression)