### PR TITLE
fix(schedules): add status badges, status filter, and fix import/export icon swap

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -16,6 +16,7 @@ import { GlobalSearchModal } from "@/features/global-search/components/GlobalSea
 import { QuickCreateDialog } from "@/features/quick-create/components/QuickCreateDialog";
 import { useConnectionHealth, ConnectionHealthContext } from "@/hooks/useConnectionHealth";
 import { useVersionCheck, VersionCheckContext } from "@/hooks/useVersionCheck";
+import { useBudgetPreferences } from "@/hooks/useBudgetPreferences";
 
 /**
  * The four-panel app shell:
@@ -41,6 +42,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // existing eager-preload behavior.
   usePreloadEntities(pathname !== "/overview");
   useKeyboardShortcuts();
+  useBudgetPreferences();
 
   const hydrated = useIsHydrated();
   const health = useConnectionHealth();

--- a/src/features/schedules/components/FilterBar.tsx
+++ b/src/features/schedules/components/FilterBar.tsx
@@ -4,8 +4,16 @@ import { Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PillGroup } from "@/components/ui/pill-group";
 
+export type StatusFilter = "active" | "all" | "missed" | "completed";
 export type AutoAddFilter = "all" | "auto" | "manual";
 export type FrequencyFilter = "all" | "once" | "daily" | "weekly" | "monthly" | "yearly";
+
+const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: "active",    label: "Active" },
+  { value: "all",       label: "All" },
+  { value: "missed",    label: "Missed" },
+  { value: "completed", label: "Completed" },
+];
 
 const AUTO_ADD_OPTIONS: { value: AutoAddFilter; label: string }[] = [
   { value: "all",    label: "All" },
@@ -27,6 +35,8 @@ export type EntityOption = { value: string; label: string };
 type Props = {
   search: string;
   onSearchChange: (v: string) => void;
+  statusFilter: StatusFilter;
+  onStatusFilterChange: (v: StatusFilter) => void;
   autoAddFilter: AutoAddFilter;
   onAutoAddFilterChange: (v: AutoAddFilter) => void;
   frequencyFilter: FrequencyFilter;
@@ -49,6 +59,7 @@ const selectCls =
 
 export function FilterBar({
   search, onSearchChange,
+  statusFilter, onStatusFilterChange,
   autoAddFilter, onAutoAddFilterChange,
   frequencyFilter, onFrequencyFilterChange,
   payeeFilter, onPayeeFilterChange, payeeOptions,
@@ -69,7 +80,7 @@ export function FilterBar({
   }
 
   const hasFilters =
-    search || autoAddFilter !== "all" ||
+    search || statusFilter !== "active" || autoAddFilter !== "all" ||
     frequencyFilter !== "all" || payeeFilter !== "" || accountFilter !== "";
 
   return (
@@ -91,6 +102,7 @@ export function FilterBar({
         )}
       </div>
 
+      <PillGroup options={STATUS_OPTIONS}    value={statusFilter}    onChange={onStatusFilterChange} />
       <PillGroup options={AUTO_ADD_OPTIONS}  value={autoAddFilter}   onChange={onAutoAddFilterChange} />
       <PillGroup options={FREQUENCY_OPTIONS} value={frequencyFilter} onChange={onFrequencyFilterChange} />
 
@@ -128,6 +140,7 @@ export function FilterBar({
         <button
           onClick={() => {
             onSearchChange("");
+            onStatusFilterChange("active");
             onAutoAddFilterChange("all");
             onFrequencyFilterChange("all");
             onPayeeFilterChange("");

--- a/src/features/schedules/components/SchedulesTable.tsx
+++ b/src/features/schedules/components/SchedulesTable.tsx
@@ -159,7 +159,7 @@ export function SchedulesTable({
       const status = statusMap.get(s.entity.id);
       if (statusFilter === "active"    && s.entity.completed) return false;
       if (statusFilter === "completed" && !s.entity.completed) return false;
-      if (statusFilter === "missed"    && status !== "missed") return false;
+      if (statusFilter === "missed" && !txsLoading && status !== "missed") return false;
       if (autoAddFilter === "auto"   && !s.entity.postsTransaction) return false;
       if (autoAddFilter === "manual" &&  s.entity.postsTransaction) return false;
       if (frequencyFilter !== "all") {
@@ -177,7 +177,7 @@ export function SchedulesTable({
       }
       return true;
     });
-  }, [staged, search, statusFilter, statusMap, autoAddFilter, frequencyFilter, payeeFilter, accountFilter, stagedPayees, stagedAccounts]);
+  }, [staged, search, statusFilter, txsLoading, statusMap, autoAddFilter, frequencyFilter, payeeFilter, accountFilter, stagedPayees, stagedAccounts]);
 
   const totalCount   = Object.values(staged).filter((s) => !s.isDeleted).length;
   const selectableIds = useMemo(() => new Set(rows.map((s) => s.entity.id)), [rows]);

--- a/src/features/schedules/components/SchedulesTable.tsx
+++ b/src/features/schedules/components/SchedulesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { usePersistedFilters } from "@/hooks/usePersistedFilters";
 import { useHighlight } from "@/hooks/useHighlight";
 import { useTableSelection } from "@/hooks/useTableSelection";
@@ -8,11 +9,15 @@ import { Pencil, Trash2, RotateCcw, Copy, Braces, AlertTriangle, Info, RefreshCw
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useStagedStore } from "@/store/staged";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { generateId } from "@/lib/uuid";
 import { recurSummary, frequencyLabel } from "../lib/recurSummary";
 import { FilterBar } from "./FilterBar";
 import type { ScheduleDeleteIntent } from "./SchedulesTableOverlays";
-import type { AutoAddFilter, FrequencyFilter, EntityOption } from "./FilterBar";
+import type { AutoAddFilter, StatusFilter, FrequencyFilter, EntityOption } from "./FilterBar";
+import { useScheduleTransactions } from "../hooks/useScheduleTransactions";
+import { computeScheduleStatus, STATUS_BADGE } from "../lib/scheduleStatus";
+import { useBudgetPreferences } from "@/hooks/useBudgetPreferences";
 import type { StagedEntity } from "@/types/staged";
 import type { Schedule, ScheduleAmountRange } from "@/types/entities";
 
@@ -77,19 +82,46 @@ export function SchedulesTable({
 
   const highlightedId = useHighlight();
 
+  const queryClient = useQueryClient();
+  const connection  = useConnectionStore(selectActiveInstance);
+
+  // Force-refresh preferences whenever the Schedules page opens so the
+  // upcomingScheduledTransactionLength value is always current, not cached.
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ["budgetPreferences", connection?.id] });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { data: scheduleTxMap, isLoading: txsLoading } = useScheduleTransactions();
+  const { upcomingScheduledTransactionLength: upcomingDays } = useBudgetPreferences();
+
   const [filters, setFilters, clearFilters] = usePersistedFilters("filters:schedules", {
     search: "",
+    statusFilter: "active" as StatusFilter,
     autoAddFilter: "all" as AutoAddFilter,
     frequencyFilter: "all" as FrequencyFilter,
     payeeFilter: "",
     accountFilter: "",
   });
-  const { search, autoAddFilter, frequencyFilter, payeeFilter, accountFilter } = filters;
-  const setSearch          = (v: string)          => setFilters((f) => ({ ...f, search: v }));
+  const { search, statusFilter, autoAddFilter, frequencyFilter, payeeFilter, accountFilter } = filters;
+  const setSearch          = (v: string)       => setFilters((f) => ({ ...f, search: v }));
+  const setStatusFilter    = (v: StatusFilter) => setFilters((f) => ({ ...f, statusFilter: v }));
   const setAutoAddFilter   = (v: AutoAddFilter)   => setFilters((f) => ({ ...f, autoAddFilter: v }));
   const setFrequencyFilter = (v: FrequencyFilter) => setFilters((f) => ({ ...f, frequencyFilter: v }));
   const setPayeeFilter     = (v: string)          => setFilters((f) => ({ ...f, payeeFilter: v }));
   const setAccountFilter   = (v: string)          => setFilters((f) => ({ ...f, accountFilter: v }));
+
+  // Precompute status for every non-deleted schedule once tx data arrives.
+  // While txsLoading the map is empty — rows show no badge until data lands.
+  const statusMap = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof computeScheduleStatus>>();
+    if (!scheduleTxMap) return map;
+    for (const s of Object.values(staged)) {
+      if (s.isDeleted) continue;
+      const txs = scheduleTxMap.get(s.entity.id) ?? [];
+      map.set(s.entity.id, computeScheduleStatus(s.entity, txs, upcomingDays));
+    }
+    return map;
+  }, [staged, scheduleTxMap, upcomingDays]);
 
   const { selectedIds, toggleSelect, toggleSelectAll: _toggleSelectAll, clearSelection } =
     useTableSelection();
@@ -124,6 +156,10 @@ export function SchedulesTable({
     const q = search.trim().toLowerCase();
     return Object.values(staged).filter((s) => {
       if (s.isDeleted) return false;
+      const status = statusMap.get(s.entity.id);
+      if (statusFilter === "active"    && s.entity.completed) return false;
+      if (statusFilter === "completed" && !s.entity.completed) return false;
+      if (statusFilter === "missed"    && status !== "missed") return false;
       if (autoAddFilter === "auto"   && !s.entity.postsTransaction) return false;
       if (autoAddFilter === "manual" &&  s.entity.postsTransaction) return false;
       if (frequencyFilter !== "all") {
@@ -141,7 +177,7 @@ export function SchedulesTable({
       }
       return true;
     });
-  }, [staged, search, autoAddFilter, frequencyFilter, payeeFilter, accountFilter, stagedPayees, stagedAccounts]);
+  }, [staged, search, statusFilter, statusMap, autoAddFilter, frequencyFilter, payeeFilter, accountFilter, stagedPayees, stagedAccounts]);
 
   const totalCount   = Object.values(staged).filter((s) => !s.isDeleted).length;
   const selectableIds = useMemo(() => new Set(rows.map((s) => s.entity.id)), [rows]);
@@ -200,6 +236,7 @@ export function SchedulesTable({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <FilterBar
         search={search}              onSearchChange={setSearch}
+        statusFilter={statusFilter}  onStatusFilterChange={setStatusFilter}
         autoAddFilter={autoAddFilter} onAutoAddFilterChange={setAutoAddFilter}
         frequencyFilter={frequencyFilter} onFrequencyFilterChange={setFrequencyFilter}
         payeeFilter={payeeFilter}    onPayeeFilterChange={setPayeeFilter}  payeeOptions={payeeOptions}
@@ -214,7 +251,7 @@ export function SchedulesTable({
         {rows.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 py-20 text-sm text-muted-foreground">
             <span>No schedules found.</span>
-            {(search || autoAddFilter !== "all" || frequencyFilter !== "all" || payeeFilter || accountFilter) && (
+            {(search || statusFilter !== "active" || autoAddFilter !== "all" || frequencyFilter !== "all" || payeeFilter || accountFilter) && (
               <button
                 className="text-xs underline hover:text-foreground"
                 onClick={clearFilters}
@@ -289,6 +326,16 @@ export function SchedulesTable({
                         <span className={cn("font-medium", !entity.name && "italic text-muted-foreground")}>
                           {entity.name || "Unnamed"}
                         </span>
+                        {(() => {
+                          const status = statusMap.get(entity.id);
+                          if (!status || txsLoading) return null;
+                          const badge = STATUS_BADGE[status];
+                          return (
+                            <span className={cn("rounded px-1 py-0.5 text-[10px] font-medium", badge.className)}>
+                              {badge.label}
+                            </span>
+                          );
+                        })()}
                       </div>
                       {saveError && <p className="mt-0.5 text-[11px] text-destructive">{saveError}</p>}
                     </td>

--- a/src/features/schedules/components/SchedulesView.tsx
+++ b/src/features/schedules/components/SchedulesView.tsx
@@ -114,11 +114,11 @@ export function SchedulesView() {
             onChange={handleImportCsv}
           />
           <Button variant="outline" size="sm" onClick={() => importInputRef.current?.click()} title="Import CSV">
-            <Upload />
+            <Download />
             Import
           </Button>
           <Button variant="outline" size="sm" onClick={handleExportCsv} title="Export CSV">
-            <Download />
+            <Upload />
             Export
           </Button>
           <Button size="sm" onClick={openNew}>

--- a/src/features/schedules/hooks/useScheduleTransactions.ts
+++ b/src/features/schedules/hooks/useScheduleTransactions.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { fetchScheduleTransactions } from "../lib/scheduleTransactionsQuery";
+import type { ScheduleTxRow } from "../lib/scheduleTransactionsQuery";
+
+/**
+ * Fetches all transactions linked to any schedule in the past 2 years via a
+ * single ActualQL query. Returns Map<scheduleId, ScheduleTxRow[]>.
+ *
+ * Fires on page mount so status badges (Paid / Missed / Due / Upcoming) are
+ * available immediately when the Schedules page loads.
+ *
+ * staleTime: 60s — avoids redundant refetches on quick navigation away/back.
+ * gcTime: 120s — keeps data briefly after unmount.
+ */
+export function useScheduleTransactions(): {
+  data: Map<string, ScheduleTxRow[]> | undefined;
+  isLoading: boolean;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["scheduleTransactions", connection?.id],
+    queryFn: () => {
+      if (!connection) throw new Error("No active connection");
+      return fetchScheduleTransactions(connection);
+    },
+    enabled: !!connection,
+    staleTime: 60_000,
+    gcTime: 120_000,
+  });
+
+  return { data, isLoading };
+}

--- a/src/features/schedules/lib/scheduleStatus.ts
+++ b/src/features/schedules/lib/scheduleStatus.ts
@@ -1,0 +1,72 @@
+import type { Schedule } from "@/types/entities";
+import type { ScheduleTxRow } from "./scheduleTransactionsQuery";
+
+export type ScheduleStatus = "paid" | "missed" | "due" | "upcoming" | "scheduled" | "completed";
+
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function addDaysStr(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y!, m! - 1, d!);
+  date.setDate(date.getDate() + days);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Derives the display status for a schedule, mirroring Actual Budget's UI logic.
+ *
+ * - "completed" — user explicitly completed the schedule (manual, one-time)
+ * - "paid"      — a linked transaction falls within 14 days before nextDate
+ *                 up to today (covers payments made slightly early)
+ * - "missed"    — nextDate is in the past with no covering transaction
+ * - "due"       — nextDate is today with no covering transaction
+ * - "upcoming"  — nextDate is within the upcoming window (driven by the
+ *                 `upcomingScheduledTransactionLength` budget preference,
+ *                 default 14 days) and no covering transaction
+ * - "scheduled" — nextDate is beyond the upcoming window
+ *
+ * Returns null when status cannot be determined (no nextDate, no transactions).
+ */
+export function computeScheduleStatus(
+  schedule: Schedule,
+  transactions: ScheduleTxRow[],
+  upcomingDays = 14
+): ScheduleStatus | null {
+  if (schedule.completed) return "completed";
+
+  const today    = todayStr();
+  const nextDate = schedule.nextDate;
+
+  if (!nextDate) {
+    return transactions.length > 0 ? "paid" : null;
+  }
+
+  // A transaction "covers" the current occurrence when its date falls within
+  // 14 days before nextDate up to today. The 14-day cushion allows for
+  // transactions posted slightly before the scheduled date.
+  const coverWindow = addDaysStr(nextDate, -14);
+  const hasCoveringTx = transactions.some(
+    (tx) => tx.date >= coverWindow && tx.date <= today
+  );
+
+  if (hasCoveringTx)   return "paid";
+  if (nextDate < today) return "missed";
+  if (nextDate === today) return "due";
+
+  // Future date — "upcoming" within the budget's configured window, "scheduled" beyond it
+  const upcomingCutoff = addDaysStr(today, upcomingDays);
+  if (nextDate <= upcomingCutoff) return "upcoming";
+  return "scheduled";
+}
+
+export const STATUS_BADGE: Record<ScheduleStatus, { label: string; className: string }> = {
+  paid:      { label: "Paid",      className: "bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400" },
+  missed:    { label: "Missed",    className: "bg-destructive/10 text-destructive dark:bg-destructive/20" },
+  due:       { label: "Due",       className: "bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400" },
+  upcoming:  { label: "Upcoming",  className: "bg-amber-50 text-amber-600 dark:bg-amber-950/20 dark:text-amber-500" },
+  scheduled: { label: "Scheduled", className: "bg-blue-50 text-blue-700 dark:bg-blue-950/30 dark:text-blue-400" },
+  completed: { label: "Completed", className: "bg-muted text-muted-foreground" },
+};

--- a/src/features/schedules/lib/scheduleTransactionsQuery.ts
+++ b/src/features/schedules/lib/scheduleTransactionsQuery.ts
@@ -1,0 +1,68 @@
+import { runQuery } from "@/lib/api/query";
+import type { ConnectionInstance } from "@/store/connection";
+
+export type ScheduleTxRow = {
+  id: string;
+  date: string;
+  scheduleId: string;
+};
+
+type RawRow = { id?: unknown; date?: unknown; schedule?: unknown };
+type QueryResponse = { data: RawRow[] };
+
+function dateOffset(daysFromToday: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromToday);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function buildScheduleTransactionsQuery(from: string, to: string) {
+  return {
+    ActualQLquery: {
+      table: "transactions",
+      options: { splits: "inline" },
+      filter: {
+        schedule: { $gt: "0" },
+        date: { $gte: from, $lte: to },
+      },
+      select: ["id", "date", "schedule"],
+    },
+  };
+}
+
+function parseRow(row: RawRow): ScheduleTxRow | null {
+  const id         = typeof row.id       === "string" && row.id       ? row.id       : null;
+  const date       = typeof row.date     === "string" && row.date     ? row.date     : null;
+  const scheduleId = typeof row.schedule === "string" && row.schedule ? row.schedule : null;
+  if (!id || !date || !scheduleId) return null;
+  return { id, date, scheduleId };
+}
+
+/**
+ * Fetches all transactions linked to any schedule in the past 2 years.
+ * Returns a Map<scheduleId, ScheduleTxRow[]>.
+ *
+ * 2-year window covers yearly schedules (a 1-year window would miss a yearly
+ * schedule whose last payment was 13 months ago).
+ */
+export async function fetchScheduleTransactions(
+  connection: ConnectionInstance
+): Promise<Map<string, ScheduleTxRow[]>> {
+  const today        = dateOffset(0);
+  const twoYearsAgo = dateOffset(-730);
+
+  const response = await runQuery<QueryResponse>(
+    connection,
+    buildScheduleTransactionsQuery(twoYearsAgo, today)
+  );
+
+  const map = new Map<string, ScheduleTxRow[]>();
+  for (const raw of response.data) {
+    const row = parseRow(raw);
+    if (!row) continue;
+    const bucket = map.get(row.scheduleId);
+    if (bucket) bucket.push(row);
+    else map.set(row.scheduleId, [row]);
+  }
+  return map;
+}

--- a/src/hooks/useBudgetPreferences.ts
+++ b/src/hooks/useBudgetPreferences.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { fetchBudgetPreferences } from "@/lib/api/preferences";
+import type { BudgetPreferences } from "@/lib/api/preferences";
+
+const REFETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Fetches budget-level preference key/value pairs from the `preferences` table
+ * via ActualQL. Fires once on first use (per active connection), then refreshes
+ * every 5 minutes so user-side setting changes are eventually reflected without
+ * a page reload.
+ *
+ * TanStack Query deduplicates the request — multiple components calling this
+ * hook share a single fetch and cache entry.
+ *
+ * Returns typed defaults when the query is still loading or the key is absent.
+ */
+export function useBudgetPreferences(): BudgetPreferences {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const { data } = useQuery({
+    queryKey: ["budgetPreferences", connection?.id],
+    queryFn: () => {
+      if (!connection) throw new Error("No active connection");
+      return fetchBudgetPreferences(connection);
+    },
+    enabled: !!connection,
+    staleTime: REFETCH_INTERVAL,
+    gcTime: REFETCH_INTERVAL * 2,
+    refetchInterval: REFETCH_INTERVAL,
+    refetchIntervalInBackground: false,
+  });
+
+  return data ?? { upcomingScheduledTransactionLength: 14 };
+}

--- a/src/lib/api/preferences.ts
+++ b/src/lib/api/preferences.ts
@@ -1,0 +1,40 @@
+import { runQuery } from "./query";
+import type { ConnectionInstance } from "@/store/connection";
+
+type RawRow = { id?: unknown; value?: unknown };
+type QueryResponse = { data: RawRow[] };
+
+export type BudgetPreferences = {
+  upcomingScheduledTransactionLength: number;
+};
+
+const DEFAULTS: BudgetPreferences = {
+  upcomingScheduledTransactionLength: 14,
+};
+
+export async function fetchBudgetPreferences(
+  connection: ConnectionInstance
+): Promise<BudgetPreferences> {
+  const response = await runQuery<QueryResponse>(connection, {
+    ActualQLquery: {
+      table: "preferences",
+      select: ["id", "value"],
+    },
+  });
+
+  const map = new Map<string, string>();
+  for (const row of response.data) {
+    if (typeof row.id === "string" && typeof row.value === "string") {
+      map.set(row.id, row.value);
+    }
+  }
+
+  const upcomingRaw = map.get("upcomingScheduledTransactionLength");
+  const upcoming = upcomingRaw !== undefined ? parseInt(upcomingRaw, 10) : NaN;
+
+  return {
+    upcomingScheduledTransactionLength: Number.isFinite(upcoming) && upcoming > 0
+      ? upcoming
+      : DEFAULTS.upcomingScheduledTransactionLength,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds real-time Paid/Missed/Due/Upcoming/Scheduled status badges to every
  schedule row, derived from ActualQL transaction data (2-year window) and the
  budget's `upcomingScheduledTransactionLength` preference
- Fetches budget preferences at connection time (AppShell) with 5-min auto-refresh;
  force-refreshes when the Schedules page opens
- Adds Active/All/Missed/Completed status filter pill to the Schedules FilterBar
- Fixes Import/Export icon swap on the Schedules page to match app-wide convention

## Test plan

- [ ] Verify status badges show correctly (Paid/Missed/Due/Upcoming/Scheduled)
- [ ] Verify "Upcoming" window matches Actual Budget UI (driven by preferences)
- [ ] Verify "Missed" filter shows only missed schedules
- [ ] Verify "Completed" filter shows only manually-completed schedules
- [ ] Verify Import/Export icons now match other entity pages
- [ ] Verify preferences refetch on Schedules page open

Covers F-025 (part a), F-022