### PR TITLE
fix(rule-diagnostics): sidebar entry, jump-to-rule filter clear, and cold-navigation data readiness

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ScrollText,
   Calendar,
   Tag,
+  ShieldCheck,
   Stethoscope,
   Terminal,
   PanelLeftClose,
@@ -103,6 +104,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
           href: "/budget-diagnostics",
           icon: Stethoscope,
         },
+        { id: "rule-diagnostics", label: "Rule Diagnostics", href: "/rules/diagnostics", icon: ShieldCheck },
         { id: "query", label: "ActualQL", href: "/query", icon: Terminal, badge: "dev" },
       ],
     },
@@ -113,11 +115,14 @@ type SidebarNavLinkProps = {
   item: NavItem;
   collapsed: boolean;
   pathname: string;
+  allHrefs: string[];
 };
 
-function SidebarNavLink({ item, collapsed, pathname }: SidebarNavLinkProps) {
+function SidebarNavLink({ item, collapsed, pathname, allHrefs }: SidebarNavLinkProps) {
   const isExactMatch = pathname === item.href;
-  const isAncestorMatch = pathname.startsWith(item.href + "/");
+  // Suppress ancestor highlighting when another sidebar item owns the exact path.
+  const anotherItemOwnsPath = allHrefs.some((h) => h !== item.href && h === pathname);
+  const isAncestorMatch = !anotherItemOwnsPath && pathname.startsWith(item.href + "/");
   const active = isExactMatch || isAncestorMatch;
   const ariaCurrent = isExactMatch ? "page" : isAncestorMatch ? "location" : undefined;
   const Icon = item.icon;
@@ -151,6 +156,12 @@ function SidebarNavLink({ item, collapsed, pathname }: SidebarNavLinkProps) {
     </Link>
   );
 }
+
+const ALL_SIDEBAR_HREFS: string[] = SIDEBAR_SECTIONS.flatMap((section) =>
+  section.type === "item"
+    ? [section.item.href]
+    : section.group.items.map((item) => item.href)
+);
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -213,6 +224,7 @@ export function Sidebar() {
                   item={section.item}
                   collapsed={collapsed}
                   pathname={pathname}
+                  allHrefs={ALL_SIDEBAR_HREFS}
                 />
               </div>
             );
@@ -234,6 +246,7 @@ export function Sidebar() {
                     item={item}
                     collapsed={collapsed}
                     pathname={pathname}
+                    allHrefs={ALL_SIDEBAR_HREFS}
                   />
                 ))}
               </div>

--- a/src/features/rule-diagnostics/components/FindingRow.tsx
+++ b/src/features/rule-diagnostics/components/FindingRow.tsx
@@ -45,6 +45,14 @@ function handleRuleLinkClick(e: MouseEvent<HTMLAnchorElement>, ruleId: string): 
   if (!entry || entry.isDeleted) {
     e.preventDefault();
     toast.error("This rule no longer exists in the current working set.");
+    return;
+  }
+  // Clear persisted Rules-page filters so the target rule is always visible
+  // after the jump — any active search/stage/action-type filter could hide it.
+  try {
+    sessionStorage.removeItem("filters:rules");
+  } catch {
+    // ignore — storage may be unavailable in some environments
   }
 }
 

--- a/src/features/rule-diagnostics/hooks/useRuleDiagnostics.ts
+++ b/src/features/rule-diagnostics/hooks/useRuleDiagnostics.ts
@@ -143,15 +143,26 @@ export function useRuleDiagnostics(): UseRuleDiagnosticsResult {
   // Only fires on a true→false transition so it never triggers prematurely
   // on mount (where isLoadingEntities starts false before fetches begin).
   // Covers both initial direct navigation and post-connection-switch loads.
+  // Also handles the edge case where the new connection's rules are already
+  // cached after a switch — no fetch occurs so the true→false transition
+  // never fires; we detect this via rulesAlreadyCached and run immediately.
   useEffect(() => {
     const wasLoading = prevIsLoadingRef.current;
     prevIsLoadingRef.current = isLoadingEntities;
-    if (wasLoading && !isLoadingEntities && awaitingPostSwitchRefreshRef.current) {
+    if (!awaitingPostSwitchRefreshRef.current) return;
+    if (wasLoading && !isLoadingEntities) {
+      // Normal path: load just completed.
+      awaitingPostSwitchRefreshRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setRunToken((t) => t + 1);
+    } else if (!wasLoading && !isLoadingEntities && rulesAlreadyCached) {
+      // Edge case: rules already cached for this connection — no fetch will
+      // happen so the transition above never fires; run immediately.
       awaitingPostSwitchRefreshRef.current = false;
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setRunToken((t) => t + 1);
     }
-  }, [isLoadingEntities]);
+  }, [isLoadingEntities, rulesAlreadyCached]);
 
   // Current working-set signature is recomputed every render and compared
   // against the report's signature to drive the stale banner.

--- a/src/features/rule-diagnostics/hooks/useRuleDiagnostics.ts
+++ b/src/features/rule-diagnostics/hooks/useRuleDiagnostics.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useIsFetching } from "@tanstack/react-query";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore } from "@/store/connection";
 import type { Rule, Payee, Category, Account, CategoryGroup, Schedule } from "@/types/entities";
@@ -75,6 +75,7 @@ function selectEntityMaps(state: {
 }
 
 export function useRuleDiagnostics(): UseRuleDiagnosticsResult {
+  const queryClient = useQueryClient();
   const stagedRules = useStagedStore((s) => s.rules);
   // Subscribe to entity maps so that staged-entity changes drive re-renders
   // (the engine reads via getState() at run time, but the React layer needs
@@ -102,21 +103,31 @@ export function useRuleDiagnostics(): UseRuleDiagnosticsResult {
     },
   }) > 0;
 
+  // Check synchronously whether rules data is already cached. `useIsFetching`
+  // is useless here — at the first render, fetches haven't started yet (they
+  // start in effects) so it returns 0 even when no rules are loaded. The
+  // query state is authoritative: "success" means data exists in the cache.
+  const rulesAlreadyCached =
+    queryClient.getQueryState(["rules", activeConnectionId])?.status === "success";
+
   const [report, setReport] = useState<DiagnosticReport | null>(null);
-  const [running, setRunning] = useState(false);
+  // Start in running=true when rules aren't cached yet so the page shows a
+  // spinner while the preload queries complete.
+  const [running, setRunning] = useState(!rulesAlreadyCached);
   const [error, setError] = useState<string | null>(null);
   const [runToken, setRunToken] = useState(0);
 
   const cancelledRef = useRef(false);
   const previousConnectionIdRef = useRef(activeConnectionId);
-  // True between "connection switched" and "engine ran for the new connection".
-  // The post-switch watcher waits for the rules query to settle before refreshing.
-  const awaitingPostSwitchRefreshRef = useRef(false);
+  // True while the engine should wait for entity data before running.
+  // Covers both direct navigation (cache miss) and connection switches.
+  const awaitingPostSwitchRefreshRef = useRef(!rulesAlreadyCached);
+  // Track the previous isLoadingEntities value to detect true→false transitions.
+  const prevIsLoadingRef = useRef(isLoadingEntities);
 
   // Effect 1: detect a connection switch.
-  // When the connection changes we clear the current report and put the view
-  // into the loading state immediately, then arm Effect 2 to refresh the
-  // engine once the new connection's entity queries have finished loading.
+  // Immediately clears the report and arms the loading watcher so the engine
+  // re-runs once the new connection's entity queries have settled.
   useEffect(() => {
     if (previousConnectionIdRef.current !== activeConnectionId) {
       previousConnectionIdRef.current = activeConnectionId;
@@ -128,18 +139,18 @@ export function useRuleDiagnostics(): UseRuleDiagnosticsResult {
     }
   }, [activeConnectionId]);
 
-  // Effect 2: when the new connection's entity queries finish loading after a
-  // switch, bump runToken so the engine re-runs against the now-fresh staged
-  // store. We gate on the queries (not on staged-rules reference changes)
-  // because `discardAll()` clears staged data BEFORE the new data arrives —
-  // reacting to the first reference change runs the engine against an empty
-  // staged store and leaves the report stuck on the empty signature.
+  // Effect 2: auto-refresh when entity queries finish loading.
+  // Only fires on a true→false transition so it never triggers prematurely
+  // on mount (where isLoadingEntities starts false before fetches begin).
+  // Covers both initial direct navigation and post-connection-switch loads.
   useEffect(() => {
-    if (!awaitingPostSwitchRefreshRef.current) return;
-    if (isLoadingEntities) return;
-    awaitingPostSwitchRefreshRef.current = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRunToken((t) => t + 1);
+    const wasLoading = prevIsLoadingRef.current;
+    prevIsLoadingRef.current = isLoadingEntities;
+    if (wasLoading && !isLoadingEntities && awaitingPostSwitchRefreshRef.current) {
+      awaitingPostSwitchRefreshRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setRunToken((t) => t + 1);
+    }
   }, [isLoadingEntities]);
 
   // Current working-set signature is recomputed every render and compared
@@ -152,6 +163,9 @@ export function useRuleDiagnostics(): UseRuleDiagnosticsResult {
   const stale = report !== null && report.workingSetSignature !== currentSignature;
 
   useEffect(() => {
+    // Entities are still loading (initial page load or connection switch) —
+    // Effect 2 will bump runToken once the queries settle. Skip for now.
+    if (awaitingPostSwitchRefreshRef.current) return;
     cancelledRef.current = false;
     let cancelled = false;
     // eslint-disable-next-line react-hooks/set-state-in-effect


### PR DESCRIPTION
## Summary
- Adds Rule Diagnostics to the Sidebar's Tools section (between Budget Diagnostics and ActualQL) so it's directly accessible from any page without going through Rules first (F-002)
- Clears the persisted Rules-page filter state (`filters:rules`) before jumping to a rule from a finding so any active search/stage/action-type filter doesn't hide the target rule; also fixes a missing `return` guard in the deleted-rule branch (F-038)
- Fixes cold-navigation data readiness in `useRuleDiagnostics`: engine now defers until entity queries complete by watching `isLoadingEntities` for a `true→false` transition — eliminating the premature run against an empty staged store on direct navigation
- Fixes sidebar ancestor-match highlighting: "Rules" no longer lights up when on `/rules/diagnostics` because the match is suppressed when another sidebar item exactly owns the current path

## Test plan
- [ ] Connect to a budget, navigate directly to Rule Diagnostics from the sidebar — results appear automatically, no Refresh click required, no stale banner
- [ ] Navigate from Rules page to Rule Diagnostics — engine runs immediately (entities already cached), same instant result
- [ ] On `/rules/diagnostics`, only "Rule Diagnostics" is highlighted in the sidebar (not "Rules")
- [ ] Click a rule chip in a finding → lands on Rules page with the target rule visible regardless of any previously active filters
- [ ] Click a rule chip for a deleted rule → toast error, no navigation
- [ ] Switch connections while on Rule Diagnostics → report clears and reloads correctly