### PR TITLE
refactor(demo): tree-shake analytics for self-host + demo docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - **React 19** — React Compiler enabled via `reactCompiler: true` in `next.config.ts` (Turbopack/SWC path). `babel-plugin-react-compiler` is in devDependencies for Jest only. `react-hooks/incompatible-library` warning is expected, do NOT fix
 - **Tailwind 4** — no `tailwind.config.js`, config is in `globals.css` via `@theme`, no v3 patterns
 - **Zustand 5** / **TanStack Query 5** / **TanStack Table 8** / **RHF 7 + Zod 4**
-- **`distDir: ".next-build"`** — non-default output dir; affects CI artifact paths, Docker COPY, and build commands
+- **`distDir`** — `.next-build` everywhere (non-default; affects CI artifact paths, Docker COPY, build commands), **except on Vercel** (`process.env.VERCEL`) where it's the default `.next` because Vercel's builder expects that path
 
 ---
 
@@ -73,6 +73,9 @@ CI (`ci.yml`) runs lint, type-check, tests, and build on every push — no need 
 | CI/CD workflows | `.github/workflows/` |
 | Docker changes | `docker/Dockerfile.prod` |
 | Query client config | `src/lib/queryClient.ts` |
+| Demo connection endpoint | `src/app/api/demo/route.ts` |
+| Demo "Try it" button | `src/components/connect/DemoButton.tsx` |
+| Demo backend (Hugging Face Space source) | `demo/` |
 
 **Feature folder structure** (mandatory baseline):
 ```
@@ -80,6 +83,15 @@ src/features/<entity>/
   components/   hooks/   csv/   schemas/
   lib/          utils/   # optional, when the feature needs them
 ```
+
+## Demo Deployment
+
+The public demo (`actual-bench-demo.vercel.app`) is **separate from the self-hosted Docker product**: the Next.js UI runs on **Vercel**, talking to a **Hugging Face Space** backend.
+
+- **`demo/`** is the Hugging Face Space source: `actual-server` (sync) + `actual-http-api` (REST) in one image, with a seed budget **baked in** (self-resets on restart). It deploys **manually/separately** — editing `demo/` does NOT auto-update the live backend. Regenerate the seed with `node demo/generate-seed.mjs`.
+- `src/app/api/demo/route.ts` + `DemoButton` are gated on `DEMO_MODE=1` + the `DEMO_*` env vars → **inert/hidden for self-hosters**.
+- Analytics (`src/components/demo-analytics.tsx`) is Vercel-only via `NEXT_PUBLIC_ANALYTICS=1` and is **tree-shaken out of self-hosted builds**.
+- Vercel deploys a **preview per push/PR** (maintainer-only, auth-protected) and **production on every `main` merge**. Full guide: `docs/DEMO_DEPLOYMENT.md`.
 
 ## Proxy Notes
 
@@ -106,6 +118,7 @@ Read these only when relevant to the task:
 | Reviewing existing features / improvements - internal| `agents/findings.md` |
 | Context behind rejected/deferred items, constraints - internal | `agents/knowledge.md` |
 | Git, workflow, or release change | `CONTRIBUTING.md` |
+| Demo / Vercel / Hugging Face deployment | `docs/DEMO_DEPLOYMENT.md` |
 | Overall agents/ folder framework -internal | `agents/FRAMEWORK.md` |
 
 Update these only when the change requires it:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,18 @@ src/
 
 ---
 
+## Preview & demo deployments
+
+There is a public demo at **[actual-bench-demo.vercel.app](https://actual-bench-demo.vercel.app)** — the Next.js UI on Vercel (auto-deploys on every merge to `main`) plus a separate **[Hugging Face Space](https://huggingface.co/spaces/x-rous/actual-bench-demo)** backend (an `actual-server` + `actual-http-api` with a seeded budget that resets periodically).
+
+A few things to know as a contributor:
+
+- **Every PR gets a Vercel preview build automatically**, but previews are **maintainer-only** (protected by Vercel authentication). Validate your changes with local `npm run dev` and the CI checks — don't rely on the preview URL.
+- The **`demo/` folder is the Hugging Face Space source**, and it deploys **manually and separately**. Editing `demo/` in a PR does **not** update the live demo backend; a maintainer redeploys it. See [`docs/DEMO_DEPLOYMENT.md`](docs/DEMO_DEPLOYMENT.md).
+- Demo-only code (`/api/demo`, the "Try the live demo" button, Vercel analytics) is gated behind env vars and is completely inert in self-hosted builds.
+
+---
+
 ## Release Process (Maintainer)
 
 ### Reviewing the draft

--- a/docs/DEMO_DEPLOYMENT.md
+++ b/docs/DEMO_DEPLOYMENT.md
@@ -1,203 +1,94 @@
-# Public Demo Deployment Guide
+# Demo Architecture
 
-A public, free demo of Actual Bench:
+How the public **“Try the live demo”** experience is built. This is a conceptual
+overview — it is intentionally free of credentials and environment-specific
+values. None of this affects self-hosting; the demo is a separate layer.
 
-- **UI** → Vercel (Hobby, free, no credit card)
-- **Backend** → one Hugging Face Docker Space running `actual-server` (sync) behind
-  `actual-http-api` (REST), with a **seed budget baked into the image** so the demo
-  resets to a clean state on every restart.
-- **Auto-deploy** → every release (`v*` tag) redeploys the Vercel demo.
+## Two products, one repo
 
-The demo connect screen offers two paths:
-1. **Try the live demo** → one click into the seeded budget on the HF backend.
-2. **Bring your own actual-http-api** → the normal connect form (unchanged default).
+The same codebase serves two independent things:
+
+| | Self-hosted app | Public demo |
+|---|---|---|
+| **Who** | You, on your own server | Anyone, to try it out |
+| **Runs on** | Your infrastructure (Docker) | A managed UI host + a managed backend |
+| **Built/deployed by** | Release tags → Docker image | Git pushes → managed host |
+
+Everything demo-specific is **gated behind environment variables**, so a
+self-hosted build contains none of it (see *Self-host safety* below).
+
+## Topology
 
 ```
-visitor ─► Vercel: actual-bench UI ─(server-side /api/proxy)─► HF Space
-                                                               ├─ actual-http-api  (:7860, public)
-                                                               └─ actual-server    (:5006, internal)
-                                                                  └─ seed budget (resets on restart)
+visitor ─► Demo UI (Next.js, managed host)
+              │  server-side proxy (/api/proxy)
+              ▼
+           Demo backend (single container)
+              ├─ actual-http-api   (REST, public port)
+              └─ actual-server     (sync, internal only)
+                 └─ seed budget (baked into the image)
 ```
 
----
+The UI never talks to the backend from the browser — calls go through the app’s
+own server-side proxy, exactly like a self-hosted deployment.
 
-## What's already done (in this repo)
+## What happens when a visitor clicks “Try the live demo”
 
-These are committed — you don't need to write any code:
+1. The connect screen asks the server route **`/api/demo`** whether a demo is
+   configured. It answers only when the deployment opts in via demo env vars;
+   otherwise it returns `404` and the button never appears.
+2. On click, the app registers the returned demo connection and drops the
+   visitor straight into the app.
+3. From there it behaves like any other connection: the server-side proxy talks
+   to the demo backend, which serves a ready-made sample budget.
 
-- **`src/app/api/demo/route.ts`** — returns the demo connection, but only when
-  `DEMO_MODE=1` + the `DEMO_*` vars are set (404s for self-hosters).
-- **`src/components/connect/DemoButton.tsx`** + wired into the connect page — the
-  "Try the live demo" button, hidden unless `/api/demo` responds.
-- **`demo/`** — the Hugging Face Space sources: `Dockerfile`, `start.sh`,
-  `README.md`, and `generate-seed.mjs` (the seed generator).
-- **`.github/workflows/release.yml`** — a `deploy-demo` job that redeploys Vercel
-  on each release (enabled by repo variable `DEMO_DEPLOY_ENABLED=true`).
+The normal **“bring your own actual-http-api”** form remains the default path on
+the same screen.
 
-## What only you can do (account/auth-gated)
+## The seed budget & self-reset
 
-These need your logins, so they can't be automated from the repo:
+- A rich, realistic sample budget (multiple accounts, category groups,
+  payees — including intentional duplicates to showcase merging — rules,
+  schedules, several months of transactions, and budgeted amounts) is generated
+  by **`demo/generate-seed.mjs`** and **baked into the backend image**.
+- On every container start the backend restores that baked copy, so the demo
+  **self-resets to a clean state** — visitor edits never persist. This is the
+  reset mechanism; there is no separate cleanup job.
 
-1. Push `demo/` to your Hugging Face Space + set its secrets.
-2. Import the repo into Vercel + set env vars + create the deploy hook.
+## Self-host safety
 
-(The seed budget is already generated and committed — no local step needed.)
+The demo layer is inert anywhere it isn’t explicitly enabled:
 
-## Values you'll collect
+- **`/api/demo`** and the **“Try the live demo”** button activate only when the
+  demo env vars are present. Self-hosted builds → endpoint `404`s, button hidden.
+- **Analytics** is loaded through a build-flag-gated dynamic import, so it is
+  **tree-shaken out of non-demo builds** entirely — no script, no network calls.
+- The build output directory differs only on the managed UI host (it expects the
+  framework default); self-hosted/CI/Docker builds keep the project’s own dir.
 
-The seed budget is **already generated and committed** to `demo/seed-data/`, so two
-of these values are fixed (Step 1 is optional — only re-run it to customize the data):
+No demo credentials live in self-hosted builds, and none are required to
+self-host.
 
-| Value | Value / where it comes from |
+## How deploys happen
+
+- **Demo UI:** the managed host builds a **preview on every push/PR**
+  (maintainer-only, access-protected) and a **production deploy on every merge to
+  `main`**. CI and the host build run independently/in parallel.
+- **Demo backend:** deployed **manually and separately** from its own
+  `demo/` sources — editing `demo/` in a PR does **not** update the live backend
+  until a maintainer redeploys it.
+- **Self-hosted app:** unaffected by either; it ships via release tags.
+
+## Where it lives in the repo
+
+| Path | Purpose |
 |---|---|
-| `ACTUAL_SERVER_PASSWORD` | `demo-budget-public` (baked into the seed) |
-| `DEMO_BUDGET_SYNC_ID` | `d49f6afd-71bf-411b-90e0-fbaf9d9bed4b` (baked into the seed) |
-| `DEMO_API_KEY` | You choose it (Step 2.2) — any random string |
-| `DEMO_BASE_URL` | Your Space URL (Step 2.3) |
+| `src/app/api/demo/route.ts` | Demo connection endpoint (env-gated) |
+| `src/components/connect/DemoButton.tsx` | “Try the live demo” button |
+| `src/components/demo-analytics.tsx` | Analytics wrapper (demo-only, tree-shaken) |
+| `demo/Dockerfile`, `demo/start.sh` | Demo backend image (sync + REST in one) |
+| `demo/generate-seed.mjs` | Regenerates the seed budget |
+| `demo/seed-data/` | The baked seed budget |
 
-The committed seed is a rich, realistic 4-month budget: 4 accounts (incl. an
-off-budget Brokerage), 7 category groups / 19 categories, 36 payees (with
-deliberate duplicates like Amazon / Amazon.com for the payee-merge demo), 15
-rules (incl. duplicate + unused rules that the Rule Diagnostics flag), 5 monthly
-schedules, ~129 transactions, and budgets set for every category each month.
-
----
-
-## Step 1 — (Optional) Regenerate the seed budget
-
-Skip this unless you want different demo data — `demo/seed-data/` is already
-populated and committed.
-
-The seed script spins up a temporary Actual sync server, creates a "Demo Budget"
-with sample accounts + transactions, and writes the synced data into
-`demo/seed-data/`. From the repo root (needs a C compiler for `better-sqlite3`):
-
-```bash
-npm i --no-save @actual-app/api @actual-app/sync-server
-node demo/generate-seed.mjs
-```
-
-
-It prints a fresh `DEMO_BUDGET_SYNC_ID` and the `ACTUAL_SERVER_PASSWORD`. A new
-budget gets a **new Sync ID** — update it in Vercel (Step 3.2). Override the
-password with `SEED_PASSWORD=… node demo/generate-seed.mjs`.
-
----
-
-## Step 2 — Backend: Hugging Face Docker Space
-
-Your Space already exists: <https://huggingface.co/spaces/x-rous/actual-bench-demo>
-
-### 2.1 Push the files
-
-```bash
-git clone https://huggingface.co/spaces/x-rous/actual-bench-demo
-cd actual-bench-demo
-cp -r /path/to/actual-bench/demo/* .   # README.md, Dockerfile, start.sh, seed-data/, generate-seed.mjs
-git add .
-git commit -m "Actual Bench demo backend"
-git push
-```
-
-The Space's `README.md` already carries the required `sdk: docker` /
-`app_port: 7860` metadata header.
-
-### 2.2 Set the secrets
-
-Space → **Settings → Variables and secrets → New secret**:
-
-| Name | Value |
-|---|---|
-| `API_KEY` | Any random string → this becomes `DEMO_API_KEY` in Vercel |
-| `ACTUAL_SERVER_PASSWORD` | The password from Step 1 (default `demo-budget-public`) |
-
-### 2.3 Verify
-
-HF builds and boots automatically. Open the **Logs** tab and wait for
-`actual-server is up`. Then smoke-test (replace the key):
-
-```bash
-curl -H "x-api-key: <DEMO_API_KEY>" \
-  https://x-rous-actual-bench-demo.hf.space/v1/budgets
-```
-
-You should get JSON listing the demo budget. Your `DEMO_BASE_URL` is
-`https://x-rous-actual-bench-demo.hf.space`.
-
-> If the build fails, it's almost always the `@actual-app/sync-server` npm install
-> on Alpine — paste the failing log lines and we'll tweak `demo/Dockerfile`.
-
----
-
-## Step 3 — UI: Vercel
-
-### 3.1 Import the repo
-
-1. At <https://vercel.com/new>, import `x-rous/actual-bench`.
-2. Framework Preset = **Next.js** (auto-detected). Leave build settings default.
-   - This project uses `distDir: ".next-build"`; recent Vercel reads that from
-     `next.config.ts` automatically. If a build ever fails looking for `.next`,
-     keep Build Command = `next build` and Output Directory = default — do **not**
-     hardcode `.next`.
-
-### 3.2 Environment variables
-
-Project → **Settings → Environment Variables** (scope: Production, and Preview if
-you want demo previews):
-
-| Name | Value |
-|---|---|
-| `DEMO_MODE` | `1` |
-| `DEMO_BASE_URL` | `https://x-rous-actual-bench-demo.hf.space` |
-| `DEMO_API_KEY` | the `API_KEY` from Step 2.2 |
-| `DEMO_BUDGET_SYNC_ID` | the Sync ID from Step 1 |
-
-### 3.3 Deploy
-
-Redeploy (Deployments → Redeploy) so the env vars take effect. You'll get a URL
-like `https://actual-bench-<hash>.vercel.app`.
-
----
-
-## Step 4 — Verify end-to-end
-
-1. Open your Vercel URL.
-2. You should see **"Try the live demo"** above the connect form.
-   - Not showing? `/api/demo` is 404ing → re-check the four Vercel env vars and
-     redeploy.
-3. Click it → you land in the app on the seed budget's accounts and transactions.
-   - First click after the Space has been idle takes ~30–60s (HF cold start).
-4. Confirm the normal form still works: enter any other actual-http-api URL + key.
-
----
-
-## Step 5 — Auto-deploy the demo on each release
-
-1. Vercel → **Settings → Git → Deploy Hooks** → create one (branch `main`), copy
-   the URL.
-2. GitHub repo → **Settings → Secrets and variables → Actions**:
-   - **Secrets** → add `VERCEL_DEPLOY_HOOK` = the hook URL.
-   - **Variables** → add `DEMO_DEPLOY_ENABLED` = `true` (this enables the
-     `deploy-demo` job in `release.yml`).
-
-Now every `v*` release fires the hook and Vercel rebuilds from the tagged commit.
-
-> Vercel also auto-deploys on every push to `main` by default — fine, the demo just
-> tracks `main`; the hook guarantees a release-time deploy too. To deploy **only**
-> on releases, set an "Ignored Build Step" in Vercel and rely solely on the hook.
-
----
-
-## Maintenance & caveats
-
-- **Cold starts:** free HF Spaces sleep after ~48h idle; first visit wakes it
-  (~30–60s).
-- **Self-resetting data:** the budget is baked into the image and re-copied on
-  every boot, so visitor edits vanish on restart. Force a reset by restarting the
-  Space.
-- **Updating the seed:** re-run Step 1, push `demo/seed-data/` to the Space. A
-  brand-new budget gets a new Sync ID — update `DEMO_BUDGET_SYNC_ID` in Vercel.
-- **Cost:** $0. Vercel Hobby (non-commercial) + HF free Space. No credit card.
-- **Security:** the demo API key is intentionally public — it only gates a
-  throwaway sandbox. Keep self-hosted deployments free of all `DEMO_*` vars so the
-  demo button and `/api/demo` stay disabled there.
+To regenerate the seed budget, run `node demo/generate-seed.mjs` (see the script
+header for prerequisites).

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import { Analytics } from "@vercel/analytics/next";
+import { DemoAnalytics } from "@/components/demo-analytics";
 import { Providers } from "@/components/providers";
 import "./globals.css";
 
@@ -32,9 +32,8 @@ export default function RootLayout({
     >
       <body className="h-full overflow-hidden font-sans">
         <Providers>{children}</Providers>
-        {/* Vercel Web Analytics — only on the Vercel-hosted demo, never in
-            self-hosted/Docker builds (no beacon injected off-Vercel). */}
-        {process.env.VERCEL ? <Analytics /> : null}
+        {/* Demo-only analytics — tree-shaken out of non-Vercel builds. */}
+        <DemoAnalytics />
       </body>
     </html>
   );

--- a/src/components/demo-analytics.tsx
+++ b/src/components/demo-analytics.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+/**
+ * Vercel Web Analytics — used ONLY on the hosted public demo.
+ *
+ * Gated on the build-time flag `NEXT_PUBLIC_ANALYTICS`, which is set exclusively
+ * on the Vercel demo deployment. In every other build (self-hosted, Docker, CI)
+ * the flag is unset, so `ENABLED` folds to `false` and the dynamic `import()`
+ * below is dead-code-eliminated during minification: `@vercel/analytics` is
+ * never bundled, no script loads, and no network request is ever made.
+ *
+ * In other words: self-hosters ship none of this and are never tracked.
+ */
+const ENABLED = process.env.NEXT_PUBLIC_ANALYTICS === "1";
+
+const Analytics = ENABLED
+  ? dynamic(() => import("@vercel/analytics/next").then((m) => m.Analytics))
+  : () => null;
+
+export function DemoAnalytics() {
+  return <Analytics />;
+}


### PR DESCRIPTION
## Analytics: zero footprint for self-hosters
- Vercel Web Analytics now loads via a **build-flag-gated dynamic import** (`NEXT_PUBLIC_ANALYTICS`). In non-demo builds the flag is unset, so the import is dead-code-eliminated — `@vercel/analytics` is never bundled and no network call is ever made.
- Removes the static `@vercel/analytics` import from the root layout (new `src/components/demo-analytics.tsx` wrapper).

## Docs
- **`docs/DEMO_DEPLOYMENT.md`** rewritten as a **credential-free architecture overview** (no secrets, no infra-specific values).
- **`CONTRIBUTING.md`**: note that PR previews are maintainer-only, and that the `demo/` backend deploys manually/separately.
- **`AGENTS.md`**: demo deployment notes, File Map entries, `distDir` Vercel exception, docs pointer.

Requires `NEXT_PUBLIC_ANALYTICS=1` in the Vercel project for analytics to load on the demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer documentation for demo deployment and preview builds, including how the public demo differs from the self-hosted product.
  * Expanded contributor guidance with details on demo and preview environments.

* **Bug Fixes**
  * Improved analytics handling so tracking is only loaded in demo-enabled builds and stays out of self-hosted deployments.
  * Clarified build output behavior for local, preview, and Vercel deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->