### PR TITLE
fix(budget): carryover toggle now applies to all selected categories

### DIFF
--- a/src/features/budget-management/components/BudgetCarryoverProgressDialog.test.tsx
+++ b/src/features/budget-management/components/BudgetCarryoverProgressDialog.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { BudgetCarryoverProgressDialog } from "./BudgetCarryoverProgressDialog";
+import { useCarryoverToggle } from "../hooks/useCarryoverToggle";
+import type { CarryoverToggleInput } from "../hooks/useCarryoverToggle";
+
+jest.mock("../hooks/useCarryoverToggle", () => ({
+  useCarryoverToggle: jest.fn(),
+}));
+
+const mockUseCarryoverToggle = useCarryoverToggle as jest.MockedFunction<typeof useCarryoverToggle>;
+
+describe("BudgetCarryoverProgressDialog", () => {
+  afterEach(() => {
+    mockUseCarryoverToggle.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  it("surfaces rejected toggle attempts through the failure UI without retrying on rerender", async () => {
+    const error = new Error("No active connection");
+    const run = jest.fn().mockRejectedValue(error);
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockUseCarryoverToggle.mockReturnValue({
+      run,
+      isPending: false,
+      progress: { completed: 0, total: 0 },
+    });
+
+    const request: CarryoverToggleInput = {
+      categoryIds: ["cat-1"],
+      months: ["2026-01", "2026-02"],
+      newValue: true,
+    };
+
+    const { rerender } = render(
+      <BudgetCarryoverProgressDialog request={request} onClose={jest.fn()} />
+    );
+
+    expect(await screen.findByText("Rollover update failed")).toBeInTheDocument();
+    expect(screen.getByText("2 months could not be updated.")).toBeInTheDocument();
+    expect(screen.getAllByText("No active connection")).toHaveLength(2);
+    expect(consoleError).toHaveBeenCalledWith("Carryover toggle failed", error);
+
+    rerender(<BudgetCarryoverProgressDialog request={request} onClose={jest.fn()} />);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls run with all category-month pairs when multi-category request is given", async () => {
+    const run = jest.fn().mockResolvedValue([
+      { categoryId: "cat-1", month: "2026-01", status: "success" },
+      { categoryId: "cat-2", month: "2026-01", status: "success" },
+    ]);
+
+    mockUseCarryoverToggle.mockReturnValue({
+      run,
+      isPending: false,
+      progress: { completed: 0, total: 0 },
+    });
+
+    const request: CarryoverToggleInput = {
+      categoryIds: ["cat-1", "cat-2"],
+      months: ["2026-01"],
+      newValue: true,
+    };
+
+    render(
+      <BudgetCarryoverProgressDialog
+        request={request}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Rollover enabled")).toBeInTheDocument();
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith(request);
+    expect(screen.getByText(/2 category-months/)).toBeInTheDocument();
+  });
+
+  it("shows multi-category failure list with categoryId and month", async () => {
+    const error = new Error("PATCH failed");
+    const run = jest.fn().mockRejectedValue(error);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockUseCarryoverToggle.mockReturnValue({
+      run,
+      isPending: false,
+      progress: { completed: 0, total: 0 },
+    });
+
+    const request: CarryoverToggleInput = {
+      categoryIds: ["cat-1", "cat-2"],
+      months: ["2026-01"],
+      newValue: false,
+    };
+
+    render(
+      <BudgetCarryoverProgressDialog request={request} onClose={jest.fn()} />
+    );
+
+    expect(await screen.findByText("Rollover update failed")).toBeInTheDocument();
+    expect(screen.getByText("cat-1: 2026-01")).toBeInTheDocument();
+    expect(screen.getByText("cat-2: 2026-01")).toBeInTheDocument();
+  });
+});

--- a/src/features/budget-management/components/BudgetCarryoverProgressDialog.tsx
+++ b/src/features/budget-management/components/BudgetCarryoverProgressDialog.tsx
@@ -28,11 +28,14 @@ function buildRejectedResults(
   error: unknown
 ): CarryoverToggleResult[] {
   const message = getErrorMessage(error);
-  return request.months.map((m) => ({
-    month: m,
-    status: "error" as const,
-    message,
-  }));
+  return request.categoryIds.flatMap((categoryId) =>
+    request.months.map((m) => ({
+      categoryId,
+      month: m,
+      status: "error" as const,
+      message,
+    }))
+  );
 }
 
 /**
@@ -110,6 +113,11 @@ export function BudgetCarryoverProgressDialog({
   const verbing = request.newValue ? "Enabling" : "Disabling";
   const verbed = request.newValue ? "enabled" : "disabled";
   const verbedTitle = request.newValue ? "Rollover enabled" : "Rollover disabled";
+  const isMultiCategory = request.categoryIds.length > 1;
+  const scopeLabel = isMultiCategory
+    ? `${request.categoryIds.length} categories`
+    : (categoryLabel ?? undefined);
+  const unitLabel = isMultiCategory ? "category-month" : "month";
 
   return (
     <div
@@ -125,12 +133,12 @@ export function BudgetCarryoverProgressDialog({
               <Loader2 className="h-4 w-4 animate-spin text-primary" />
               <h2 className="text-base font-semibold text-foreground">
                 {verbing} rollover
-                {categoryLabel ? ` for ${categoryLabel}` : ""}
+                {scopeLabel ? ` for ${scopeLabel}` : ""}
               </h2>
             </div>
             <p className="text-sm text-muted-foreground mb-3">
               {progress.total > 0
-                ? `${progress.completed} of ${progress.total} months updated…`
+                ? `${progress.completed} of ${progress.total} ${unitLabel}${progress.total !== 1 ? "s" : ""} updated…`
                 : "Preparing…"}
             </p>
             {progress.total > 0 && (
@@ -153,9 +161,9 @@ export function BudgetCarryoverProgressDialog({
               <h2 className="text-base font-semibold text-foreground">{verbedTitle}</h2>
             </div>
             <p className="text-sm text-muted-foreground mb-4">
-              Rollover {verbed} on {succeededResults.length} month
-              {succeededResults.length !== 1 ? "s" : ""}
-              {categoryLabel ? ` for ${categoryLabel}` : ""}.
+              Rollover {verbed} on {succeededResults.length}{" "}
+              {unitLabel}{succeededResults.length !== 1 ? "s" : ""}
+              {scopeLabel && !isMultiCategory ? ` for ${scopeLabel}` : ""}.
             </p>
             <div className="flex justify-end">
               <button
@@ -179,13 +187,15 @@ export function BudgetCarryoverProgressDialog({
             </div>
             <p className="text-sm text-muted-foreground mb-3">
               {dialogState === "partial-failure"
-                ? `${succeededResults.length} month${succeededResults.length !== 1 ? "s" : ""} updated, ${failedResults.length} failed.`
-                : `${failedResults.length} month${failedResults.length !== 1 ? "s" : ""} could not be updated.`}
+                ? `${succeededResults.length} ${unitLabel}${succeededResults.length !== 1 ? "s" : ""} updated, ${failedResults.length} failed.`
+                : `${failedResults.length} ${unitLabel}${failedResults.length !== 1 ? "s" : ""} could not be updated.`}
             </p>
             <div className="mb-4 max-h-44 overflow-y-auto rounded border border-border divide-y divide-border">
-              {failedResults.map((r) => (
-                <div key={r.month} className="px-3 py-2 text-xs">
-                  <span className="font-mono text-foreground">{r.month}</span>
+              {failedResults.map((r, i) => (
+                <div key={i} className="px-3 py-2 text-xs">
+                  <span className="font-mono text-foreground">
+                    {isMultiCategory ? `${r.categoryId}: ${r.month}` : r.month}
+                  </span>
                   {r.message && (
                     <p className="text-destructive mt-0.5">{r.message}</p>
                   )}

--- a/src/features/budget-management/components/BudgetWorkspace.tsx
+++ b/src/features/budget-management/components/BudgetWorkspace.tsx
@@ -587,7 +587,7 @@ function BudgetWorkspaceInner({
 
     setCarryoverRequest({
       input: {
-        categoryId,
+        categoryIds: [categoryId],
         months: monthsToUpdate,
         newValue: !carryover,
       },
@@ -743,11 +743,8 @@ function BudgetWorkspaceInner({
     return true;
   }, [selection, handleContextMenuBulkAction]);
 
-  // Alt+C: toggle carryover for the anchor's category across the selected
-  // month range. The carryover dialog API is single-category, so a
-  // multi-category selection is downgraded to the anchor's category — the
-  // user can repeat Alt+C with each category selected. Right-click still
-  // exposes the per-cell forward-propagation flow.
+  // Alt+C: toggle carryover for all selected categories across the selected
+  // month range. newValue is derived from the anchor cell's current carryover state.
   const toggleCarryoverForSelection = useCallback((): boolean => {
     if (!selection || !connection) return false;
     const anchorCatId = selection.anchorCategoryId;
@@ -764,16 +761,23 @@ function BudgetWorkspaceInner({
     const anchorCat = rawMonthsMap.get(selection.anchorMonth)?.categoriesById[anchorCatId];
     if (!anchorCat) return false;
 
+    const anchorCatIdx = categories.findIndex((c) => c.id === selection.anchorCategoryId);
+    const focusCatIdx = categories.findIndex((c) => c.id === selection.focusCategoryId);
+    if (anchorCatIdx === -1 || focusCatIdx === -1) return false;
+    const minCatIdx = Math.min(anchorCatIdx, focusCatIdx);
+    const maxCatIdx = Math.max(anchorCatIdx, focusCatIdx);
+    const categoryIds = categories.slice(minCatIdx, maxCatIdx + 1).map((c) => c.id);
+
     setCarryoverRequest({
       input: {
-        categoryId: anchorCatId,
+        categoryIds,
         months: monthsToUpdate,
         newValue: !anchorCat.carryover,
       },
-      categoryLabel: anchorCat.name,
+      categoryLabel: categoryIds.length === 1 ? anchorCat.name : undefined,
     });
     return true;
-  }, [selection, connection, activeMonths, readOnlyMonths, rawMonthsMap]);
+  }, [selection, connection, activeMonths, readOnlyMonths, rawMonthsMap, categories]);
 
   const handleKeyDown = useWorkspaceKeymap({
     undo,

--- a/src/features/budget-management/hooks/useCarryoverToggle.ts
+++ b/src/features/budget-management/hooks/useCarryoverToggle.ts
@@ -7,7 +7,7 @@ import { apiRequest } from "@/lib/api/client";
 import { addMonths } from "@/lib/budget/monthMath";
 
 export type CarryoverToggleInput = {
-  categoryId: string;
+  categoryIds: string[];
   /** Months to update, in chronological order. */
   months: string[];
   /** The carryover value to set on every month. */
@@ -15,6 +15,7 @@ export type CarryoverToggleInput = {
 };
 
 export type CarryoverToggleResult = {
+  categoryId: string;
   month: string;
   status: "success" | "error";
   message?: string;
@@ -52,38 +53,42 @@ export function useCarryoverToggle(): UseCarryoverToggleReturn {
   const run = useCallback(
     async (input: CarryoverToggleInput): Promise<CarryoverToggleResult[]> => {
       if (!connection) throw new Error("No active connection");
-      if (input.months.length === 0) return [];
+      if (input.months.length === 0 || input.categoryIds.length === 0) return [];
+
+      const pairs = input.categoryIds.flatMap((catId) =>
+        input.months.map((m) => ({ catId, m }))
+      );
 
       setIsPending(true);
-      setProgress({ completed: 0, total: input.months.length });
+      setProgress({ completed: 0, total: pairs.length });
 
       const results: CarryoverToggleResult[] = [];
-      const successMonths: string[] = [];
+      const successMonths = new Set<string>();
 
-      for (let i = 0; i < input.months.length; i++) {
-        const m = input.months[i]!;
+      for (let i = 0; i < pairs.length; i++) {
+        const { catId, m } = pairs[i]!;
         try {
           await apiRequest(
             connection,
-            `/months/${m}/categories/${input.categoryId}`,
+            `/months/${m}/categories/${catId}`,
             {
               method: "PATCH",
               body: { category: { carryover: input.newValue } },
             }
           );
-          successMonths.push(m);
-          results.push({ month: m, status: "success" });
+          successMonths.add(m);
+          results.push({ categoryId: catId, month: m, status: "success" });
         } catch (err) {
           const message =
             err instanceof Error ? err.message : "Carryover update failed";
-          results.push({ month: m, status: "error", message });
+          results.push({ categoryId: catId, month: m, status: "error", message });
         }
-        setProgress({ completed: i + 1, total: input.months.length });
+        setProgress({ completed: i + 1, total: pairs.length });
       }
 
-      if (successMonths.length > 0) {
+      if (successMonths.size > 0) {
         await Promise.all(
-          successMonths.map((m) =>
+          [...successMonths].map((m) =>
             queryClient.invalidateQueries({
               queryKey: ["budget-month-data", connection.id, m],
             })


### PR DESCRIPTION
## Summary
- Alt+C with a multi-category selection was silently applying the
  carryover toggle to the anchor category only — the rest were ignored
- `CarryoverToggleInput` now takes `categoryIds: string[]`; the hook
  iterates every `(categoryId, month)` pair sequentially
- `toggleCarryoverForSelection` computes the full category range from
  the anchor↔focus selection bounds (same logic used by copy/paste/fill)
- Right-click "Toggle carryover" is unchanged — wraps single `categoryId`
  in an array, no behavioral difference
- Progress dialog shows "category-months" as the unit when multiple
  categories are in scope; failure list includes `categoryId: month`
  for attribution

## Test plan
- [ ] Select a single category cell, press Alt+C — carryover toggles for
      that category across the active months (existing behavior preserved)
- [ ] Select a range spanning 2+ categories, press Alt+C — carryover
      toggles for all selected categories
- [ ] Progress dialog shows correct "N category-months" count for
      multi-category selections
- [ ] Right-click → Toggle carryover still works as before
- [ ] All 872 tests pass