### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",

--- a/src/app/(app)/accounts/page.tsx
+++ b/src/app/(app)/accounts/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { AccountsView } from "@/features/accounts/components/AccountsView";
 
 export const metadata: Metadata = {
-  title: "Accounts — Actual Bench",
+  title: "Accounts - Actual Bench",
 };
 
 export default function AccountsPage() {

--- a/src/app/(app)/budget-diagnostics/page.tsx
+++ b/src/app/(app)/budget-diagnostics/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { BudgetDiagnosticsClient } from "./BudgetDiagnosticsClient";
 
 export const metadata: Metadata = {
-  title: "Budget File Health — Actual Bench",
+  title: "Budget File Health - Actual Bench",
 };
 
 export default function BudgetDiagnosticsPage() {

--- a/src/app/(app)/budget-management/page.tsx
+++ b/src/app/(app)/budget-management/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { BudgetManagementView } from "@/features/budget-management/components/BudgetManagementView";
 
 export const metadata: Metadata = {
-  title: "Budget Management — Actual Bench",
+  title: "Budget Management - Actual Bench",
 };
 
 export default function BudgetManagementPage() {

--- a/src/app/(app)/categories/page.tsx
+++ b/src/app/(app)/categories/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { CategoriesView } from "@/features/categories/components/CategoriesView";
 
 export const metadata: Metadata = {
-  title: "Categories — Actual Bench",
+  title: "Categories - Actual Bench",
 };
 
 export default function CategoriesPage() {

--- a/src/app/(app)/data-browser/page.tsx
+++ b/src/app/(app)/data-browser/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { DataBrowserClient } from "./DataBrowserClient";
 
 export const metadata: Metadata = {
-  title: "Data Browser — Actual Bench",
+  title: "Data Browser - Actual Bench",
 };
 
 export default function DataBrowserPage() {

--- a/src/app/(app)/overview/page.tsx
+++ b/src/app/(app)/overview/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { BudgetOverviewView } from "@/features/overview/components/BudgetOverviewView";
 
 export const metadata: Metadata = {
-  title: "Budget Overview — Actual Bench",
+  title: "Budget Overview - Actual Bench",
 };
 
 export default function OverviewPage() {

--- a/src/app/(app)/payees/page.tsx
+++ b/src/app/(app)/payees/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { PayeesView } from "@/features/payees/components/PayeesView";
 
 export const metadata: Metadata = {
-  title: "Payees — Actual Bench",
+  title: "Payees - Actual Bench",
 };
 
 export default function PayeesPage() {

--- a/src/app/(app)/query/page.tsx
+++ b/src/app/(app)/query/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { QueryWorkspace } from "@/features/query/components/QueryWorkspace";
 
 export const metadata: Metadata = {
-  title: "ActualQL Queries — Actual Bench",
+  title: "ActualQL Queries - Actual Bench",
 };
 
 export default function QueryPage() {

--- a/src/app/(app)/rules/diagnostics/page.tsx
+++ b/src/app/(app)/rules/diagnostics/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { RuleDiagnosticsView } from "@/features/rule-diagnostics/components/RuleDiagnosticsView";
 
 export const metadata: Metadata = {
-  title: "Rule Diagnostics — Actual Bench",
+  title: "Rule Diagnostics - Actual Bench",
 };
 
 export default function RuleDiagnosticsPage() {

--- a/src/app/(app)/rules/page.tsx
+++ b/src/app/(app)/rules/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { RulesView } from "@/features/rules/components/RulesView";
 
 export const metadata: Metadata = {
-  title: "Rules — Actual Bench",
+  title: "Rules - Actual Bench",
 };
 
 export default function RulesPage() {

--- a/src/app/(app)/schedules/page.tsx
+++ b/src/app/(app)/schedules/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { SchedulesView } from "@/features/schedules/components/SchedulesView";
 
 export const metadata: Metadata = {
-  title: "Schedules — Actual Bench",
+  title: "Schedules - Actual Bench",
 };
 
 export default function SchedulesPage() {

--- a/src/app/(app)/tags/page.tsx
+++ b/src/app/(app)/tags/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { TagsView } from "@/features/tags/components/TagsView";
 
 export const metadata: Metadata = {
-  title: "Tags — Actual Bench",
+  title: "Tags - Actual Bench",
 };
 
 export default function TagsPage() {

--- a/src/app/(connect)/connect/page.tsx
+++ b/src/app/(connect)/connect/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { ConnectForm } from "@/components/connect/ConnectForm";
 
 export const metadata: Metadata = {
-  title: "Connect — Actual Bench",
+  title: "Connect - Actual Bench",
 };
 
 export default function ConnectPage() {

--- a/src/app/(connect)/layout.tsx
+++ b/src/app/(connect)/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Connect — Actual Bench",
+  title: "Connect - Actual Bench",
 };
 
 /** Minimal centered layout for the connection screen. */

--- a/src/app/api/proxy/download/route.ts
+++ b/src/app/api/proxy/download/route.ts
@@ -48,7 +48,7 @@ async function upstreamDownload(
     const message =
       err instanceof Error ? err.message : "Network error reaching API server";
     const ms = Date.now() - start;
-    logger.warn(`${method} 502 ${path} (${ms}ms) [${reqId}] — ${message}`);
+    logger.warn(`${method} 502 ${path} (${ms}ms) [${reqId}] - ${message}`);
     return NextResponse.json({ error: message }, { status: 502 });
   }
 
@@ -67,7 +67,7 @@ async function upstreamDownload(
       }
     }
     const ms = Date.now() - start;
-    logger.warn(`${method} ${upstream.status} ${path} (${ms}ms) [${reqId}] — ${message}`);
+    logger.warn(`${method} ${upstream.status} ${path} (${ms}ms) [${reqId}] - ${message}`);
     return NextResponse.json(
       { error: message },
       { status: upstream.status }

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -59,7 +59,7 @@ async function upstreamFetch(
     const message =
       err instanceof Error ? err.message : "Network error reaching API server";
     const ms = Date.now() - start;
-    logger.warn(`${method} 502 ${path} (${ms}ms) [${reqId}] — ${message}`);
+    logger.warn(`${method} 502 ${path} (${ms}ms) [${reqId}] - ${message}`);
     return NextResponse.json({ error: message }, { status: 502 });
   }
 
@@ -83,7 +83,7 @@ async function upstreamFetch(
       // ignore — use status string
     }
     const ms = Date.now() - start;
-    logger.warn(`${method} ${upstreamResponse.status} ${path} (${ms}ms) [${reqId}] — ${message}`);
+    logger.warn(`${method} ${upstreamResponse.status} ${path} (${ms}ms) [${reqId}] - ${message}`);
     return NextResponse.json(
       { error: message },
       { status: upstreamResponse.status }

--- a/src/components/connect/utils.ts
+++ b/src/components/connect/utils.ts
@@ -34,7 +34,7 @@ export function parseApiError(err: unknown): string {
   // they add no information beyond what the status-based messages already say.
   const detail =
     raw && !["fetch failed", "failed to fetch"].includes(raw.toLowerCase())
-      ? ` — ${raw}`
+      ? ` - ${raw}`
       : "";
 
   if (status === -1 || status === 0)    return `Cannot reach the server. Check the URL and that it is running.${detail}`;
@@ -44,7 +44,7 @@ export function parseApiError(err: unknown): string {
                                         return `Server unavailable (HTTP ${status})${detail}.`;
   if (status >= 500)                    return `Server error (HTTP ${status})${detail}.`;
   if (status >= 400)                    return `Request error (HTTP ${status})${detail}.`;
-  return detail ? detail.slice(4) : "Unexpected error."; // strip leading " — "
+  return detail ? detail.slice(4) : "Unexpected error."; // strip leading " - "
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/components/layout/ConnectionOfflineBanner.tsx
+++ b/src/components/layout/ConnectionOfflineBanner.tsx
@@ -15,7 +15,7 @@ export function ConnectionOfflineBanner() {
       className="flex items-center gap-2 border-b border-red-200 bg-red-50 px-4 py-1.5 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400"
     >
       <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-      <span>Lost connection to server — save disabled until reconnected.</span>
+      <span>Lost connection to server - save disabled until reconnected.</span>
     </div>
   );
 }

--- a/src/components/layout/GlobalShortcutsHelp.tsx
+++ b/src/components/layout/GlobalShortcutsHelp.tsx
@@ -56,7 +56,7 @@ export function GlobalShortcutsHelp({
         <DialogHeader>
           <DialogTitle>Keyboard shortcuts</DialogTitle>
           <DialogDescription id="shortcuts-desc" className="text-[11px]">
-            App-wide shortcuts. The Budget workspace has additional shortcuts — press{" "}
+            App-wide shortcuts. The Budget workspace has additional shortcuts - press{" "}
             <Kbd>?</Kbd> there to see them.
           </DialogDescription>
         </DialogHeader>

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -95,7 +95,7 @@ export function PageLayout({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      {/* Toolbar — always visible regardless of loading/error state */}
+      {/* Toolbar - always visible regardless of loading/error state */}
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2">
         <div className="flex items-center gap-2">
           <h1 className="text-sm font-semibold">{title}</h1>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -331,7 +331,7 @@ export function Sidebar() {
         <button
           type="button"
           onClick={cycleTheme}
-          title={`Theme: ${themeLabels[theme ?? "system"]} — click to cycle`}
+          title={`Theme: ${themeLabels[theme ?? "system"]} - click to cycle`}
           className={cn(
             "flex w-full items-center rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground",
             collapsed ? "justify-center" : "gap-2"

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -423,7 +423,7 @@ export function TopBar() {
             )}
             disabled={saveDisabled}
             onClick={handleSave}
-            title={isOffline ? "Cannot save — server is unreachable" : undefined}
+            title={isOffline ? "Cannot save - server is unreachable" : undefined}
           >
             <Save className="mr-1 h-3.5 w-3.5" />
             {isSaving ? "Saving…" : "Save"}

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -95,7 +95,7 @@ export function SearchableCombobox({
   options,
   value,
   onChange,
-  placeholder = "— select —",
+  placeholder = "- select -",
   footer,
   triggerClassName,
 }: {
@@ -152,7 +152,7 @@ export function SearchableCombobox({
                 className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
               >
                 <Check className={cn("h-3 w-3 shrink-0", value === "" ? "opacity-100" : "opacity-0")} />
-                — none —
+                - none -
               </button>
             </li>
             {filtered.filter((o) => !o.isGroupHeader).length === 0 ? (
@@ -206,7 +206,7 @@ export function MultiSearchableCombobox({
   options,
   values,
   onChange,
-  placeholder = "— select —",
+  placeholder = "- select -",
   triggerClassName,
 }: {
   options: ComboboxOption[];

--- a/src/features/accounts/components/AccountsView.tsx
+++ b/src/features/accounts/components/AccountsView.tsx
@@ -116,7 +116,7 @@ export function AccountsView() {
       if (imported === 0) {
         toast.warning("No valid rows found in CSV.");
       } else if (result.skipped > 0) {
-        toast.success(`Imported ${imported} account${imported !== 1 ? "s" : ""} (${result.skipped} skipped — empty name).`);
+        toast.success(`Imported ${imported} account${imported !== 1 ? "s" : ""} (${result.skipped} skipped - empty name).`);
       } else {
         toast.success(`Imported ${imported} account${imported !== 1 ? "s" : ""}.`);
       }

--- a/src/features/budget-diagnostics/components/DiagnosticsTable.tsx
+++ b/src/features/budget-diagnostics/components/DiagnosticsTable.tsx
@@ -98,7 +98,7 @@ export function DiagnosticsTable({
         header: "Row",
         cell: ({ row }) => {
           const finding = row.original;
-          if (!finding.table && !finding.rowId) return <span className="text-muted-foreground">—</span>;
+          if (!finding.table && !finding.rowId) return <span className="text-muted-foreground">-</span>;
           return (
             <div className="max-w-56 truncate text-xs" title={`${finding.table ?? ""}:${finding.rowId ?? ""}`}>
               {finding.table}
@@ -113,7 +113,7 @@ export function DiagnosticsTable({
         cell: ({ row }) => {
           const finding = row.original;
           if (!finding.relatedTable && !finding.relatedId) {
-            return <span className="text-muted-foreground">—</span>;
+            return <span className="text-muted-foreground">-</span>;
           }
           return (
             <div

--- a/src/features/budget-diagnostics/components/MetadataSummary.tsx
+++ b/src/features/budget-diagnostics/components/MetadataSummary.tsx
@@ -1,6 +1,6 @@
 import type { MetadataJson } from "../types";
 
-const EMPTY_VALUE = "—";
+const EMPTY_VALUE = "-";
 
 type MetadataField = {
   label: string;

--- a/src/features/budget-diagnostics/components/SchemaObjectDetails.tsx
+++ b/src/features/budget-diagnostics/components/SchemaObjectDetails.tsx
@@ -90,7 +90,7 @@ function ColumnsTable({ columns }: { columns: ColumnInfo[] }) {
                 {column.notNull ? "Yes" : "No"}
               </td>
               <td className="whitespace-nowrap px-3 py-1.5 font-mono tabular-nums text-muted-foreground">
-                {column.primaryKeyPosition || "—"}
+                {column.primaryKeyPosition || "-"}
               </td>
               <td
                 className="max-w-56 truncate px-3 py-1.5 font-mono text-muted-foreground"
@@ -144,7 +144,7 @@ function IndexesTable({ indexes }: { indexes: IndexInfo[] }) {
                 {index.unique ? "Yes" : "No"}
               </td>
               <td className="whitespace-nowrap px-3 py-1.5 font-mono text-muted-foreground">
-                {index.origin ?? "—"}
+                {index.origin ?? "-"}
               </td>
               <td className="whitespace-nowrap px-3 py-1.5 text-muted-foreground">
                 {index.partial ? "Yes" : "No"}

--- a/src/features/budget-diagnostics/lib/cellFormatters.test.ts
+++ b/src/features/budget-diagnostics/lib/cellFormatters.test.ts
@@ -13,12 +13,12 @@ describe("cellFormatters", () => {
       kind: "date",
     });
     expect(formatCellDisplay("date", 0)).toEqual({
-      text: "—",
+      text: "-",
       title: "0",
       kind: "date",
     });
     expect(formatCellDisplay("posted_date", 20260230)).toEqual({
-      text: "—",
+      text: "-",
       title: "20260230",
       kind: "date",
     });

--- a/src/features/budget-diagnostics/lib/cellFormatters.ts
+++ b/src/features/budget-diagnostics/lib/cellFormatters.ts
@@ -152,7 +152,7 @@ export function formatCellDisplay(column: string, value: unknown): CellDisplay {
   if (integer !== null && isDateColumn(column)) {
     const formatted = formatDateInteger(integer);
     return {
-      text: formatted ?? "—",
+      text: formatted ?? "-",
       title: String(value),
       kind: "date",
     };

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -303,7 +303,7 @@ export function BudgetCell({
     const blockedLabel = isReadOnlyMonth
       ? `${category.name} budget for ${month} - no budget exists for this past month`
       : blocked
-      ? `${category.name} budget for ${month} — income editing blocked in envelope mode`
+      ? `${category.name} budget for ${month} - income editing blocked in envelope mode`
       : `${category.name} ${cellView} for ${month}`;
     const displayText =
       isReadOnlyMonth && !hasMonthData ? "--" : formatMinor(displayMinor);
@@ -425,7 +425,7 @@ export function BudgetCell({
       className={`${cellClass}${dimClass}`}
       role="gridcell"
       tabIndex={0}
-      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " — save error" : ""}`}
+      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}`}
       aria-selected={isSelected}
       onPointerDown={handlePointerDown}
       onPointerEnter={handlePointerEnter}

--- a/src/features/budget-management/components/BudgetDraftPanel.tsx
+++ b/src/features/budget-management/components/BudgetDraftPanel.tsx
@@ -35,7 +35,7 @@ export function BudgetDraftPanel() {
             variant="outline"
             className="text-amber-600 border-amber-300 dark:text-amber-400 dark:border-amber-700 cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-950/20"
             onClick={() => setDialogOpen(true)}
-            aria-label={`${changeCount} staged change${changeCount !== 1 ? "s" : ""} — click to review`}
+            aria-label={`${changeCount} staged change${changeCount !== 1 ? "s" : ""} - click to review`}
             title="Review staged changes"
           >
             {changeCount} {changeCount === 1 ? "change" : "changes"}

--- a/src/features/budget-management/components/BudgetExportDialog.tsx
+++ b/src/features/budget-management/components/BudgetExportDialog.tsx
@@ -319,7 +319,7 @@ export function BudgetExportDialog({
           </div>
         )}
 
-        {/* Select — searchable multi-select combobox constrained to availableMonths */}
+        {/* Select - searchable multi-select combobox constrained to availableMonths */}
         {mode === "select" && (
           <div className="mb-4">
             <label className="block text-xs text-muted-foreground mb-1">
@@ -334,7 +334,7 @@ export function BudgetExportDialog({
           </div>
         )}
 
-        {/* Resolution summary — always visible */}
+        {/* Resolution summary - always visible */}
         <div
           className={`mb-4 px-3 py-2 rounded text-xs ${
             canExport

--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -342,7 +342,7 @@ export function BudgetGrid({
         />
       ))}
 
-      {/* Separator between summary and data — matches the expense ↔ income
+      {/* Separator between summary and data - matches the expense ↔ income
           divider thickness so both section-total rows ("Total Budgeted
           Expenses" and "Total Received Income") get the same border style. */}
       {summaryRows.length > 0 && (

--- a/src/features/budget-management/components/BudgetImportDialog.tsx
+++ b/src/features/budget-management/components/BudgetImportDialog.tsx
@@ -296,7 +296,7 @@ export function BudgetImportDialog({
                             <span className="text-destructive">Unmatched</span>
                           )}
                           {Object.values(result.monthAvailability).some((s) => s === "absent") && (
-                            <span className="text-destructive ml-1">— month absent</span>
+                            <span className="text-destructive ml-1">- month absent</span>
                           )}
                         </td>
                       </tr>

--- a/src/features/budget-management/components/BudgetSelectionSummary.tsx
+++ b/src/features/budget-management/components/BudgetSelectionSummary.tsx
@@ -60,7 +60,7 @@ export function BudgetSelectionSummary({
       aria-live="polite"
       aria-label="Selection summary"
     >
-      {/* Global staged edits — always visible */}
+      {/* Global staged edits - always visible */}
       {totalStaged > 0 ? (
         <>
           <span

--- a/src/features/budget-management/components/StagedCategoryTransferDialog.tsx
+++ b/src/features/budget-management/components/StagedCategoryTransferDialog.tsx
@@ -158,7 +158,7 @@ export function StagedCategoryTransferDialog({
       destServerBudgeted: monthData?.categoriesById[destinationCategoryId]?.budgeted ?? 0,
     });
 
-    toast.success("Transfer staged — save to apply");
+    toast.success("Transfer staged - save to apply");
     onClose();
   }
 

--- a/src/features/budget-management/components/details/BudgetTransactionsDialog.tsx
+++ b/src/features/budget-management/components/details/BudgetTransactionsDialog.tsx
@@ -326,7 +326,7 @@ function WeeklySpending({
 
   return (
     <div className="flex h-full flex-col gap-1">
-      {/* Amount labels — row above bars, outside each bar button */}
+      {/* Amount labels - row above bars, outside each bar button */}
       <div className="flex shrink-0 gap-1.5">
         {buckets.map((bucket) => (
           <div
@@ -338,7 +338,7 @@ function WeeklySpending({
         ))}
       </div>
 
-      {/* Bar chart — flex-1 so each button gets a properly defined height */}
+      {/* Bar chart - flex-1 so each button gets a properly defined height */}
       <div className="flex min-h-0 flex-1 gap-1.5">
         {buckets.map((bucket) => {
           const isActive = selectedId === bucket.id;
@@ -639,7 +639,7 @@ export function BudgetTransactionsDialog({ target, browserOptions, statesByMonth
           </div>
         </DialogHeader>
 
-        {/* Summary strip — only when data is loaded */}
+        {/* Summary strip - only when data is loaded */}
         {hasData && (
           <div className="shrink-0 border-b border-border/70 bg-muted/5 px-4 py-2">
             <div className="flex items-stretch divide-x divide-border/50">
@@ -668,7 +668,7 @@ export function BudgetTransactionsDialog({ target, browserOptions, statesByMonth
               />
               <StripItem
                 label="Average"
-                value={analytics.averageTransaction > 0 ? formatSigned(analytics.averageTransaction) : "—"}
+                value={analytics.averageTransaction > 0 ? formatSigned(analytics.averageTransaction) : "-"}
               />
             </div>
           </div>

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -219,7 +219,7 @@ export function BudgetGridGroupRows({
 
   return (
     <>
-      {/* Group header — light bg, black text. Clicking anywhere outside the
+      {/* Group header - light bg, black text. Clicking anywhere outside the
           chevron selects the group row; the chevron continues to toggle
           collapse via stopPropagation. */}
       <div
@@ -281,7 +281,7 @@ export function BudgetGridGroupRows({
         />
       ))}
 
-      {/* Category rows — hidden when collapsed */}
+      {/* Category rows - hidden when collapsed */}
       {!collapsed &&
         group.categoryIds.map((catId) => {
           const cat = categoriesById[catId];
@@ -304,7 +304,7 @@ export function BudgetGridGroupRows({
               role="row"
               aria-label={cat.name}
             >
-              {/* Category label — clickable / focusable to select the row */}
+              {/* Category label - clickable / focusable to select the row */}
               <div
                 className={`h-7 pl-4 pr-2 flex items-center border-r border-b border-border/50 text-xs sticky left-0 bg-background cursor-default outline-none${catDimClass}${catRowSelectedClass}`}
                 role="gridcell"

--- a/src/features/budget-management/components/grid/SummaryRows.tsx
+++ b/src/features/budget-management/components/grid/SummaryRows.tsx
@@ -310,7 +310,7 @@ function SummaryHeaderCell({
         {cell
           ? formatSummaryCellValue(cell)
           : value == null
-            ? "—"
+            ? "-"
             : formatSummary(value)}
       </span>
     </div>

--- a/src/features/budget-management/components/grid/summaryDisplay.ts
+++ b/src/features/budget-management/components/grid/summaryDisplay.ts
@@ -46,7 +46,7 @@ function formatSummaryDelta(value: number): string {
 }
 
 export function formatSummaryCellValue(cell: SummaryCellMetric): string {
-  if (cell.value == null) return "—";
+  if (cell.value == null) return "-";
   if (cell.valueKind === "percent") {
     return `${cell.value.toLocaleString("en-US")}%`;
   }

--- a/src/features/budget-management/hooks/useBudgetSave.ts
+++ b/src/features/budget-management/hooks/useBudgetSave.ts
@@ -144,7 +144,7 @@ export function useBudgetSave(): UseBudgetSaveReturn {
         const [key, edit] = entry;
         if (validCategoryIds && !validCategoryIds.has(edit.categoryId)) {
           const message =
-            "Category was removed from this budget — discard the staged edit to continue.";
+            "Category was removed from this budget - discard the staged edit to continue.";
           setSaveError(key, message);
           results.push({
             month: edit.month,

--- a/src/features/budget-management/hooks/usePrefetchAdjacentMonths.ts
+++ b/src/features/budget-management/hooks/usePrefetchAdjacentMonths.ts
@@ -46,7 +46,7 @@ export function usePrefetchAdjacentMonths({ windowStart, availableMonths }: Prop
       if (!availableSet.has(month)) continue;
       queryClient.prefetchQuery({
         ...budgetMonthDataQueryOptions(connection, month),
-        staleTime: 2 * 60 * 1000, // 2 min — keeps prefetched months fresh across navigation
+        staleTime: 2 * 60 * 1000, // 2 min - keeps prefetched months fresh across navigation
       });
     }
   }, [windowStart, availableMonths, connection, queryClient]);

--- a/src/features/budget-management/keyboard/actions.ts
+++ b/src/features/budget-management/keyboard/actions.ts
@@ -175,7 +175,7 @@ export const ACTION_META: Record<ActionId, ActionMeta> = {
     id: "selection.toggle-carryover",
     label: "Toggle carryover (rollover) on selected months",
     category: "selection",
-    description: "Anchor category only — multi-category selections fall back to the anchor's category",
+    description: "Anchor category only - multi-category selections fall back to the anchor's category",
   },
 
   "help.open-shortcuts": {

--- a/src/features/budget-management/keyboard/scopes.ts
+++ b/src/features/budget-management/keyboard/scopes.ts
@@ -9,4 +9,4 @@ export type Scope =
   | "cell-edit"     // budget cell, input focused
   | "group-cell"    // group month aggregate (first column of a group row's data)
   | "row-label"     // first-column label cell (group or category name)
-  | "workspace";    // outermost workspace container — global shortcuts
+  | "workspace";    // outermost workspace container - global shortcuts

--- a/src/features/budget-management/keyboard/useBudgetKeymap.ts
+++ b/src/features/budget-management/keyboard/useBudgetKeymap.ts
@@ -40,7 +40,7 @@ function dispatch<Ctx>(
   const handler = handlers[action];
   if (!handler) return;
   const result = handler(e, ctx);
-  if (result === false) return; // explicit no-op — let the event continue
+  if (result === false) return; // explicit no-op - let the event continue
   e.preventDefault();
 }
 

--- a/src/features/budget-management/types.ts
+++ b/src/features/budget-management/types.ts
@@ -42,7 +42,7 @@ export type LoadedGroup = {
   name: string;
   isIncome: boolean;
   hidden: boolean;
-  categoryIds: string[];  // ordered list — use with LoadedMonthState.categoriesById
+  categoryIds: string[];  // ordered list - use with LoadedMonthState.categoriesById
   budgeted: number;
   /** Actual money flow for the month: `spent` (expense groups) or `received` (income groups). */
   actuals: number;

--- a/src/features/bundle/components/BundleExportDialog.tsx
+++ b/src/features/bundle/components/BundleExportDialog.tsx
@@ -158,14 +158,14 @@ function ExportDialogBody({
           {rulesMissingDeps && (
             <p className="flex items-start gap-1.5 rounded-md bg-amber-50 px-2.5 py-2 text-xs text-amber-700 dark:bg-amber-950/40 dark:text-amber-400">
               <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
-              Rules reference Payees, Categories, and Accounts — include them
+              Rules reference Payees, Categories, and Accounts - include them
               for a portable bundle.
             </p>
           )}
           {schedulesMissingDeps && (
             <p className="flex items-start gap-1.5 rounded-md bg-amber-50 px-2.5 py-2 text-xs text-amber-700 dark:bg-amber-950/40 dark:text-amber-400">
               <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
-              Schedules reference Payees and Accounts — include them for a
+              Schedules reference Payees and Accounts - include them for a
               portable bundle.
             </p>
           )}

--- a/src/features/bundle/components/BundleImportDialog.tsx
+++ b/src/features/bundle/components/BundleImportDialog.tsx
@@ -214,7 +214,7 @@ export function BundleImportDialog({ open, onOpenChange }: Props) {
 
     const totalStaged = results.reduce((sum, r) => sum + r.staged, 0);
     if (totalStaged > 0) {
-      toast.success(`${totalStaged} entities staged — save to persist.`);
+      toast.success(`${totalStaged} entities staged - save to persist.`);
     } else {
       toast.warning("No entities were staged.");
     }
@@ -230,7 +230,7 @@ export function BundleImportDialog({ open, onOpenChange }: Props) {
             <DialogTitle>Import Bundle</DialogTitle>
             <DialogDescription>
               Select a ZIP bundle exported from Actual Bench. Entities will be
-              staged — nothing is saved until you click Save.
+              staged - nothing is saved until you click Save.
             </DialogDescription>
           </DialogHeader>
 

--- a/src/features/categories/components/CategoriesTableCategoryRow.tsx
+++ b/src/features/categories/components/CategoriesTableCategoryRow.tsx
@@ -173,7 +173,7 @@ export function CategoriesTableCategoryRow({
         {isInheritedHidden ? (
           <span
             className="flex cursor-default items-center gap-1 text-xs text-amber-500/70"
-            title="Hidden because the group is hidden — unhide the group first"
+            title="Hidden because the group is hidden - unhide the group first"
           >
             <EyeOff className="h-3 w-3" />
             Hidden - Inherited

--- a/src/features/categories/components/CategoriesView.tsx
+++ b/src/features/categories/components/CategoriesView.tsx
@@ -100,7 +100,7 @@ export function CategoriesView() {
       const total = groupsImported + catsImported;
 
       if (total === 0) {
-        toast.warning(result.skipped > 0 ? `No rows imported — ${result.skipped} skipped.` : "No valid rows found in CSV.");
+        toast.warning(result.skipped > 0 ? `No rows imported - ${result.skipped} skipped.` : "No valid rows found in CSV.");
       } else {
         const parts: string[] = [];
         if (groupsImported > 0) parts.push(`${groupsImported} group${groupsImported !== 1 ? "s" : ""}`);

--- a/src/features/payees/components/PayeesView.tsx
+++ b/src/features/payees/components/PayeesView.tsx
@@ -97,7 +97,7 @@ export function PayeesView() {
       if (imported === 0) {
         toast.warning("No valid rows found in CSV.");
       } else if (result.skipped > 0) {
-        toast.success(`Imported ${imported} payee${imported !== 1 ? "s" : ""} (${result.skipped} skipped — empty name).`);
+        toast.success(`Imported ${imported} payee${imported !== 1 ? "s" : ""} (${result.skipped} skipped - empty name).`);
       } else {
         toast.success(`Imported ${imported} payee${imported !== 1 ? "s" : ""}.`);
       }

--- a/src/features/query/components/CopyCurlButton.tsx
+++ b/src/features/query/components/CopyCurlButton.tsx
@@ -15,7 +15,7 @@ export function CopyCurlButton({ lastRequest }: CopyCurlButtonProps) {
     const curl = buildSanitizedCurl(lastRequest);
     navigator.clipboard
       .writeText(curl)
-      .then(() => toast.success("Sanitized cURL copied — secrets replaced with placeholders"))
+      .then(() => toast.success("Sanitized cURL copied - secrets replaced with placeholders"))
       .catch(() => toast.error("Failed to copy"));
   }
 
@@ -23,30 +23,30 @@ export function CopyCurlButton({ lastRequest }: CopyCurlButtonProps) {
     const curl = buildFullCurl(lastRequest);
     navigator.clipboard
       .writeText(curl)
-      .then(() => toast.warning("Full cURL copied — includes real API key and credentials"))
+      .then(() => toast.warning("Full cURL copied - includes real API key and credentials"))
       .catch(() => toast.error("Failed to copy"));
   }
 
   return (
     <>
-      {/* Safe version — prominent, always the first */}
+      {/* Safe version - prominent, always the first */}
       <Button
         size="sm"
         variant="ghost"
         onClick={copyDefaultCurl}
-        title="Copy a cURL command with secrets replaced by placeholders — safe to share"
+        title="Copy a cURL command with secrets replaced by placeholders - safe to share"
         className="gap-1.5 text-xs text-muted-foreground"
       >
         <Terminal className="h-3 w-3" />
         Copy cURL
       </Button>
 
-      {/* Dangerous version — amber styling signals risk */}
+      {/* Dangerous version - amber styling signals risk */}
       <Button
         size="sm"
         variant="ghost"
         onClick={copyFullCurl}
-        title="Copy a cURL command with real API key and credentials — do not share publicly"
+        title="Copy a cURL command with real API key and credentials - do not share publicly"
         className="gap-1.5 text-xs text-amber-600 hover:bg-amber-50 hover:text-amber-700 dark:text-amber-500 dark:hover:bg-amber-950/40 dark:hover:text-amber-400"
       >
         <ShieldAlert className="h-3 w-3" />

--- a/src/features/query/components/JsonEditor.tsx
+++ b/src/features/query/components/JsonEditor.tsx
@@ -25,10 +25,10 @@ import { colorizeJson } from "../lib/jsonColorize";
 // ─── Layout constants ─────────────────────────────────────────────────────────
 // These must match the textarea's rendered metrics exactly.
 
-const GUTTER_W   = 40;    // px — wide enough for 4-digit line numbers
-const PAD_X      = 16;    // px — horizontal content padding (matches px-4)
-const PAD_Y      = 12;    // px — vertical content padding (matches py-3)
-const FONT_SIZE  = 12;    // px — text-xs
+const GUTTER_W   = 40;    // px - wide enough for 4-digit line numbers
+const PAD_X      = 16;    // px - horizontal content padding (matches px-4)
+const PAD_Y      = 12;    // px - vertical content padding (matches py-3)
+const FONT_SIZE  = 12;    // px - text-xs
 const LINE_H_R   = 1.625; // leading-relaxed
 const LINE_H_PX  = FONT_SIZE * LINE_H_R; // 19.5 px
 

--- a/src/features/query/components/QueryExamplesPanel.tsx
+++ b/src/features/query/components/QueryExamplesPanel.tsx
@@ -51,7 +51,7 @@ function ExampleItem({
         )}
       </div>
 
-      {/* Insert affordance — always visible, signals the action */}
+      {/* Insert affordance - always visible, signals the action */}
       <ArrowUpRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-colors group-hover:text-foreground" />
     </button>
   );

--- a/src/features/query/components/QueryReferenceDialog.tsx
+++ b/src/features/query/components/QueryReferenceDialog.tsx
@@ -139,15 +139,15 @@ function BasicsSection() {
 
       <div>
         <Heading>Required field</Heading>
-        <Kv label="table">Target table name — e.g. <code className="font-mono text-[11px]">transactions</code>, <code className="font-mono text-[11px]">payees</code>, <code className="font-mono text-[11px]">categories</code>, <code className="font-mono text-[11px]">schedules</code>, <code className="font-mono text-[11px]">rules</code></Kv>
+        <Kv label="table">Target table name - e.g. <code className="font-mono text-[11px]">transactions</code>, <code className="font-mono text-[11px]">payees</code>, <code className="font-mono text-[11px]">categories</code>, <code className="font-mono text-[11px]">schedules</code>, <code className="font-mono text-[11px]">rules</code></Kv>
       </div>
 
       <div>
         <Heading>Optional fields</Heading>
-        <Kv label="filter">Filter conditions — see Filters section</Kv>
-        <Kv label="select">Fields to return — array of field names or aggregate objects</Kv>
-        <Kv label="groupBy">Array of fields to group by — pair with aggregates in select</Kv>
-        <Kv label="calculate">Scalar aggregate — returns a single value instead of rows</Kv>
+        <Kv label="filter">Filter conditions - see Filters section</Kv>
+        <Kv label="select">Fields to return - array of field names or aggregate objects</Kv>
+        <Kv label="groupBy">Array of fields to group by - pair with aggregates in select</Kv>
+        <Kv label="calculate">Scalar aggregate - returns a single value instead of rows</Kv>
         <Kv label="orderBy">Array of field names or <code className="font-mono text-[11px]">{"{ field: \"asc\" | \"desc\" }"}</code></Kv>
         <Kv label="limit">Maximum number of rows to return</Kv>
         <Kv label="offset">Number of rows to skip (for pagination)</Kv>
@@ -179,35 +179,35 @@ function FiltersSection() {
       </div>
 
       <div>
-        <Heading>Comparison — $gte, $lte</Heading>
+        <Heading>Comparison - $gte, $lte</Heading>
         <Snippet
           code={`"filter": {\n  "date": { "$gte": "2025-01-01", "$lte": "2025-01-31" }\n}`}
         />
       </div>
 
       <div>
-        <Heading>$oneof — match any in a list</Heading>
+        <Heading>$oneof - match any in a list</Heading>
         <Snippet
           code={`"filter": { "payee": { "$oneof": ["id-1", "id-2", "id-3"] } }`}
         />
       </div>
 
       <div>
-        <Heading>$and — all conditions must match</Heading>
+        <Heading>$and - all conditions must match</Heading>
         <Snippet
           code={`"filter": {\n  "$and": [\n    { "date": { "$gte": "2025-01-01" } },\n    { "category": null }\n  ]\n}`}
         />
       </div>
 
       <div>
-        <Heading>$or — any condition must match</Heading>
+        <Heading>$or - any condition must match</Heading>
         <Snippet
           code={`"filter": {\n  "$or": [\n    { "payee": "id-1" },\n    { "payee": "id-2" }\n  ]\n}`}
         />
       </div>
 
       <div>
-        <Heading>$like — pattern match</Heading>
+        <Heading>$like - pattern match</Heading>
         <Snippet code={`"filter": { "notes": { "$like": "%refund%" } }`} />
       </div>
     </div>
@@ -266,8 +266,8 @@ function AggregatesSection() {
 
       <div>
         <Heading>Functions</Heading>
-        <Kv label="$count">Count rows — typically <code className="font-mono text-[11px]">{"{ \"$count\": \"$id\" }"}</code></Kv>
-        <Kv label="$sum">Sum a numeric field — typically amount</Kv>
+        <Kv label="$count">Count rows - typically <code className="font-mono text-[11px]">{"{ \"$count\": \"$id\" }"}</code></Kv>
+        <Kv label="$sum">Sum a numeric field - typically amount</Kv>
         <Kv label="$avg">Average a numeric field</Kv>
         <Kv label="$min">Minimum value</Kv>
         <Kv label="$max">Maximum value</Kv>
@@ -401,7 +401,7 @@ function DataModelSection() {
   return (
     <div className="flex flex-col gap-5">
       <Para>
-        ActualQL exposes the following tables. Use dotted paths to traverse relationships —
+        ActualQL exposes the following tables. Use dotted paths to traverse relationships -
         e.g. <code className="font-mono text-[11px]">payee.name</code> on a{" "}
         <code className="font-mono text-[11px]">transactions</code> query resolves the linked payee&apos;s name.
       </Para>
@@ -421,7 +421,7 @@ function DataModelSection() {
             </thead>
             <tbody className="font-mono">
               {[
-                ["id", "string", "UUID — primary key"],
+                ["id", "string", "UUID - primary key"],
                 ["date", "string", "ISO date, e.g. 2025-01-15"],
                 ["amount", "integer", "Cents (÷ 100 for dollar value). Negative = expense"],
                 ["notes", "string | null", "Free-text memo"],
@@ -555,7 +555,7 @@ function DataModelSection() {
                 ["id", "UUID"],
                 ["name", "Human-readable name"],
                 ["next_date", "ISO date of next occurrence"],
-                ["posts_transaction", "boolean — auto-post when due"],
+                ["posts_transaction", "boolean - auto-post when due"],
                 ["rule", "Foreign key → rules.id (nullable)"],
               ].map(([f, n]) => (
                 <tr key={f} className="border-b border-border/40">
@@ -591,8 +591,8 @@ function DataModelSection() {
                 ["category.group", "Category group ID"],
                 ["category.group.name", "Category group display name"],
                 ["account.name", "Account display name"],
-                ["account.offbudget", "boolean — off-budget / tracking account"],
-                ["account.closed", "boolean — account is closed"],
+                ["account.offbudget", "boolean - off-budget / tracking account"],
+                ["account.closed", "boolean - account is closed"],
               ].map(([p, r]) => (
                 <tr key={p} className="border-b border-border/40">
                   <td className="px-3 py-1 text-foreground">{p}</td>

--- a/src/features/query/components/QueryResults.tsx
+++ b/src/features/query/components/QueryResults.tsx
@@ -290,7 +290,7 @@ function TableView({ data, centCols }: { data: unknown; centCols: Set<string> })
         </span>
         {isCapped && (
           <span className="text-amber-600 dark:text-amber-500">
-            Showing first {TABLE_ROW_CAP} — add{" "}
+            Showing first {TABLE_ROW_CAP} - add{" "}
             <code className="font-mono">&quot;limit&quot;</code> to control
             result size.
           </span>
@@ -463,7 +463,7 @@ export function QueryResults({
   if (error) {
     return (
       <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Status bar — shown on error too */}
+        {/* Status bar - shown on error too */}
         {execTime !== null && execTime !== undefined && (
           <ResultsActionBar
             hasResult={false}
@@ -609,7 +609,7 @@ function ResultsActionBar({
           </>
         )}
 
-        {/* Export CSV — only for array-of-objects results */}
+        {/* Export CSV - only for array-of-objects results */}
         {hasResult && isTableResult && (
           <Button
             size="sm"
@@ -637,7 +637,7 @@ function ResultsActionBar({
           </Button>
         )}
 
-        {/* cURL buttons — safe first, secrets second (amber) */}
+        {/* cURL buttons - safe first, secrets second (amber) */}
         {lastRequest && <CopyCurlButton lastRequest={lastRequest} />}
       </div>
     </div>

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -167,7 +167,7 @@ function LeftPanel({
         )}
       </div>
 
-      {/* Footer — only shown on Examples tab */}
+      {/* Footer - only shown on Examples tab */}
       {activeTab === "examples" && (
         <div className="shrink-0 border-t border-border px-3 py-2 text-[10px] text-muted-foreground/50">
           Click an example to load it into the editor.

--- a/src/features/query/lib/queryExplain.ts
+++ b/src/features/query/lib/queryExplain.ts
@@ -55,7 +55,7 @@ export function explainQuery(query: ActualQLQuery): string[] {
       all: "returns both parent and sub-transactions",
     };
     const desc = splitDesc[query.options.splits] ?? query.options.splits;
-    lines.push(`Split behavior is set to \`${query.options.splits}\` — ${desc}.`);
+    lines.push(`Split behavior is set to \`${query.options.splits}\` - ${desc}.`);
   }
 
   // Result type summary
@@ -166,7 +166,7 @@ function describeCalculate(calculate: Record<string, unknown>): string {
   };
 
   const desc = fnNames[fn] ?? `computes ${fn} of`;
-  return `Computes a scalar — ${desc} \`${operandStr}\` across matching rows.`;
+  return `Computes a scalar - ${desc} \`${operandStr}\` across matching rows.`;
 }
 
 function describeOrderBy(

--- a/src/features/query/lib/queryValidation.ts
+++ b/src/features/query/lib/queryValidation.ts
@@ -33,7 +33,7 @@ export function parseQuery(input: string): ParsedQuery | Error {
   try {
     parsed = JSON.parse(input);
   } catch {
-    return new Error("Invalid JSON — check syntax.");
+    return new Error("Invalid JSON - check syntax.");
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -91,7 +91,7 @@ export function lintQuery(query: ActualQLQuery): LintWarning[] {
     warnings.push({
       id: "unbounded-transactions",
       message:
-        'Unbounded transaction scan — may return thousands of rows and time out (15s proxy limit). Add "limit", "groupBy", or "calculate" to narrow the scope.',
+        'Unbounded transaction scan - may return thousands of rows and time out (15s proxy limit). Add "limit", "groupBy", or "calculate" to narrow the scope.',
     });
   }
 
@@ -100,7 +100,7 @@ export function lintQuery(query: ActualQLQuery): LintWarning[] {
     warnings.push({
       id: "empty-oneof",
       message:
-        'Empty "$oneof" array — this filter matches nothing and will return no results.',
+        'Empty "$oneof" array - this filter matches nothing and will return no results.',
     });
   }
 
@@ -130,7 +130,7 @@ export function lintQuery(query: ActualQLQuery): LintWarning[] {
       warnings.push({
         id: "groupby-no-aggregate",
         message:
-          '"groupBy" without an aggregate — grouped queries typically need a "$count" or "$sum" in "select".',
+          '"groupBy" without an aggregate - grouped queries typically need a "$count" or "$sum" in "select".',
       });
     }
   }

--- a/src/features/quick-create/components/QuickCreateDialog.tsx
+++ b/src/features/quick-create/components/QuickCreateDialog.tsx
@@ -111,7 +111,7 @@ function QuickCreateForm({
         break;
     }
 
-    toast.success(`${label} staged — save to persist.`);
+    toast.success(`${label} staged - save to persist.`);
     close();
   }
 
@@ -167,12 +167,12 @@ function QuickCreateForm({
         {isDuplicate && (
           <p className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
             <AlertTriangle className="h-3 w-3 shrink-0" />
-            A {ENTITY_LABELS[selectedType].toLowerCase()} named &ldquo;{trimmedName}&rdquo; already exists — it will still be staged.
+            A {ENTITY_LABELS[selectedType].toLowerCase()} named &ldquo;{trimmedName}&rdquo; already exists - it will still be staged.
           </p>
         )}
       </div>
 
-      {/* Secondary field — Category group */}
+      {/* Secondary field - Category group */}
       {selectedType === "category" && (
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-foreground">
@@ -186,13 +186,13 @@ function QuickCreateForm({
           />
           {groupOptions.length === 0 && (
             <p className="text-xs text-muted-foreground italic">
-              No category groups exist yet — create one on the Categories page first.
+              No category groups exist yet - create one on the Categories page first.
             </p>
           )}
         </div>
       )}
 
-      {/* Secondary field — Account budget type */}
+      {/* Secondary field - Account budget type */}
       {selectedType === "account" && (
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-foreground">Budget type</label>
@@ -220,7 +220,7 @@ function QuickCreateForm({
         </div>
       )}
 
-      {/* Secondary field — Tag color */}
+      {/* Secondary field - Tag color */}
       {selectedType === "tag" && (
         <div className="space-y-1.5">
           <label className="text-xs font-medium text-foreground">Color (optional)</label>

--- a/src/features/rule-diagnostics/components/RuleDiagnosticsView.tsx
+++ b/src/features/rule-diagnostics/components/RuleDiagnosticsView.tsx
@@ -144,7 +144,7 @@ export function RuleDiagnosticsView() {
           >
             <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
             <span>
-              Results are out of date — the working set has changed since this report was generated.
+              Results are out of date - the working set has changed since this report was generated.
             </span>
             <Button
               variant="ghost"

--- a/src/features/rule-diagnostics/lib/findingMessages.ts
+++ b/src/features/rule-diagnostics/lib/findingMessages.ts
@@ -112,9 +112,9 @@ function composeMessage(
     }
     case "RULE_DUPLICATE_GROUP": {
       const count = affected.length;
-      const detail = `${count} rules in this group are structurally identical — same stage, condition operator, conditions, and actions.`;
+      const detail = `${count} rules in this group are structurally identical - same stage, condition operator, conditions, and actions.`;
       return {
-        title: `${count} duplicate rules — consider merging`,
+        title: `${count} duplicate rules - consider merging`,
         message: `Use the Merge button to collapse them into one rule.`,
         details: [detail],
       };
@@ -128,7 +128,7 @@ function composeMessage(
         details.push(`Differs by ${diffPhrase} (out of conditions and actions combined).`);
       }
       return {
-        title: "Near-duplicate rules — consider merging",
+        title: "Near-duplicate rules - consider merging",
         message: `This rule differs from another rule in the same stage by only ${diffPhrase}. Use the Merge button to combine them, or confirm the difference is intentional. Other rule: ${other}.`,
         details: details.length > 0 ? details : undefined,
       };

--- a/src/features/rules/components/ActionRow.tsx
+++ b/src/features/rules/components/ActionRow.tsx
@@ -211,7 +211,7 @@ export function ActionRow({
               placeholder="=IF(ISBLANK(notes), …)"
             />
             <span className="text-[10px] text-muted-foreground">
-              Excel formula — e.g. <code>{"=IF(ISBLANK(notes), imported_payee, notes)"}</code>
+              Excel formula - e.g. <code>{"=IF(ISBLANK(notes), imported_payee, notes)"}</code>
             </span>
           </div>
         ) : isTemplate ? (
@@ -223,7 +223,7 @@ export function ActionRow({
               placeholder="{{handlebars expression…}}"
             />
             <span className="text-[10px] text-muted-foreground">
-              Handlebars template — e.g. <code>{"{{regex imported_payee 'foo' 'bar'}}"}</code>
+              Handlebars template - e.g. <code>{"{{regex imported_payee 'foo' 'bar'}}"}</code>
             </span>
           </div>
         ) : fieldDef?.type === "boolean" ? (

--- a/src/features/rules/components/ConditionRow.tsx
+++ b/src/features/rules/components/ConditionRow.tsx
@@ -157,7 +157,7 @@ function ConditionValueInput({
         placeholder="regex pattern…"
       />
       <span className="text-[10px] text-muted-foreground">
-        Regex pattern — e.g. <code>^amazon</code>
+        Regex pattern - e.g. <code>^amazon</code>
       </span>
     </div>
   ) : (

--- a/src/features/rules/components/RuleChips.tsx
+++ b/src/features/rules/components/RuleChips.tsx
@@ -92,13 +92,13 @@ export function ConditionChip({
 
   return (
     <div className="flex items-center gap-1 flex-wrap">
-      {/* Field — indigo */}
+      {/* Field - indigo */}
       <span className="rounded px-1 py-0.5 text-[11px] font-semibold bg-indigo-50 text-indigo-700 dark:bg-indigo-950/30 dark:text-indigo-400">
         {fieldLabel}
       </span>
-      {/* Op — muted */}
+      {/* Op - muted */}
       <span className="text-[11px] text-muted-foreground">{condition.op}</span>
-      {/* Values — amber for missing refs, sky for entity references, emerald for plain strings */}
+      {/* Values - amber for missing refs, sky for entity references, emerald for plain strings */}
       {resolvedValues.map(({ label, missing }, i) => (
         <span key={i} className={cn(
           "rounded px-1 py-0.5 text-[11px] font-medium",

--- a/src/features/rules/components/RuleDrawer.tsx
+++ b/src/features/rules/components/RuleDrawer.tsx
@@ -401,7 +401,7 @@ export function RuleDrawer({ open, onOpenChange, ruleId, seed }: Props) {
               )}
               {!isNew && isScheduleLinked && (
                 <span className="text-[11px] italic text-muted-foreground">
-                  Managed by schedule — delete via Schedules page
+                  Managed by schedule - delete via Schedules page
                 </span>
               )}
               <Button

--- a/src/features/rules/components/RuleEditorFields.tsx
+++ b/src/features/rules/components/RuleEditorFields.tsx
@@ -61,7 +61,7 @@ export function RuleEditorFields({
 
   return (
     <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
-      {/* Stage — pill-style toggle */}
+      {/* Stage - pill-style toggle */}
       <div className="flex items-center gap-2">
         <span id="stage-label" className="whitespace-nowrap text-xs font-medium text-muted-foreground">Stage</span>
         <div

--- a/src/features/rules/components/RulesTable.tsx
+++ b/src/features/rules/components/RulesTable.tsx
@@ -359,7 +359,7 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
                       </span>
                     </td>
 
-                    {/* Conditions — one chip per line */}
+                    {/* Conditions - one chip per line */}
                     <td className="px-3 py-2.5">
                       {rule.conditions.length === 0 ? (
                         <span className="flex items-center gap-1.5">
@@ -378,7 +378,7 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
                       )}
                     </td>
 
-                    {/* Actions — one chip per line */}
+                    {/* Actions - one chip per line */}
                     <td className="px-3 py-2.5">
                       {rule.actions.length === 0 ? (
                         <span className="text-[11px] italic text-muted-foreground">No actions</span>
@@ -437,7 +437,7 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
                           variant="ghost"
                           size="icon-xs"
                           className="text-destructive hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed"
-                          title={isScheduleLinked ? "Rule is linked to a schedule — delete it from the Schedules page" : "Delete rule"}
+                          title={isScheduleLinked ? "Rule is linked to a schedule - delete it from the Schedules page" : "Delete rule"}
                           aria-label={isScheduleLinked ? "Delete (managed by schedule)" : "Delete"}
                           disabled={isScheduleLinked}
                           aria-disabled={isScheduleLinked}

--- a/src/features/rules/components/RulesView.tsx
+++ b/src/features/rules/components/RulesView.tsx
@@ -182,7 +182,7 @@ export function RulesView() {
       } else if (result.rules.length === 0) {
         toast.warning(
           result.skipped > 0
-            ? `No rules imported — ${result.skipped} row(s) skipped.`
+            ? `No rules imported - ${result.skipped} row(s) skipped.`
             : "No valid rules found in CSV."
         );
       } else {

--- a/src/features/schedules/components/AmountModeInput.tsx
+++ b/src/features/schedules/components/AmountModeInput.tsx
@@ -52,7 +52,7 @@ export function AmountModeInput({
 
   return (
     <div className="flex flex-col gap-2">
-      {/* Mode selector — roving tabindex radiogroup */}
+      {/* Mode selector - roving tabindex radiogroup */}
       <div
         role="radiogroup"
         aria-label="Amount mode"

--- a/src/features/schedules/components/ScheduleDetailsSection.tsx
+++ b/src/features/schedules/components/ScheduleDetailsSection.tsx
@@ -59,7 +59,7 @@ export function ScheduleDetailsSection({
             options={payeeOptions}
             value={payeeId}
             onChange={(value) => setFieldValue("payeeId", value)}
-            placeholder="— none —"
+            placeholder="- none -"
           />
           {errors.payeeId?.message && (
             <p className="text-xs text-destructive">{errors.payeeId.message}</p>
@@ -73,7 +73,7 @@ export function ScheduleDetailsSection({
             options={accountOptions}
             value={accountId}
             onChange={(value) => setFieldValue("accountId", value)}
-            placeholder="— none —"
+            placeholder="- none -"
           />
           {errors.accountId?.message && (
             <p className="text-xs text-destructive">{errors.accountId.message}</p>

--- a/src/features/schedules/components/SchedulesTable.tsx
+++ b/src/features/schedules/components/SchedulesTable.tsx
@@ -419,7 +419,7 @@ export function SchedulesTable({
                           <Check className="h-3.5 w-3.5" />
                         </span>
                       ) : (
-                        <span className="text-muted-foreground/40">—</span>
+                        <span className="text-muted-foreground/40">-</span>
                       )}
                     </td>
 
@@ -430,22 +430,22 @@ export function SchedulesTable({
 
                     {/* Repeats */}
                     <td className="px-3 py-2 text-muted-foreground">
-                      {recurSummary(entity.date) || <span className="italic text-muted-foreground/40">—</span>}
+                      {recurSummary(entity.date) || <span className="italic text-muted-foreground/40">-</span>}
                     </td>
 
                     {/* Payee */}
                     <td className="px-3 py-2 text-muted-foreground">
-                      {payeeName || <span className="italic text-muted-foreground/40">—</span>}
+                      {payeeName || <span className="italic text-muted-foreground/40">-</span>}
                     </td>
 
                     {/* Account */}
                     <td className="px-3 py-2 text-muted-foreground">
-                      {accountName || <span className="italic text-muted-foreground/40">—</span>}
+                      {accountName || <span className="italic text-muted-foreground/40">-</span>}
                     </td>
 
                     {/* Auto Add */}
                     <td className="px-3 py-2 text-center">
-                      {entity.postsTransaction ? "Auto" : <span className="text-muted-foreground/40">—</span>}
+                      {entity.postsTransaction ? "Auto" : <span className="text-muted-foreground/40">-</span>}
                     </td>
 
                     {/* Row actions */}

--- a/src/features/schedules/components/SchedulesView.tsx
+++ b/src/features/schedules/components/SchedulesView.tsx
@@ -91,7 +91,7 @@ export function SchedulesView() {
       if (result.schedules.length === 0) {
         toast.warning(
           result.skipped > 0
-            ? `No schedules imported — ${result.skipped} row(s) skipped.`
+            ? `No schedules imported - ${result.skipped} row(s) skipped.`
             : "No valid schedules found in CSV."
         );
       } else {

--- a/src/features/tags/components/TagsTableRow.tsx
+++ b/src/features/tags/components/TagsTableRow.tsx
@@ -219,7 +219,7 @@ function TagsTableRowComponent({
           />
         ) : (
           <span className="block truncate">
-            {entity.description || <span className="italic text-muted-foreground/50">—</span>}
+            {entity.description || <span className="italic text-muted-foreground/50">-</span>}
           </span>
         )}
       </td>

--- a/src/features/tags/components/TagsView.tsx
+++ b/src/features/tags/components/TagsView.tsx
@@ -74,7 +74,7 @@ export function TagsView() {
       if (imported === 0) {
         toast.warning(
           result.skipped > 0
-            ? `No tags imported — ${result.skipped} row(s) skipped.`
+            ? `No tags imported - ${result.skipped} row(s) skipped.`
             : "No valid tags found in CSV."
         );
       } else {

--- a/src/features/usage-inspector/components/UsageInspectorDrawer.tsx
+++ b/src/features/usage-inspector/components/UsageInspectorDrawer.tsx
@@ -69,10 +69,10 @@ export function UsageInspectorDrawer({ entityId, entityType, open, onOpenChange 
             <>
               {/* ── Stats row ────────────────────────────────────────────── */}
               <div className="flex flex-wrap gap-2">
-                {/* Rules badge — always shown */}
+                {/* Rules badge - always shown */}
                 <StatBadge label="Rules" value={String(usage.ruleCount)} />
 
-                {/* Tx count badge — not for tags */}
+                {/* Tx count badge - not for tags */}
                 {usage.entityType !== "tag" && (
                   <StatBadge
                     label="Transactions"
@@ -81,7 +81,7 @@ export function UsageInspectorDrawer({ entityId, entityType, open, onOpenChange 
                   />
                 )}
 
-                {/* Balance badge — accounts only */}
+                {/* Balance badge - accounts only */}
                 {usage.entityType === "account" && usage.balance !== undefined && (
                   <StatBadge
                     label="Balance"
@@ -90,7 +90,7 @@ export function UsageInspectorDrawer({ entityId, entityType, open, onOpenChange 
                   />
                 )}
 
-                {/* Child count — category groups only */}
+                {/* Child count - category groups only */}
                 {usage.entityType === "categoryGroup" && usage.childCount !== undefined && (
                   <StatBadge label="Categories" value={String(usage.childCount)} />
                 )}

--- a/src/features/usage-inspector/hooks/useEntityUsage.ts
+++ b/src/features/usage-inspector/hooks/useEntityUsage.ts
@@ -60,7 +60,7 @@ export function useEntityUsage(
   }, [entityId, entityType, open, groupField, stagedCategories, stagedAccounts, stagedPayees, stagedSchedules]);
 
   const { data: txCounts, isLoading: txLoading } = useTransactionCountsForIds(
-    groupField ?? "payee", // safe fallback — hook is disabled when groupField is null
+    groupField ?? "payee", // safe fallback - hook is disabled when groupField is null
     queryIds,
     { enabled: open && !!groupField && queryIds.length > 0 }
   );

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -51,7 +51,7 @@ export function useVersionCheck(): VersionCheckState {
         setLatestVersion(latest);
         setDismissed(localStorage.getItem(dismissKey(latest)) === "1");
       })
-      .catch(() => { /* silently ignore — version check is non-critical */ });
+      .catch(() => { /* silently ignore - version check is non-critical */ });
 
     return () => { cancelled = true; };
   }, []);

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -42,7 +42,7 @@ export async function apiRequest<T>(
       kind: "api",
       status: 0,
       message:
-        err instanceof Error ? err.message : "Network error — is the dev server running?",
+        err instanceof Error ? err.message : "Network error - is the dev server running?",
     };
     throw error;
   }
@@ -134,7 +134,7 @@ export async function apiDownload(
       kind: "api",
       status: 0,
       message:
-        err instanceof Error ? err.message : "Network error — is the dev server running?",
+        err instanceof Error ? err.message : "Network error - is the dev server running?",
     };
     throw error;
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -61,7 +61,7 @@ export const logger = {
   },
 
   exception(message: string, error: unknown, meta?: LogMeta) {
-    write("error", `${message} — ${serializeError(error)}`, meta);
+    write("error", `${message} - ${serializeError(error)}`, meta);
   },
 
   child(context: LogMeta) {
@@ -79,7 +79,7 @@ export const logger = {
         write("error", message, { ...context, ...(meta ?? {}) });
       },
       exception(message: string, error: unknown, meta?: LogMeta) {
-        write("error", `${message} — ${serializeError(error)}`, {
+        write("error", `${message} - ${serializeError(error)}`, {
           ...context,
           ...(meta ?? {}),
         });

--- a/src/lib/usageWarnings.ts
+++ b/src/lib/usageWarnings.ts
@@ -34,7 +34,7 @@ export function buildPayeeDeleteWarning(
 ): string {
   // txLine is only set when we have a definite non-zero count; loading is handled separately.
   const txLine = !loading && txCount && txCount > 0
-    ? `${plural(txCount, "transaction")} will be unlinked — their payee will be cleared.`
+    ? `${plural(txCount, "transaction")} will be unlinked - their payee will be cleared.`
     : null;
 
   if (ruleCount > 0 && txLine) {
@@ -79,7 +79,7 @@ export function buildPayeeBulkDeleteWarning(
   if (loading) {
     parts.push("Checking usage...");
   } else if (txCount && txCount > 0) {
-    parts.push(`${plural(txCount, "transaction")} will be unlinked (not deleted) — their payee will be cleared.`);
+    parts.push(`${plural(txCount, "transaction")} will be unlinked (not deleted) - their payee will be cleared.`);
   }
 
   return parts.join(" ");
@@ -215,7 +215,7 @@ export function buildAccountDeleteWarning(
   if (balance !== 0) {
     parts.push(
       `Warning: "${name}" has an outstanding balance of ${formatBalance(balance)}. ` +
-      `Deleting it may cause inconsistencies — consider closing instead.`
+      `Deleting it may cause inconsistencies - consider closing instead.`
     );
   }
 
@@ -226,7 +226,7 @@ export function buildAccountDeleteWarning(
   if (loading) {
     parts.push("Checking usage...");
   } else if (txCount && txCount > 0) {
-    parts.push(`Contains ${plural(txCount, "transaction")} — these will be permanently lost.`);
+    parts.push(`Contains ${plural(txCount, "transaction")} - these will be permanently lost.`);
   }
 
   if (parts.length === 0) {
@@ -247,7 +247,7 @@ export function buildAccountBulkCloseWarning(
   if (nonZeroBalanceCount > 0) {
     return (
       `Close ${plural(count, "account")}? ` +
-      `${plural(nonZeroBalanceCount, "account")} ${nonZeroBalanceCount === 1 ? "has" : "have"} a non-zero balance — ` +
+      `${plural(nonZeroBalanceCount, "account")} ${nonZeroBalanceCount === 1 ? "has" : "have"} a non-zero balance - ` +
       `verify transfers are handled in Actual Budget before saving.`
     );
   }


### PR DESCRIPTION
## Release v1.2.0

Bumps the version **1.1.9 → 1.2.0**, capturing this cycle's work now on `main`:
- Lazy-loading of heavy components (#126)
- Native multi-arch + standalone Docker image, CI tuning
- Diagnostics snapshot caching + standalone Data Browser + clearer Tools nav (#127)
- Budget type detected from the `preferences` table (#128)

### Bundled minor polish
Normalizes em dashes (`—`) to hyphens (`-`) in **user-facing strings** for consistent typography (158 occurrences across 80 files). Comments and test descriptions are intentionally left unchanged.

Full suite **898/898 green**, tsc + eslint clean.

After merge, tag `v1.2.0` to cut the release per CONTRIBUTING.