### PR TITLE
ci: native arm64 builds, provenance/SBOM, post-deploy health check

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -12,19 +12,83 @@ permissions:
 
 concurrency:
   group: deploy-edge
-  cancel-in-progress: true
+  cancel-in-progress: false
+
+env:
+  IMAGE_GHCR: ghcr.io/x-rous/actual-bench
+  IMAGE_DOCKERHUB: docker.io/xrous/actual-bench
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
+  # ── Build each architecture natively (no QEMU), push by digest ───────────────
+  build:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.prod
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ env.IMAGE_GHCR }},${{ env.IMAGE_DOCKERHUB }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          provenance: true
+          sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Merge per-arch digests into a single multi-arch manifest ─────────────────
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -47,25 +111,23 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/x-rous/actual-bench
-            docker.io/xrous/actual-bench
+            ${{ env.IMAGE_GHCR }}
+            ${{ env.IMAGE_DOCKERHUB }}
           tags: |
             type=raw,value=edge
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.prod
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-                QEMU_CPU=cortex-a72
-                
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_GHCR }}@sha256:%s ' *)
+
+  # ── Deploy to the VPS and verify the app actually answers ────────────────────
+  deploy:
+    needs: merge
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
         with:
@@ -73,7 +135,20 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
+            set -e
             cd ${{ secrets.VPS_DEPLOY_PATH }}
             docker compose pull
             docker compose up -d --remove-orphans
+            # Wait for the new container to actually serve before declaring success
+            for i in $(seq 1 15); do
+              if curl -fsS -o /dev/null http://localhost:3000/; then
+                echo "✓ healthy"
+                break
+              fi
+              if [ "$i" = 15 ]; then
+                echo "::error::health check failed after deploy"
+                exit 1
+              fi
+              sleep 2
+            done
             docker image prune -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  IMAGE_GHCR: ghcr.io/x-rous/actual-bench
+  IMAGE_DOCKERHUB: docker.io/xrous/actual-bench
+
 jobs:
   # ── Gate: run the full CI suite and verify version consistency ────────────────
   validate-and-test:
@@ -57,22 +61,82 @@ jobs:
           fi
           echo "✓ Version match: $PKG_VERSION"
 
-  # ── Release: build, push, deploy, publish GitHub Release ─────────────────────
-  release:
-    name: release
-    runs-on: ubuntu-latest
+  # ── Build each architecture natively (no QEMU), push by digest ───────────────
+  build:
+    name: build
     needs: validate-and-test
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.prod
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ env.IMAGE_GHCR }},${{ env.IMAGE_DOCKERHUB }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          provenance: true
+          sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Merge per-arch digests into a single multi-arch manifest ─────────────────
+  merge:
+    name: merge
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -95,8 +159,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/x-rous/actual-bench
-            docker.io/xrous/actual-bench
+            ${{ env.IMAGE_GHCR }}
+            ${{ env.IMAGE_DOCKERHUB }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ steps.version.outputs.VERSION }}
@@ -104,18 +168,19 @@ jobs:
             org.opencontainers.image.title=Actual Bench
             org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.prod
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_GHCR }}@sha256:%s ' *)
 
+  # ── Deploy to the VPS and verify the app actually answers ────────────────────
+  deploy:
+    name: deploy
+    needs: merge
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
         with:
@@ -123,11 +188,30 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
+            set -e
             cd ${{ secrets.VPS_DEPLOY_PATH }}
             docker compose pull
             docker compose up -d --remove-orphans
+            # Wait for the new container to actually serve before declaring success
+            for i in $(seq 1 15); do
+              if curl -fsS -o /dev/null http://localhost:3000/; then
+                echo "✓ healthy"
+                break
+              fi
+              if [ "$i" = 15 ]; then
+                echo "::error::health check failed after deploy"
+                exit 1
+              fi
+              sleep 2
+            done
             docker image prune -f
 
+  # ── Publish the GitHub Release once the image is live ────────────────────────
+  publish-release:
+    name: publish-release
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
       - name: Publish GitHub Release
         uses: release-drafter/release-drafter@v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ npm run dev
 npm run lint      # must pass with 0 errors
 npx tsc --noEmit  # must pass with 0 errors
 npm test          # must pass
+npm run build     # must succeed (CI builds too — catch build-only errors early)
 ```
 
 ### Branch naming
@@ -146,10 +147,10 @@ src/
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| **CI** (`.github/workflows/ci.yml`) | All pushes + PRs | Lint, type-check, test, build — must pass before any merge |
-| **Edge** (`.github/workflows/edge.yml`) | `workflow_run` after CI succeeds on `main` | Builds and pushes the `:edge` Docker tag, deploys to VPS |
+| **CI** (`.github/workflows/ci.yml`) | Pushes to `main` (skips doc-only) + all PRs | Lint, type-check, test, build — must pass before any merge |
+| **Edge** (`.github/workflows/edge.yml`) | `workflow_run` after CI succeeds on `main` | Builds the multi-arch (`amd64` + `arm64`) `:edge` Docker tag natively in parallel, then deploys to the VPS and health-checks the running app |
 | **Release Drafter** (`.github/workflows/release-drafter.yml`) | Push to `main` | Updates a draft GitHub Release with all merged PRs since the last tag |
-| **Release** (`.github/workflows/release.yml`) | Push `v*` tag | Runs full CI, verifies version, builds and pushes `:latest` + `:<version>` Docker tags, deploys to VPS, publishes the draft GitHub Release |
+| **Release** (`.github/workflows/release.yml`) | Push `v*` tag | Runs full CI, verifies version, builds the multi-arch `:latest` + `:<version>` Docker tags, deploys to the VPS, health-checks it, then publishes the draft GitHub Release |
 
 ## Docker Tags
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Actual Bench is built around a review-before-save workflow.
 ```mermaid
 flowchart LR
   Browser[Browser]
-  App[Actual Bench\nNext.js app]
+  App["Actual Bench<br/>Next.js app"]
   Proxy[Internal /api/proxy]
   API[actual-http-api]
   Actual[Actual Budget server]
@@ -305,7 +305,7 @@ CSV exports include a UTF-8 BOM for better compatibility with Excel and Google S
 - TanStack Query for server-state caching
 - TanStack Table for entity tables
 - SQLite WASM worker for local diagnostics snapshot inspection
-- Docker images published for stable releases and edge builds
+- Docker images published for stable releases and edge builds — multi-arch (`linux/amd64` + `linux/arm64`)
 
 ## Development
 


### PR DESCRIPTION
## Summary
Removes QEMU emulation from the Docker pipeline (`edge.yml` + `release.yml`) and hardens the deploy. **Stacked on #115 — merge that first.**

- **Native multi-arch:** matrix builds `linux/amd64` on `ubuntu-latest` and `linux/arm64` on `ubuntu-24.04-arm` in parallel, push by digest, then merge into one manifest with `buildx imagetools`. No more emulated arm64.
- **Per-arch GHA cache** (`scope=${{ matrix.platform }}`) so the two arches stop overwriting each other's layers.
- **Provenance + SBOM** attestations attached to published images.
- **Post-deploy health check:** the VPS deploy polls `http://localhost:3000/` and fails the run if the new container doesn't answer.
- **Edge concurrency** → `cancel-in-progress: false` so an in-flight VPS deploy isn't killed mid-update.
- **Docs:** corrected CONTRIBUTING workflows table; README multi-arch note + Mermaid `<br/>` fix.

## How to test (these triggers don't fire on PRs)
`edge.yml`/`release.yml` only run on `workflow_run`/tag, so this PR's checks only cover CI. Plan:
1. Merge #115, confirm a clean `main` CI run.
2. Merge this PR → watch the real **Edge** run: native arm64 build (no QEMU), digest merge, then health-checked deploy.
3. Verify the manifest: `docker buildx imagetools inspect ghcr.io/x-rous/actual-bench:edge` should list **both** `amd64` and `arm64`.
4. First tagged release after merge exercises `release.yml` (same build path).

## Watch-item
`provenance`/`sbom` + `push-by-digest` is the least battle-tested combo. If the first Edge manifest looks wrong, removing those two lines is the complete fix — nothing else depends on them.