### PR TITLE
feat(demo): add Vercel Web Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.1.9",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",
@@ -14,6 +14,7 @@
         "@sqlite.org/sqlite-wasm": "^3.41.2",
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-table": "^8.21.3",
+        "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "fflate": "^0.8.2",
@@ -4223,6 +4224,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@sqlite.org/sqlite-wasm": "^3.41.2",
     "@tanstack/react-query": "^5.95.2",
     "@tanstack/react-table": "^8.21.3",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "fflate": "^0.8.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import { Providers } from "@/components/providers";
 import "./globals.css";
 
@@ -31,6 +32,9 @@ export default function RootLayout({
     >
       <body className="h-full overflow-hidden font-sans">
         <Providers>{children}</Providers>
+        {/* Vercel Web Analytics — only on the Vercel-hosted demo, never in
+            self-hosted/Docker builds (no beacon injected off-Vercel). */}
+        {process.env.VERCEL ? <Analytics /> : null}
       </body>
     </html>
   );


### PR DESCRIPTION
Adds `@vercel/analytics` and renders `<Analytics/>` in the root layout, **gated on `process.env.VERCEL`** so the tracking beacon is only injected on the Vercel-hosted demo — self-hosted/Docker builds are unaffected.

Enable Web Analytics in the Vercel dashboard (Project → Analytics) to start collecting page views.