### PR TITLE
perf(app): lazy-load rule drawer and heavy dialogs

### DIFF
--- a/src/features/accounts/components/AccountsView.tsx
+++ b/src/features/accounts/components/AccountsView.tsx
@@ -14,12 +14,19 @@ import { useAccountBalances } from "../hooks/useAccountBalances";
 import { AccountsTable } from "./AccountsTable";
 import { AccountFormDrawer } from "./AccountFormDrawer";
 import type { AccountFormValues } from "../schemas/account.schema";
-import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import dynamic from "next/dynamic";
 import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { AccountsTableOverlays } from "./AccountsTableOverlays";
 import type { AccountDeleteIntent } from "./AccountsTableOverlays";
 import { exportAccountsToCsv } from "../csv/accountsCsvExport";
 import { importAccountsFromCsv } from "../csv/accountsCsvImport";
+
+// Lazy-loaded: the rule builder is a secondary action on this page, so keep its
+// bundle out of the initial Accounts route load.
+const RuleDrawer = dynamic(
+  () => import("@/features/rules/components/RuleDrawer").then((m) => m.RuleDrawer),
+  { ssr: false },
+);
 
 export function AccountsView() {
   const [ruleDrawerOpen, setRuleDrawerOpen] = useState(false);

--- a/src/features/budget-management/components/details/TrackingDetailsPanel.tsx
+++ b/src/features/budget-management/components/details/TrackingDetailsPanel.tsx
@@ -16,7 +16,7 @@ import {
   PrimaryMetric,
   StagedImpactBlock,
 } from "./DetailsPrimitives";
-import { BudgetTransactionsDialog } from "./BudgetTransactionsDialog";
+import dynamic from "next/dynamic";
 import { BudgetNoteSection, type BudgetNoteTarget } from "./BudgetNoteSection";
 import { useSpendingDetailsShortcut } from "./useSpendingDetailsShortcut";
 
@@ -44,6 +44,13 @@ const PERIOD_TOOLTIP = {
   fullExpenseBudget: "Sum of expenses budgeted across the visible 12 months.",
   plannedResult: "Full-period income budgeted minus expenses budgeted.",
 } as const;
+
+// Lazy-loaded: the transactions dialog (large) is only shown when a user drills
+// into a cell, so keep it out of the initial budget workspace bundle.
+const BudgetTransactionsDialog = dynamic(
+  () => import("./BudgetTransactionsDialog").then((m) => m.BudgetTransactionsDialog),
+  { ssr: false },
+);
 
 export function TrackingDetailsPanel({
   metrics,

--- a/src/features/categories/components/CategoriesView.tsx
+++ b/src/features/categories/components/CategoriesView.tsx
@@ -10,12 +10,19 @@ import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { useCategoryGroups } from "../hooks/useCategoryGroups";
 import { CategoriesTable } from "./CategoriesTable";
-import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import dynamic from "next/dynamic";
 import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { CategoriesTableOverlays } from "./CategoriesTableOverlays";
 import type { CategoryDeleteIntent, CategoryInspectTarget } from "./CategoriesTableOverlays";
 import { exportCategoriesToCsv } from "../csv/categoriesCsvExport";
 import { importCategoriesFromCsv } from "../csv/categoriesCsvImport";
+
+// Lazy-loaded: the rule builder is a secondary action on this page, so keep its
+// bundle out of the initial Categories route load.
+const RuleDrawer = dynamic(
+  () => import("@/features/rules/components/RuleDrawer").then((m) => m.RuleDrawer),
+  { ssr: false },
+);
 
 export function CategoriesView() {
   const { isLoading, isError, error, refetch } = useCategoryGroups();

--- a/src/features/payees/components/PayeesView.tsx
+++ b/src/features/payees/components/PayeesView.tsx
@@ -10,7 +10,7 @@ import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import { usePayees } from "../hooks/usePayees";
 import { PayeesTable } from "./PayeesTable";
-import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import dynamic from "next/dynamic";
 import type { RuleSeed } from "@/features/rules/components/RuleDrawer";
 import { PayeesTableOverlays } from "./PayeesTableOverlays";
 import type { PayeeDeleteIntent } from "./PayeesTableOverlays";
@@ -18,6 +18,13 @@ import { PayeesMergeDialog } from "./PayeesMergeDialog";
 import type { PayeeMergeState } from "./PayeesMergeDialog";
 import { exportPayeesToCsv } from "../csv/payeesCsvExport";
 import { importPayeesFromCsv } from "../csv/payeesCsvImport";
+
+// Lazy-loaded: the rule builder is a secondary action on this page, so keep its
+// bundle out of the initial Payees route load.
+const RuleDrawer = dynamic(
+  () => import("@/features/rules/components/RuleDrawer").then((m) => m.RuleDrawer),
+  { ssr: false },
+);
 
 export function PayeesView() {
   const importInputRef = useRef<HTMLInputElement>(null);

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -14,7 +14,7 @@ import { SaveQueryDialog } from "./SaveQueryDialog";
 import { QueryExamplesPanel } from "./QueryExamplesPanel";
 import { QueryExplanationPanel } from "./QueryExplanationPanel";
 import { QueryLintPanel } from "./QueryLintPanel";
-import { QueryReferenceDialog } from "./QueryReferenceDialog";
+import dynamic from "next/dynamic";
 import { parseQuery, lintQuery } from "../lib/queryValidation";
 import { formatJson } from "../lib/queryFormatting";
 import { explainQuery } from "../lib/queryExplain";
@@ -176,6 +176,13 @@ function LeftPanel({
     </aside>
   );
 }
+
+// Lazy-loaded: the reference dialog is only shown on demand, so keep its large
+// bundle out of the initial Query route load.
+const QueryReferenceDialog = dynamic(
+  () => import("./QueryReferenceDialog").then((m) => m.QueryReferenceDialog),
+  { ssr: false },
+);
 
 export function QueryWorkspace() {
   const connection = useConnectionStore(selectActiveInstance);

--- a/src/features/schedules/components/SchedulesView.tsx
+++ b/src/features/schedules/components/SchedulesView.tsx
@@ -14,7 +14,14 @@ import { SchedulesTable } from "./SchedulesTable";
 import { ScheduleFormDrawer } from "./ScheduleFormDrawer";
 import { SchedulesTableOverlays } from "./SchedulesTableOverlays";
 import type { ScheduleDeleteIntent } from "./SchedulesTableOverlays";
-import { RuleDrawer } from "@/features/rules/components/RuleDrawer";
+import dynamic from "next/dynamic";
+
+// Lazy-loaded: the rule builder is a secondary action on this page, so keep its
+// bundle out of the initial Schedules route load.
+const RuleDrawer = dynamic(
+  () => import("@/features/rules/components/RuleDrawer").then((m) => m.RuleDrawer),
+  { ssr: false },
+);
 
 export function SchedulesView() {
   const { isLoading, isError, error, refetch } = useSchedules();


### PR DESCRIPTION
## Summary
Splits heavy, interaction-only components out of the initial route bundles via `next/dynamic`, so they load on demand instead of blocking first paint / Time-to-Interactive.

- **`RuleDrawer`** → lazy on **Payees, Accounts, Categories, Schedules** (secondary 'create rule' action). Kept **eager on the Rules page** where it's the primary action.
- **`QueryReferenceDialog`** (616 lines) → lazy on the Query workspace.
- **`BudgetTransactionsDialog`** (845 lines) → lazy in the budget details panel.

No rendering-logic change — just code-splitting. `tsc` and `eslint` clean.

## Context
First of a small performance series. React Compiler is already on and rows are `React.memo`'d, so the wins are architectural: this is the bundle-splitting piece. Next up: row **virtualization** for large entity tables (the README's 'large budgets feel slow' limitation).

## Verify after deploy
On `:edge`, confirm these still open/work (now loaded on demand): rule drawer from Payees/Accounts/Categories/Schedules, the ActualQL reference dialog, and a budget cell → transactions drill-in.