### PR TITLE
ci: stop double runs, cache Next build, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  # No paths-ignore on pull_request: CI is a required status check, so every PR
+  # must report it (a skipped run leaves the check pending and blocks merge).
   pull_request:
 
 permissions:
@@ -25,7 +30,15 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next-build/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Summary
Speed/cost tuning for CI with zero behavior change to the app.

- **Triggers:** `push` now fires only on `main` (was `["**"]`), so PR commits no longer run CI twice. Doc-only pushes to `main` are skipped via `paths-ignore`. **`pull_request` intentionally has no `paths-ignore`** — CI is a required status check, so every PR must report it (a skipped run would block merge).
- **Next.js build cache:** keyed `actions/cache` on `.next-build/cache` (matches the custom `distDir`) for faster incremental `next build`.
- **Install:** `npm ci --prefer-offline --no-audit --no-fund`.
- **Dependabot:** weekly `github-actions` + `npm` updates.

## Testing
Opening this PR exercises the change: CI should run **once** (not twice) and pass lint/type-check/test/build. A second push to the branch should show a warm Next build cache.

Part 1 of 2 — Part 2 (#TBD, native multi-arch + health-checked deploy) is stacked on this branch.