### PR TITLE
ci: drop post-deploy health check

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -123,7 +123,7 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_GHCR }}@sha256:%s ' *)
 
-  # ── Deploy to the VPS and verify the app actually answers ────────────────────
+  # ── Deploy to the VPS ────────────────────────────────────────────────────────
   deploy:
     needs: merge
     runs-on: ubuntu-latest
@@ -135,20 +135,7 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
-            set -e
             cd ${{ secrets.VPS_DEPLOY_PATH }}
             docker compose pull
             docker compose up -d --remove-orphans
-            # Wait for the new container to actually serve before declaring success
-            for i in $(seq 1 15); do
-              if curl -fsS -o /dev/null http://localhost:3000/; then
-                echo "✓ healthy"
-                break
-              fi
-              if [ "$i" = 15 ]; then
-                echo "::error::health check failed after deploy"
-                exit 1
-              fi
-              sleep 2
-            done
             docker image prune -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_GHCR }}@sha256:%s ' *)
 
-  # ── Deploy to the VPS and verify the app actually answers ────────────────────
+  # ── Deploy to the VPS ────────────────────────────────────────────────────────
   deploy:
     name: deploy
     needs: merge
@@ -188,22 +188,9 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
-            set -e
             cd ${{ secrets.VPS_DEPLOY_PATH }}
             docker compose pull
             docker compose up -d --remove-orphans
-            # Wait for the new container to actually serve before declaring success
-            for i in $(seq 1 15); do
-              if curl -fsS -o /dev/null http://localhost:3000/; then
-                echo "✓ healthy"
-                break
-              fi
-              if [ "$i" = 15 ]; then
-                echo "::error::health check failed after deploy"
-                exit 1
-              fi
-              sleep 2
-            done
             docker image prune -f
 
   # ── Publish the GitHub Release once the image is live ────────────────────────

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,9 +148,9 @@ src/
 | Workflow | Trigger | What it does |
 |---|---|---|
 | **CI** (`.github/workflows/ci.yml`) | Pushes to `main` (skips doc-only) + all PRs | Lint, type-check, test, build — must pass before any merge |
-| **Edge** (`.github/workflows/edge.yml`) | `workflow_run` after CI succeeds on `main` | Builds the multi-arch (`amd64` + `arm64`) `:edge` Docker tag natively in parallel, then deploys to the VPS and health-checks the running app |
+| **Edge** (`.github/workflows/edge.yml`) | `workflow_run` after CI succeeds on `main` | Builds the multi-arch (`amd64` + `arm64`) `:edge` Docker tag natively in parallel, then deploys to the VPS |
 | **Release Drafter** (`.github/workflows/release-drafter.yml`) | Push to `main` | Updates a draft GitHub Release with all merged PRs since the last tag |
-| **Release** (`.github/workflows/release.yml`) | Push `v*` tag | Runs full CI, verifies version, builds the multi-arch `:latest` + `:<version>` Docker tags, deploys to the VPS, health-checks it, then publishes the draft GitHub Release |
+| **Release** (`.github/workflows/release.yml`) | Push `v*` tag | Runs full CI, verifies version, builds the multi-arch `:latest` + `:<version>` Docker tags, deploys to the VPS, then publishes the draft GitHub Release |
 
 ## Docker Tags
 


### PR DESCRIPTION
## Summary
Removes the post-deploy health check added in #122. It curled `http://localhost:3000` on the VPS host, but in the reverse-proxy production setup the container isn't published to host port 3000 (it's served via the proxy on 443), so the check failed with connection-refused on every deploy **even though the deploy succeeded and the site stayed live** (verified: `https://actual-bench.nafverse.com` returns 200/307 throughout).

Rather than re-point the check at a proxied/secret URL, we're dropping it — the deploy itself is reliable and the added complexity isn't wanted.

## Changes
- `edge.yml` / `release.yml`: deploy step back to `docker compose pull && up -d && image prune`.
- `CONTRIBUTING.md`: removed the health-check wording from the workflows table.

No change to the native multi-arch build/merge (the valuable part of #122) — only the deploy step is simplified.