### PR TITLE
perf(docker): Next.js standalone output for a leaner, faster image

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,12 +1,4 @@
-# ── Stage 1: production dependencies only ─────────────────────────────────────
-FROM node:20-alpine AS deps
-WORKDIR /app
-COPY package*.json ./
-COPY scripts/copy-sqlite-wasm.mjs ./scripts/copy-sqlite-wasm.mjs
-# --omit=dev installs only the runtime dependencies (~60% smaller than full install)
-RUN npm ci --omit=dev
-
-# ── Stage 2: full build ────────────────────────────────────────────────────────
+# ── Stage 1: full build ────────────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
@@ -14,39 +6,41 @@ COPY scripts/copy-sqlite-wasm.mjs ./scripts/copy-sqlite-wasm.mjs
 RUN npm ci
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
+# Produces a standalone server under .next-build/standalone (output: "standalone")
 RUN npm run build
 
-# ── Stage 3: lean runtime image ───────────────────────────────────────────────
+# ── Stage 2: lean runtime image (Next.js standalone output) ───────────────────
 FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-# 256 MB is sufficient for next start (production server is lean)
+# The standalone server is lean; 256 MB is plenty.
 ENV NODE_OPTIONS=--max-old-space-size=256
+# Bind all interfaces so the reverse proxy can reach the container.
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
 
 # Non-root user for security
 RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 nextjs
 
-# Static assets
+# Public static assets (includes public/sqlite/sqlite3.wasm for in-browser
+# Budget Diagnostics).
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
-# Build output — uses distDir: ".next-build" from next.config.ts
-COPY --from=builder --chown=nextjs:nodejs /app/.next-build ./.next-build
+# Standalone server bundle: server.js + traced node_modules + package.json +
+# the server-side build output (.next-build/…). This replaces copying the full
+# production node_modules — only the modules the server actually imports ship.
+COPY --from=builder --chown=nextjs:nodejs /app/.next-build/standalone ./
 
-# Config — next start reads this to locate the custom distDir
-COPY --from=builder --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
+# Client static assets emitted by the build, served by the standalone server.
+COPY --from=builder --chown=nextjs:nodejs /app/.next-build/static ./.next-build/static
 
-# Production node_modules from the deps stage (no devDependencies)
-COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
-
-# package.json required by npm start
-COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
-
-# Branded startup wrapper (reads package.json version, spawns next start)
-COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
+# Branded startup wrapper (reads package.json version, spawns the standalone
+# server.js). package.json comes from the standalone bundle copied above.
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/start.mjs ./scripts/start.mjs
 
 USER nextjs
 EXPOSE 3000
-CMD ["npm", "start"]
+CMD ["node", "scripts/start.mjs"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,10 @@ const pkg = JSON.parse(
 ) as { version?: string };
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained standalone server (server.js + only the traced
+  // runtime node_modules) so the Docker runtime image doesn't carry the full
+  // production dependency tree. Output lands in `${distDir}/standalone`.
+  output: "standalone",
   // Enable React Compiler via the Turbopack/SWC-native path (top-level in
   // Next.js 16 — promoted out of experimental).
   // babel-plugin-react-compiler remains in devDependencies for Jest only.

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Branded startup wrapper for `next start`.
+ * Branded startup wrapper for the Next.js standalone server.
  *
- * Spawns the Next.js production server, pipes its stdout through a line
+ * Spawns the standalone production server (server.js), pipes its stdout through a line
  * filter that suppresses the default Next.js banner and replaces the
  * "✓ Ready in Xms" line with a single clean branded message. All other
  * output (errors, warnings, request logs) is forwarded unchanged so
@@ -58,7 +58,7 @@ function filterLine(line) {
   return line;
 }
 
-const child = spawn("node_modules/.bin/next", ["start"], {
+const child = spawn("node", ["server.js"], {
   stdio: ["inherit", "pipe", "pipe"],
   env: process.env,
 });


### PR DESCRIPTION
## Summary
Switches the production image to **Next.js `output: "standalone"`** so the runtime carries only the traced server dependencies instead of the full production `node_modules` (currently the bulk of the image).

- `next.config.ts`: `output: "standalone"`
- `Dockerfile.prod`: dropped the `deps` stage (one fewer `npm ci`); runtime copies `.next-build/standalone` + `.next-build/static` + `public`; binds `HOSTNAME=0.0.0.0`; runs `node server.js`
- `scripts/start.mjs`: branded wrapper now spawns the standalone `server.js` (banner preserved)

App build/runtime stays on **Node 20**; no app code changed.

## Expected impact
- Runtime `node_modules` shrinks from the full prod tree to the traced subset → meaningfully smaller image, faster pulls.
- Faster cold start (minimal `server.js` vs full `next start`).

## ⚠️ Not build-tested — verify after deploy
Merging auto-builds `:edge` and deploys to prod. Two things to confirm on the live site once deployed:
1. App loads and the **Budget Diagnostics** sqlite feature works (it fetches `/sqlite/sqlite3.wasm` from `public/`).
2. The `/api/proxy` route still reaches `actual-http-api`.

**Rollback if broken:** on the VPS, re-pin to the last good image (e.g. `xrous/actual-bench:1.1.9` or the previous `:edge` digest) and `docker compose up -d`. A *build* failure is safe (no deploy fires); only a build-success-but-runtime-broken image would affect prod.