### PR TITLE
feat(navigation): add missing overview cards and global bundle access

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw, Search, Package } from "lucide-react";
+import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw, Search } from "lucide-react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -41,8 +41,6 @@ import {
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useBudgetSavePipeline } from "./useBudgetSavePipeline";
 import { useBudgetSave } from "@/features/budget-management/hooks/useBudgetSave";
-import { BundleExportDialog } from "@/features/bundle/components/BundleExportDialog";
-import { BundleImportDialog } from "@/features/bundle/components/BundleImportDialog";
 import { BudgetSaveProgressDialog } from "@/features/budget-management/components/BudgetSaveProgressDialog";
 import { BudgetSaveReviewDialog } from "@/features/budget-management/components/BudgetSaveReviewDialog";
 import {
@@ -95,9 +93,6 @@ export function TopBar() {
   const [budgetSaveReviewHolds, setBudgetSaveReviewHolds] = useState<Record<string, StagedHold>>({});
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
   const [budgetSaveHolds, setBudgetSaveHolds] = useState<Record<string, StagedHold>>({});
-
-  const [bundleExportOpen, setBundleExportOpen] = useState(false);
-  const [bundleImportOpen, setBundleImportOpen] = useState(false);
 
   const openSearch = useGlobalSearchStore((s) => s.open);
   const searchShortcutLabel = "Ctrl+k";
@@ -394,25 +389,6 @@ export function TopBar() {
             <RefreshCw className={`h-3.5 w-3.5${isRefreshing ? " animate-spin" : ""}`} />
           </Button>
 
-          {activeInstance && (
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
-                title="Bundle Export / Import"
-              >
-                <Package className="h-3.5 w-3.5" />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setBundleExportOpen(true)}>
-                  Export bundle…
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setBundleImportOpen(true)}>
-                  Import bundle…
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-
           <Button
             variant="ghost"
             size="sm"
@@ -506,12 +482,6 @@ export function TopBar() {
         </DialogContent>
       </Dialog>
 
-      {bundleExportOpen && (
-        <BundleExportDialog open={bundleExportOpen} onOpenChange={setBundleExportOpen} />
-      )}
-      {bundleImportOpen && (
-        <BundleImportDialog open={bundleImportOpen} onOpenChange={setBundleImportOpen} />
-      )}
     </>
   );
 }

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw, Search } from "lucide-react";
+import { ChevronDown, Save, X, Undo2, Redo2, RefreshCw, Search, Package } from "lucide-react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -41,6 +41,8 @@ import {
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useBudgetSavePipeline } from "./useBudgetSavePipeline";
 import { useBudgetSave } from "@/features/budget-management/hooks/useBudgetSave";
+import { BundleExportDialog } from "@/features/bundle/components/BundleExportDialog";
+import { BundleImportDialog } from "@/features/bundle/components/BundleImportDialog";
 import { BudgetSaveProgressDialog } from "@/features/budget-management/components/BudgetSaveProgressDialog";
 import { BudgetSaveReviewDialog } from "@/features/budget-management/components/BudgetSaveReviewDialog";
 import {
@@ -93,6 +95,9 @@ export function TopBar() {
   const [budgetSaveReviewHolds, setBudgetSaveReviewHolds] = useState<Record<string, StagedHold>>({});
   const [budgetSaveEdits, setBudgetSaveEdits] = useState<Record<BudgetCellKey, StagedBudgetEdit> | null>(null);
   const [budgetSaveHolds, setBudgetSaveHolds] = useState<Record<string, StagedHold>>({});
+
+  const [bundleExportOpen, setBundleExportOpen] = useState(false);
+  const [bundleImportOpen, setBundleImportOpen] = useState(false);
 
   const openSearch = useGlobalSearchStore((s) => s.open);
   const searchShortcutLabel = "Ctrl+k";
@@ -389,6 +394,25 @@ export function TopBar() {
             <RefreshCw className={`h-3.5 w-3.5${isRefreshing ? " animate-spin" : ""}`} />
           </Button>
 
+          {activeInstance && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-accent-foreground"
+                title="Bundle Export / Import"
+              >
+                <Package className="h-3.5 w-3.5" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setBundleExportOpen(true)}>
+                  Export bundle…
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setBundleImportOpen(true)}>
+                  Import bundle…
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+
           <Button
             variant="ghost"
             size="sm"
@@ -481,6 +505,13 @@ export function TopBar() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {bundleExportOpen && (
+        <BundleExportDialog open={bundleExportOpen} onOpenChange={setBundleExportOpen} />
+      )}
+      {bundleImportOpen && (
+        <BundleImportDialog open={bundleImportOpen} onOpenChange={setBundleImportOpen} />
+      )}
     </>
   );
 }

--- a/src/features/overview/components/BudgetOverviewView.test.tsx
+++ b/src/features/overview/components/BudgetOverviewView.test.tsx
@@ -87,15 +87,13 @@ describe("BudgetOverviewView", () => {
     mockUseBudgetOverview.mockReset();
   });
 
-  it("shows the selected budget name immediately and a loading badge during budget switches", () => {
+  it("shows loading placeholders for all snapshot metrics while data is being fetched", () => {
     mockUseBudgetOverview.mockReturnValue(
       buildHookResult({ snapshot: null, isLoading: true })
     );
 
     render(<BudgetOverviewView />);
 
-    expect(screen.getByText("Household Budget")).toBeInTheDocument();
-    expect(screen.getByText("Loading budget")).toBeInTheDocument();
     expect(screen.getAllByLabelText("Loading snapshot metric")).toHaveLength(8);
   });
 

--- a/src/features/overview/components/BudgetOverviewView.tsx
+++ b/src/features/overview/components/BudgetOverviewView.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { selectActiveInstance, useConnectionStore } from "@/store/connection";
+import { useState } from "react";
+import { BundleExportDialog } from "@/features/bundle/components/BundleExportDialog";
+import { BundleImportDialog } from "@/features/bundle/components/BundleImportDialog";
 import { useBudgetOverview } from "../hooks/useBudgetOverview";
 import { useOverviewHeaderState } from "../hooks/useOverviewHeaderState";
 import { OverviewHeader } from "./OverviewHeader";
@@ -9,25 +11,25 @@ import { OverviewStatsSection } from "./OverviewStatsSection";
 
 export function BudgetOverviewView() {
   const { snapshot, isLoading, refresh } = useBudgetOverview();
-  const connection = useConnectionStore(selectActiveInstance);
   const headerState = useOverviewHeaderState({
     hasStats: !!snapshot,
     isLoading,
     refresh,
   });
+  const [exportOpen, setExportOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
   return (
     <div className="min-h-0 flex-1 overflow-auto">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 sm:py-5">
         <div className="space-y-3">
           <OverviewHeader
-            budgetLabel={connection?.label ?? ""}
-            statusLabel={headerState.statusLabel}
-            statusDotClass={headerState.statusDotClass}
             refreshButtonLabel={headerState.refreshButtonLabel}
             refreshStatusLabel={headerState.refreshStatusLabel}
             isRefreshing={headerState.isRefreshing}
             onRefresh={headerState.handleRefresh}
+            onExportBundle={() => setExportOpen(true)}
+            onImportBundle={() => setImportOpen(true)}
           />
 
           <OverviewStatsSection
@@ -42,6 +44,9 @@ export function BudgetOverviewView() {
 
         <OverviewNavigationSection />
       </div>
+
+      <BundleExportDialog open={exportOpen} onOpenChange={setExportOpen} />
+      <BundleImportDialog open={importOpen} onOpenChange={setImportOpen} />
     </div>
   );
 }

--- a/src/features/overview/components/BudgetOverviewView.tsx
+++ b/src/features/overview/components/BudgetOverviewView.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { useState } from "react";
 import { selectActiveInstance, useConnectionStore } from "@/store/connection";
-import { BundleExportDialog } from "@/features/bundle/components/BundleExportDialog";
-import { BundleImportDialog } from "@/features/bundle/components/BundleImportDialog";
 import { useBudgetOverview } from "../hooks/useBudgetOverview";
 import { useOverviewHeaderState } from "../hooks/useOverviewHeaderState";
 import { OverviewHeader } from "./OverviewHeader";
@@ -18,8 +15,6 @@ export function BudgetOverviewView() {
     isLoading,
     refresh,
   });
-  const [exportOpen, setExportOpen] = useState(false);
-  const [importOpen, setImportOpen] = useState(false);
 
   return (
     <div className="min-h-0 flex-1 overflow-auto">
@@ -33,8 +28,6 @@ export function BudgetOverviewView() {
             refreshStatusLabel={headerState.refreshStatusLabel}
             isRefreshing={headerState.isRefreshing}
             onRefresh={headerState.handleRefresh}
-            onExportBundle={() => setExportOpen(true)}
-            onImportBundle={() => setImportOpen(true)}
           />
 
           <OverviewStatsSection
@@ -49,9 +42,6 @@ export function BudgetOverviewView() {
 
         <OverviewNavigationSection />
       </div>
-
-      <BundleExportDialog open={exportOpen} onOpenChange={setExportOpen} />
-      <BundleImportDialog open={importOpen} onOpenChange={setImportOpen} />
     </div>
   );
 }

--- a/src/features/overview/components/OverviewHeader.tsx
+++ b/src/features/overview/components/OverviewHeader.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Download, RefreshCw, Upload } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 
 type OverviewHeaderProps = {
   budgetLabel: string;
@@ -10,8 +10,6 @@ type OverviewHeaderProps = {
   refreshStatusLabel: string | null;
   isRefreshing: boolean;
   onRefresh: () => void;
-  onExportBundle?: () => void;
-  onImportBundle?: () => void;
 };
 
 export function OverviewHeader({
@@ -22,11 +20,7 @@ export function OverviewHeader({
   refreshStatusLabel,
   isRefreshing,
   onRefresh,
-  onExportBundle,
-  onImportBundle,
 }: OverviewHeaderProps) {
-  const hasConnection = Boolean(budgetLabel);
-
   return (
     <header className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-1">
@@ -45,29 +39,6 @@ export function OverviewHeader({
       </div>
 
       <div className="flex flex-wrap items-center gap-2 self-start sm:ml-auto sm:self-auto">
-        {onExportBundle && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onExportBundle}
-            disabled={!hasConnection}
-          >
-            <Upload />
-            Export
-          </Button>
-        )}
-        {onImportBundle && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onImportBundle}
-            disabled={!hasConnection}
-          >
-            <Download />
-            Import
-          </Button>
-        )}
-        <div className="h-4 w-px bg-border/60" aria-hidden />
         <div className="min-h-4 text-xs text-muted-foreground" aria-live="polite">
           {refreshStatusLabel}
         </div>

--- a/src/features/overview/components/OverviewHeader.tsx
+++ b/src/features/overview/components/OverviewHeader.tsx
@@ -1,44 +1,43 @@
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { RefreshCw } from "lucide-react";
+import { Download, RefreshCw, Upload } from "lucide-react";
 
 type OverviewHeaderProps = {
-  budgetLabel: string;
-  statusLabel: string;
-  statusDotClass: string;
   refreshButtonLabel: string;
   refreshStatusLabel: string | null;
   isRefreshing: boolean;
   onRefresh: () => void;
+  onExportBundle?: () => void;
+  onImportBundle?: () => void;
 };
 
 export function OverviewHeader({
-  budgetLabel,
-  statusLabel,
-  statusDotClass,
   refreshButtonLabel,
   refreshStatusLabel,
   isRefreshing,
   onRefresh,
+  onExportBundle,
+  onImportBundle,
 }: OverviewHeaderProps) {
   return (
-    <header className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
-      <div className="space-y-1">
-        <h1 className="text-xl font-semibold tracking-tight">Budget Overview</h1>
-        <div className="flex flex-wrap items-center gap-2.5">
-          <Badge variant="outline" className="gap-1.5">
-            <span className={statusDotClass} />
-            {statusLabel}
-          </Badge>
-          {budgetLabel ? (
-            <span className="text-[15px] font-semibold tracking-tight text-foreground">
-              {budgetLabel}
-            </span>
-          ) : null}
-        </div>
-      </div>
+    <header className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between">
+      <h1 className="text-xl font-semibold tracking-tight">Budget Overview</h1>
 
       <div className="flex flex-wrap items-center gap-2 self-start sm:ml-auto sm:self-auto">
+        {onExportBundle && (
+          <Button variant="ghost" size="sm" onClick={onExportBundle}>
+            <Upload />
+            Export Bundle
+          </Button>
+        )}
+        {onImportBundle && (
+          <Button variant="ghost" size="sm" onClick={onImportBundle}>
+            <Download />
+            Import Bundle
+          </Button>
+        )}
+        {(onExportBundle || onImportBundle) && (
+          <div className="h-4 w-px bg-border/60" aria-hidden />
+        )}
         <div className="min-h-4 text-xs text-muted-foreground" aria-live="polite">
           {refreshStatusLabel}
         </div>

--- a/src/features/overview/hooks/useOverviewHeaderState.ts
+++ b/src/features/overview/hooks/useOverviewHeaderState.ts
@@ -86,19 +86,12 @@ export function useOverviewHeaderState({
     }
   }
 
-  const isHeaderLoading = isLoading || isRefreshing;
-
   return {
     isRefreshing,
-    isHeaderLoading,
     refreshButtonLabel: isRefreshing ? "Refreshing" : "Refresh",
     refreshStatusLabel: isRefreshing
       ? `Refreshing${ELLIPSIS_FRAMES[ellipsisIndex]}`
       : getRelativeRefreshLabel(lastRefreshedAt, now),
-    statusLabel: isHeaderLoading ? "Loading budget" : "Connected",
-    statusDotClass: isHeaderLoading
-      ? "h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse"
-      : "h-1.5 w-1.5 rounded-full bg-green-500",
     handleRefresh,
   };
 }

--- a/src/features/overview/lib/overviewCards.ts
+++ b/src/features/overview/lib/overviewCards.ts
@@ -4,9 +4,11 @@ import {
   Landmark,
   LayoutList,
   ScrollText,
+  ShieldCheck,
   Tag,
   Terminal,
   Users,
+  Wallet,
 } from "lucide-react";
 import type { OverviewActionCard } from "../types";
 
@@ -19,6 +21,15 @@ export const ADVANCED_TOOLS_DESCRIPTION =
   "Tools for deeper inspection and analysis.";
 
 export const ENTITY_CARDS: OverviewActionCard[] = [
+  {
+    id: "budget-management",
+    label: "Budget Management",
+    description:
+      "Manage monthly budget amounts, carryover settings, and holds across all category groups.",
+    href: "/budget-management",
+    icon: Wallet,
+    tone: "entity",
+  },
   {
     id: "rules",
     label: "Rules",
@@ -93,5 +104,14 @@ export const TOOL_CARDS: OverviewActionCard[] = [
     icon: FileSearch,
     tone: "tool",
     href: "/budget-diagnostics",
+  },
+  {
+    id: "rule-diagnostics",
+    label: "Rule Diagnostics",
+    description:
+      "Analyse rule coverage and conflicts across your transactions to identify gaps and overlapping conditions.",
+    icon: ShieldCheck,
+    tone: "tool",
+    href: "/rules/diagnostics",
   },
 ];


### PR DESCRIPTION
## Summary
- Adds Overview cards for Budget Management and Rule Diagnostics — both
  had pages but no entry point on the Overview landing screen
- Moves Bundle Export/Import from the Overview header into a TopBar
  dropdown (Package icon), making it reachable from any page
- Removes the Export/Import buttons from OverviewHeader — bundle is now
  consolidated in the TopBar only, avoiding duplicate entry points

## Decision: bundle entry point consolidation
The old Overview-header Export/Import buttons are removed. The TopBar
Package dropdown is the single entry point, visible from all pages.
Keeping both would create inconsistency and confusion about which one
to use.

## Test plan
- [ ] Overview shows cards for Budget Management and Rule Diagnostics
- [ ] Budget Management and Rule Diagnostics cards link to correct pages
- [ ] Package icon appears in TopBar when connected
- [ ] "Export bundle…" and "Import bundle…" open the correct dialogs from any page
- [ ] Overview header no longer shows Export/Import buttons