### PR TITLE
PR-017: Direct Browser API Transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Actual Bench — Agent Rules
 
-> Self-hosted admin UI for Actual Budget. Backend: `actual-http-api`.
-> Architecture: **Client → Next.js Proxy → actual-http-api**
+> Self-hosted admin UI for Actual Budget. Target backend: **Direct Actual Server** via the browser API transport; compatibility backend: **HTTP API Server** via `actual-http-api`.
+> Architecture: **Client → Direct transport → Actual Server** (target) and **Client → Next.js Proxy → actual-http-api** (maintained compatibility).
 > Editing model: **Staged. Nothing writes to server until user clicks Save.**
 
 ---
@@ -26,8 +26,8 @@ import { generateId } from "@/lib/uuid";
 
 **API calls**
 ```ts
-// ❌ fetch() directly to actual-http-api
-// ✅ apiRequest() → /api/proxy → actual-http-api
+// ❌ fetch() directly to actual-http-api or Actual Server from feature code
+// ✅ feature code uses transport/business helpers; HTTP API Server helpers use apiRequest() → /api/proxy → actual-http-api
 ```
 
 **Mutations**
@@ -63,8 +63,9 @@ CI (`ci.yml`) runs lint, type-check, tests, and build on every push — no need 
 ## File Map
 | Task | Path |
 |---|---|
-| API logic | `src/lib/api/<entity>.ts` |
-| Proxy | `src/app/api/proxy/route.ts` |
+| Transport logic | `src/lib/actual/*` |
+| HTTP API Server helper logic | `src/lib/api/<entity>.ts` |
+| Proxy (HTTP API Server mode) | `src/app/api/proxy/route.ts` |
 | Staged store (entity pages) | `src/store/staged.ts` |
 | Budget cell edits store | `src/store/budgetEdits.ts` |
 | Budget mode shared utility | `src/lib/budget/deriveBudgetMode.ts` |
@@ -95,7 +96,7 @@ The public demo (`actual-bench-demo.vercel.app`) is **separate from the self-hos
 
 ## Proxy Notes
 
-The proxy is responsible for:
+The proxy is the maintained HTTP API Server compatibility path. Direct mode should not duplicate proxy behavior; it should go through the transport abstraction. The proxy is responsible for:
 
 - CORS handling.
 - Request serialization using `serverQueueTails`.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,7 +5,7 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
-- Experimental Direct Actual Server mode opens a selected budget through the browser API worker for read-only core entity pages without an `actual-http-api` proxy; writes remain Classic-only in this milestone
+- Experimental Direct Actual Server mode opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages support reads and staged entity saves, while Budget Management saves remain Classic-only in this milestone
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,7 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
+- Experimental Direct Actual Server mode opens a selected budget through the browser API worker for read-only core entity pages without an `actual-http-api` proxy; writes remain Classic-only in this milestone
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,7 +5,7 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
-- Experimental Direct Actual Server mode opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages support reads and staged entity saves, while Budget Management saves remain Classic-only in this milestone
+- Experimental Direct Actual Server mode opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages and Budget Management support reads and staged saves in the Direct transport
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,8 +5,8 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
-- Direct Actual Server mode is available by default and opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages and Budget Management support reads and staged saves in the Direct transport
-- Direct mode is clearly gated for HTTP API Server-only tools: Budget File Health, Data Browser, and the generic ActualQL Query workspace show unavailable states instead of running broken export/query paths
+- Direct Actual Server mode is available by default and opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages, Budget Management, Budget File Health, and Data Browser support the Direct transport
+- Direct mode is clearly gated for HTTP API Server-only tools: the generic ActualQL Query workspace shows an unavailable state instead of running an unsupported query-console path
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,7 +5,7 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
-- Direct Actual Server mode opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages and Budget Management support reads and staged saves in the Direct transport when `DIRECT_BROWSER_API=1` or `NEXT_PUBLIC_DIRECT_BROWSER_API=1` is enabled
+- Direct Actual Server mode is available by default and opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages and Budget Management support reads and staged saves in the Direct transport
 - Direct mode is clearly gated for HTTP API Server-only tools: Budget File Health, Data Browser, and the generic ActualQL Query workspace show unavailable states instead of running broken export/query paths
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,7 +5,8 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
-- Experimental Direct Actual Server mode opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages and Budget Management support reads and staged saves in the Direct transport
+- Direct Actual Server mode opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages and Budget Management support reads and staged saves in the Direct transport when `DIRECT_BROWSER_API=1` or `NEXT_PUBLIC_DIRECT_BROWSER_API=1` is enabled
+- Direct mode is clearly gated for HTTP API Server-only tools: Budget File Health, Data Browser, and the generic ActualQL Query workspace show unavailable states instead of running broken export/query paths
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed
@@ -506,7 +507,7 @@ budget-bundle-<label>-<date>.zip
 - Help menu in the sidebar with links to the GitHub repository, issue tracker, and changelog; a separate standalone "Keyboard shortcuts" button below it opens an app-wide shortcuts cheatsheet
 - Top bar shows a compact version cluster beside the active connection with `API` and `Actual` version badges when available
 - **Dark mode toggle** in the sidebar footer: cycles System → Light → Dark; preference persists in `localStorage`; icon reflects the resolved appearance (Moon when OS is dark in System mode, Sun when OS is light)
-- **Connection health indicator**: a coloured dot inside the connection dropdown trigger in the top bar actively polls `GET /actualhttpapiversion` every 30 seconds. Green = healthy (with round-trip latency in the tooltip), pulsing amber = checking, solid amber = degraded (>3 s response), red = offline. When the server is unreachable for two consecutive checks, a non-blocking red strip appears below the top bar and the Save button is disabled with an explanatory tooltip. The banner and disabled state clear automatically as soon as a check succeeds. Polling pauses when the browser tab is hidden and resumes immediately on tab focus.
+- **Connection health indicator**: HTTP API Server connections poll `GET /actualhttpapiversion` every 30 seconds through the proxy. Green = healthy (with round-trip latency in the tooltip), pulsing amber = checking, solid amber = degraded (>3 s response), red = offline. Direct connections show a distinct Direct browser-session status without pinging HTTP API version endpoints. When an HTTP API Server is unreachable for two consecutive checks, a non-blocking red strip appears below the top bar and the Save button is disabled with an explanatory tooltip. The banner and disabled state clear automatically as soon as a check succeeds. Polling pauses when the browser tab is hidden and resumes immediately on tab focus.
 
 ---
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,8 +5,8 @@
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
 - Save multiple server connections and switch between them with one click from the top bar
 - Optional encryption password for end-to-end encrypted budgets
-- Direct Actual Server mode is available by default and opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages, Budget Management, Budget File Health, and Data Browser support the Direct transport
-- Direct mode is clearly gated for HTTP API Server-only tools: the generic ActualQL Query workspace shows an unavailable state instead of running an unsupported query-console path
+- Direct Actual Server mode is the target architecture and opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages, Budget Management, Budget File Health, Data Browser, and ActualQL Queries support the Direct transport
+- HTTP API Server mode remains fully maintained as the `actual-http-api` compatibility path; HTTP-specific actions stay mode-aware, and ActualQL cURL generation is shown only for HTTP API Server query executions
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
 - Connections are stored in session storage and cleared automatically when the tab is closed
@@ -351,7 +351,8 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
 
 ## ActualQL Queries
 
-- Dedicated query workspace for running arbitrary ActualQL JSON queries against the open budget
+- Dedicated query workspace for running arbitrary ActualQL JSON queries against the open budget in HTTP API Server mode or Direct Actual Server mode
+- Accepts bare ActualQL query objects and the wrapped `{ "ActualQLquery": ... }` shape used by actual-http-api
 - Resizable editor / results split — drag the divider to adjust the balance; position persists across reloads via session storage
 - Syntax-highlighted JSON editor with line numbers, current-line highlight, and JetBrains Mono font; edit raw JSON directly with no normalization or auto-correction
 - Action bar: Run (or Ctrl/Cmd+Enter), Format JSON, Save, Explain, and ActualQL Reference buttons
@@ -364,8 +365,8 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
   - **Tree** — collapsible recursive JSON tree; auto-selected for plain-object results; nodes with more than 5 children start collapsed
 - Smart cell formatting in the table view: ISO date strings displayed as human-readable dates (e.g. `Jan 15, 2024`); `amount` and `balance` integer columns formatted as decimal values (cents ÷ 100); raw value always accessible via hover tooltip
 - Execution metadata bar: OK / Error status chip, elapsed time, row count, and payload size shown inline with the result actions
-- Result actions: Copy result JSON, Copy query JSON, Copy sanitized cURL (secrets replaced with placeholders), and Copy full cURL (opt-in, clearly marked as containing real credentials)
-- cURL is always generated from the last successfully executed request, not the current editor state
+- Result actions: Copy result JSON and Copy query JSON in all modes; HTTP API Server executions also expose sanitized cURL (secrets replaced with placeholders) and full cURL (opt-in, clearly marked as containing real credentials)
+- HTTP cURL is always generated from the last HTTP API Server request, not the current editor state
 - **Explain this query** — one-click plain-English summary of what the current query does: target table, filters, grouping, aggregation, ordering, and whether the result is tabular or scalar
 - **ActualQL Reference** dialog — six-section quick reference covering basics, filter operators, joined fields, aggregates, transactions-specific options, and copyable snippets
 - Built-in example packs in four groups (Data inspection, Cleanup & validation, Aggregation, Targeted subset) — one-click insert into the editor

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -3,13 +3,14 @@
 ## Connection Management
 
 - Two-step connect flow: validate server credentials (URL + API key), then pick from the list of budgets returned by the server
-- Save multiple server connections and switch between them with one click from the top bar
+- Add multiple in-memory budget connections and switch between them with one click from the top bar
+- Saved server presets keep non-secret URLs/labels for reconnecting without retyping the server URL
 - Optional encryption password for end-to-end encrypted budgets
 - Direct Actual Server mode is the target architecture and opens a selected budget through the browser API worker without an `actual-http-api` proxy; core entity pages, Budget Management, Budget File Health, Data Browser, and ActualQL Queries support the Direct transport
 - HTTP API Server mode remains fully maintained as the `actual-http-api` compatibility path; HTTP-specific actions stay mode-aware, and ActualQL cURL generation is shown only for HTTP API Server query executions
 - Remove saved connections individually
 - Per-connection query cache and staged data scoping — switching connections never leaks data between sessions
-- Connections are stored in session storage and cleared automatically when the tab is closed
+- API keys, Actual Server passwords, and budget encryption passwords are kept in memory only; saved server presets in session storage contain non-secret connection details only
 
 ## Quick Create
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ---
 
-**Actual Bench** is a companion app for [Actual Budget](https://github.com/actualbudget/actual). It connects to a self-hosted [actual-http-api](https://github.com/jhonderson/actual-http-api) server and gives power users a focused interface for the work that is hard to do in the native Actual Budget UI: bulk setup, master-data cleanup, advanced rule maintenance, full year view budget editing, diagnostics, and ad-hoc ActualQL analysis.
+**Actual Bench** is a companion app for [Actual Budget](https://github.com/actualbudget/actual). It connects through the self-hosted [actual-http-api](https://github.com/jhonderson/actual-http-api) proxy by default, with an opt-in Direct Actual Server mode for selected browser-transport workflows. It gives power users a focused interface for the work that is hard to do in the native Actual Budget UI: bulk setup, master-data cleanup, advanced rule maintenance, full year view budget editing, diagnostics, and ad-hoc ActualQL analysis.
 
 It is not trying to replace Actual Budget's day-to-day transaction entry experience. It is the workbench you open when you need to inspect, repair, seed, audit, or reshape your budget data with confidence.
 
@@ -172,14 +172,22 @@ flowchart LR
   App --> Proxy
   Proxy --> API
   API --> Actual
+  Browser -. Direct mode .-> Actual
   Actual --> Budget
 ```
 
-All requests to `actual-http-api` go through Actual Bench's internal Next.js proxy. The browser does not call `actual-http-api` directly.
+HTTP API Server mode sends all `actual-http-api` requests through Actual Bench's internal Next.js proxy; the browser never calls `actual-http-api` directly. Direct mode bypasses `actual-http-api` and uses Actual's browser API worker from the user's browser.
+
+### Direct mode
+
+Direct mode is opt-in. Set `DIRECT_BROWSER_API=1` or `NEXT_PUBLIC_DIRECT_BROWSER_API=1` and restart the app to enable the Direct connection tab and the worker/static asset headers. The app must be served with cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`), and the Actual Server must be reachable from the browser through CORS or a same-origin reverse proxy.
+
+Direct mode currently supports core entity pages and Budget Management reads/staged saves. Budget File Health, Data Browser, and the generic ActualQL Query workspace remain HTTP API Server-only because they depend on full budget export or broader query-console compatibility.
 
 ## Privacy and data handling
 
 - Saved connections are stored in **session storage** and are cleared when the browser tab is closed.
+- Direct mode credentials are also kept in session storage; use **Disconnect All Connections** or **Clear all data** to remove Actual Bench connection state in the current tab. Actual's browser worker cache may require clearing this site's browser data if it becomes stale or corrupt.
 - Staged data and query cache are scoped per connection so switching budgets does not leak local state between sessions.
 - Budget File Health and the Data Browser process exported snapshots locally in the browser and do not write changes back to the budget.
 - Exported budget ZIP files and diagnostic data may still contain personal financial information, so handle downloaded files carefully.
@@ -189,8 +197,8 @@ All requests to `actual-http-api` go through Actual Bench's internal Next.js pro
 ## Requirements
 
 - A running [Actual Budget](https://github.com/actualbudget/actual) server
-- A running [actual-http-api](https://github.com/jhonderson/actual-http-api) instance connected to that server
-- An `ACTUAL_API_KEY` configured for `actual-http-api`
+- For HTTP API Server mode: a running [actual-http-api](https://github.com/jhonderson/actual-http-api) instance and an `ACTUAL_API_KEY`
+- For Direct mode: `DIRECT_BROWSER_API=1` or `NEXT_PUBLIC_DIRECT_BROWSER_API=1`, cross-origin isolation headers, and browser access from Actual Bench to Actual Server
 - Docker, Docker Compose, or Node.js 20+ for local development
 
 
@@ -267,20 +275,22 @@ Replace `actual-stack` with your real Docker network name.
 
 ## Connecting to a budget
 
-Actual Bench uses a two-step connection flow.
+Actual Bench uses a two-step connection flow for both HTTP API Server and Direct Actual Server connections.
 
 ### 1. Choose a server
 
-Enter your `actual-http-api` base URL and API key, then click **Load Budgets**.
+Choose **HTTP API Server** for an `actual-http-api` proxy, or **Direct Actual Server** for a browser-to-Actual Server connection. Enter the matching server URL and credential, then click **Load Budgets**.
 
 | Field | Description |
 |---|---|
-| **API Server URL** | Base URL of your `actual-http-api` server, for example `https://actual-api.example.com` |
-| **API Key** | The `ACTUAL_API_KEY` configured on the API server |
+| **HTTP API Server URL** | Base URL of your `actual-http-api` server, for example `https://actual-api.example.com` |
+| **API Key** | The `ACTUAL_API_KEY` configured on the HTTP API server |
+| **Actual Server URL** | Base URL of your Actual Server when using Direct mode, for example `https://actual.example.com` |
+| **Actual Server password** | The password used by Actual Server browser clients |
 
 ### 2. Choose a budget
 
-Pick a budget returned by the API server, optionally enter the encryption password for encrypted budgets, and click **Connect**.
+Pick a budget returned by the selected server, optionally enter the encryption password for encrypted budgets, and click **Connect**.
 
 Previously used connections appear on the connection screen for one-click reconnect during the current browser session.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ---
 
-**Actual Bench** is a companion app for [Actual Budget](https://github.com/actualbudget/actual). Its target architecture is Direct Actual Server access through Actual's browser API transport, while HTTP API Server mode through [actual-http-api](https://github.com/jhonderson/actual-http-api) remains fully supported for existing deployments and integrations. It gives power users a focused interface for the work that is hard to do in the native Actual Budget UI: bulk setup, master-data cleanup, advanced rule maintenance, full year view budget editing, diagnostics, and ad-hoc ActualQL analysis.
+**Actual Bench** is a companion app for [Actual Budget](https://github.com/actualbudget/actual). Its target architecture is Direct Actual Server access through Actual's browser API transport, while HTTP API Server mode through [actual-http-api](https://github.com/jhonderson/actual-http-api) remains fully supported for existing deployments and integrations. It gives power users a focused interface for the work that is cumbersome in the native Actual Budget UI: bulk setup, master-data cleanup, advanced rule maintenance, full-year view budget editing, diagnostics, and ad-hoc ActualQL analysis.
 
 It is not trying to replace Actual Budget's day-to-day transaction entry experience. It is the workbench you open when you need to inspect, repair, seed, audit, or reshape your budget data with confidence.
 
@@ -190,8 +190,8 @@ Direct mode currently supports core entity pages, Budget Management reads/staged
 
 ## Privacy and data handling
 
-- Saved connections are stored in **session storage** and are cleared when the browser tab is closed.
-- Direct mode credentials are also kept in session storage; use **Disconnect All Connections** or **Clear all data** to remove Actual Bench connection state in the current tab. Actual's browser worker cache may require clearing this site's browser data if it becomes stale or corrupt.
+- Saved server presets store only non-secret details in **session storage** and are cleared when the browser tab is closed.
+- API keys, Actual Server passwords, and budget encryption passwords are kept in memory only. Refreshing or reopening the tab requires reconnecting. Actual's browser worker cache may require clearing this site's browser data if it becomes stale or corrupt.
 - Staged data and query cache are scoped per connection so switching budgets does not leak local state between sessions.
 - Budget File Health and the Data Browser process exported snapshots locally in the browser and do not write changes back to the budget.
 - Exported budget ZIP files and diagnostic data may still contain personal financial information, so handle downloaded files carefully.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ HTTP API Server mode sends all `actual-http-api` requests through Actual Bench's
 
 ### Direct mode
 
-Direct mode is opt-in. Set `DIRECT_BROWSER_API=1` or `NEXT_PUBLIC_DIRECT_BROWSER_API=1` and restart the app to enable the Direct connection tab and the worker/static asset headers. The app must be served with cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`), and the Actual Server must be reachable from the browser through CORS or a same-origin reverse proxy.
+Direct mode is shown by default alongside HTTP API Server mode. It uses worker/static asset headers required for cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`), and the Actual Server must be reachable from the browser through CORS or a same-origin reverse proxy. Set `DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0` only if your deployment cannot support Direct mode.
 
 Direct mode currently supports core entity pages and Budget Management reads/staged saves. Budget File Health, Data Browser, and the generic ActualQL Query workspace remain HTTP API Server-only because they depend on full budget export or broader query-console compatibility.
 
@@ -198,7 +198,7 @@ Direct mode currently supports core entity pages and Budget Management reads/sta
 
 - A running [Actual Budget](https://github.com/actualbudget/actual) server
 - For HTTP API Server mode: a running [actual-http-api](https://github.com/jhonderson/actual-http-api) instance and an `ACTUAL_API_KEY`
-- For Direct mode: `DIRECT_BROWSER_API=1` or `NEXT_PUBLIC_DIRECT_BROWSER_API=1`, cross-origin isolation headers, and browser access from Actual Bench to Actual Server
+- For Direct mode: browser access from Actual Bench to Actual Server, plus cross-origin isolation/CORS support. Direct mode is enabled by default; set `DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0` to hide it when a deployment cannot support it
 - Docker, Docker Compose, or Node.js 20+ for local development
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ---
 
-**Actual Bench** is a companion app for [Actual Budget](https://github.com/actualbudget/actual). It connects through the self-hosted [actual-http-api](https://github.com/jhonderson/actual-http-api) proxy by default, with an opt-in Direct Actual Server mode for selected browser-transport workflows. It gives power users a focused interface for the work that is hard to do in the native Actual Budget UI: bulk setup, master-data cleanup, advanced rule maintenance, full year view budget editing, diagnostics, and ad-hoc ActualQL analysis.
+**Actual Bench** is a companion app for [Actual Budget](https://github.com/actualbudget/actual). Its target architecture is Direct Actual Server access through Actual's browser API transport, while HTTP API Server mode through [actual-http-api](https://github.com/jhonderson/actual-http-api) remains fully supported for existing deployments and integrations. It gives power users a focused interface for the work that is hard to do in the native Actual Budget UI: bulk setup, master-data cleanup, advanced rule maintenance, full year view budget editing, diagnostics, and ad-hoc ActualQL analysis.
 
 It is not trying to replace Actual Budget's day-to-day transaction entry experience. It is the workbench you open when you need to inspect, repair, seed, audit, or reshape your budget data with confidence.
 
@@ -126,7 +126,7 @@ A read-only local diagnostics workspace for the exported budget snapshots.
 
 ### ActualQL Queries
 
-A dedicated query console using ActualQL API end point for advanced queries and analysis.
+A dedicated query console using ActualQL for advanced queries and analysis, available in HTTP API Server mode and Direct Actual Server mode.
 
 - Syntax-highlighted JSON editor with line numbers
 - Run with button or `Ctrl/Cmd+Enter`
@@ -134,7 +134,7 @@ A dedicated query console using ActualQL API end point for advanced queries and 
 - Explain query intent in plain English
 - Built-in ActualQL reference and example packs
 - Result views: table, raw JSON, scalar, and collapsible tree
-- Copy result JSON, query JSON, sanitized cURL, or full cURL when explicitly needed
+- Copy result JSON and query JSON in all modes; copy sanitized or full actual-http-api cURL from HTTP API Server executions when explicitly needed
 - Warns when staged local changes exist because query results reflect saved server state
 
 ### Excel Companion Workbook
@@ -163,26 +163,30 @@ Actual Bench is built around a review-before-save workflow.
 flowchart LR
   Browser[Browser]
   App["Actual Bench<br/>Next.js app"]
-  Proxy[Internal /api/proxy]
+  Direct["Direct transport<br/>@actual-app/api browser build"]
+  Worker["Browser worker<br/>local budget runtime"]
+  Proxy["Internal /api/proxy"]
   API[actual-http-api]
   Actual[Actual Budget server]
   Budget[(Budget data)]
 
   Browser --> App
-  App --> Proxy
-  Proxy --> API
-  API --> Actual
-  Browser -. Direct mode .-> Actual
+  App --> Direct
+  Direct --> Worker
+  Worker --> Actual
+  App -. HTTP API Server mode .-> Proxy
+  Proxy -.-> API
+  API -.-> Actual
   Actual --> Budget
 ```
 
-HTTP API Server mode sends all `actual-http-api` requests through Actual Bench's internal Next.js proxy; the browser never calls `actual-http-api` directly. Direct mode bypasses `actual-http-api` and uses Actual's browser API worker from the user's browser.
+Direct mode is the target architecture for browser-based Actual Bench workflows: it bypasses `actual-http-api` and uses Actual's browser API worker from the user's browser. HTTP API Server mode remains a maintained compatibility architecture; it sends all `actual-http-api` requests through Actual Bench's internal Next.js proxy, and the browser never calls `actual-http-api` directly.
 
 ### Direct mode
 
-Direct mode is shown by default alongside HTTP API Server mode. It uses worker/static asset headers required for cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`), and the Actual Server must be reachable from the browser through CORS or a same-origin reverse proxy. Set `DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0` only if your deployment cannot support Direct mode.
+Direct mode is shown by default alongside HTTP API Server mode and is the preferred target for new browser workflows. It uses worker/static asset headers required for cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`), and the Actual Server must be reachable from the browser through CORS or a same-origin reverse proxy. Set `DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0` only if your deployment cannot support Direct mode.
 
-Direct mode currently supports core entity pages, Budget Management reads/staged saves, Budget File Health, and Data Browser. The generic ActualQL Query workspace remains HTTP API Server-only because it depends on broader query-console compatibility.
+Direct mode currently supports core entity pages, Budget Management reads/staged saves, Budget File Health, Data Browser, and the ActualQL Query workspace. HTTP API Server mode remains first-class and maintained for deployments that prefer or require `actual-http-api`; query cURL generation remains HTTP API Server-only because it targets actual-http-api's `/run-query` endpoint.
 
 ## Privacy and data handling
 
@@ -197,8 +201,8 @@ Direct mode currently supports core entity pages, Budget Management reads/staged
 ## Requirements
 
 - A running [Actual Budget](https://github.com/actualbudget/actual) server
-- For HTTP API Server mode: a running [actual-http-api](https://github.com/jhonderson/actual-http-api) instance and an `ACTUAL_API_KEY`
 - For Direct mode: browser access from Actual Bench to Actual Server, plus cross-origin isolation/CORS support. Direct mode is enabled by default; set `DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0` to hide it when a deployment cannot support it
+- For HTTP API Server mode: a running [actual-http-api](https://github.com/jhonderson/actual-http-api) instance and an `ACTUAL_API_KEY`
 - Docker, Docker Compose, or Node.js 20+ for local development
 
 
@@ -222,7 +226,7 @@ docker run -d \
   xrous/actual-bench:edge
 ```
 
-Open `http://localhost:3000` and connect to your `actual-http-api` server.
+Open `http://localhost:3000` and connect with Direct Actual Server mode, or use HTTP API Server mode if you run `actual-http-api`.
 
 ### Docker Compose
 
@@ -244,7 +248,7 @@ docker compose up -d
 
 ### Docker networking note
 
-If Actual Bench and `actual-http-api` are running in separate containers, Actual Bench must be able to reach `actual-http-api` **from inside the Actual Bench container**.
+Direct mode is browser-to-Actual-Server, so the browser must be able to reach your Actual Server URL and the response must satisfy CORS/cross-origin-isolation requirements. HTTP API Server mode is server-to-`actual-http-api`: if Actual Bench and `actual-http-api` are running in separate containers, Actual Bench must be able to reach `actual-http-api` **from inside the Actual Bench container**.
 
 If the UI shows `fetch failed` or `502 Bad Gateway`, check whether both containers share a Docker network:
 
@@ -279,7 +283,7 @@ Actual Bench uses a two-step connection flow for both HTTP API Server and Direct
 
 ### 1. Choose a server
 
-Choose **HTTP API Server** for an `actual-http-api` proxy, or **Direct Actual Server** for a browser-to-Actual Server connection. Enter the matching server URL and credential, then click **Load Budgets**.
+Choose **Direct Actual Server** for the target browser-to-Actual Server connection, or **HTTP API Server** for the maintained `actual-http-api` compatibility path. Enter the matching server URL and credential, then click **Load Budgets**.
 
 | Field | Description |
 |---|---|
@@ -358,7 +362,7 @@ Open `http://localhost:3000`.
 ## Known limitations
 
 - Main entity admin pages load the full entity set; very large budgets may feel slower on Accounts, Payees, Categories, Rules, and similar pages.
-- Actual Bench depends on `actual-http-api`; unsupported or changing API endpoints may affect some features.
+- Direct mode depends on browser cross-origin isolation, CORS, and Actual's browser API package. HTTP API Server mode depends on `actual-http-api`; unsupported or changing API endpoints may affect that compatibility path.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ HTTP API Server mode sends all `actual-http-api` requests through Actual Bench's
 
 Direct mode is shown by default alongside HTTP API Server mode. It uses worker/static asset headers required for cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`), and the Actual Server must be reachable from the browser through CORS or a same-origin reverse proxy. Set `DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0` only if your deployment cannot support Direct mode.
 
-Direct mode currently supports core entity pages and Budget Management reads/staged saves. Budget File Health, Data Browser, and the generic ActualQL Query workspace remain HTTP API Server-only because they depend on full budget export or broader query-console compatibility.
+Direct mode currently supports core entity pages, Budget Management reads/staged saves, Budget File Health, and Data Browser. The generic ActualQL Query workspace remains HTTP API Server-only because it depends on broader query-console compatibility.
 
 ## Privacy and data handling
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -13,15 +13,15 @@ services:
     volumes:
       # Source code — edits on the host are reflected immediately via HMR
       - /opt/projects/actual-bench:/workspace
-      # Persist Turbopack's build cache across container restarts.
-      # Without this, every restart rebuilds from scratch and triggers
-      # an HMR loop while Turbopack writes its initial dev/types/*.ts files.
+      # Persist Turbopack's cache volume, but clear .next-build/dev on
+      # startup below so stale route manifests/locks cannot survive branch
+      # switches or host-side source updates.
       - next-build-cache:/workspace/.next-build
     # Do NOT run npm install here — install on the host once and let the
     # volume mount bring node_modules in. Installing inside the container on
     # every start is slow and compiles native addons for the wrong platform.
     #command: npm run dev -- --hostname 0.0.0.0
-    command: sh -c "npm run dev -- --hostname 0.0.0.0"
+    command: sh -c "rm -rf .next-build/dev && npm run dev -- --hostname 0.0.0.0"
     environment:
       - NODE_ENV=development
       - NEXT_TELEMETRY_DISABLED=1

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -7,6 +7,8 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/.next-build/'],
+  modulePathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/.next-build/'],
 }
 
 module.exports = createJestConfig(customJestConfig)

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,24 @@ const pkg = JSON.parse(
   readFileSync(join(process.cwd(), "package.json"), "utf8")
 ) as { version?: string };
 
+const directBrowserApiLabEnabled =
+  process.env.NEXT_PUBLIC_DIRECT_BROWSER_API === "1";
+
+const directBrowserApiLabHeaders = [
+  {
+    key: "Cross-Origin-Opener-Policy",
+    value: "same-origin",
+  },
+  {
+    key: "Cross-Origin-Embedder-Policy",
+    value: "require-corp",
+  },
+  {
+    key: "Cross-Origin-Resource-Policy",
+    value: "same-origin",
+  },
+];
+
 const nextConfig: NextConfig = {
   // Emit a self-contained standalone server (server.js + only the traced
   // runtime node_modules) so the Docker runtime image doesn't carry the full
@@ -36,6 +54,28 @@ const nextConfig: NextConfig = {
   // current release without needing it set in .env files.
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version ?? "0.0.0",
+  },
+  async headers() {
+    if (!directBrowserApiLabEnabled) return [];
+
+    return [
+      {
+        source: "/browser-api-lab",
+        headers: directBrowserApiLabHeaders,
+      },
+      {
+        source: "/browser-api-lab/:path*",
+        headers: directBrowserApiLabHeaders,
+      },
+      {
+        source: "/_next/static/:path*",
+        headers: directBrowserApiLabHeaders,
+      },
+      {
+        source: "/actual-api-assets/:path*",
+        headers: directBrowserApiLabHeaders,
+      },
+    ];
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,9 +6,14 @@ const pkg = JSON.parse(
   readFileSync(join(process.cwd(), "package.json"), "utf8")
 ) as { version?: string };
 
-const directBrowserApiLabEnabled =
-  process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]?.trim() === "1" ||
-  process.env["DIRECT_BROWSER_API"]?.trim() === "1";
+function isDirectBrowserApiDisabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "off";
+}
+
+const directBrowserApiEnabled =
+  !isDirectBrowserApiDisabled(process.env["DIRECT_BROWSER_API"]) &&
+  !isDirectBrowserApiDisabled(process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]);
 
 const directBrowserApiLabHeaders = [
   {
@@ -55,10 +60,10 @@ const nextConfig: NextConfig = {
   // current release without needing it set in .env files.
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version ?? "0.0.0",
-    NEXT_PUBLIC_DIRECT_BROWSER_API_ENABLED: directBrowserApiLabEnabled ? "1" : "0",
+    NEXT_PUBLIC_DIRECT_BROWSER_API_ENABLED: directBrowserApiEnabled ? "1" : "0",
   },
   async headers() {
-    if (!directBrowserApiLabEnabled) return [];
+    if (!directBrowserApiEnabled) return [];
 
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,34 +1,5 @@
 import type { NextConfig } from "next";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
-const pkg = JSON.parse(
-  readFileSync(join(process.cwd(), "package.json"), "utf8")
-) as { version?: string };
-
-function isDirectBrowserApiDisabled(value: string | undefined): boolean {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === "0" || normalized === "false" || normalized === "off";
-}
-
-const directBrowserApiEnabled =
-  !isDirectBrowserApiDisabled(process.env["DIRECT_BROWSER_API"]) &&
-  !isDirectBrowserApiDisabled(process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]);
-
-const directBrowserApiLabHeaders = [
-  {
-    key: "Cross-Origin-Opener-Policy",
-    value: "same-origin",
-  },
-  {
-    key: "Cross-Origin-Embedder-Policy",
-    value: "require-corp",
-  },
-  {
-    key: "Cross-Origin-Resource-Policy",
-    value: "same-origin",
-  },
-];
+import pkg from "./package.json";
 
 const nextConfig: NextConfig = {
   // Emit a self-contained standalone server (server.js + only the traced
@@ -36,12 +7,12 @@ const nextConfig: NextConfig = {
   // production dependency tree. Output lands in `${distDir}/standalone`.
   output: "standalone",
   // Enable React Compiler via the Turbopack/SWC-native path (top-level in
-  // Next.js 16 — promoted out of experimental).
+  // Next.js 16 - promoted out of experimental).
   // babel-plugin-react-compiler remains in devDependencies for Jest only.
   reactCompiler: true,
   // Use a fresh output directory so Turbopack doesn't try to acquire a
   // lockfile on the root-owned .next/dev/cache from a prior container run.
-  // Exception: on Vercel, use the default ".next" — Vercel's Next.js builder
+  // Exception: on Vercel, use the default ".next" - Vercel's Next.js builder
   // hard-expects ".next" and fails to locate a custom distDir, so the demo
   // deployment needs the standard path. CI/Docker keep ".next-build".
   distDir: process.env.VERCEL ? ".next" : ".next-build",
@@ -60,29 +31,6 @@ const nextConfig: NextConfig = {
   // current release without needing it set in .env files.
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version ?? "0.0.0",
-    NEXT_PUBLIC_DIRECT_BROWSER_API_ENABLED: directBrowserApiEnabled ? "1" : "0",
-  },
-  async headers() {
-    if (!directBrowserApiEnabled) return [];
-
-    return [
-      {
-        source: "/browser-api-lab",
-        headers: directBrowserApiLabHeaders,
-      },
-      {
-        source: "/browser-api-lab/:path*",
-        headers: directBrowserApiLabHeaders,
-      },
-      {
-        source: "/_next/static/:path*",
-        headers: directBrowserApiLabHeaders,
-      },
-      {
-        source: "/actual-api-assets/:path*",
-        headers: directBrowserApiLabHeaders,
-      },
-    ];
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -55,6 +55,7 @@ const nextConfig: NextConfig = {
   // current release without needing it set in .env files.
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version ?? "0.0.0",
+    NEXT_PUBLIC_DIRECT_BROWSER_API_ENABLED: directBrowserApiLabEnabled ? "1" : "0",
   },
   async headers() {
     if (!directBrowserApiLabEnabled) return [];

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,8 @@ const pkg = JSON.parse(
 ) as { version?: string };
 
 const directBrowserApiLabEnabled =
-  process.env.NEXT_PUBLIC_DIRECT_BROWSER_API === "1";
+  process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]?.trim() === "1" ||
+  process.env["DIRECT_BROWSER_API"]?.trim() === "1";
 
 const directBrowserApiLabHeaders = [
   {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,10 @@
 import type { NextConfig } from "next";
-import pkg from "./package.json";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const pkg = JSON.parse(
+  readFileSync(join(process.cwd(), "package.json"), "utf8")
+) as { version?: string };
 
 const nextConfig: NextConfig = {
   // Emit a self-contained standalone server (server.js + only the traced

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@actual-app/api": "26.7.0",
         "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@sqlite.org/sqlite-wasm": "^3.41.2",
@@ -46,6 +47,66 @@
         "jest-environment-jsdom": "^30.3.0",
         "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@actual-app/api": {
+      "version": "26.7.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.7.0.tgz",
+      "integrity": "sha512-nZDZAE6blc1HTdNEDGomAijE9Xgw+vBwUPkUsD63MVyAu92Vyi8H7hqueePtoERo2T9HYkMunXlABRrcPwr1KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actual-app/core": "26.7.0",
+        "@actual-app/crdt": "3.1.0",
+        "better-sqlite3": "^12.10.0",
+        "compare-versions": "^6.1.1",
+        "uuid": "^14.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@actual-app/core": {
+      "version": "26.7.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.7.0.tgz",
+      "integrity": "sha512-OkssXglnNvyq2kVCPvBNNOSb9FoXwyEHWeYGyW0OwoL34Rirp8eCiz4Gz33AweEEPieW9EdWLR7rU3fPPs/8ZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@jlongster/sql.js": "^1.6.7",
+        "@rschedule/core": "^1.5.0",
+        "@rschedule/standard-date-adapter": "^1.5.0",
+        "absurd-sql": "0.0.54",
+        "adm-zip": "^0.5.17",
+        "better-sqlite3": "^12.10.0",
+        "csv-parse": "^6.2.1",
+        "csv-stringify": "^6.7.0",
+        "date-fns": "^4.4.0",
+        "es-toolkit": "^1.47.1",
+        "handlebars": "^4.7.9",
+        "hyperformula": "^3.3.0",
+        "lru-cache": "^11.5.1",
+        "mitt": "^3.0.1",
+        "uuid": "^14.0.1",
+        "xml2js": "^0.6.2"
+      }
+    },
+    "node_modules/@actual-app/core/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@actual-app/crdt": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/crdt/-/crdt-3.1.0.tgz",
+      "integrity": "sha512-1XQM2e4zA73kI8WJ/Le0Q3aMA9X9BRYQsCpAl0R6NN+jGgUN0CylfaupknhAjUGU8m3mY9xomOkPKj4JqJF1Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "murmurhash": "^2.0.1",
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -90,12 +151,12 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -104,29 +165,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -143,13 +204,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -171,13 +232,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -208,9 +269,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -230,27 +291,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -311,52 +372,52 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -666,31 +727,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -698,13 +759,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -769,6 +830,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1901,9 +1968,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2379,6 +2446,12 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jlongster/sql.js": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@jlongster/sql.js/-/sql.js-1.6.7.tgz",
+      "integrity": "sha512-4hf0kZr5WPoirdR5hUSfQ9O0JpH/qlW1CaR2wZ6zGrDz1xjSdTPuR8AW/oXzIHnJvZSEvlcIE+dfXJZwh/Lxfw==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2517,9 +2590,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
-      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2533,9 +2606,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
-      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -2549,9 +2622,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -2565,9 +2638,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
@@ -2581,9 +2654,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
@@ -2597,9 +2670,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
@@ -2613,9 +2686,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
@@ -2629,9 +2702,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -2645,9 +2718,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -2788,6 +2861,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@rschedule/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-uN6Kjx4dnpheesXx+wm0B3E+xJPCw3TdNFmNAIXj9oPVD5t4smbpu/IBPZIzfv8bf7I88s/ahDKkltU6W3H6dw==",
+      "license": "Unlicense"
+    },
+    "node_modules/@rschedule/standard-date-adapter": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/standard-date-adapter/-/standard-date-adapter-1.5.0.tgz",
+      "integrity": "sha512-gQUlCOmYVaGvq6IZT29VVl4uZhaauwgG9aWxXLvC7x3lSF1f+z52iLAj853Mc4a1UgXQtEwt7Wujb9twl740Ew==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@rschedule/core": "^1.5.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3357,9 +3445,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3853,9 +3941,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4267,6 +4355,14 @@
         }
       }
     },
+    "node_modules/absurd-sql": {
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/absurd-sql/-/absurd-sql-0.0.54.tgz",
+      "integrity": "sha512-p+SWTtpRs2t3sXMLxkTyLRZkEzxTv/zG/Bl93wibegLZTGAHGk68SJMWslRWHBGh63ka/ePGTXGHh1117++45Q==",
+      "dependencies": {
+        "safari-14-idb-fix": "^1.0.4"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4301,6 +4397,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -4792,6 +4897,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
@@ -4802,6 +4927,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -4892,6 +5051,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -5038,6 +5221,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chevrotain": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.5.0.tgz",
+      "integrity": "sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-to-ast": "0.4.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -5239,6 +5437,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5389,6 +5593,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
+      "integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5473,6 +5689,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5497,6 +5723,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -5509,6 +5750,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -5626,7 +5876,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5761,6 +6010,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5982,6 +6240,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -6533,6 +6801,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
@@ -6595,12 +6872,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6663,9 +6940,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -6770,6 +7047,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -6904,6 +7187,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -7129,6 +7418,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -7247,6 +7542,27 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -7363,9 +7679,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7447,6 +7763,16 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyperformula": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
+      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "chevrotain": "^6.5.0",
+        "tiny-emitter": "^2.1.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -7462,6 +7788,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7546,6 +7892,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -7562,9 +7914,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9254,9 +9606,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9990,6 +10352,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10031,6 +10405,18 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -10140,6 +10526,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/murmurhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-2.0.1.tgz",
+      "integrity": "sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==",
+      "license": "MIT"
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -10150,9 +10542,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -10166,6 +10558,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -10199,13 +10597,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
     "node_modules/next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
-      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.3",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -10219,14 +10623,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.3",
-        "@next/swc-darwin-x64": "16.2.3",
-        "@next/swc-linux-arm64-gnu": "16.2.3",
-        "@next/swc-linux-arm64-musl": "16.2.3",
-        "@next/swc-linux-x64-gnu": "16.2.3",
-        "@next/swc-linux-x64-musl": "16.2.3",
-        "@next/swc-win32-arm64-msvc": "16.2.3",
-        "@next/swc-win32-x64-msvc": "16.2.3",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -10288,6 +10692,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -10977,9 +11405,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10996,7 +11424,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11027,6 +11455,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -11138,6 +11593,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11166,12 +11631,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -11224,6 +11690,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -11268,6 +11758,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/recast": {
       "version": "0.23.11",
@@ -11321,6 +11825,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
+      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -11545,6 +12055,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safari-14-idb-fix": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -11564,6 +12080,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -11605,6 +12141,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -12022,14 +12567,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -12041,13 +12586,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12103,6 +12648,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/sisteransi": {
@@ -12237,6 +12827,15 @@
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -12656,6 +13255,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -12692,6 +13319,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -12854,6 +13487,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -13030,6 +13675,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -13184,6 +13842,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -13425,6 +14096,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -13531,9 +14208,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13576,6 +14253,28 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean": "rm -rf .next .next-build tsconfig.tsbuildinfo"
   },
   "dependencies": {
+    "@actual-app/api": "26.7.0",
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@sqlite.org/sqlite-wasm": "^3.41.2",

--- a/src/app/(connect)/connect/page.tsx
+++ b/src/app/(connect)/connect/page.tsx
@@ -2,14 +2,27 @@ import type { Metadata } from "next";
 import { ConnectForm } from "@/components/connect/ConnectForm";
 import { DemoButton } from "@/components/connect/DemoButton";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Connect - Actual Bench",
 };
 
+function isDemoConfigured() {
+  const { DEMO_MODE, DEMO_BASE_URL, DEMO_API_KEY, DEMO_BUDGET_SYNC_ID } =
+    process.env;
+  return (
+    DEMO_MODE === "1" &&
+    Boolean(DEMO_BASE_URL) &&
+    Boolean(DEMO_API_KEY) &&
+    Boolean(DEMO_BUDGET_SYNC_ID)
+  );
+}
+
 export default function ConnectPage() {
   return (
     <div className="w-full flex flex-col items-center gap-4">
-      <DemoButton />
+      {isDemoConfigured() && <DemoButton />}
       <ConnectForm />
     </div>
   );

--- a/src/app/(connect)/connect/page.tsx
+++ b/src/app/(connect)/connect/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { ConnectForm } from "@/components/connect/ConnectForm";
 import { DemoButton } from "@/components/connect/DemoButton";
+import { isDirectBrowserApiEnabled } from "@/lib/directMode";
 
 export const dynamic = "force-dynamic";
 
@@ -23,7 +24,7 @@ export default function ConnectPage() {
   return (
     <div className="w-full flex flex-col items-center gap-4">
       {isDemoConfigured() && <DemoButton />}
-      <ConnectForm />
+      <ConnectForm directBrowserApiEnabled={isDirectBrowserApiEnabled()} />
     </div>
   );
 }

--- a/src/app/actual-api-assets/[...assetPath]/route.ts
+++ b/src/app/actual-api-assets/[...assetPath]/route.ts
@@ -1,6 +1,8 @@
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { extname, resolve, sep } from "node:path";
+import { extname, join } from "node:path";
 import { NextResponse } from "next/server";
+import { DIRECT_MODE_HEADERS, isDirectBrowserApiEnabled } from "@/lib/directMode";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -11,21 +13,86 @@ type RouteContext = {
   }>;
 };
 
-const API_DIST_DIR = resolve(process.cwd(), "node_modules/@actual-app/api/dist");
+const CACHE_CONTROL = "public, max-age=86400, must-revalidate";
 
-const ASSET_HEADERS = {
-  "Cross-Origin-Opener-Policy": "same-origin",
-  "Cross-Origin-Embedder-Policy": "require-corp",
-  "Cross-Origin-Resource-Policy": "same-origin",
-};
+const WORKER_CLONE_GUARD = `
+(() => {
+  const scope = self;
+  const nativePostMessage = scope.postMessage.bind(scope);
 
-const WORKER_CLONE_GUARD = "\n(() => {\n  const scope = self;\n  const nativePostMessage = scope.postMessage.bind(scope);\n\n  function cloneSafe(value, seen = new WeakMap()) {\n    if (typeof value === \"function\") return undefined;\n    if (typeof value === \"bigint\") return String(value);\n    if (value instanceof Error) {\n      return { name: value.name, message: value.message, stack: value.stack };\n    }\n    if (value instanceof Date) return value.toISOString();\n    if (value instanceof RegExp) return String(value);\n    if (value instanceof ArrayBuffer) return value.slice(0);\n    if (ArrayBuffer.isView(value)) return new value.constructor(value);\n    if (value instanceof Map) {\n      return Array.from(value.entries()).map(([key, item]) => [\n        cloneSafe(key, seen),\n        cloneSafe(item, seen),\n      ]);\n    }\n    if (value instanceof Set) {\n      return Array.from(value.values()).map((item) => cloneSafe(item, seen));\n    }\n    if (Array.isArray(value)) return value.map((item) => cloneSafe(item, seen));\n    if (value && typeof value === \"object\") {\n      if (seen.has(value)) return seen.get(value);\n\n      const output = {};\n      seen.set(value, output);\n\n      for (const [key, item] of Object.entries(value)) {\n        const safeItem = cloneSafe(item, seen);\n        if (safeItem !== undefined) output[key] = safeItem;\n      }\n      return output;\n    }\n    return value;\n  }\n\n  function safePostMessage(message, transfer) {\n    try {\n      if (transfer === undefined) {\n        nativePostMessage(message);\n      } else {\n        nativePostMessage(message, transfer);\n      }\n    } catch (error) {\n      if (!(error instanceof DOMException) || error.name !== \"DataCloneError\") {\n        throw error;\n      }\n\n      nativePostMessage(cloneSafe(message));\n    }\n  }\n\n  try {\n    Object.defineProperty(scope, \"postMessage\", {\n      configurable: true,\n      value: safePostMessage,\n      writable: true,\n    });\n  } catch {\n    scope.postMessage = safePostMessage;\n  }\n\n  const scopePrototype = Object.getPrototypeOf(scope);\n  if (scopePrototype?.postMessage) {\n    try {\n      Object.defineProperty(scopePrototype, \"postMessage\", {\n        configurable: true,\n        value: safePostMessage,\n        writable: true,\n      });\n    } catch {}\n  }\n})();\n";
+  function cloneSafe(value, seen = new WeakMap()) {
+    if (typeof value === "function") return undefined;
+    if (typeof value === "bigint") return String(value);
+    if (value instanceof Error) {
+      return { name: value.name, message: value.message, stack: value.stack };
+    }
+    if (value instanceof Date) return value.toISOString();
+    if (value instanceof RegExp) return String(value);
+    if (value instanceof ArrayBuffer) return value.slice(0);
+    if (ArrayBuffer.isView(value)) return new value.constructor(value);
+    if (value instanceof Map) {
+      return Array.from(value.entries()).map(([key, item]) => [
+        cloneSafe(key, seen),
+        cloneSafe(item, seen),
+      ]);
+    }
+    if (value instanceof Set) {
+      return Array.from(value.values()).map((item) => cloneSafe(item, seen));
+    }
+    if (Array.isArray(value)) return value.map((item) => cloneSafe(item, seen));
+    if (value && typeof value === "object") {
+      if (seen.has(value)) return seen.get(value);
 
+      const output = {};
+      seen.set(value, output);
 
-function isDirectBrowserApiDisabled(value: string | undefined): boolean {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === "0" || normalized === "false" || normalized === "off";
-}
+      for (const [key, item] of Object.entries(value)) {
+        const safeItem = cloneSafe(item, seen);
+        if (safeItem !== undefined) output[key] = safeItem;
+      }
+      return output;
+    }
+    return value;
+  }
+
+  function safePostMessage(message, transfer) {
+    try {
+      if (transfer === undefined) {
+        nativePostMessage(message);
+      } else {
+        nativePostMessage(message, transfer);
+      }
+    } catch (error) {
+      if (!(error instanceof DOMException) || error.name !== "DataCloneError") {
+        throw error;
+      }
+
+      nativePostMessage(cloneSafe(message));
+    }
+  }
+
+  try {
+    Object.defineProperty(scope, "postMessage", {
+      configurable: true,
+      value: safePostMessage,
+      writable: true,
+    });
+  } catch {
+    scope.postMessage = safePostMessage;
+  }
+
+  const scopePrototype = Object.getPrototypeOf(scope);
+  if (scopePrototype?.postMessage) {
+    try {
+      Object.defineProperty(scopePrototype, "postMessage", {
+        configurable: true,
+        value: safePostMessage,
+        writable: true,
+      });
+    } catch {}
+  }
+})();
+`;
 
 function contentTypeFor(pathname: string): string {
   switch (extname(pathname)) {
@@ -47,38 +114,102 @@ function contentTypeFor(pathname: string): string {
   }
 }
 
-function isAllowedAsset(assetPath: string): boolean {
+const STATIC_ASSET_PATHS = new Map([
+  [
+    "worker.js",
+    join(
+      /*turbopackIgnore: true*/ process.cwd(),
+      "node_modules",
+      "@actual-app",
+      "api",
+      "dist",
+      "worker.js"
+    ),
+  ],
+  [
+    "worker.js.map",
+    join(
+      /*turbopackIgnore: true*/ process.cwd(),
+      "node_modules",
+      "@actual-app",
+      "api",
+      "dist",
+      "worker.js.map"
+    ),
+  ],
+  [
+    "sql-wasm.wasm",
+    join(
+      /*turbopackIgnore: true*/ process.cwd(),
+      "node_modules",
+      "@actual-app",
+      "api",
+      "dist",
+      "sql-wasm.wasm"
+    ),
+  ],
+  [
+    "data-file-index.txt",
+    join(
+      /*turbopackIgnore: true*/ process.cwd(),
+      "node_modules",
+      "@actual-app",
+      "api",
+      "dist",
+      "data-file-index.txt"
+    ),
+  ],
+]);
+
+function isUnsafePathPart(part: string): boolean {
   return (
-    assetPath === "worker.js" ||
-    assetPath === "worker.js.map" ||
-    assetPath === "sql-wasm.wasm" ||
-    assetPath === "data-file-index.txt" ||
-    assetPath.startsWith("data/")
+    part === "" ||
+    part === "." ||
+    part === ".." ||
+    part.includes("\0") ||
+    part.includes("/") ||
+    part.includes("\\")
   );
 }
 
 function resolveAssetPath(parts: string[]): string | null {
-  if (parts.length === 0) return null;
-  if (parts.some((part) => part === ".." || part.includes("\0"))) return null;
+  if (parts.length === 0 || parts.some(isUnsafePathPart)) return null;
 
   const assetPath = parts.join("/");
-  if (!isAllowedAsset(assetPath)) return null;
+  const staticFilePath = STATIC_ASSET_PATHS.get(assetPath);
+  if (staticFilePath) return staticFilePath;
 
-  const filePath = resolve(API_DIST_DIR, ...parts);
-  if (filePath !== API_DIST_DIR && !filePath.startsWith(API_DIST_DIR + sep)) {
-    return null;
-  }
+  if (parts[0] !== "data" || parts.length === 1) return null;
 
-  return filePath;
+  return join(
+    /*turbopackIgnore: true*/ process.cwd(),
+    "node_modules",
+    "@actual-app",
+    "api",
+    "dist",
+    "data",
+    ...parts.slice(1)
+  );
 }
 
-export async function GET(_request: Request, context: RouteContext) {
-  const enabled =
-    !isDirectBrowserApiDisabled(process.env["DIRECT_BROWSER_API"]) &&
-    !isDirectBrowserApiDisabled(process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]);
+function etagFor(body: string | Uint8Array): string {
+  const hash = createHash("sha256");
+  hash.update(typeof body === "string" ? Buffer.from(body, "utf8") : Buffer.from(body));
+  return '"sha256-' + hash.digest("base64url") + '"';
+}
 
-  if (!enabled) {
-    return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
+function responseHeaders(filePath: string, etag: string): Record<string, string> {
+  return {
+    ...DIRECT_MODE_HEADERS,
+    "Content-Type": contentTypeFor(filePath),
+    "Cache-Control": CACHE_CONTROL,
+    ETag: etag,
+  };
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  if (!isDirectBrowserApiEnabled()) {
+    return new NextResponse(null, { status: 404 });
   }
 
   const params = await context.params;
@@ -86,7 +217,7 @@ export async function GET(_request: Request, context: RouteContext) {
   const filePath = resolveAssetPath(assetPath);
 
   if (!filePath) {
-    return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
+    return new NextResponse(null, { status: 404, headers: DIRECT_MODE_HEADERS });
   }
 
   try {
@@ -95,15 +226,15 @@ export async function GET(_request: Request, context: RouteContext) {
       assetPath.join("/") === "worker.js"
         ? WORKER_CLONE_GUARD + body.toString("utf8")
         : new Uint8Array(body);
+    const etag = etagFor(responseBody);
+    const headers = responseHeaders(filePath, etag);
 
-    return new NextResponse(responseBody, {
-      headers: {
-        ...ASSET_HEADERS,
-        "Content-Type": contentTypeFor(filePath),
-        "Cache-Control": "no-store",
-      },
-    });
+    if (request.headers.get("if-none-match") === etag) {
+      return new NextResponse(null, { status: 304, headers });
+    }
+
+    return new NextResponse(responseBody, { headers });
   } catch {
-    return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
+    return new NextResponse(null, { status: 404, headers: DIRECT_MODE_HEADERS });
   }
 }

--- a/src/app/actual-api-assets/[...assetPath]/route.ts
+++ b/src/app/actual-api-assets/[...assetPath]/route.ts
@@ -1,0 +1,99 @@
+import { readFile } from "node:fs/promises";
+import { extname, resolve, sep } from "node:path";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{
+    assetPath?: string[];
+  }>;
+};
+
+const API_DIST_DIR = resolve(process.cwd(), "node_modules/@actual-app/api/dist");
+
+const ASSET_HEADERS = {
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "require-corp",
+  "Cross-Origin-Resource-Policy": "same-origin",
+};
+
+const WORKER_CLONE_GUARD = "\n(() => {\n  const scope = self;\n  const nativePostMessage = scope.postMessage.bind(scope);\n\n  function cloneSafe(value, seen = new WeakMap()) {\n    if (typeof value === \"function\") return undefined;\n    if (typeof value === \"bigint\") return String(value);\n    if (value instanceof Error) {\n      return { name: value.name, message: value.message, stack: value.stack };\n    }\n    if (value instanceof Date) return value.toISOString();\n    if (value instanceof RegExp) return String(value);\n    if (value instanceof ArrayBuffer) return value.slice(0);\n    if (ArrayBuffer.isView(value)) return new value.constructor(value);\n    if (value instanceof Map) {\n      return Array.from(value.entries()).map(([key, item]) => [\n        cloneSafe(key, seen),\n        cloneSafe(item, seen),\n      ]);\n    }\n    if (value instanceof Set) {\n      return Array.from(value.values()).map((item) => cloneSafe(item, seen));\n    }\n    if (Array.isArray(value)) return value.map((item) => cloneSafe(item, seen));\n    if (value && typeof value === \"object\") {\n      if (seen.has(value)) return seen.get(value);\n\n      const output = {};\n      seen.set(value, output);\n\n      for (const [key, item] of Object.entries(value)) {\n        const safeItem = cloneSafe(item, seen);\n        if (safeItem !== undefined) output[key] = safeItem;\n      }\n      return output;\n    }\n    return value;\n  }\n\n  function safePostMessage(message, transfer) {\n    try {\n      if (transfer === undefined) {\n        nativePostMessage(message);\n      } else {\n        nativePostMessage(message, transfer);\n      }\n    } catch (error) {\n      if (!(error instanceof DOMException) || error.name !== \"DataCloneError\") {\n        throw error;\n      }\n\n      nativePostMessage(cloneSafe(message));\n    }\n  }\n\n  try {\n    Object.defineProperty(scope, \"postMessage\", {\n      configurable: true,\n      value: safePostMessage,\n      writable: true,\n    });\n  } catch {\n    scope.postMessage = safePostMessage;\n  }\n\n  const scopePrototype = Object.getPrototypeOf(scope);\n  if (scopePrototype?.postMessage) {\n    try {\n      Object.defineProperty(scopePrototype, \"postMessage\", {\n        configurable: true,\n        value: safePostMessage,\n        writable: true,\n      });\n    } catch {}\n  }\n})();\n";
+
+function contentTypeFor(pathname: string): string {
+  switch (extname(pathname)) {
+    case ".js":
+      return "application/javascript; charset=utf-8";
+    case ".json":
+    case ".map":
+      return "application/json; charset=utf-8";
+    case ".sqlite":
+    case ".data":
+      return "application/octet-stream";
+    case ".txt":
+    case ".sql":
+      return "text/plain; charset=utf-8";
+    case ".wasm":
+      return "application/wasm";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function isAllowedAsset(assetPath: string): boolean {
+  return (
+    assetPath === "worker.js" ||
+    assetPath === "worker.js.map" ||
+    assetPath === "sql-wasm.wasm" ||
+    assetPath === "data-file-index.txt" ||
+    assetPath.startsWith("data/")
+  );
+}
+
+function resolveAssetPath(parts: string[]): string | null {
+  if (parts.length === 0) return null;
+  if (parts.some((part) => part === ".." || part.includes("\0"))) return null;
+
+  const assetPath = parts.join("/");
+  if (!isAllowedAsset(assetPath)) return null;
+
+  const filePath = resolve(API_DIST_DIR, ...parts);
+  if (filePath !== API_DIST_DIR && !filePath.startsWith(API_DIST_DIR + sep)) {
+    return null;
+  }
+
+  return filePath;
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  if (process.env.NEXT_PUBLIC_DIRECT_BROWSER_API !== "1") {
+    return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
+  }
+
+  const params = await context.params;
+  const assetPath = params.assetPath ?? [];
+  const filePath = resolveAssetPath(assetPath);
+
+  if (!filePath) {
+    return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
+  }
+
+  try {
+    const body = await readFile(filePath);
+    const responseBody =
+      assetPath.join("/") === "worker.js"
+        ? WORKER_CLONE_GUARD + body.toString("utf8")
+        : new Uint8Array(body);
+
+    return new NextResponse(responseBody, {
+      headers: {
+        ...ASSET_HEADERS,
+        "Content-Type": contentTypeFor(filePath),
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch {
+    return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
+  }
+}

--- a/src/app/actual-api-assets/[...assetPath]/route.ts
+++ b/src/app/actual-api-assets/[...assetPath]/route.ts
@@ -67,7 +67,11 @@ function resolveAssetPath(parts: string[]): string | null {
 }
 
 export async function GET(_request: Request, context: RouteContext) {
-  if (process.env.NEXT_PUBLIC_DIRECT_BROWSER_API !== "1") {
+  const enabled =
+    process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]?.trim() === "1" ||
+    process.env["DIRECT_BROWSER_API"]?.trim() === "1";
+
+  if (!enabled) {
     return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });
   }
 

--- a/src/app/actual-api-assets/[...assetPath]/route.ts
+++ b/src/app/actual-api-assets/[...assetPath]/route.ts
@@ -21,6 +21,12 @@ const ASSET_HEADERS = {
 
 const WORKER_CLONE_GUARD = "\n(() => {\n  const scope = self;\n  const nativePostMessage = scope.postMessage.bind(scope);\n\n  function cloneSafe(value, seen = new WeakMap()) {\n    if (typeof value === \"function\") return undefined;\n    if (typeof value === \"bigint\") return String(value);\n    if (value instanceof Error) {\n      return { name: value.name, message: value.message, stack: value.stack };\n    }\n    if (value instanceof Date) return value.toISOString();\n    if (value instanceof RegExp) return String(value);\n    if (value instanceof ArrayBuffer) return value.slice(0);\n    if (ArrayBuffer.isView(value)) return new value.constructor(value);\n    if (value instanceof Map) {\n      return Array.from(value.entries()).map(([key, item]) => [\n        cloneSafe(key, seen),\n        cloneSafe(item, seen),\n      ]);\n    }\n    if (value instanceof Set) {\n      return Array.from(value.values()).map((item) => cloneSafe(item, seen));\n    }\n    if (Array.isArray(value)) return value.map((item) => cloneSafe(item, seen));\n    if (value && typeof value === \"object\") {\n      if (seen.has(value)) return seen.get(value);\n\n      const output = {};\n      seen.set(value, output);\n\n      for (const [key, item] of Object.entries(value)) {\n        const safeItem = cloneSafe(item, seen);\n        if (safeItem !== undefined) output[key] = safeItem;\n      }\n      return output;\n    }\n    return value;\n  }\n\n  function safePostMessage(message, transfer) {\n    try {\n      if (transfer === undefined) {\n        nativePostMessage(message);\n      } else {\n        nativePostMessage(message, transfer);\n      }\n    } catch (error) {\n      if (!(error instanceof DOMException) || error.name !== \"DataCloneError\") {\n        throw error;\n      }\n\n      nativePostMessage(cloneSafe(message));\n    }\n  }\n\n  try {\n    Object.defineProperty(scope, \"postMessage\", {\n      configurable: true,\n      value: safePostMessage,\n      writable: true,\n    });\n  } catch {\n    scope.postMessage = safePostMessage;\n  }\n\n  const scopePrototype = Object.getPrototypeOf(scope);\n  if (scopePrototype?.postMessage) {\n    try {\n      Object.defineProperty(scopePrototype, \"postMessage\", {\n        configurable: true,\n        value: safePostMessage,\n        writable: true,\n      });\n    } catch {}\n  }\n})();\n";
 
+
+function isDirectBrowserApiDisabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "off";
+}
+
 function contentTypeFor(pathname: string): string {
   switch (extname(pathname)) {
     case ".js":
@@ -68,8 +74,8 @@ function resolveAssetPath(parts: string[]): string | null {
 
 export async function GET(_request: Request, context: RouteContext) {
   const enabled =
-    process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]?.trim() === "1" ||
-    process.env["DIRECT_BROWSER_API"]?.trim() === "1";
+    !isDirectBrowserApiDisabled(process.env["DIRECT_BROWSER_API"]) &&
+    !isDirectBrowserApiDisabled(process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]);
 
   if (!enabled) {
     return new NextResponse(null, { status: 404, headers: ASSET_HEADERS });

--- a/src/app/api/proxy/download/route.ts
+++ b/src/app/api/proxy/download/route.ts
@@ -13,17 +13,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { logger } from "@/lib/logger";
-import { queueServerRequest } from "../serverQueue";
-
-type DownloadConnection = {
-  baseUrl: string;
-  apiKey: string;
-  budgetSyncId?: string;
-  encryptionPassword?: string;
-};
+import { queueServerRequest, type HttpProxyConnection } from "../serverQueue";
 
 type DownloadRequestBody = {
-  connection: DownloadConnection;
+  connection: HttpProxyConnection;
   path: string;
   method?: string;
 };

--- a/src/app/api/proxy/download/route.ts
+++ b/src/app/api/proxy/download/route.ts
@@ -12,15 +12,18 @@
 
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import type { ConnectionInstance } from "@/store/connection";
 import { logger } from "@/lib/logger";
 import { queueServerRequest } from "../serverQueue";
 
+type DownloadConnection = {
+  baseUrl: string;
+  apiKey: string;
+  budgetSyncId?: string;
+  encryptionPassword?: string;
+};
+
 type DownloadRequestBody = {
-  connection: Pick<ConnectionInstance, "baseUrl" | "apiKey"> & {
-    budgetSyncId?: string;
-    encryptionPassword?: string;
-  };
+  connection: DownloadConnection;
   path: string;
   method?: string;
 };

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -21,15 +21,18 @@
 
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import type { ConnectionInstance } from "@/store/connection";
 import { logger } from "@/lib/logger";
 import { queueServerRequest } from "./serverQueue";
 
+type ProxyConnection = {
+  baseUrl: string;
+  apiKey: string;
+  budgetSyncId?: string;
+  encryptionPassword?: string;
+};
+
 type ProxyRequestBody = {
-  connection: Pick<ConnectionInstance, "baseUrl" | "apiKey"> & {
-    budgetSyncId?: string;
-    encryptionPassword?: string;
-  };
+  connection: ProxyConnection;
   path: string;
   method?: string;
   body?: unknown;

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -22,17 +22,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { logger } from "@/lib/logger";
-import { queueServerRequest } from "./serverQueue";
-
-type ProxyConnection = {
-  baseUrl: string;
-  apiKey: string;
-  budgetSyncId?: string;
-  encryptionPassword?: string;
-};
+import { queueServerRequest, type HttpProxyConnection } from "./serverQueue";
 
 type ProxyRequestBody = {
-  connection: ProxyConnection;
+  connection: HttpProxyConnection;
   path: string;
   method?: string;
   body?: unknown;

--- a/src/app/api/proxy/serverQueue.ts
+++ b/src/app/api/proxy/serverQueue.ts
@@ -15,6 +15,7 @@
  */
 import type { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import type { HttpApiConnection } from "@/store/connection";
 
 // Each entry in the map is the tail of a server's request chain — a void
 // promise that resolves when the previous request finishes. A new request
@@ -52,11 +53,10 @@ async function tryCloseBudget(
   }
 }
 
-type QueueConnection = {
-  baseUrl: string;
-  budgetSyncId?: string;
-  apiKey: string;
-};
+export type HttpProxyConnection = Pick<HttpApiConnection, "baseUrl" | "apiKey"> &
+  Partial<Pick<HttpApiConnection, "budgetSyncId" | "encryptionPassword">>;
+
+type QueueConnection = Pick<HttpProxyConnection, "baseUrl" | "budgetSyncId" | "apiKey">;
 
 /**
  * Enqueue a request operation against a server. Returns the operation's

--- a/src/app/browser-api-lab/BrowserApiLabClient.tsx
+++ b/src/app/browser-api-lab/BrowserApiLabClient.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2, Play, ShieldCheck, XCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type {
+  BrowserApiLabInput,
+  BrowserApiLabResult,
+  BrowserApiLabStepId,
+  BrowserApiLabStepStatus,
+} from "@/lib/actual/browser/labRuntime";
+import { cn } from "@/lib/utils";
+
+type BrowserApiLabClientProps = {
+  enabled: boolean;
+};
+
+type LabStep = {
+  id: BrowserApiLabStepId;
+  label: string;
+  status: "idle" | BrowserApiLabStepStatus;
+  detail?: string;
+};
+
+const INITIAL_STEPS: LabStep[] = [
+  { id: "load", label: "Load browser API", status: "idle" },
+  { id: "init", label: "Initialize worker", status: "idle" },
+  { id: "budgets", label: "List budgets", status: "idle" },
+  { id: "download", label: "Download budget", status: "idle" },
+  { id: "accounts", label: "Read accounts", status: "idle" },
+  { id: "sync", label: "Sync", status: "idle" },
+  { id: "shutdown", label: "Shutdown", status: "idle" },
+];
+
+function stepIcon(status: LabStep["status"]) {
+  if (status === "running") return <Loader2 className="h-4 w-4 animate-spin text-primary" />;
+  if (status === "success") return <CheckCircle2 className="h-4 w-4 text-green-600" />;
+  if (status === "error") return <XCircle className="h-4 w-4 text-destructive" />;
+  return <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />;
+}
+
+function getCrossOriginIsolated(): boolean | null {
+  if (typeof window === "undefined") return null;
+  return window.crossOriginIsolated;
+}
+
+export function BrowserApiLabClient({ enabled }: BrowserApiLabClientProps) {
+  const [form, setForm] = useState<BrowserApiLabInput>({
+    serverUrl: "",
+    serverPassword: "",
+    budgetSyncId: "",
+    encryptionPassword: "",
+  });
+  const [steps, setSteps] = useState<LabStep[]>(INITIAL_STEPS);
+  const [result, setResult] = useState<BrowserApiLabResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [crossOriginIsolated, setCrossOriginIsolated] = useState<boolean | null>(null);
+  const [browserEvents, setBrowserEvents] = useState<string[]>([]);
+
+  useEffect(() => {
+    setCrossOriginIsolated(getCrossOriginIsolated());
+
+    function addBrowserEvent(message: string) {
+      setBrowserEvents((current) => [message, ...current].slice(0, 8));
+    }
+
+    function handleError(event: ErrorEvent) {
+      addBrowserEvent(event.message || "Unhandled browser error");
+    }
+
+    function handleUnhandledRejection(event: PromiseRejectionEvent) {
+      const reason = event.reason;
+      addBrowserEvent(
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === "string"
+            ? reason
+            : "Unhandled promise rejection"
+      );
+    }
+
+    window.addEventListener("error", handleError);
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+    return () => {
+      window.removeEventListener("error", handleError);
+      window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+    };
+  }, []);
+
+  const canRun =
+    enabled &&
+    !isRunning &&
+    form.serverUrl.trim() !== "" &&
+    form.serverPassword !== "" &&
+    form.budgetSyncId.trim() !== "";
+
+  const statusLabel = !enabled
+    ? "Disabled"
+    : isRunning
+      ? "Running"
+      : error
+        ? "Failed"
+        : result
+          ? "Passed"
+          : "Ready";
+
+  function updateField(field: keyof BrowserApiLabInput, value: string) {
+    setForm((current) => ({ ...current, [field]: value }));
+  }
+
+  function resetRunState() {
+    setSteps(INITIAL_STEPS);
+    setResult(null);
+    setError(null);
+    setBrowserEvents([]);
+  }
+
+  function runLab() {
+    if (!canRun) return;
+    resetRunState();
+    setIsRunning(true);
+    void (async () => {
+      try {
+        const { runBrowserApiLab } = await import("@/lib/actual/browser/labRuntime");
+        const labResult = await runBrowserApiLab(form, (update) => {
+          setSteps((current) =>
+            current.map((step) =>
+              step.id === update.id
+                ? { ...step, status: update.status, detail: update.detail }
+                : step
+            )
+          );
+        });
+        setResult(labResult);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown browser API lab failure");
+      } finally {
+        setIsRunning(false);
+      }
+    })();
+  }
+
+  return (
+    <main className="h-screen overflow-y-auto bg-muted/30 p-4 text-foreground">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 py-4 md:py-8">
+        <header className="flex flex-col gap-3 rounded-lg border border-border bg-background p-5 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-xl font-semibold tracking-normal">Direct Browser API Lab</h1>
+              <Badge variant={enabled ? "status-warning" : "status-inactive"}>Experimental</Badge>
+              <Badge variant={error ? "destructive" : result ? "status-active" : "outline"}>
+                {statusLabel}
+              </Badge>
+            </div>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Hidden runtime check for Actual browser API worker before the main app transport is migrated.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm">
+            <ShieldCheck className={cn("h-4 w-4", crossOriginIsolated ? "text-green-600" : "text-muted-foreground")} />
+            <span>crossOriginIsolated:</span>
+            <span className="font-mono text-xs">{String(crossOriginIsolated)}</span>
+          </div>
+        </header>
+
+        {!enabled && (
+          <section className="flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-50 p-4 text-sm text-amber-900 dark:bg-amber-950/20 dark:text-amber-200">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-medium">Browser API lab is disabled.</p>
+              <p className="mt-1">Set NEXT_PUBLIC_DIRECT_BROWSER_API=1 and restart the dev server to enable this route.</p>
+            </div>
+          </section>
+        )}
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <section className="rounded-lg border border-border bg-background p-5">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex flex-col gap-2 md:col-span-2">
+                <Label htmlFor="serverUrl">Actual Server URL</Label>
+                <Input
+                  id="serverUrl"
+                  type="url"
+                  placeholder="https://actual.example.com"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={form.serverUrl}
+                  onChange={(event) => updateField("serverUrl", event.target.value)}
+                  disabled={!enabled || isRunning}
+                />
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="serverPassword">Server Password</Label>
+                <Input
+                  id="serverPassword"
+                  type="password"
+                  autoComplete="current-password"
+                  value={form.serverPassword}
+                  onChange={(event) => updateField("serverPassword", event.target.value)}
+                  disabled={!enabled || isRunning}
+                />
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="encryptionPassword">Budget Encryption Password</Label>
+                <Input
+                  id="encryptionPassword"
+                  type="password"
+                  autoComplete="current-password"
+                  value={form.encryptionPassword ?? ""}
+                  onChange={(event) => updateField("encryptionPassword", event.target.value)}
+                  disabled={!enabled || isRunning}
+                />
+              </div>
+
+              <div className="flex flex-col gap-2 md:col-span-2">
+                <Label htmlFor="budgetSyncId">Budget Sync ID</Label>
+                <Input
+                  id="budgetSyncId"
+                  type="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={form.budgetSyncId}
+                  onChange={(event) => updateField("budgetSyncId", event.target.value)}
+                  disabled={!enabled || isRunning}
+                />
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-wrap items-center gap-2">
+              <Button type="button" onClick={runLab} disabled={!canRun}>
+                {isRunning ? (
+                  <Loader2 data-icon="inline-start" className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play data-icon="inline-start" className="h-4 w-4" />
+                )}
+                Run lab
+              </Button>
+              <Button type="button" variant="outline" onClick={resetRunState} disabled={isRunning}>
+                Reset
+              </Button>
+            </div>
+
+            {error && (
+              <div className="mt-4 flex items-start gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+          </section>
+
+          <aside className="rounded-lg border border-border bg-background p-5">
+            <h2 className="text-sm font-semibold">Run Steps</h2>
+            <ol className="mt-4 space-y-3">
+              {steps.map((step) => (
+                <li key={step.id} className="flex gap-3">
+                  <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center">
+                    {stepIcon(step.status)}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium">{step.label}</span>
+                      <span className="text-xs capitalize text-muted-foreground">{step.status}</span>
+                    </div>
+                    {step.detail && <p className="mt-1 text-xs text-muted-foreground">{step.detail}</p>}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </aside>
+        </div>
+
+
+        {browserEvents.length > 0 && (
+          <section className="rounded-lg border border-border bg-background p-5">
+            <h2 className="text-sm font-semibold">Browser Events</h2>
+            <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+              {browserEvents.map((event, index) => (
+                <li key={`${index}-${event}`} className="rounded-md bg-muted/50 px-3 py-2 font-mono text-xs">
+                  {event}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {result && (
+          <section className="rounded-lg border border-border bg-background p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-semibold">Result</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {result.budgetCount} budgets returned. Opened {result.selectedBudgetName ?? result.selectedBudgetSyncId}.
+                </p>
+              </div>
+              <Badge variant="status-active">{result.accounts.length} accounts</Badge>
+            </div>
+
+            <div className="mt-4 overflow-hidden rounded-lg border border-border">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-muted/60 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Name</th>
+                    <th className="px-3 py-2 font-medium">State</th>
+                    <th className="px-3 py-2 font-medium">Budget</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.accounts.slice(0, 12).map((account) => (
+                    <tr key={account.id} className="border-t border-border">
+                      <td className="px-3 py-2 font-medium">{account.name}</td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {account.closed ? "Closed" : "Open"}
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {account.offbudget ? "Off budget" : "On budget"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/browser-api-lab/BrowserApiLabClient.tsx
+++ b/src/app/browser-api-lab/BrowserApiLabClient.tsx
@@ -58,12 +58,10 @@ export function BrowserApiLabClient({ enabled }: BrowserApiLabClientProps) {
   const [result, setResult] = useState<BrowserApiLabResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
-  const [crossOriginIsolated, setCrossOriginIsolated] = useState<boolean | null>(null);
+  const [crossOriginIsolated] = useState<boolean | null>(() => getCrossOriginIsolated());
   const [browserEvents, setBrowserEvents] = useState<string[]>([]);
 
   useEffect(() => {
-    setCrossOriginIsolated(getCrossOriginIsolated());
-
     function addBrowserEvent(message: string) {
       setBrowserEvents((current) => [message, ...current].slice(0, 8));
     }

--- a/src/app/browser-api-lab/BrowserApiLabClient.tsx
+++ b/src/app/browser-api-lab/BrowserApiLabClient.tsx
@@ -158,7 +158,7 @@ export function BrowserApiLabClient({ enabled }: BrowserApiLabClientProps) {
               </Badge>
             </div>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Hidden runtime check for Actual browser API worker before the main app transport is migrated.
+              Runtime check for Actual browser API worker, deployment headers, and Direct transport setup.
             </p>
           </div>
           <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm">
@@ -172,8 +172,8 @@ export function BrowserApiLabClient({ enabled }: BrowserApiLabClientProps) {
           <section className="flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-50 p-4 text-sm text-amber-900 dark:bg-amber-950/20 dark:text-amber-200">
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
             <div>
-              <p className="font-medium">Browser API lab is disabled.</p>
-              <p className="mt-1">Set NEXT_PUBLIC_DIRECT_BROWSER_API=1 and restart the dev server to enable this route.</p>
+              <p className="font-medium">Browser API lab is disabled for this deployment.</p>
+              <p className="mt-1">Remove DIRECT_BROWSER_API=0 or NEXT_PUBLIC_DIRECT_BROWSER_API=0 and restart the app to enable this route.</p>
             </div>
           </section>
         )}

--- a/src/app/browser-api-lab/page.tsx
+++ b/src/app/browser-api-lab/page.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from "next";
 import { BrowserApiLabClient } from "./BrowserApiLabClient";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Browser API Lab - Actual Bench",
 };
 
 export default function BrowserApiLabPage() {
-  const enabled = process.env.NEXT_PUBLIC_DIRECT_BROWSER_API === "1";
+  const enabled =
+    process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]?.trim() === "1" ||
+    process.env["DIRECT_BROWSER_API"]?.trim() === "1";
 
   return <BrowserApiLabClient enabled={enabled} />;
 }

--- a/src/app/browser-api-lab/page.tsx
+++ b/src/app/browser-api-lab/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { BrowserApiLabClient } from "./BrowserApiLabClient";
+
+export const metadata: Metadata = {
+  title: "Browser API Lab - Actual Bench",
+};
+
+export default function BrowserApiLabPage() {
+  const enabled = process.env.NEXT_PUBLIC_DIRECT_BROWSER_API === "1";
+
+  return <BrowserApiLabClient enabled={enabled} />;
+}

--- a/src/app/browser-api-lab/page.tsx
+++ b/src/app/browser-api-lab/page.tsx
@@ -3,14 +3,20 @@ import { BrowserApiLabClient } from "./BrowserApiLabClient";
 
 export const dynamic = "force-dynamic";
 
+
+function isDirectBrowserApiDisabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "off";
+}
+
 export const metadata: Metadata = {
   title: "Browser API Lab - Actual Bench",
 };
 
 export default function BrowserApiLabPage() {
   const enabled =
-    process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]?.trim() === "1" ||
-    process.env["DIRECT_BROWSER_API"]?.trim() === "1";
+    !isDirectBrowserApiDisabled(process.env["DIRECT_BROWSER_API"]) &&
+    !isDirectBrowserApiDisabled(process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]);
 
   return <BrowserApiLabClient enabled={enabled} />;
 }

--- a/src/app/browser-api-lab/page.tsx
+++ b/src/app/browser-api-lab/page.tsx
@@ -1,22 +1,13 @@
 import type { Metadata } from "next";
+import { isDirectBrowserApiEnabled } from "@/lib/directMode";
 import { BrowserApiLabClient } from "./BrowserApiLabClient";
 
 export const dynamic = "force-dynamic";
-
-
-function isDirectBrowserApiDisabled(value: string | undefined): boolean {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === "0" || normalized === "false" || normalized === "off";
-}
 
 export const metadata: Metadata = {
   title: "Browser API Lab - Actual Bench",
 };
 
 export default function BrowserApiLabPage() {
-  const enabled =
-    !isDirectBrowserApiDisabled(process.env["DIRECT_BROWSER_API"]) &&
-    !isDirectBrowserApiDisabled(process.env["NEXT_PUBLIC_DIRECT_BROWSER_API"]);
-
-  return <BrowserApiLabClient enabled={enabled} />;
+  return <BrowserApiLabClient enabled={isDirectBrowserApiEnabled()} />;
 }

--- a/src/components/DirectModeUnavailable.tsx
+++ b/src/components/DirectModeUnavailable.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, ArrowRight } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type DirectModeUnavailableProps = {
+  title: string;
+  description: string;
+  detail?: string;
+};
+
+export function DirectModeUnavailable({
+  title,
+  description,
+  detail,
+}: DirectModeUnavailableProps) {
+  return (
+    <main className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-6">
+      <section className="w-full max-w-lg rounded-md border border-amber-200 bg-amber-50/60 p-6 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/20">
+        <div className="flex h-11 w-11 items-center justify-center rounded-md bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
+          <AlertTriangle className="h-5 w-5" />
+        </div>
+        <h1 className="mt-5 text-2xl font-semibold tracking-tight">{title}</h1>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {description}
+        </p>
+        {detail && (
+          <p className="mt-2 text-xs leading-5 text-muted-foreground">
+            {detail}
+          </p>
+        )}
+        <Link href="/accounts" className={cn(buttonVariants({ className: "mt-5" }))}>
+          Open supported page
+          <ArrowRight data-icon="inline-end" />
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -360,7 +360,7 @@ export function ConnectForm() {
       {connectStatus.kind === "success" && activeValidatedMode === "browser-api" && (
         <div className="flex items-start gap-2.5 rounded-lg bg-green-50 px-3.5 py-3 text-sm text-green-700">
           <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>Direct read-only connection opened. Core entity pages now use the browser transport.</span>
+          <span>Direct connection opened. Core entity pages now use the browser transport.</span>
         </div>
       )}
 

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -7,7 +7,11 @@ import { Loader2, AlertCircle, CheckCircle2, Server, Plus, Check, KeyRound } fro
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isBrowserApiConnection,
+} from "@/store/connection";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { useConnectForm } from "./useConnectForm";
 import { ConnectionCard } from "./ConnectionCard";
@@ -63,7 +67,7 @@ export function ConnectForm() {
 
   useEffect(() => {
     if (hydrated && connectedInstance) {
-      router.replace("/overview");
+      router.replace(isBrowserApiConnection(connectedInstance) ? "/accounts" : "/overview");
     }
   }, [hydrated, connectedInstance, router]);
 
@@ -356,7 +360,7 @@ export function ConnectForm() {
       {connectStatus.kind === "success" && activeValidatedMode === "browser-api" && (
         <div className="flex items-start gap-2.5 rounded-lg bg-green-50 px-3.5 py-3 text-sm text-green-700">
           <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>Direct connection saved. Classic connections still power app pages.</span>
+          <span>Direct read-only connection opened. Core entity pages now use the browser transport.</span>
         </div>
       )}
 
@@ -369,10 +373,10 @@ export function ConnectForm() {
         {connectBusy ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />
-            {activeValidatedMode === "browser-api" ? "Saving…" : "Connecting…"}
+            {activeValidatedMode === "browser-api" ? "Opening…" : "Connecting…"}
           </>
         ) : activeValidatedMode === "browser-api" ? (
-          "Save Direct Connection"
+          "Open Direct Connection"
         ) : (
           "Connect"
         )}

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -43,6 +43,7 @@ export function ConnectForm() {
     validatedMode,
     validatedUrl,
     validatedApiVersion,
+    validatedServerVersion,
     selectedGroupId,
     setSelectedGroupId,
     encryptionPassword,
@@ -76,6 +77,8 @@ export function ConnectForm() {
   }
 
   const activeValidatedMode = validatedMode ?? connectionMode;
+  const directBrowserApiEnabled =
+    process.env.NEXT_PUBLIC_DIRECT_BROWSER_API_ENABLED === "1";
 
   // ── Panels ──────────────────────────────────────────────────────────────────
 
@@ -118,13 +121,18 @@ export function ConnectForm() {
           )}
         >
           <Server className="h-4 w-4" />
-          Classic API Server
+          <span className="whitespace-nowrap">HTTP API Server</span>
         </button>
         <button
           type="button"
           role="tab"
           aria-selected={connectionMode === "browser-api"}
-          disabled={anyBusy}
+          disabled={anyBusy || !directBrowserApiEnabled}
+          title={
+            directBrowserApiEnabled
+              ? "Direct Actual Server"
+              : "Set DIRECT_BROWSER_API=1 and restart the app to enable Direct mode"
+          }
           onClick={() => handleModeChange("browser-api")}
           className={cn(
             "flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
@@ -134,12 +142,28 @@ export function ConnectForm() {
           )}
         >
           <KeyRound className="h-4 w-4" />
-          <span>Direct Actual Server</span>
-          <span className="rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700">
-            Experimental
-          </span>
+          <span className="whitespace-nowrap">Direct Actual Server</span>
         </button>
       </div>
+
+      {!directBrowserApiEnabled && (
+        <div className="flex items-start gap-2.5 rounded-lg border border-muted bg-muted/40 px-3.5 py-3 text-xs leading-5 text-muted-foreground">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>Set <code>DIRECT_BROWSER_API=1</code> and restart the app to enable Direct Actual Server mode.</span>
+        </div>
+      )}
+
+      {connectionMode === "browser-api" && (
+        <div className="flex items-start gap-2.5 rounded-lg border border-emerald-200 bg-emerald-50/70 px-3.5 py-3 text-xs leading-5 text-emerald-950 dark:border-emerald-900/50 dark:bg-emerald-950/20 dark:text-emerald-100">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <p className="font-medium">Direct connects this browser to your Actual Server.</p>
+            <p className="mt-1 text-emerald-950/75 dark:text-emerald-100/80">
+              It needs Direct mode enabled on this app and browser access to your server. Credentials stay in session storage for this tab. If local budget data ever looks stale, clear browser data for this site.
+            </p>
+          </div>
+        </div>
+      )}
 
       {savedServersForMode.length > 0 && (
         <div className="flex flex-wrap gap-2">
@@ -181,7 +205,7 @@ export function ConnectForm() {
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Label htmlFor="baseUrl">
-              {connectionMode === "browser-api" ? "Actual Server URL" : "API Server URL"}
+              {connectionMode === "browser-api" ? "Actual Server URL" : "HTTP API Server URL"}
             </Label>
             <Input
               id="baseUrl"
@@ -279,7 +303,8 @@ export function ConnectForm() {
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
           <span>{deriveLabel(validatedUrl)}</span>
           <span className="text-green-600/70">· {getConnectionModeBadge(activeValidatedMode)}</span>
-          {validatedApiVersion && <span className="text-green-600/70">· v{validatedApiVersion}</span>}
+          {validatedApiVersion && <span className="text-green-600/70">· API v{validatedApiVersion}</span>}
+          {validatedServerVersion && <span className="text-green-600/70">· Actual v{validatedServerVersion}</span>}
         </div>
       </div>
 
@@ -360,7 +385,7 @@ export function ConnectForm() {
       {connectStatus.kind === "success" && activeValidatedMode === "browser-api" && (
         <div className="flex items-start gap-2.5 rounded-lg bg-green-50 px-3.5 py-3 text-sm text-green-700">
           <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>Direct connection opened. Core entity pages now use the browser transport.</span>
+          <span>Direct connection opened. Core entity pages and Budget Management now use the browser transport.</span>
         </div>
       )}
 
@@ -373,10 +398,8 @@ export function ConnectForm() {
         {connectBusy ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />
-            {activeValidatedMode === "browser-api" ? "Opening…" : "Connecting…"}
+            Connecting…
           </>
-        ) : activeValidatedMode === "browser-api" ? (
-          "Open Direct Connection"
         ) : (
           "Connect"
         )}

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -154,12 +154,9 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
       {connectionMode === "browser-api" && (
         <div className="flex items-start gap-2.5 rounded-lg border border-emerald-200 bg-emerald-50/70 px-3.5 py-3 text-xs leading-5 text-emerald-950 dark:border-emerald-900/50 dark:bg-emerald-950/20 dark:text-emerald-100">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <div>
-            <p className="font-medium">Direct connects this browser to your Actual Server.</p>
-            <p className="mt-1 text-emerald-950/75 dark:text-emerald-100/80">
-              Your browser must be able to reach the Actual Server URL directly. Credentials stay in session storage for this tab.
-            </p>
-          </div>
+          <span>
+            Direct mode connects this browser to your Actual Server. Credentials are kept in memory and cleared when you refresh or close this tab.
+          </span>
         </div>
       )}
 
@@ -215,6 +212,7 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
               onChange={(e) => {
                 setBaseUrl(e.target.value);
                 if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
+                setSelectedServerId(null);
                 handleCredentialChange();
               }}
               onKeyDown={handleKeyDown}
@@ -240,7 +238,7 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
                 disabled={anyBusy}
               />
               <p className="text-xs text-muted-foreground">
-                The <code>ACTUAL_API_KEY</code> on your API server.
+                The <code>ACTUAL_API_KEY</code> on your API server. Kept in memory only.
               </p>
             </div>
           ) : (
@@ -261,7 +259,7 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
                 disabled={anyBusy}
               />
               <p className="text-xs text-muted-foreground">
-                Stored in session storage for this browser tab.
+                Kept in memory only for this browser tab.
               </p>
             </div>
           )}
@@ -371,6 +369,9 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
           }}
           disabled={connectBusy || !!reconnectBusyId}
         />
+        <p className="text-xs text-muted-foreground">
+          Kept in memory only for this browser tab.
+        </p>
       </div>
 
       {connectStatus.kind === "error" && (

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -131,7 +131,7 @@ export function ConnectForm() {
           title={
             directBrowserApiEnabled
               ? "Direct Actual Server"
-              : "Set DIRECT_BROWSER_API=1 and restart the app to enable Direct mode"
+              : "Direct Actual Server mode is disabled for this deployment"
           }
           onClick={() => handleModeChange("browser-api")}
           className={cn(
@@ -149,7 +149,7 @@ export function ConnectForm() {
       {!directBrowserApiEnabled && (
         <div className="flex items-start gap-2.5 rounded-lg border border-muted bg-muted/40 px-3.5 py-3 text-xs leading-5 text-muted-foreground">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>Set <code>DIRECT_BROWSER_API=1</code> and restart the app to enable Direct Actual Server mode.</span>
+          <span>Direct Actual Server mode is disabled for this deployment. Remove <code>DIRECT_BROWSER_API=0</code> or <code>NEXT_PUBLIC_DIRECT_BROWSER_API=0</code> and restart the app to show both connection modes.</span>
         </div>
       )}
 
@@ -159,7 +159,7 @@ export function ConnectForm() {
           <div>
             <p className="font-medium">Direct connects this browser to your Actual Server.</p>
             <p className="mt-1 text-emerald-950/75 dark:text-emerald-100/80">
-              It needs Direct mode enabled on this app and browser access to your server. Credentials stay in session storage for this tab. If local budget data ever looks stale, clear browser data for this site.
+              Your browser must be able to reach the Actual Server URL directly. Credentials stay in session storage for this tab.
             </p>
           </div>
         </div>

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -7,17 +7,17 @@ import { Loader2, AlertCircle, CheckCircle2, Server, Plus, Check, KeyRound } fro
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import {
-  useConnectionStore,
-  selectActiveInstance,
-  isBrowserApiConnection,
-} from "@/store/connection";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { useConnectForm } from "./useConnectForm";
 import { ConnectionCard } from "./ConnectionCard";
 import { deriveLabel, getConnectionModeBadge } from "./utils";
 
-export function ConnectForm() {
+type ConnectFormProps = {
+  directBrowserApiEnabled: boolean;
+};
+
+export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
   const router = useRouter();
   const hydrated = useIsHydrated();
   const connectedInstance = useConnectionStore(selectActiveInstance);
@@ -68,7 +68,7 @@ export function ConnectForm() {
 
   useEffect(() => {
     if (hydrated && connectedInstance) {
-      router.replace(isBrowserApiConnection(connectedInstance) ? "/accounts" : "/overview");
+      router.replace("/overview");
     }
   }, [hydrated, connectedInstance, router]);
 
@@ -77,8 +77,6 @@ export function ConnectForm() {
   }
 
   const activeValidatedMode = validatedMode ?? connectionMode;
-  const directBrowserApiEnabled =
-    process.env.NEXT_PUBLIC_DIRECT_BROWSER_API_ENABLED === "1";
 
   // ── Panels ──────────────────────────────────────────────────────────────────
 

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, AlertCircle, CheckCircle2, Server, Plus, Check } from "lucide-react";
+import { Loader2, AlertCircle, CheckCircle2, Server, Plus, Check, KeyRound } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
@@ -11,7 +11,7 @@ import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
 import { useConnectForm } from "./useConnectForm";
 import { ConnectionCard } from "./ConnectionCard";
-import { deriveLabel } from "./utils";
+import { deriveLabel, getConnectionModeBadge } from "./utils";
 
 export function ConnectForm() {
   const router = useRouter();
@@ -21,17 +21,22 @@ export function ConnectForm() {
   const {
     instances,
     activeInstance,
-    savedServers,
+    savedServersForMode,
     removeInstance,
+    connectionMode,
+    handleModeChange,
     baseUrl,
     setBaseUrl,
     apiKey,
     setApiKey,
+    serverPassword,
+    setServerPassword,
     validateStatus,
     setValidateStatus,
     selectedServerId,
     setSelectedServerId,
     budgets,
+    validatedMode,
     validatedUrl,
     validatedApiVersion,
     selectedGroupId,
@@ -66,6 +71,8 @@ export function ConnectForm() {
     return null;
   }
 
+  const activeValidatedMode = validatedMode ?? connectionMode;
+
   // ── Panels ──────────────────────────────────────────────────────────────────
 
   const step1Panel = (
@@ -92,9 +99,47 @@ export function ConnectForm() {
         )}
       </div>
 
-      {savedServers.length > 0 && (
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2" role="tablist" aria-label="Connection type">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={connectionMode === "http-api"}
+          disabled={anyBusy}
+          onClick={() => handleModeChange("http-api")}
+          className={cn(
+            "flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+            connectionMode === "http-api"
+              ? "border-primary bg-primary/5 text-primary"
+              : "border-border hover:bg-muted"
+          )}
+        >
+          <Server className="h-4 w-4" />
+          Classic API Server
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={connectionMode === "browser-api"}
+          disabled={anyBusy}
+          onClick={() => handleModeChange("browser-api")}
+          className={cn(
+            "flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+            connectionMode === "browser-api"
+              ? "border-primary bg-primary/5 text-primary"
+              : "border-border hover:bg-muted"
+          )}
+        >
+          <KeyRound className="h-4 w-4" />
+          <span>Direct Actual Server</span>
+          <span className="rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700">
+            Experimental
+          </span>
+        </button>
+      </div>
+
+      {savedServersForMode.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {savedServers.map((server) => (
+          {savedServersForMode.map((server) => (
             <button
               key={server.id}
               type="button"
@@ -131,11 +176,13 @@ export function ConnectForm() {
       {showManualForm && (
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="baseUrl">API Server URL</Label>
+            <Label htmlFor="baseUrl">
+              {connectionMode === "browser-api" ? "Actual Server URL" : "API Server URL"}
+            </Label>
             <Input
               id="baseUrl"
               type="text"
-              placeholder="https://budgetapi.example.com"
+              placeholder={connectionMode === "browser-api" ? "https://actual.example.com" : "https://budgetapi.example.com"}
               autoComplete="off"
               spellCheck={false}
               value={baseUrl}
@@ -148,26 +195,50 @@ export function ConnectForm() {
               disabled={anyBusy}
             />
           </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="apiKey">API Key</Label>
-            <Input
-              id="apiKey"
-              type="password"
-              placeholder="••••••••••••••••"
-              autoComplete="current-password"
-              value={apiKey}
-              onChange={(e) => {
-                setApiKey(e.target.value);
-                if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
-                handleCredentialChange();
-              }}
-              onKeyDown={handleKeyDown}
-              disabled={anyBusy}
-            />
-            <p className="text-xs text-muted-foreground">
-              The <code>ACTUAL_API_KEY</code> on your API server.
-            </p>
-          </div>
+
+          {connectionMode === "http-api" ? (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="apiKey">API Key</Label>
+              <Input
+                id="apiKey"
+                type="password"
+                placeholder="••••••••••••••••"
+                autoComplete="current-password"
+                value={apiKey}
+                onChange={(e) => {
+                  setApiKey(e.target.value);
+                  if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
+                  handleCredentialChange();
+                }}
+                onKeyDown={handleKeyDown}
+                disabled={anyBusy}
+              />
+              <p className="text-xs text-muted-foreground">
+                The <code>ACTUAL_API_KEY</code> on your API server.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="serverPassword">Server password</Label>
+              <Input
+                id="serverPassword"
+                type="password"
+                placeholder="••••••••••••••••"
+                autoComplete="current-password"
+                value={serverPassword}
+                onChange={(e) => {
+                  setServerPassword(e.target.value);
+                  if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
+                  handleCredentialChange();
+                }}
+                onKeyDown={handleKeyDown}
+                disabled={anyBusy}
+              />
+              <p className="text-xs text-muted-foreground">
+                Stored in session storage for this browser tab.
+              </p>
+            </div>
+          )}
         </div>
       )}
 
@@ -203,6 +274,7 @@ export function ConnectForm() {
         <div className="ml-auto flex items-center gap-1.5 rounded-full bg-green-50 px-2.5 py-1 text-xs text-green-700">
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
           <span>{deriveLabel(validatedUrl)}</span>
+          <span className="text-green-600/70">· {getConnectionModeBadge(activeValidatedMode)}</span>
           {validatedApiVersion && <span className="text-green-600/70">· v{validatedApiVersion}</span>}
         </div>
       </div>
@@ -242,7 +314,7 @@ export function ConnectForm() {
                   </span>
                   {alreadyConnected && (
                     <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                      connected
+                      {activeValidatedMode === "browser-api" ? "saved" : "connected"}
                     </span>
                   )}
                 </span>
@@ -281,6 +353,13 @@ export function ConnectForm() {
         </div>
       )}
 
+      {connectStatus.kind === "success" && activeValidatedMode === "browser-api" && (
+        <div className="flex items-start gap-2.5 rounded-lg bg-green-50 px-3.5 py-3 text-sm text-green-700">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>Direct connection saved. Classic connections still power app pages.</span>
+        </div>
+      )}
+
       <button
         type="button"
         disabled={connectBusy || !!reconnectBusyId || !selectedGroupId}
@@ -288,7 +367,12 @@ export function ConnectForm() {
         className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {connectBusy ? (
-          <><Loader2 className="h-4 w-4 animate-spin" />Connecting…</>
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {activeValidatedMode === "browser-api" ? "Saving…" : "Connecting…"}
+          </>
+        ) : activeValidatedMode === "browser-api" ? (
+          "Save Direct Connection"
         ) : (
           "Connect"
         )}

--- a/src/components/connect/ConnectionCard.tsx
+++ b/src/components/connect/ConnectionCard.tsx
@@ -56,9 +56,9 @@ export function ConnectionCard({
       <div className="flex items-center gap-1.5 shrink-0">
         <button
           type="button"
-          disabled={anyBusy || isDirect}
+          disabled={anyBusy}
           onClick={() => onConnect(instance)}
-          title={isDirect ? "Direct app transport is not active yet" : "Connect"}
+          title={isDirect ? "Open Direct read-only connection" : "Connect"}
           className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? (
@@ -67,7 +67,7 @@ export function ConnectionCard({
               Connecting…
             </>
           ) : isDirect ? (
-            "Saved"
+            "Open"
           ) : (
             "Connect"
           )}

--- a/src/components/connect/ConnectionCard.tsx
+++ b/src/components/connect/ConnectionCard.tsx
@@ -27,7 +27,7 @@ export function ConnectionCard({
       className={cn(
         "flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors",
         isActive ? "border-primary bg-primary/5" : "border-border bg-background",
-        isDirect && "border-amber-200 bg-amber-50/40"
+        isDirect && "border-emerald-200 bg-emerald-50/40"
       )}
     >
       <div className="flex-1 min-w-0">
@@ -37,7 +37,7 @@ export function ConnectionCard({
             className={cn(
               "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium",
               isDirect
-                ? "bg-amber-100 text-amber-700"
+                ? "bg-emerald-100 text-emerald-700"
                 : "bg-muted text-muted-foreground"
             )}
           >
@@ -58,7 +58,7 @@ export function ConnectionCard({
           type="button"
           disabled={anyBusy}
           onClick={() => onConnect(instance)}
-          title={isDirect ? "Open Direct connection" : "Connect"}
+          title="Connect"
           className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? (
@@ -66,8 +66,6 @@ export function ConnectionCard({
               <Loader2 className="h-3 w-3 animate-spin" />
               Connecting…
             </>
-          ) : isDirect ? (
-            "Open"
           ) : (
             "Connect"
           )}
@@ -76,9 +74,13 @@ export function ConnectionCard({
           type="button"
           disabled={anyBusy}
           onClick={() => onRemove(instance.id)}
-          title="Remove"
+          title={
+            isDirect
+              ? "Forget Direct connection and saved credentials if no other budget uses this server"
+              : "Remove connection"
+          }
           aria-label={
-            "Remove " + instance.label
+            (isDirect ? "Forget Direct connection " : "Remove connection ") + instance.label
           }
           className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
         >

--- a/src/components/connect/ConnectionCard.tsx
+++ b/src/components/connect/ConnectionCard.tsx
@@ -2,8 +2,8 @@
 
 import { Loader2, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { type ConnectionInstance } from "@/store/connection";
-import { deriveLabel } from "./utils";
+import { isBrowserApiConnection, type ConnectionInstance } from "@/store/connection";
+import { deriveLabel, getConnectionModeBadge } from "./utils";
 
 export function ConnectionCard({
   instance,
@@ -20,17 +20,29 @@ export function ConnectionCard({
 }) {
   const busy = connectBusyId === instance.id;
   const anyBusy = connectBusyId !== null;
+  const isDirect = isBrowserApiConnection(instance);
 
   return (
     <div
       className={cn(
         "flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors",
-        isActive ? "border-primary bg-primary/5" : "border-border bg-background"
+        isActive ? "border-primary bg-primary/5" : "border-border bg-background",
+        isDirect && "border-amber-200 bg-amber-50/40"
       )}
     >
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium truncate">{instance.label}</span>
+          <span
+            className={cn(
+              "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium",
+              isDirect
+                ? "bg-amber-100 text-amber-700"
+                : "bg-muted text-muted-foreground"
+            )}
+          >
+            {getConnectionModeBadge(instance.mode)}
+          </span>
           {isActive && (
             <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
               active
@@ -44,8 +56,9 @@ export function ConnectionCard({
       <div className="flex items-center gap-1.5 shrink-0">
         <button
           type="button"
-          disabled={anyBusy}
+          disabled={anyBusy || isDirect}
           onClick={() => onConnect(instance)}
+          title={isDirect ? "Direct app transport is not active yet" : "Connect"}
           className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? (
@@ -53,6 +66,8 @@ export function ConnectionCard({
               <Loader2 className="h-3 w-3 animate-spin" />
               Connecting…
             </>
+          ) : isDirect ? (
+            "Saved"
           ) : (
             "Connect"
           )}
@@ -62,7 +77,9 @@ export function ConnectionCard({
           disabled={anyBusy}
           onClick={() => onRemove(instance.id)}
           title="Remove"
-          aria-label={`Remove ${instance.label}`}
+          aria-label={
+            "Remove " + instance.label
+          }
           className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/connect/ConnectionCard.tsx
+++ b/src/components/connect/ConnectionCard.tsx
@@ -58,7 +58,7 @@ export function ConnectionCard({
           type="button"
           disabled={anyBusy}
           onClick={() => onConnect(instance)}
-          title={isDirect ? "Open Direct read-only connection" : "Connect"}
+          title={isDirect ? "Open Direct connection" : "Connect"}
           className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? (

--- a/src/components/connect/DemoButton.tsx
+++ b/src/components/connect/DemoButton.tsx
@@ -11,10 +11,11 @@ type DemoConnection = { baseUrl: string; apiKey: string; budgetSyncId: string };
 /**
  * "Try the live demo" entry point on the connect screen.
  *
- * Fetches the demo connection from /api/demo (which 404s unless the deployment
- * sets DEMO_MODE=1 + the DEMO_* vars), so this renders nothing on self-hosted
- * builds. Clicking it registers the demo as the active connection and drops the
- * visitor straight into the app — the normal "bring your own actual-http-api"
+ * Fetches the demo connection from /api/demo after the server-rendered connect
+ * page confirms DEMO_MODE=1 + the DEMO_* vars are present. Self-hosted builds
+ * do not render this component, so they do not probe the demo endpoint. Clicking
+ * it registers the demo as the active connection and drops the visitor straight
+ * into the app — the normal "bring your own actual-http-api"
  * form below remains the default path.
  */
 export function DemoButton() {

--- a/src/components/connect/DemoButton.tsx
+++ b/src/components/connect/DemoButton.tsx
@@ -47,6 +47,7 @@ export function DemoButton() {
     addInstance({
       id,
       label: "Live Demo",
+      mode: "http-api",
       baseUrl: demo.baseUrl,
       apiKey: demo.apiKey,
       budgetSyncId: demo.budgetSyncId,

--- a/src/components/connect/useConnectForm.test.tsx
+++ b/src/components/connect/useConnectForm.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useConnectForm } from "./useConnectForm";
+import { useConnectionStore, type ConnectionInstance } from "@/store/connection";
+import { useSavedServersStore } from "@/store/savedServers";
+import { useStagedStore } from "@/store/staged";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockEnsureTransportReady = jest.fn();
+const mockGetTransport = jest.fn();
+const mockLoadBrowserApiBudgetList = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("../../lib/api/client", () => ({
+  listBudgets: jest.fn(),
+  testConnection: jest.fn(),
+  getApiVersion: jest.fn(),
+  getServerVersion: jest.fn(),
+}));
+
+jest.mock("../../lib/actual", () => ({
+  ensureTransportReady: (connection: unknown) => mockEnsureTransportReady(connection),
+  getTransport: (connection: unknown) => mockGetTransport(connection),
+}));
+
+jest.mock("../../lib/actual/browser/labRuntime", () => ({
+  listBrowserApiBudgets: jest.fn(),
+  loadBrowserApiBudgetList: (input: unknown) => mockLoadBrowserApiBudgetList(input),
+}));
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function resetStores() {
+  useConnectionStore.getState().clearAll();
+  useSavedServersStore.getState().clearServers();
+  useStagedStore.getState().discardAll();
+}
+
+describe("useConnectForm Direct redirects", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockReplace.mockReset();
+    mockEnsureTransportReady.mockReset().mockResolvedValue(undefined);
+    mockGetTransport.mockReset().mockReturnValue({
+      getServerVersion: jest.fn().mockResolvedValue(null),
+    });
+    mockLoadBrowserApiBudgetList.mockReset();
+
+    resetStores();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      resetStores();
+    });
+  });
+
+  it("redirects a successful Direct budget connection to overview", async () => {
+    mockLoadBrowserApiBudgetList.mockResolvedValue({
+      budgets: [{ groupId: "budget-1", name: "Budget One" }],
+      serverVersion: "25.1.0",
+    });
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useConnectForm(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.handleModeChange("browser-api");
+      result.current.setBaseUrl("https://actual.example.com");
+      result.current.setServerPassword("password");
+    });
+
+    act(() => {
+      result.current.handleValidate();
+    });
+
+    await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
+    expect(mockPush).not.toHaveBeenCalledWith("/accounts");
+  });
+
+  it("redirects a successful Direct reconnect to overview", async () => {
+    const instance: ConnectionInstance = {
+      id: "direct-1",
+      mode: "browser-api",
+      label: "Direct Budget",
+      baseUrl: "https://actual.example.com",
+      serverPassword: "password",
+      budgetSyncId: "budget-1",
+    };
+    useConnectionStore.getState().addInstance(instance);
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useConnectForm(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.handleReconnect(instance);
+    });
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
+    expect(mockPush).not.toHaveBeenCalledWith("/accounts");
+  });
+});

--- a/src/components/connect/useConnectForm.test.tsx
+++ b/src/components/connect/useConnectForm.test.tsx
@@ -10,6 +10,10 @@ const mockPush = jest.fn();
 const mockReplace = jest.fn();
 const mockEnsureTransportReady = jest.fn();
 const mockGetTransport = jest.fn();
+const mockListBudgets = jest.fn();
+const mockTestConnection = jest.fn();
+const mockGetApiVersion = jest.fn();
+const mockGetServerVersion = jest.fn();
 const mockLoadBrowserApiBudgetList = jest.fn();
 
 jest.mock("next/navigation", () => ({
@@ -24,10 +28,11 @@ jest.mock("sonner", () => ({
 }));
 
 jest.mock("../../lib/api/client", () => ({
-  listBudgets: jest.fn(),
-  testConnection: jest.fn(),
-  getApiVersion: jest.fn(),
-  getServerVersion: jest.fn(),
+  listBudgets: (baseUrl: string, apiKey: string) => mockListBudgets(baseUrl, apiKey),
+  testConnection: (connection: unknown) => mockTestConnection(connection),
+  getApiVersion: (baseUrl: string, apiKey: string) => mockGetApiVersion(baseUrl, apiKey),
+  getServerVersion: (baseUrl: string, apiKey: string, budgetSyncId?: string) =>
+    mockGetServerVersion(baseUrl, apiKey, budgetSyncId),
 }));
 
 jest.mock("../../lib/actual", () => ({
@@ -57,6 +62,10 @@ describe("useConnectForm Direct redirects", () => {
     mockPush.mockReset();
     mockReplace.mockReset();
     mockEnsureTransportReady.mockReset().mockResolvedValue(undefined);
+    mockListBudgets.mockReset();
+    mockTestConnection.mockReset().mockResolvedValue(undefined);
+    mockGetApiVersion.mockReset().mockResolvedValue(null);
+    mockGetServerVersion.mockReset().mockResolvedValue(null);
     mockGetTransport.mockReset().mockReturnValue({
       getServerVersion: jest.fn().mockResolvedValue(null),
     });
@@ -94,6 +103,7 @@ describe("useConnectForm Direct redirects", () => {
     });
 
     await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+    expect(result.current.showManualForm).toBe(false);
 
     act(() => {
       result.current.handleConnect();
@@ -101,6 +111,135 @@ describe("useConnectForm Direct redirects", () => {
 
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
     expect(mockPush).not.toHaveBeenCalledWith("/accounts");
+    const [savedServer] = useSavedServersStore.getState().servers;
+    expect(savedServer).toEqual(
+      expect.objectContaining({
+        mode: "browser-api",
+        label: "actual.example.com",
+        baseUrl: "https://actual.example.com",
+      })
+    );
+    expect(savedServer).not.toHaveProperty("serverPassword");
+  });
+
+  it("hides server fields after HTTP API budgets load", async () => {
+    mockListBudgets.mockResolvedValue([
+      { groupId: "budget-1", cloudFileId: "budget-1", name: "Budget One" },
+    ]);
+    mockGetApiVersion.mockResolvedValue("1.2.3");
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useConnectForm(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.setBaseUrl("https://api.example.com");
+      result.current.setApiKey("api-key");
+    });
+
+    act(() => {
+      result.current.handleValidate();
+    });
+
+    await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+    expect(result.current.showManualForm).toBe(false);
+  });
+
+  it("selects a saved Direct server as URL prefill without restoring or validating a password", () => {
+    useSavedServersStore.getState().addServer({
+      mode: "browser-api",
+      label: "actual.example.com",
+      baseUrl: "https://actual.example.com",
+    });
+    const [server] = useSavedServersStore.getState().servers;
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useConnectForm(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.handleSelectServer(server);
+    });
+
+    expect(result.current.connectionMode).toBe("browser-api");
+    expect(result.current.selectedServerId).toBe(server.id);
+    expect(result.current.baseUrl).toBe("https://actual.example.com");
+    expect(result.current.serverPassword).toBe("");
+    expect(result.current.budgets).toBeNull();
+    expect(mockLoadBrowserApiBudgetList).not.toHaveBeenCalled();
+  });
+
+  it("reuses an in-memory Direct password when selecting the same saved server", async () => {
+    mockLoadBrowserApiBudgetList.mockResolvedValue({
+      budgets: [{ groupId: "budget-2", name: "Budget Two" }],
+      serverVersion: "25.1.0",
+    });
+    useConnectionStore.getState().addInstance({
+      id: "direct-1",
+      mode: "browser-api",
+      label: "Budget One",
+      baseUrl: "https://actual.example.com",
+      serverPassword: "password",
+      budgetSyncId: "budget-1",
+    });
+    useSavedServersStore.getState().addServer({
+      mode: "browser-api",
+      label: "actual.example.com",
+      baseUrl: "https://actual.example.com",
+    });
+    const [server] = useSavedServersStore.getState().servers;
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useConnectForm(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.handleSelectServer(server);
+    });
+
+    expect(result.current.serverPassword).toBe("password");
+    await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+    expect(mockLoadBrowserApiBudgetList).toHaveBeenCalledWith({
+      serverUrl: "https://actual.example.com",
+      serverPassword: "password",
+    });
+  });
+
+  it("allows a Direct budget that exposes id instead of groupId", async () => {
+    mockLoadBrowserApiBudgetList.mockResolvedValue({
+      budgets: [{ id: "local-budget-1", name: "Local Budget", state: "remote" }],
+      serverVersion: "25.1.0",
+    });
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useConnectForm(), {
+      wrapper: makeWrapper(client),
+    });
+
+    act(() => {
+      result.current.handleModeChange("browser-api");
+      result.current.setBaseUrl("https://actual.example.com");
+      result.current.setServerPassword("password");
+    });
+
+    act(() => {
+      result.current.handleValidate();
+    });
+
+    await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+    expect(result.current.selectedGroupId).toBe("local-budget-1");
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
+    expect(mockEnsureTransportReady).toHaveBeenCalledWith(
+      expect.objectContaining({ budgetSyncId: "local-budget-1" })
+    );
   });
 
   it("redirects a successful Direct reconnect to overview", async () => {

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -179,7 +179,7 @@ export function useConnectForm() {
         discardAll();
         queryClient.clear();
         setActiveInstance(instance.id);
-        toast.success("Direct read-only connection opened. Redirecting…");
+        toast.success("Direct connection opened. Redirecting…");
         await new Promise((r) => setTimeout(r, 600));
         router.push("/accounts");
       } finally {
@@ -359,7 +359,7 @@ export function useConnectForm() {
       queryClient.clear();
       setActiveInstance(directConnection.id);
       setConnectStatus({ kind: "success" });
-      toast.success("Direct read-only connection opened. Redirecting…");
+      toast.success("Direct connection opened. Redirecting…");
       await new Promise((r) => setTimeout(r, 800));
       router.push("/accounts");
       return;

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -9,7 +9,11 @@ import {
   getServerVersion,
   type BudgetFile,
 } from "@/lib/api/client";
-import { listBrowserApiBudgets } from "@/lib/actual/browser/labRuntime";
+import { getTransport } from "@/lib/actual";
+import {
+  listBrowserApiBudgets,
+  loadBrowserApiBudgetList,
+} from "@/lib/actual/browser/labRuntime";
 import {
   useConnectionStore,
   selectActiveInstance,
@@ -57,6 +61,7 @@ export function useConnectForm() {
   const instances = useConnectionStore((s) => s.instances);
   const discardAll = useStagedStore((s) => s.discardAll);
   const addServer = useSavedServersStore((s) => s.addServer);
+  const removeServer = useSavedServersStore((s) => s.removeServer);
   const savedServers = useSavedServersStore((s) => s.servers);
 
   // Server credentials
@@ -76,6 +81,7 @@ export function useConnectForm() {
   const [validatedApiKey, setValidatedApiKey] = useState("");
   const [validatedServerPassword, setValidatedServerPassword] = useState("");
   const [validatedApiVersion, setValidatedApiVersion] = useState<string | null>(null);
+  const [validatedServerVersion, setValidatedServerVersion] = useState<string | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [encryptionPassword, setEncryptionPassword] = useState("");
   const [connectStatus, setConnectStatus] = useState<ConnectStatus>({ kind: "idle" });
@@ -113,6 +119,36 @@ export function useConnectForm() {
 
   // ── State helpers ────────────────────────────────────────────────────────────
 
+  function removeSavedServerIfUnused(instance: ConnectionInstance) {
+    const stillUsed = useConnectionStore
+      .getState()
+      .instances.some(
+        (other) =>
+          other.id !== instance.id &&
+          other.mode === instance.mode &&
+          other.baseUrl === instance.baseUrl
+      );
+
+    if (stillUsed) return;
+
+    const savedServer = useSavedServersStore
+      .getState()
+      .servers.find(
+        (server) =>
+          server.mode === instance.mode && server.baseUrl === instance.baseUrl
+      );
+
+    if (savedServer) removeServer(savedServer.id);
+  }
+
+  function handleRemoveInstance(id: string) {
+    const instance = useConnectionStore
+      .getState()
+      .instances.find((candidate) => candidate.id === id);
+    if (instance) removeSavedServerIfUnused(instance);
+    removeInstance(id);
+  }
+
   function resetStep2() {
     setBudgets(null);
     setSelectedGroupId(null);
@@ -123,6 +159,7 @@ export function useConnectForm() {
     setValidatedApiKey("");
     setValidatedServerPassword("");
     setValidatedApiVersion(null);
+    setValidatedServerVersion(null);
   }
 
   function handleCredentialChange() {
@@ -178,6 +215,8 @@ export function useConnectForm() {
       try {
         discardAll();
         queryClient.clear();
+        const version = await getTransport(instance).getServerVersion().catch(() => null);
+        if (version) updateInstance(instance.id, { serverVersion: version });
         setActiveInstance(instance.id);
         toast.success("Direct connection opened. Redirecting…");
         await new Promise((r) => setTimeout(r, 600));
@@ -263,6 +302,7 @@ export function useConnectForm() {
     try {
       let fetched: BudgetFile[];
       let apiVersion: string | null = null;
+      let serverVersion: string | null = null;
 
       if (mode === "http-api") {
         const [budgetsResult, apiVersionResult] = await Promise.allSettled([
@@ -278,10 +318,12 @@ export function useConnectForm() {
 
         addServer({ mode: "http-api", label: deriveLabel(url), baseUrl: url, apiKey: key });
       } else {
-        fetched = (await listBrowserApiBudgets({
+        const result = await loadBrowserApiBudgetList({
           serverUrl: url,
           serverPassword: password,
-        })).map(toBudgetFile);
+        });
+        fetched = result.budgets.map(toBudgetFile);
+        serverVersion = result.serverVersion;
 
         addServer({
           mode: "browser-api",
@@ -301,6 +343,7 @@ export function useConnectForm() {
       setValidatedApiKey(mode === "http-api" ? key : "");
       setValidatedServerPassword(mode === "browser-api" ? password : "");
       setValidatedApiVersion(apiVersion);
+      setValidatedServerVersion(serverVersion);
       setBudgets(fetched);
       setSelectedGroupId(fetched[0].groupId!);
       setValidateStatus({ kind: "idle" });
@@ -346,6 +389,7 @@ export function useConnectForm() {
         baseUrl: validatedUrl,
         serverPassword: validatedServerPassword,
         budgetSyncId: selected.groupId!,
+        ...(validatedServerVersion ? { serverVersion: validatedServerVersion } : {}),
         ...(encryptionPassword.trim() ? { encryptionPassword: encryptionPassword.trim() } : {}),
       };
 
@@ -365,7 +409,7 @@ export function useConnectForm() {
       return;
     }
 
-    // If this Classic budget is already saved, reconnect to the existing instance
+    // If this HTTP API budget is already saved, reconnect to the existing instance
     // instead of creating a duplicate.
     const existing = instances
       .filter(isHttpApiConnection)
@@ -467,7 +511,7 @@ export function useConnectForm() {
     activeInstance,
     savedServers,
     savedServersForMode,
-    removeInstance,
+    removeInstance: handleRemoveInstance,
     // Credentials
     connectionMode,
     handleModeChange,
@@ -485,6 +529,7 @@ export function useConnectForm() {
     validatedMode,
     validatedUrl,
     validatedApiVersion,
+    validatedServerVersion,
     selectedGroupId,
     setSelectedGroupId,
     encryptionPassword,

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -22,13 +22,9 @@ import {
   type ConnectionInstance,
   type ConnectionMode,
 } from "@/store/connection";
-import {
-  useSavedServersStore,
-  isHttpApiSavedServer,
-  isBrowserApiSavedServer,
-  type SavedServer,
-} from "@/store/savedServers";
+import { useSavedServersStore, type SavedServer } from "@/store/savedServers";
 import { useStagedStore } from "@/store/staged";
+import { removeSavedServerIfUnused } from "@/lib/savedServerCleanup";
 import { generateId } from "@/lib/uuid";
 import {
   normalizeUrl,
@@ -39,11 +35,12 @@ import {
 } from "@/components/connect/utils";
 
 function toBudgetFile(budget: Awaited<ReturnType<typeof listBrowserApiBudgets>>[number]): BudgetFile {
+  const syncId = budget.groupId ?? budget.id ?? budget.cloudFileId ?? "";
   return {
-    cloudFileId: budget.cloudFileId ?? budget.groupId ?? "",
-    name: budget.name ?? budget.groupId ?? "Unnamed budget",
+    cloudFileId: budget.cloudFileId ?? syncId,
+    name: (budget.name ?? syncId) || "Unnamed budget",
     state: budget.state,
-    groupId: budget.groupId,
+    groupId: syncId,
     encryptKeyId: budget.encryptKeyId,
     hasKey: budget.hasKey,
     owner: budget.owner,
@@ -99,9 +96,9 @@ export function useConnectForm() {
     [savedServers, connectionMode]
   );
 
-  // Show the manual credential form when there are no saved servers for this
-  // mode, or when the "New server" chip is explicitly selected.
-  const showManualForm = savedServersForMode.length === 0 || selectedServerId === null;
+  // Keep server URL and credential fields visible only until the budget
+  // list is loaded. The Change button resets step 1 if the user needs edits.
+  const showManualForm = !step1Complete;
 
   // Set of budgetSyncIds already connected for the validated server and mode.
   const connectedSyncIds = useMemo(
@@ -119,33 +116,18 @@ export function useConnectForm() {
 
   // ── State helpers ────────────────────────────────────────────────────────────
 
-  function removeSavedServerIfUnused(instance: ConnectionInstance) {
-    const stillUsed = useConnectionStore
-      .getState()
-      .instances.some(
-        (other) =>
-          other.id !== instance.id &&
-          other.mode === instance.mode &&
-          other.baseUrl === instance.baseUrl
-      );
-
-    if (stillUsed) return;
-
-    const savedServer = useSavedServersStore
-      .getState()
-      .servers.find(
-        (server) =>
-          server.mode === instance.mode && server.baseUrl === instance.baseUrl
-      );
-
-    if (savedServer) removeServer(savedServer.id);
-  }
-
   function handleRemoveInstance(id: string) {
     const instance = useConnectionStore
       .getState()
       .instances.find((candidate) => candidate.id === id);
-    if (instance) removeSavedServerIfUnused(instance);
+    if (instance) {
+      removeSavedServerIfUnused({
+        instance,
+        instances: useConnectionStore.getState().instances,
+        savedServers: useSavedServersStore.getState().servers,
+        removeServer,
+      });
+    }
     removeInstance(id);
   }
 
@@ -164,7 +146,6 @@ export function useConnectForm() {
 
   function handleCredentialChange() {
     resetStep2();
-    setSelectedServerId(null);
   }
 
   function handleModeChange(mode: ConnectionMode) {
@@ -195,14 +176,37 @@ export function useConnectForm() {
     setSelectedServerId(server.id);
     setBaseUrl(server.baseUrl);
 
-    if (isHttpApiSavedServer(server)) {
-      setApiKey(server.apiKey);
+    const reusableConnection = instances.find(
+      (instance) => instance.mode === server.mode && instance.baseUrl === server.baseUrl
+    );
+
+    if (server.mode === "http-api") {
+      const reusableApiKey = isHttpApiConnection(reusableConnection)
+        ? reusableConnection.apiKey
+        : "";
+      setApiKey(reusableApiKey);
       setServerPassword("");
-      validate({ mode: "http-api", baseUrl: server.baseUrl, apiKey: server.apiKey }).catch(console.error);
-    } else if (isBrowserApiSavedServer(server)) {
-      setServerPassword(server.serverPassword);
-      setApiKey("");
-      validate({ mode: "browser-api", baseUrl: server.baseUrl, serverPassword: server.serverPassword }).catch(console.error);
+      if (reusableApiKey) {
+        validate({
+          mode: "http-api",
+          baseUrl: server.baseUrl,
+          apiKey: reusableApiKey,
+        }).catch(console.error);
+      }
+      return;
+    }
+
+    const reusableServerPassword = isBrowserApiConnection(reusableConnection)
+      ? reusableConnection.serverPassword
+      : "";
+    setApiKey("");
+    setServerPassword(reusableServerPassword);
+    if (reusableServerPassword) {
+      validate({
+        mode: "browser-api",
+        baseUrl: server.baseUrl,
+        serverPassword: reusableServerPassword,
+      }).catch(console.error);
     }
   }
 
@@ -317,7 +321,7 @@ export function useConnectForm() {
         apiVersion =
           apiVersionResult.status === "fulfilled" ? apiVersionResult.value : null;
 
-        addServer({ mode: "http-api", label: deriveLabel(url), baseUrl: url, apiKey: key });
+        addServer({ mode: "http-api", label: deriveLabel(url), baseUrl: url });
       } else {
         const result = await loadBrowserApiBudgetList({
           serverUrl: url,
@@ -330,7 +334,6 @@ export function useConnectForm() {
           mode: "browser-api",
           label: deriveLabel(url),
           baseUrl: url,
-          serverPassword: password,
         });
       }
 

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -173,8 +173,18 @@ export function useConnectForm() {
   // Does NOT handle errors — callers decide the UX (toast vs inline).
 
   async function reconnect(instance: ConnectionInstance) {
-    if (!isHttpApiConnection(instance)) {
-      toast.info("Direct connections are saved for the experimental transport path. Use a Classic connection for app pages for now.");
+    if (isBrowserApiConnection(instance)) {
+      setReconnectBusyId(instance.id);
+      try {
+        discardAll();
+        queryClient.clear();
+        setActiveInstance(instance.id);
+        toast.success("Direct read-only connection opened. Redirecting…");
+        await new Promise((r) => setTimeout(r, 600));
+        router.push("/accounts");
+      } finally {
+        setReconnectBusyId(null);
+      }
       return;
     }
 
@@ -345,8 +355,13 @@ export function useConnectForm() {
       } else {
         addInstance(directConnection);
       }
+      discardAll();
+      queryClient.clear();
+      setActiveInstance(directConnection.id);
       setConnectStatus({ kind: "success" });
-      toast.success("Direct connection saved. Feature pages still use Classic connections until the transport milestone lands.");
+      toast.success("Direct read-only connection opened. Redirecting…");
+      await new Promise((r) => setTimeout(r, 800));
+      router.push("/accounts");
       return;
     }
 

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -9,12 +9,21 @@ import {
   getServerVersion,
   type BudgetFile,
 } from "@/lib/api/client";
+import { listBrowserApiBudgets } from "@/lib/actual/browser/labRuntime";
 import {
   useConnectionStore,
   selectActiveInstance,
+  isHttpApiConnection,
+  isBrowserApiConnection,
   type ConnectionInstance,
+  type ConnectionMode,
 } from "@/store/connection";
-import { useSavedServersStore } from "@/store/savedServers";
+import {
+  useSavedServersStore,
+  isHttpApiSavedServer,
+  isBrowserApiSavedServer,
+  type SavedServer,
+} from "@/store/savedServers";
 import { useStagedStore } from "@/store/staged";
 import { generateId } from "@/lib/uuid";
 import {
@@ -24,6 +33,18 @@ import {
   type ValidateStatus,
   type ConnectStatus,
 } from "@/components/connect/utils";
+
+function toBudgetFile(budget: Awaited<ReturnType<typeof listBrowserApiBudgets>>[number]): BudgetFile {
+  return {
+    cloudFileId: budget.cloudFileId ?? budget.groupId ?? "",
+    name: budget.name ?? budget.groupId ?? "Unnamed budget",
+    state: budget.state,
+    groupId: budget.groupId,
+    encryptKeyId: budget.encryptKeyId,
+    hasKey: budget.hasKey,
+    owner: budget.owner,
+  };
+}
 
 export function useConnectForm() {
   const router = useRouter();
@@ -39,8 +60,10 @@ export function useConnectForm() {
   const savedServers = useSavedServersStore((s) => s.servers);
 
   // Server credentials
+  const [connectionMode, setConnectionMode] = useState<ConnectionMode>("http-api");
   const [baseUrl, setBaseUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [serverPassword, setServerPassword] = useState("");
   const [validateStatus, setValidateStatus] = useState<ValidateStatus>({ kind: "idle" });
 
   // Which saved server chip is selected (null = "New server" / manual entry)
@@ -48,8 +71,10 @@ export function useConnectForm() {
 
   // Step 2 state
   const [budgets, setBudgets] = useState<BudgetFile[] | null>(null);
+  const [validatedMode, setValidatedMode] = useState<ConnectionMode | null>(null);
   const [validatedUrl, setValidatedUrl] = useState("");
-  const [validatedKey, setValidatedKey] = useState("");
+  const [validatedApiKey, setValidatedApiKey] = useState("");
+  const [validatedServerPassword, setValidatedServerPassword] = useState("");
   const [validatedApiVersion, setValidatedApiVersion] = useState<string | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [encryptionPassword, setEncryptionPassword] = useState("");
@@ -63,14 +88,27 @@ export function useConnectForm() {
   const anyBusy = validateBusy || connectBusy || reconnectBusyId !== null;
   const step1Complete = budgets !== null;
 
-  // Show the manual URL+key form when there are no saved servers, or when
-  // the "New server" chip is explicitly selected (selectedServerId === null).
-  const showManualForm = savedServers.length === 0 || selectedServerId === null;
+  const savedServersForMode = useMemo(
+    () => savedServers.filter((server) => server.mode === connectionMode),
+    [savedServers, connectionMode]
+  );
 
-  // Set of budgetSyncIds already connected for the validated server
+  // Show the manual credential form when there are no saved servers for this
+  // mode, or when the "New server" chip is explicitly selected.
+  const showManualForm = savedServersForMode.length === 0 || selectedServerId === null;
+
+  // Set of budgetSyncIds already connected for the validated server and mode.
   const connectedSyncIds = useMemo(
-    () => new Set(instances.filter((i) => i.baseUrl === validatedUrl).map((i) => i.budgetSyncId)),
-    [instances, validatedUrl]
+    () =>
+      new Set(
+        instances
+          .filter(
+            (instance) =>
+              instance.mode === validatedMode && instance.baseUrl === validatedUrl
+          )
+          .map((instance) => instance.budgetSyncId)
+      ),
+    [instances, validatedMode, validatedUrl]
   );
 
   // ── State helpers ────────────────────────────────────────────────────────────
@@ -80,8 +118,10 @@ export function useConnectForm() {
     setSelectedGroupId(null);
     setEncryptionPassword("");
     setConnectStatus({ kind: "idle" });
+    setValidatedMode(null);
     setValidatedUrl("");
-    setValidatedKey("");
+    setValidatedApiKey("");
+    setValidatedServerPassword("");
     setValidatedApiVersion(null);
   }
 
@@ -90,28 +130,54 @@ export function useConnectForm() {
     setSelectedServerId(null);
   }
 
+  function handleModeChange(mode: ConnectionMode) {
+    if (mode === connectionMode) return;
+    setConnectionMode(mode);
+    setBaseUrl("");
+    setApiKey("");
+    setServerPassword("");
+    setValidateStatus({ kind: "idle" });
+    setSelectedServerId(null);
+    resetStep2();
+  }
+
   // ── Saved server chip selection ──────────────────────────────────────────────
 
-  function handleSelectServer(server: { id: string; baseUrl: string; apiKey: string } | null) {
+  function handleSelectServer(server: SavedServer | null) {
     resetStep2();
     setValidateStatus({ kind: "idle" });
     if (!server) {
       setSelectedServerId(null);
       setBaseUrl("");
       setApiKey("");
+      setServerPassword("");
       return;
     }
+
+    setConnectionMode(server.mode);
     setSelectedServerId(server.id);
     setBaseUrl(server.baseUrl);
-    setApiKey(server.apiKey);
-    // validate() handles its own errors internally; no outer catch needed.
-    validate(server.baseUrl, server.apiKey).catch(console.error);
+
+    if (isHttpApiSavedServer(server)) {
+      setApiKey(server.apiKey);
+      setServerPassword("");
+      validate({ mode: "http-api", baseUrl: server.baseUrl, apiKey: server.apiKey }).catch(console.error);
+    } else if (isBrowserApiSavedServer(server)) {
+      setServerPassword(server.serverPassword);
+      setApiKey("");
+      validate({ mode: "browser-api", baseUrl: server.baseUrl, serverPassword: server.serverPassword }).catch(console.error);
+    }
   }
 
   // ── Reconnect saved instance ─────────────────────────────────────────────────
   // Does NOT handle errors — callers decide the UX (toast vs inline).
 
   async function reconnect(instance: ConnectionInstance) {
+    if (!isHttpApiConnection(instance)) {
+      toast.info("Direct connections are saved for the experimental transport path. Use a Classic connection for app pages for now.");
+      return;
+    }
+
     setReconnectBusyId(instance.id);
     try {
       await testConnection(instance);
@@ -152,12 +218,29 @@ export function useConnectForm() {
 
   // ── Validate: fetch budget list ─────────────────────────────────────────────
 
-  async function validate(overrideUrl?: string, overrideKey?: string) {
-    const url = normalizeUrl(overrideUrl ?? baseUrl);
-    const key = (overrideKey ?? apiKey).trim();
+  async function validate(overrides: {
+    mode?: ConnectionMode;
+    baseUrl?: string;
+    apiKey?: string;
+    serverPassword?: string;
+  } = {}) {
+    const mode = overrides.mode ?? connectionMode;
+    const url = normalizeUrl(overrides.baseUrl ?? baseUrl);
+    const key = (overrides.apiKey ?? apiKey).trim();
+    const password = overrides.serverPassword ?? serverPassword;
 
-    if (!url || !key) {
-      setValidateStatus({ kind: "error", message: "Server URL and API Key are required." });
+    if (!url) {
+      setValidateStatus({ kind: "error", message: "Server URL is required." });
+      return;
+    }
+
+    if (mode === "http-api" && !key) {
+      setValidateStatus({ kind: "error", message: "API Key is required." });
+      return;
+    }
+
+    if (mode === "browser-api" && !password) {
+      setValidateStatus({ kind: "error", message: "Actual Server password is required." });
       return;
     }
 
@@ -168,32 +251,54 @@ export function useConnectForm() {
     setConnectStatus({ kind: "idle" });
 
     try {
-      const [budgetsResult, apiVersionResult] = await Promise.allSettled([
-        listBudgets(url, key),
-        getApiVersion(url, key),
-      ]);
+      let fetched: BudgetFile[];
+      let apiVersion: string | null = null;
 
-      if (budgetsResult.status === "rejected") throw budgetsResult.reason;
+      if (mode === "http-api") {
+        const [budgetsResult, apiVersionResult] = await Promise.allSettled([
+          listBudgets(url, key),
+          getApiVersion(url, key),
+        ]);
 
-      const fetched = budgetsResult.value;
-      const apiVersion =
-        apiVersionResult.status === "fulfilled" ? apiVersionResult.value : null;
+        if (budgetsResult.status === "rejected") throw budgetsResult.reason;
+
+        fetched = budgetsResult.value;
+        apiVersion =
+          apiVersionResult.status === "fulfilled" ? apiVersionResult.value : null;
+
+        addServer({ mode: "http-api", label: deriveLabel(url), baseUrl: url, apiKey: key });
+      } else {
+        fetched = (await listBrowserApiBudgets({
+          serverUrl: url,
+          serverPassword: password,
+        })).map(toBudgetFile);
+
+        addServer({
+          mode: "browser-api",
+          label: deriveLabel(url),
+          baseUrl: url,
+          serverPassword: password,
+        });
+      }
 
       if (fetched.length === 0) {
         setValidateStatus({ kind: "error", message: "No budgets found on this server." });
         return;
       }
 
+      setValidatedMode(mode);
       setValidatedUrl(url);
-      setValidatedKey(key);
+      setValidatedApiKey(mode === "http-api" ? key : "");
+      setValidatedServerPassword(mode === "browser-api" ? password : "");
       setValidatedApiVersion(apiVersion);
       setBudgets(fetched);
       setSelectedGroupId(fetched[0].groupId!);
       setValidateStatus({ kind: "idle" });
 
       // Persist the server, then select its chip so the manual form collapses.
-      addServer({ label: deriveLabel(url), baseUrl: url, apiKey: key });
-      const persisted = useSavedServersStore.getState().servers.find((s) => s.baseUrl === url);
+      const persisted = useSavedServersStore
+        .getState()
+        .servers.find((server) => server.mode === mode && server.baseUrl === url);
       if (persisted) setSelectedServerId(persisted.id);
     } catch (err) {
       setValidateStatus({ kind: "error", message: parseApiError(err) });
@@ -212,21 +317,52 @@ export function useConnectForm() {
   // ── Connect to selected budget ──────────────────────────────────────────────
 
   async function connect() {
-    if (!budgets || !selectedGroupId) return;
+    if (!budgets || !selectedGroupId || !validatedMode) return;
 
     const selected = budgets.find((b) => b.groupId === selectedGroupId);
     if (!selected) return;
 
-    // If this budget is already saved, reconnect to the existing instance
+    if (validatedMode === "browser-api") {
+      const existing = instances
+        .filter(isBrowserApiConnection)
+        .find(
+          (instance) =>
+            instance.baseUrl === validatedUrl && instance.budgetSyncId === selected.groupId
+        );
+      const directConnection: ConnectionInstance = {
+        id: existing?.id ?? generateId(),
+        mode: "browser-api",
+        label: selected.name || deriveLabel(validatedUrl),
+        baseUrl: validatedUrl,
+        serverPassword: validatedServerPassword,
+        budgetSyncId: selected.groupId!,
+        ...(encryptionPassword.trim() ? { encryptionPassword: encryptionPassword.trim() } : {}),
+      };
+
+      setConnectStatus({ kind: "busy" });
+      if (existing) {
+        updateInstance(existing.id, directConnection);
+      } else {
+        addInstance(directConnection);
+      }
+      setConnectStatus({ kind: "success" });
+      toast.success("Direct connection saved. Feature pages still use Classic connections until the transport milestone lands.");
+      return;
+    }
+
+    // If this Classic budget is already saved, reconnect to the existing instance
     // instead of creating a duplicate.
-    const existing = instances.find(
-      (i) => i.baseUrl === validatedUrl && i.budgetSyncId === selected.groupId
-    );
+    const existing = instances
+      .filter(isHttpApiConnection)
+      .find(
+        (instance) =>
+          instance.baseUrl === validatedUrl && instance.budgetSyncId === selected.groupId
+      );
     if (existing) {
       // Use fresh credentials from the current validation in case the key was rotated.
       const freshInstance: ConnectionInstance = {
         ...existing,
-        apiKey: validatedKey,
+        apiKey: validatedApiKey,
         // Explicitly set to undefined when blank so clearing the field removes
         // a stored encryption password rather than silently preserving it.
         encryptionPassword: encryptionPassword.trim() || undefined,
@@ -254,9 +390,10 @@ export function useConnectForm() {
 
     const instance: ConnectionInstance = {
       id: generateId(),
+      mode: "http-api",
       label: selected.name || deriveLabel(validatedUrl),
       baseUrl: validatedUrl,
-      apiKey: validatedKey,
+      apiKey: validatedApiKey,
       budgetSyncId: selected.groupId!,
       ...(encryptionPassword.trim() ? { encryptionPassword: encryptionPassword.trim() } : {}),
     };
@@ -265,8 +402,8 @@ export function useConnectForm() {
     try {
       await testConnection(instance);
       const [apiVersionResult, serverVersionResult] = await Promise.allSettled([
-        getApiVersion(validatedUrl, validatedKey),
-        getServerVersion(validatedUrl, validatedKey, selected.groupId!),
+        getApiVersion(validatedUrl, validatedApiKey),
+        getServerVersion(validatedUrl, validatedApiKey, selected.groupId!),
       ]);
       const finalInstance: ConnectionInstance = {
         ...instance,
@@ -314,17 +451,23 @@ export function useConnectForm() {
     instances,
     activeInstance,
     savedServers,
+    savedServersForMode,
     removeInstance,
     // Credentials
+    connectionMode,
+    handleModeChange,
     baseUrl,
     setBaseUrl,
     apiKey,
     setApiKey,
+    serverPassword,
+    setServerPassword,
     validateStatus,
     setValidateStatus,
     selectedServerId,
     // Step 2
     budgets,
+    validatedMode,
     validatedUrl,
     validatedApiVersion,
     selectedGroupId,

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -9,7 +9,7 @@ import {
   getServerVersion,
   type BudgetFile,
 } from "@/lib/api/client";
-import { getTransport } from "@/lib/actual";
+import { ensureTransportReady, getTransport } from "@/lib/actual";
 import {
   listBrowserApiBudgets,
   loadBrowserApiBudgetList,
@@ -213,14 +213,15 @@ export function useConnectForm() {
     if (isBrowserApiConnection(instance)) {
       setReconnectBusyId(instance.id);
       try {
-        discardAll();
-        queryClient.clear();
+        await ensureTransportReady(instance);
         const version = await getTransport(instance).getServerVersion().catch(() => null);
         if (version) updateInstance(instance.id, { serverVersion: version });
+        discardAll();
+        queryClient.clear();
         setActiveInstance(instance.id);
         toast.success("Direct connection opened. Redirecting…");
         await new Promise((r) => setTimeout(r, 600));
-        router.push("/accounts");
+        router.push("/overview");
       } finally {
         setReconnectBusyId(null);
       }
@@ -394,18 +395,23 @@ export function useConnectForm() {
       };
 
       setConnectStatus({ kind: "busy" });
-      if (existing) {
-        updateInstance(existing.id, directConnection);
-      } else {
-        addInstance(directConnection);
+      try {
+        await ensureTransportReady(directConnection);
+        if (existing) {
+          updateInstance(existing.id, directConnection);
+        } else {
+          addInstance(directConnection);
+        }
+        discardAll();
+        queryClient.clear();
+        setActiveInstance(directConnection.id);
+        setConnectStatus({ kind: "success" });
+        toast.success("Direct connection opened. Redirecting…");
+        await new Promise((r) => setTimeout(r, 800));
+        router.push("/overview");
+      } catch (err) {
+        setConnectStatus({ kind: "error", message: parseApiError(err) });
       }
-      discardAll();
-      queryClient.clear();
-      setActiveInstance(directConnection.id);
-      setConnectStatus({ kind: "success" });
-      toast.success("Direct connection opened. Redirecting…");
-      await new Promise((r) => setTimeout(r, 800));
-      router.push("/accounts");
       return;
     }
 

--- a/src/components/connect/utils.ts
+++ b/src/components/connect/utils.ts
@@ -15,6 +15,16 @@ export function deriveLabel(baseUrl: string): string {
   }
 }
 
+// ─── Connection mode labels ───────────────────────────────────────────────────
+
+export function getConnectionModeLabel(mode: "http-api" | "browser-api"): string {
+  return mode === "browser-api" ? "Direct Actual Server" : "Classic API Server";
+}
+
+export function getConnectionModeBadge(mode: "http-api" | "browser-api"): string {
+  return mode === "browser-api" ? "Direct experimental" : "Classic";
+}
+
 // ─── Error parsing ────────────────────────────────────────────────────────────
 
 /**

--- a/src/components/connect/utils.ts
+++ b/src/components/connect/utils.ts
@@ -18,11 +18,11 @@ export function deriveLabel(baseUrl: string): string {
 // ─── Connection mode labels ───────────────────────────────────────────────────
 
 export function getConnectionModeLabel(mode: "http-api" | "browser-api"): string {
-  return mode === "browser-api" ? "Direct Actual Server" : "Classic API Server";
+  return mode === "browser-api" ? "Direct Actual Server" : "HTTP API Server";
 }
 
 export function getConnectionModeBadge(mode: "http-api" | "browser-api"): string {
-  return mode === "browser-api" ? "Direct experimental" : "Classic";
+  return mode === "browser-api" ? "Direct" : "HTTP API";
 }
 
 // ─── Error parsing ────────────────────────────────────────────────────────────

--- a/src/components/layout/ConnectionHealthDot.tsx
+++ b/src/components/layout/ConnectionHealthDot.tsx
@@ -10,6 +10,7 @@ function statusLabel(status: HealthStatus, latencyMs: number | null): string {
     case "checking": return "Checking…";
     case "degraded": return `Slow${latency}`;
     case "offline":  return "Offline";
+    case "direct":   return "Direct browser session";
     case "unknown":  return "Unknown";
   }
 }
@@ -31,6 +32,7 @@ export function ConnectionHealthDot() {
         status === "checking" && "animate-pulse bg-amber-400",
         status === "degraded" && "bg-amber-400",
         status === "offline"  && "bg-red-500",
+        status === "direct"   && "bg-emerald-500",
       )}
     />
   );

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -61,23 +61,37 @@ function TopBarVersionChip({
   label,
   value,
   title,
+  tone = "neutral",
 }: {
   label: string;
-  value: string;
+  value?: string;
   title: string;
+  tone?: "neutral" | "direct";
 }) {
   return (
     <span
       title={title}
       aria-label={title}
-      className="inline-flex items-center gap-1 rounded-sm bg-muted/55 px-1.5 py-0.5 ring-1 ring-border/50"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 ring-1",
+        tone === "direct"
+          ? "bg-emerald-100 text-emerald-700 ring-emerald-200"
+          : "bg-muted/55 ring-border/50"
+      )}
     >
-      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+      <span
+        className={cn(
+          "text-[10px] font-semibold uppercase leading-none tracking-wide",
+          tone === "direct" ? "text-emerald-700" : "text-muted-foreground/80"
+        )}
+      >
         {label}
       </span>
-      <span className="font-mono text-[11px] leading-none text-foreground/85">
-        {value}
-      </span>
+      {value && (
+        <span className="font-mono text-[11px] leading-none text-foreground/85">
+          {value}
+        </span>
+      )}
     </span>
   );
 }
@@ -105,10 +119,13 @@ export function TopBar() {
   const activeInstance = useConnectionStore(selectActiveInstance);
   const activeHttpInstance = isHttpApiConnection(activeInstance) ? activeInstance : null;
   const activeDirectInstance = isBrowserApiConnection(activeInstance) ? activeInstance : null;
+  const activeActualServerVersion = activeInstance?.serverVersion;
   const instances = useConnectionStore((s) => s.instances);
   const setActive = useConnectionStore((s) => s.setActiveInstance);
   const clearAll = useConnectionStore((s) => s.clearAll);
   const clearServers = useSavedServersStore((s) => s.clearServers);
+  const savedServers = useSavedServersStore((s) => s.servers);
+  const removeServer = useSavedServersStore((s) => s.removeServer);
   const removeInstance = useConnectionStore((s) => s.removeInstance);
 
   // Entity pages store
@@ -144,6 +161,24 @@ export function TopBar() {
     isOffline ||
     (isBudgetPage && budgetSaveReviewEdits !== null);
 
+  function removeSavedServerIfUnused(instance: typeof activeInstance) {
+    if (!instance) return;
+    const stillUsed = instances.some(
+      (other) =>
+        other.id !== instance.id &&
+        other.mode === instance.mode &&
+        other.baseUrl === instance.baseUrl
+    );
+
+    if (stillUsed) return;
+
+    const savedServer = savedServers.find(
+      (server) =>
+        server.mode === instance.mode && server.baseUrl === instance.baseUrl
+    );
+    if (savedServer) removeServer(savedServer.id);
+  }
+
   function handleDiscardAll() {
     if (isBudgetPage) {
       budgetDiscardAll();
@@ -177,6 +212,7 @@ export function TopBar() {
       handleDiscardAll();
       queryClient.clear();
       if (activeInstance) {
+        removeSavedServerIfUnused(activeInstance);
         removeInstance(activeInstance.id);
       }
       if (useConnectionStore.getState().instances.length === 0) {
@@ -323,37 +359,36 @@ export function TopBar() {
             </DropdownMenu>
           )}
 
-          {activeHttpInstance && (activeHttpInstance.apiVersion ?? activeHttpInstance.serverVersion) && (
+          {activeInstance && (activeDirectInstance || activeHttpInstance?.apiVersion || activeActualServerVersion) && (
             <div
               className="inline-flex items-center gap-2 text-xs select-none"
               title="Server versions are fetched when the connection is established or reconnected."
               aria-label="Current server versions"
             >
-              {activeHttpInstance.apiVersion && (
+              {activeDirectInstance && (
+                <TopBarVersionChip
+                  label="Direct"
+                  title="Direct Actual Server connection"
+                  tone="direct"
+                />
+              )}
+              {activeHttpInstance?.apiVersion && (
                 <TopBarVersionChip
                   label="API"
                   value={activeHttpInstance.apiVersion}
                   title={`actual-http-api v${activeHttpInstance.apiVersion}`}
                 />
               )}
-              {activeHttpInstance.serverVersion && (
+              {activeActualServerVersion && (
                 <TopBarVersionChip
                   label="Actual"
-                  value={activeHttpInstance.serverVersion}
-                  title={`Actual Budget v${activeHttpInstance.serverVersion}`}
+                  value={activeActualServerVersion}
+                  title={`Actual Budget v${activeActualServerVersion}`}
                 />
               )}
             </div>
           )}
 
-          {activeDirectInstance && (
-            <span
-              className="inline-flex items-center rounded-sm bg-emerald-100 px-1.5 py-0.5 text-[11px] font-medium text-emerald-800 ring-1 ring-emerald-200"
-              title="Direct browser API mode: reads and staged saves use the browser transport."
-            >
-              Direct
-            </span>
-          )}
         </div>
 
         {/* Right: search + undo/redo + unsaved indicator + save/discard */}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -27,6 +27,7 @@ import {
 import {
   useConnectionStore,
   selectActiveInstance,
+  isHttpApiConnection,
 } from "@/store/connection";
 import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSearchStore";
 import { useConnectionHealthContext } from "@/hooks/useConnectionHealth";
@@ -101,6 +102,7 @@ export function TopBar() {
   const isOffline = healthStatus === "offline";
 
   const activeInstance = useConnectionStore(selectActiveInstance);
+  const activeHttpInstance = isHttpApiConnection(activeInstance) ? activeInstance : null;
   const instances = useConnectionStore((s) => s.instances);
   const setActive = useConnectionStore((s) => s.setActiveInstance);
   const clearAll = useConnectionStore((s) => s.clearAll);
@@ -316,24 +318,24 @@ export function TopBar() {
             </DropdownMenu>
           )}
 
-          {activeInstance && (activeInstance.apiVersion ?? activeInstance.serverVersion) && (
+          {activeHttpInstance && (activeHttpInstance.apiVersion ?? activeHttpInstance.serverVersion) && (
             <div
               className="inline-flex items-center gap-2 text-xs select-none"
               title="Server versions are fetched when the connection is established or reconnected."
               aria-label="Current server versions"
             >
-              {activeInstance.apiVersion && (
+              {activeHttpInstance.apiVersion && (
                 <TopBarVersionChip
                   label="API"
-                  value={activeInstance.apiVersion}
-                  title={`actual-http-api v${activeInstance.apiVersion}`}
+                  value={activeHttpInstance.apiVersion}
+                  title={`actual-http-api v${activeHttpInstance.apiVersion}`}
                 />
               )}
-              {activeInstance.serverVersion && (
+              {activeHttpInstance.serverVersion && (
                 <TopBarVersionChip
                   label="Actual"
-                  value={activeInstance.serverVersion}
-                  title={`Actual Budget v${activeInstance.serverVersion}`}
+                  value={activeHttpInstance.serverVersion}
+                  title={`Actual Budget v${activeHttpInstance.serverVersion}`}
                 />
               )}
             </div>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -142,7 +142,7 @@ export function TopBar() {
     !hasChanges ||
     isSaving ||
     isOffline ||
-    activeDirectInstance !== null ||
+    (activeDirectInstance !== null && isBudgetPage) ||
     (isBudgetPage && budgetSaveReviewEdits !== null);
 
   function handleDiscardAll() {
@@ -201,8 +201,8 @@ export function TopBar() {
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
   async function handleSave() {
-    if (activeDirectInstance) {
-      toast.info("Direct browser API mode is read-only in this milestone.");
+    if (activeDirectInstance && isBudgetPage) {
+      toast.info("Direct browser API mode does not support Budget Management saves yet.");
       return;
     }
 
@@ -354,10 +354,10 @@ export function TopBar() {
 
           {activeDirectInstance && (
             <span
-              className="inline-flex items-center rounded-sm bg-amber-100 px-1.5 py-0.5 text-[11px] font-medium text-amber-800 ring-1 ring-amber-200"
-              title="Direct browser API mode is read-only in this milestone."
+              className="inline-flex items-center rounded-sm bg-emerald-100 px-1.5 py-0.5 text-[11px] font-medium text-emerald-800 ring-1 ring-emerald-200"
+              title="Direct browser API mode: entity reads and staged entity saves use the browser transport. Budget Management saves remain Classic-only."
             >
-              Direct read-only
+              Direct
             </span>
           )}
         </div>
@@ -446,8 +446,8 @@ export function TopBar() {
             disabled={saveDisabled}
             onClick={handleSave}
             title={
-              activeDirectInstance
-                ? "Direct browser API mode is read-only in this milestone"
+              activeDirectInstance && isBudgetPage
+                ? "Direct browser API mode does not support Budget Management saves yet"
                 : isOffline
                   ? "Cannot save - server is unreachable"
                   : undefined

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -142,7 +142,6 @@ export function TopBar() {
     !hasChanges ||
     isSaving ||
     isOffline ||
-    (activeDirectInstance !== null && isBudgetPage) ||
     (isBudgetPage && budgetSaveReviewEdits !== null);
 
   function handleDiscardAll() {
@@ -201,11 +200,6 @@ export function TopBar() {
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
   async function handleSave() {
-    if (activeDirectInstance && isBudgetPage) {
-      toast.info("Direct browser API mode does not support Budget Management saves yet.");
-      return;
-    }
-
     if (isBudgetPage) {
       const { edits, holds } = useBudgetEditsStore.getState();
       const editSnapshot = { ...edits };
@@ -355,7 +349,7 @@ export function TopBar() {
           {activeDirectInstance && (
             <span
               className="inline-flex items-center rounded-sm bg-emerald-100 px-1.5 py-0.5 text-[11px] font-medium text-emerald-800 ring-1 ring-emerald-200"
-              title="Direct browser API mode: entity reads and staged entity saves use the browser transport. Budget Management saves remain Classic-only."
+              title="Direct browser API mode: reads and staged saves use the browser transport."
             >
               Direct
             </span>
@@ -445,13 +439,7 @@ export function TopBar() {
             )}
             disabled={saveDisabled}
             onClick={handleSave}
-            title={
-              activeDirectInstance && isBudgetPage
-                ? "Direct browser API mode does not support Budget Management saves yet"
-                : isOffline
-                  ? "Cannot save - server is unreachable"
-                  : undefined
-            }
+            title={isOffline ? "Cannot save - server is unreachable" : undefined}
           >
             <Save className="mr-1 h-3.5 w-3.5" />
             {isSaving ? "Saving…" : "Save"}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -28,6 +28,7 @@ import {
   useConnectionStore,
   selectActiveInstance,
   isHttpApiConnection,
+  isBrowserApiConnection,
 } from "@/store/connection";
 import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSearchStore";
 import { useConnectionHealthContext } from "@/hooks/useConnectionHealth";
@@ -103,6 +104,7 @@ export function TopBar() {
 
   const activeInstance = useConnectionStore(selectActiveInstance);
   const activeHttpInstance = isHttpApiConnection(activeInstance) ? activeInstance : null;
+  const activeDirectInstance = isBrowserApiConnection(activeInstance) ? activeInstance : null;
   const instances = useConnectionStore((s) => s.instances);
   const setActive = useConnectionStore((s) => s.setActiveInstance);
   const clearAll = useConnectionStore((s) => s.clearAll);
@@ -137,7 +139,11 @@ export function TopBar() {
   const canRedo = isBudgetPage ? budgetCanRedo : stagedCanRedo;
   const isSaving = isBudgetPage ? (isBudgetSaving || budgetSaveEdits !== null) : isEntitySaving;
   const saveDisabled =
-    !hasChanges || isSaving || isOffline || (isBudgetPage && budgetSaveReviewEdits !== null);
+    !hasChanges ||
+    isSaving ||
+    isOffline ||
+    activeDirectInstance !== null ||
+    (isBudgetPage && budgetSaveReviewEdits !== null);
 
   function handleDiscardAll() {
     if (isBudgetPage) {
@@ -195,6 +201,11 @@ export function TopBar() {
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
   async function handleSave() {
+    if (activeDirectInstance) {
+      toast.info("Direct browser API mode is read-only in this milestone.");
+      return;
+    }
+
     if (isBudgetPage) {
       const { edits, holds } = useBudgetEditsStore.getState();
       const editSnapshot = { ...edits };
@@ -340,6 +351,15 @@ export function TopBar() {
               )}
             </div>
           )}
+
+          {activeDirectInstance && (
+            <span
+              className="inline-flex items-center rounded-sm bg-amber-100 px-1.5 py-0.5 text-[11px] font-medium text-amber-800 ring-1 ring-amber-200"
+              title="Direct browser API mode is read-only in this milestone."
+            >
+              Direct read-only
+            </span>
+          )}
         </div>
 
         {/* Right: search + undo/redo + unsaved indicator + save/discard */}
@@ -425,7 +445,13 @@ export function TopBar() {
             )}
             disabled={saveDisabled}
             onClick={handleSave}
-            title={isOffline ? "Cannot save - server is unreachable" : undefined}
+            title={
+              activeDirectInstance
+                ? "Direct browser API mode is read-only in this milestone"
+                : isOffline
+                  ? "Cannot save - server is unreachable"
+                  : undefined
+            }
           >
             <Save className="mr-1 h-3.5 w-3.5" />
             {isSaving ? "Saving…" : "Save"}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -34,6 +34,7 @@ import { useGlobalSearchStore } from "@/features/global-search/store/useGlobalSe
 import { useConnectionHealthContext } from "@/hooks/useConnectionHealth";
 import { ConnectionHealthDot } from "./ConnectionHealthDot";
 import { useSavedServersStore } from "@/store/savedServers";
+import { removeSavedServerIfUnused } from "@/lib/savedServerCleanup";
 import {
   useStagedStore,
   selectHasChanges,
@@ -161,24 +162,6 @@ export function TopBar() {
     isOffline ||
     (isBudgetPage && budgetSaveReviewEdits !== null);
 
-  function removeSavedServerIfUnused(instance: typeof activeInstance) {
-    if (!instance) return;
-    const stillUsed = instances.some(
-      (other) =>
-        other.id !== instance.id &&
-        other.mode === instance.mode &&
-        other.baseUrl === instance.baseUrl
-    );
-
-    if (stillUsed) return;
-
-    const savedServer = savedServers.find(
-      (server) =>
-        server.mode === instance.mode && server.baseUrl === instance.baseUrl
-    );
-    if (savedServer) removeServer(savedServer.id);
-  }
-
   function handleDiscardAll() {
     if (isBudgetPage) {
       budgetDiscardAll();
@@ -212,7 +195,12 @@ export function TopBar() {
       handleDiscardAll();
       queryClient.clear();
       if (activeInstance) {
-        removeSavedServerIfUnused(activeInstance);
+        removeSavedServerIfUnused({
+          instance: activeInstance,
+          instances,
+          savedServers,
+          removeServer,
+        });
         removeInstance(activeInstance.id);
       }
       if (useConnectionStore.getState().instances.length === 0) {

--- a/src/components/ui/entity-note-button.tsx
+++ b/src/components/ui/entity-note-button.tsx
@@ -9,11 +9,6 @@ import { useAllNotes } from "@/hooks/useAllNotes";
 import { useNoteMutation, type EntityNoteKind } from "@/hooks/useNoteMutation";
 import { toAccountNoteId, toBudgetNoteId } from "@/lib/api/notes";
 import { cn } from "@/lib/utils";
-import {
-  useConnectionStore,
-  selectActiveInstance,
-  isBrowserApiConnection,
-} from "@/store/connection";
 
 type EntityNoteButtonProps = {
   entityId: string;
@@ -44,8 +39,6 @@ export function EntityNoteButton({
   const [draft, setDraft] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const connection = useConnectionStore(selectActiveInstance);
-  const directReadOnly = isBrowserApiConnection(connection);
   const notesQuery = useAllNotes();
   // Notes intentionally bypass the staged-mutation model (AGENTS.md): these
   // save/remove handlers write straight to the server. See useNoteMutation.
@@ -64,7 +57,7 @@ export function EntityNoteButton({
   // Until the batch resolves, fall back to the index hint; afterwards, trust the data.
   const noteExists = notesQuery.isSuccess ? loadedNote.trim().length > 0 : hasNote;
   // An empty note opens straight into edit (the "add note" path); otherwise read.
-  const mode = directReadOnly ? "read" : userMode ?? (noteExists ? "read" : "edit");
+  const mode = userMode ?? (noteExists ? "read" : "edit");
   const dirty = draft !== loadedNote;
   const label = entityLabel || entityId;
 
@@ -163,8 +156,6 @@ export function EntityNoteButton({
               size="xs"
               className="-mr-1 shrink-0 text-muted-foreground hover:text-foreground"
               onClick={enterEdit}
-              disabled={directReadOnly}
-              title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
             >
               <Pencil className="h-3.5 w-3.5" />
               Edit
@@ -251,8 +242,6 @@ export function EntityNoteButton({
               variant="outline"
               size="xs"
               onClick={enterEdit}
-              disabled={directReadOnly}
-              title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
             >
               <Plus className="h-3.5 w-3.5" />
               Add note

--- a/src/components/ui/entity-note-button.tsx
+++ b/src/components/ui/entity-note-button.tsx
@@ -9,6 +9,11 @@ import { useAllNotes } from "@/hooks/useAllNotes";
 import { useNoteMutation, type EntityNoteKind } from "@/hooks/useNoteMutation";
 import { toAccountNoteId, toBudgetNoteId } from "@/lib/api/notes";
 import { cn } from "@/lib/utils";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isBrowserApiConnection,
+} from "@/store/connection";
 
 type EntityNoteButtonProps = {
   entityId: string;
@@ -39,6 +44,8 @@ export function EntityNoteButton({
   const [draft, setDraft] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const connection = useConnectionStore(selectActiveInstance);
+  const directReadOnly = isBrowserApiConnection(connection);
   const notesQuery = useAllNotes();
   // Notes intentionally bypass the staged-mutation model (AGENTS.md): these
   // save/remove handlers write straight to the server. See useNoteMutation.
@@ -57,7 +64,7 @@ export function EntityNoteButton({
   // Until the batch resolves, fall back to the index hint; afterwards, trust the data.
   const noteExists = notesQuery.isSuccess ? loadedNote.trim().length > 0 : hasNote;
   // An empty note opens straight into edit (the "add note" path); otherwise read.
-  const mode = userMode ?? (noteExists ? "read" : "edit");
+  const mode = directReadOnly ? "read" : userMode ?? (noteExists ? "read" : "edit");
   const dirty = draft !== loadedNote;
   const label = entityLabel || entityId;
 
@@ -156,6 +163,8 @@ export function EntityNoteButton({
               size="xs"
               className="-mr-1 shrink-0 text-muted-foreground hover:text-foreground"
               onClick={enterEdit}
+              disabled={directReadOnly}
+              title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
             >
               <Pencil className="h-3.5 w-3.5" />
               Edit
@@ -238,7 +247,13 @@ export function EntityNoteButton({
             <p aria-live="polite" className="text-sm text-muted-foreground">
               No note yet.
             </p>
-            <Button variant="outline" size="xs" onClick={enterEdit}>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={enterEdit}
+              disabled={directReadOnly}
+              title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
+            >
               <Plus className="h-3.5 w-3.5" />
               Add note
             </Button>

--- a/src/features/accounts/hooks/useAccountBalances.ts
+++ b/src/features/accounts/hooks/useAccountBalances.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { getAccountBalances } from "@/lib/api/accounts";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 
 /**
@@ -20,7 +20,7 @@ export function useAccountBalances() {
     queryKey: ["accountBalances", connection?.budgetSyncId],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getAccountBalances(connection);
+      return getTransport(connection).getAccountBalances();
     },
     enabled: !!connection,
     staleTime: 60_000,

--- a/src/features/accounts/hooks/useAccounts.ts
+++ b/src/features/accounts/hooks/useAccounts.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getAccounts } from "@/lib/api/accounts";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
@@ -22,7 +22,7 @@ export function useAccounts(options: PreloadOptions = {}) {
     queryKey: ["accounts", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getAccounts(connection);
+      return getTransport(connection).getAccounts();
     },
     enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.

--- a/src/features/accounts/hooks/useAccountsSave.test.tsx
+++ b/src/features/accounts/hooks/useAccountsSave.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAccountsSave } from "./useAccountsSave";
+import { useStagedStore } from "../../../store/staged";
+import type { ActualBenchTransport } from "../../../lib/actual";
+import type { ConnectionInstance } from "../../../store/connection";
+
+const mockGetTransport = jest.fn();
+const mockSyncTransportAfterChanges = jest.fn(
+  async (transport: ActualBenchTransport, changed: boolean) => {
+    if (changed && transport.mode === "browser-api") await transport.sync();
+  }
+);
+
+jest.mock("../../../lib/actual", () => ({
+  getTransport: (connection: unknown) => (mockGetTransport as jest.Mock)(connection),
+  syncTransportAfterChanges: (transport: unknown, changed: unknown) =>
+    (mockSyncTransportAfterChanges as jest.Mock)(transport, changed),
+}));
+
+let mockActiveConnection: ConnectionInstance = {
+  id: "conn-1",
+  label: "Classic",
+  mode: "http-api",
+  baseUrl: "https://api.example.com",
+  apiKey: "key",
+  budgetSyncId: "budget-1",
+};
+
+jest.mock("../../../store/connection", () => ({
+  useConnectionStore: jest.fn(() => mockActiveConnection),
+  selectActiveInstance: jest.fn(),
+}));
+
+function makeTransport(mode: "http-api" | "browser-api") {
+  return {
+    mode,
+    sync: jest.fn(() => Promise.resolve()),
+    createAccount: jest.fn((input) =>
+      Promise.resolve({ id: "server-account-1", ...input })
+    ),
+    updateAccount: jest.fn(() => Promise.resolve()),
+    deleteAccount: jest.fn(() => Promise.resolve()),
+  } as unknown as ActualBenchTransport & {
+    sync: jest.Mock;
+    createAccount: jest.Mock;
+  };
+}
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function stageNewAccount() {
+  useStagedStore.getState().stageNew("accounts", {
+    id: "client-account-1",
+    name: "New Checking",
+    offBudget: false,
+    closed: false,
+    initialBalance: 12.34,
+  });
+}
+
+describe("useAccountsSave", () => {
+  beforeEach(() => {
+    useStagedStore.getState().discardAll();
+    mockGetTransport.mockReset();
+    mockSyncTransportAfterChanges.mockClear();
+    mockActiveConnection = {
+      id: "conn-1",
+      label: "Classic",
+      mode: "http-api",
+      baseUrl: "https://api.example.com",
+      apiKey: "key",
+      budgetSyncId: "budget-1",
+    };
+  });
+
+  afterEach(() => {
+    useStagedStore.getState().discardAll();
+  });
+
+  it("saves Classic staged creates through the selected transport without Direct sync", async () => {
+    const transport = makeTransport("http-api");
+    mockGetTransport.mockReturnValue(transport);
+    stageNewAccount();
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useAccountsSave(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(mockGetTransport).toHaveBeenCalledWith(mockActiveConnection);
+    expect(transport.createAccount).toHaveBeenCalledWith({
+      name: "New Checking",
+      offBudget: false,
+      closed: false,
+      initialBalance: 12.34,
+    });
+    expect(mockSyncTransportAfterChanges).toHaveBeenCalledWith(transport, true);
+    expect(transport.sync).not.toHaveBeenCalled();
+  });
+
+  it("syncs the browser transport after Direct staged creates succeed", async () => {
+    mockActiveConnection = {
+      id: "conn-2",
+      label: "Direct",
+      mode: "browser-api",
+      baseUrl: "https://actual.example.com",
+      serverPassword: "password",
+      budgetSyncId: "budget-1",
+    };
+    const transport = makeTransport("browser-api");
+    mockGetTransport.mockReturnValue(transport);
+    stageNewAccount();
+
+    const client = new QueryClient();
+    const { result } = renderHook(() => useAccountsSave(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(transport.createAccount).toHaveBeenCalledTimes(1);
+    expect(mockSyncTransportAfterChanges).toHaveBeenCalledWith(transport, true);
+    expect(transport.sync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/accounts/hooks/useAccountsSave.test.tsx
+++ b/src/features/accounts/hooks/useAccountsSave.test.tsx
@@ -15,6 +15,22 @@ const mockSyncTransportAfterChanges = jest.fn(
 
 jest.mock("../../../lib/actual", () => ({
   getTransport: (connection: unknown) => (mockGetTransport as jest.Mock)(connection),
+  settleTransportWrites: async <TInput, TResult>(
+    transport: { mode: string },
+    inputs: TInput[],
+    write: (input: TInput) => Promise<TResult>
+  ) => {
+    if (transport.mode !== "browser-api") return Promise.allSettled(inputs.map(write));
+    const results: PromiseSettledResult<TResult>[] = [];
+    for (const input of inputs) {
+      try {
+        results.push({ status: "fulfilled", value: await write(input) });
+      } catch (reason) {
+        results.push({ status: "rejected", reason });
+      }
+    }
+    return results;
+  },
   syncTransportAfterChanges: (transport: unknown, changed: unknown) =>
     (mockSyncTransportAfterChanges as jest.Mock)(transport, changed),
 }));

--- a/src/features/accounts/hooks/useAccountsSave.test.tsx
+++ b/src/features/accounts/hooks/useAccountsSave.test.tsx
@@ -21,7 +21,7 @@ jest.mock("../../../lib/actual", () => ({
 
 let mockActiveConnection: ConnectionInstance = {
   id: "conn-1",
-  label: "Classic",
+  label: "HTTP API",
   mode: "http-api",
   baseUrl: "https://api.example.com",
   apiKey: "key",
@@ -71,7 +71,7 @@ describe("useAccountsSave", () => {
     mockSyncTransportAfterChanges.mockClear();
     mockActiveConnection = {
       id: "conn-1",
-      label: "Classic",
+      label: "HTTP API",
       mode: "http-api",
       baseUrl: "https://api.example.com",
       apiKey: "key",
@@ -83,7 +83,7 @@ describe("useAccountsSave", () => {
     useStagedStore.getState().discardAll();
   });
 
-  it("saves Classic staged creates through the selected transport without Direct sync", async () => {
+  it("saves HTTP API staged creates through the selected transport without Direct sync", async () => {
     const transport = makeTransport("http-api");
     mockGetTransport.mockReturnValue(transport);
     stageNewAccount();

--- a/src/features/accounts/hooks/useAccountsSave.test.tsx
+++ b/src/features/accounts/hooks/useAccountsSave.test.tsx
@@ -13,27 +13,15 @@ const mockSyncTransportAfterChanges = jest.fn(
   }
 );
 
-jest.mock("../../../lib/actual", () => ({
-  getTransport: (connection: unknown) => (mockGetTransport as jest.Mock)(connection),
-  settleTransportWrites: async <TInput, TResult>(
-    transport: { mode: string },
-    inputs: TInput[],
-    write: (input: TInput) => Promise<TResult>
-  ) => {
-    if (transport.mode !== "browser-api") return Promise.allSettled(inputs.map(write));
-    const results: PromiseSettledResult<TResult>[] = [];
-    for (const input of inputs) {
-      try {
-        results.push({ status: "fulfilled", value: await write(input) });
-      } catch (reason) {
-        results.push({ status: "rejected", reason });
-      }
-    }
-    return results;
-  },
-  syncTransportAfterChanges: (transport: unknown, changed: unknown) =>
-    (mockSyncTransportAfterChanges as jest.Mock)(transport, changed),
-}));
+jest.mock("../../../lib/actual", () => {
+  const actualTransport = jest.requireActual("../../../lib/actual/transport") as typeof import("../../../lib/actual/transport");
+  return {
+    getTransport: (connection: unknown) => (mockGetTransport as jest.Mock)(connection),
+    settleTransportWrites: actualTransport.settleTransportWrites,
+    syncTransportAfterChanges: (transport: unknown, changed: unknown) =>
+      (mockSyncTransportAfterChanges as jest.Mock)(transport, changed),
+  };
+});
 
 let mockActiveConnection: ConnectionInstance = {
   id: "conn-1",

--- a/src/features/accounts/hooks/useAccountsSave.ts
+++ b/src/features/accounts/hooks/useAccountsSave.ts
@@ -4,7 +4,11 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -39,15 +43,16 @@ export function useAccountsSave() {
       const idMap: Record<string, string> = {};
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
-      const createResults = await Promise.allSettled(
-        toCreate.map((a) =>
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (a) =>
           transport.createAccount({
             name: a.name,
             offBudget: a.offBudget,
             closed: a.closed,
             initialBalance: a.initialBalance,
           })
-        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
@@ -62,14 +67,15 @@ export function useAccountsSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((a) =>
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (a) =>
           transport.updateAccount(a.id, {
             name: a.name,
             offBudget: a.offBudget,
             closed: a.closed,
           })
-        )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -82,8 +88,10 @@ export function useAccountsSave() {
       }
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
-      const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => transport.deleteAccount(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        toDelete,
+        (id) => transport.deleteAccount(id)
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];

--- a/src/features/accounts/hooks/useAccountsSave.ts
+++ b/src/features/accounts/hooks/useAccountsSave.ts
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { createAccount, updateAccount, deleteAccount } from "@/lib/api/accounts";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -31,6 +31,7 @@ export function useAccountsSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const { toCreate, toUpdate, toDelete } = computeSaveOperations<Account>(staged);
       const succeeded: SaveResult[] = [];
       const failed: SaveResult[] = [];
@@ -40,12 +41,17 @@ export function useAccountsSave() {
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
         toCreate.map((a) =>
-          createAccount(connection, { name: a.name, offBudget: a.offBudget, closed: a.closed, initialBalance: a.initialBalance })
+          transport.createAccount({
+            name: a.name,
+            offBudget: a.offBudget,
+            closed: a.closed,
+            initialBalance: a.initialBalance,
+          })
         )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
-        const r  = createResults[i];
+        const r = createResults[i];
         if (r.status === "fulfilled") {
           idMap[id] = r.value.id;
           succeeded.push({ status: "success", id });
@@ -58,12 +64,16 @@ export function useAccountsSave() {
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
         toUpdate.map((a) =>
-          updateAccount(connection, a.id, { name: a.name, offBudget: a.offBudget, closed: a.closed })
+          transport.updateAccount(a.id, {
+            name: a.name,
+            offBudget: a.offBudget,
+            closed: a.closed,
+          })
         )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
-        const r  = updateResults[i];
+        const r = updateResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -73,11 +83,11 @@ export function useAccountsSave() {
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
       const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => deleteAccount(connection, id))
+        toDelete.map((id) => transport.deleteAccount(id))
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];
-        const r  = deleteResults[i];
+        const r = deleteResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -111,6 +121,8 @@ export function useAccountsSave() {
         }
         useStagedStore.getState().setSaveErrors("accounts", errors);
       }
+
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
 
       await queryClient.invalidateQueries({ queryKey: ["accounts", connection.id] });
       await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "account", connection.id] });

--- a/src/features/budget-diagnostics/components/BudgetDiagnosticsView.test.tsx
+++ b/src/features/budget-diagnostics/components/BudgetDiagnosticsView.test.tsx
@@ -76,6 +76,15 @@ const secondConnection: ConnectionInstance = {
   budgetSyncId: "budget-2",
 };
 
+const directConnection: ConnectionInstance = {
+  id: "direct-1",
+  label: "Direct Household",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "secret",
+  budgetSyncId: "budget-1",
+};
+
 const download: DownloadResult = {
   bytes: new ArrayBuffer(8),
   filename: "household.zip",
@@ -206,6 +215,15 @@ describe("BudgetDiagnosticsView", () => {
       useConnectionStore.setState({ instances: [], activeInstanceId: null });
     });
     jest.clearAllMocks();
+  });
+
+  it("gates Direct connections before exporting a snapshot", () => {
+    setActiveConnection(directConnection);
+
+    render(<BudgetDiagnosticsView />);
+
+    expect(screen.getByText("Budget File Health needs HTTP API Server mode")).toBeInTheDocument();
+    expect(mockExportSnapshot).not.toHaveBeenCalled();
   });
 
   it("opens the active budget snapshot and renders the tabbed diagnostics workspace", async () => {

--- a/src/features/budget-diagnostics/components/BudgetDiagnosticsView.test.tsx
+++ b/src/features/budget-diagnostics/components/BudgetDiagnosticsView.test.tsx
@@ -63,6 +63,7 @@ const mockResetSqliteWorkerClient = resetSqliteWorkerClient as jest.MockedFuncti
 const connection: ConnectionInstance = {
   id: "conn-1",
   label: "Household Budget",
+  mode: "http-api",
   baseUrl: "http://localhost:5006",
   apiKey: "key",
   budgetSyncId: "budget-1",

--- a/src/features/budget-diagnostics/components/BudgetDiagnosticsView.test.tsx
+++ b/src/features/budget-diagnostics/components/BudgetDiagnosticsView.test.tsx
@@ -217,13 +217,13 @@ describe("BudgetDiagnosticsView", () => {
     jest.clearAllMocks();
   });
 
-  it("gates Direct connections before exporting a snapshot", () => {
+  it("opens Direct connection snapshots through the shared diagnostics workspace", async () => {
     setActiveConnection(directConnection);
 
     render(<BudgetDiagnosticsView />);
 
-    expect(screen.getByText("Budget File Health needs HTTP API Server mode")).toBeInTheDocument();
-    expect(mockExportSnapshot).not.toHaveBeenCalled();
+    expect(await screen.findByText("Snapshot counts")).toBeInTheDocument();
+    expect(mockExportSnapshot).toHaveBeenCalledWith(directConnection, expect.any(Function));
   });
 
   it("opens the active budget snapshot and renders the tabbed diagnostics workspace", async () => {

--- a/src/features/budget-diagnostics/components/BudgetDiagnosticsView.tsx
+++ b/src/features/budget-diagnostics/components/BudgetDiagnosticsView.tsx
@@ -8,12 +8,6 @@ import { ArrowRight, LockKeyhole, Stethoscope } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { DirectModeUnavailable } from "@/components/DirectModeUnavailable";
-import {
-  isBrowserApiConnection,
-  selectActiveInstance,
-  useConnectionStore,
-} from "@/store/connection";
 import { useDiagnosticsSnapshot } from "../hooks/useDiagnosticsSnapshot";
 import { SnapshotReloadControls } from "./SnapshotReloadControls";
 import { DiagnosticsSection } from "./DiagnosticsSection";
@@ -78,7 +72,6 @@ export function BudgetDiagnosticsView() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const activeConnection = useConnectionStore(selectActiveInstance);
   // Snapshot loading/caching (incl. reload + integrity check) lives in a shared
   // hook so the standalone Data Browser reuses the exact same cache + worker.
   const { connection, snapshot, loadedAt, retry, runIntegrityCheck } =
@@ -99,16 +92,6 @@ export function BudgetDiagnosticsView() {
     },
     [pathname, router, searchParams]
   );
-
-  if (isBrowserApiConnection(activeConnection)) {
-    return (
-      <DirectModeUnavailable
-        title="Budget File Health needs HTTP API Server mode"
-        description="Direct mode does not have a safe browser API export helper yet, so snapshot diagnostics are unavailable for this connection."
-        detail="Use an HTTP API Server connection for Budget File Health and Data Browser until Direct export support is added."
-      />
-    );
-  }
 
   if (!connection) {
     return <ConnectBudgetState />;

--- a/src/features/budget-diagnostics/components/BudgetDiagnosticsView.tsx
+++ b/src/features/budget-diagnostics/components/BudgetDiagnosticsView.tsx
@@ -8,6 +8,12 @@ import { ArrowRight, LockKeyhole, Stethoscope } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { DirectModeUnavailable } from "@/components/DirectModeUnavailable";
+import {
+  isBrowserApiConnection,
+  selectActiveInstance,
+  useConnectionStore,
+} from "@/store/connection";
 import { useDiagnosticsSnapshot } from "../hooks/useDiagnosticsSnapshot";
 import { SnapshotReloadControls } from "./SnapshotReloadControls";
 import { DiagnosticsSection } from "./DiagnosticsSection";
@@ -72,6 +78,7 @@ export function BudgetDiagnosticsView() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const activeConnection = useConnectionStore(selectActiveInstance);
   // Snapshot loading/caching (incl. reload + integrity check) lives in a shared
   // hook so the standalone Data Browser reuses the exact same cache + worker.
   const { connection, snapshot, loadedAt, retry, runIntegrityCheck } =
@@ -92,6 +99,16 @@ export function BudgetDiagnosticsView() {
     },
     [pathname, router, searchParams]
   );
+
+  if (isBrowserApiConnection(activeConnection)) {
+    return (
+      <DirectModeUnavailable
+        title="Budget File Health needs HTTP API Server mode"
+        description="Direct mode does not have a safe browser API export helper yet, so snapshot diagnostics are unavailable for this connection."
+        detail="Use an HTTP API Server connection for Budget File Health and Data Browser until Direct export support is added."
+      />
+    );
+  }
 
   if (!connection) {
     return <ConnectBudgetState />;

--- a/src/features/budget-diagnostics/components/DataBrowserView.tsx
+++ b/src/features/budget-diagnostics/components/DataBrowserView.tsx
@@ -3,7 +3,13 @@
 import Link from "next/link";
 import { ArrowRight, Database, Loader2, LockKeyhole } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { DirectModeUnavailable } from "@/components/DirectModeUnavailable";
 import { cn } from "@/lib/utils";
+import {
+  isBrowserApiConnection,
+  selectActiveInstance,
+  useConnectionStore,
+} from "@/store/connection";
 import { useDiagnosticsSnapshot } from "../hooks/useDiagnosticsSnapshot";
 import { DataBrowserSection } from "./DataBrowserSection";
 import { SnapshotReloadControls } from "./SnapshotReloadControls";
@@ -81,7 +87,18 @@ function ErrorState({ message, onRetry }: { message: string | null; onRetry: () 
  * loads instantly without re-downloading.
  */
 export function DataBrowserView() {
+  const activeConnection = useConnectionStore(selectActiveInstance);
   const { connection, snapshot, loadedAt, retry } = useDiagnosticsSnapshot();
+
+  if (isBrowserApiConnection(activeConnection)) {
+    return (
+      <DirectModeUnavailable
+        title="Data Browser needs HTTP API Server mode"
+        description="Direct mode cannot export the full budget database for local SQLite browsing yet."
+        detail="Use an HTTP API Server connection for raw SQLite table browsing until Direct export support is added."
+      />
+    );
+  }
 
   if (!connection) {
     return <ConnectState />;

--- a/src/features/budget-diagnostics/components/DataBrowserView.tsx
+++ b/src/features/budget-diagnostics/components/DataBrowserView.tsx
@@ -3,13 +3,7 @@
 import Link from "next/link";
 import { ArrowRight, Database, Loader2, LockKeyhole } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { DirectModeUnavailable } from "@/components/DirectModeUnavailable";
 import { cn } from "@/lib/utils";
-import {
-  isBrowserApiConnection,
-  selectActiveInstance,
-  useConnectionStore,
-} from "@/store/connection";
 import { useDiagnosticsSnapshot } from "../hooks/useDiagnosticsSnapshot";
 import { DataBrowserSection } from "./DataBrowserSection";
 import { SnapshotReloadControls } from "./SnapshotReloadControls";
@@ -87,18 +81,7 @@ function ErrorState({ message, onRetry }: { message: string | null; onRetry: () 
  * loads instantly without re-downloading.
  */
 export function DataBrowserView() {
-  const activeConnection = useConnectionStore(selectActiveInstance);
   const { connection, snapshot, loadedAt, retry } = useDiagnosticsSnapshot();
-
-  if (isBrowserApiConnection(activeConnection)) {
-    return (
-      <DirectModeUnavailable
-        title="Data Browser needs HTTP API Server mode"
-        description="Direct mode cannot export the full budget database for local SQLite browsing yet."
-        detail="Use an HTTP API Server connection for raw SQLite table browsing until Direct export support is added."
-      />
-    );
-  }
 
   if (!connection) {
     return <ConnectState />;

--- a/src/features/budget-diagnostics/hooks/useDiagnosticsSnapshot.ts
+++ b/src/features/budget-diagnostics/hooks/useDiagnosticsSnapshot.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { selectActiveInstance, useConnectionStore, isHttpApiConnection } from "@/store/connection";
+import { selectActiveInstance, useConnectionStore } from "@/store/connection";
 import { exportSnapshot } from "../lib/exportSnapshot";
 import {
   getSqliteWorkerClient,
@@ -39,12 +39,15 @@ function getErrorMessage(error: unknown): string {
  */
 export function useDiagnosticsSnapshot() {
   const connection = useConnectionStore(selectActiveInstance);
-  const httpConnection = isHttpApiConnection(connection) ? connection : null;
   const [reloadToken, setReloadToken] = useState(0);
   const snapshot = useDiagnosticsCacheStore((s) => s.snapshot);
   const setSnapshot = useDiagnosticsCacheStore((s) => s.setSnapshot);
   const loadedAt = useDiagnosticsCacheStore((s) => s.loadedAt);
   const integrityRunGeneration = useRef(0);
+  const connectionApiKey =
+    connection?.mode === "http-api" ? connection.apiKey : undefined;
+  const connectionServerPassword =
+    connection?.mode === "browser-api" ? connection.serverPassword : undefined;
 
   const retry = useCallback(() => {
     // Force a fresh export: drop the cached snapshot and the loaded worker DB,
@@ -108,7 +111,7 @@ export function useDiagnosticsSnapshot() {
   }, [setSnapshot]);
 
   useEffect(() => {
-    if (!httpConnection) {
+    if (!connection) {
       integrityRunGeneration.current += 1;
       resetSqliteWorkerClient();
       useDiagnosticsCacheStore.getState().reset();
@@ -120,16 +123,16 @@ export function useDiagnosticsSnapshot() {
     // change, and disconnect all clear the cache, so a stale snapshot can't stick.
     const cache = useDiagnosticsCacheStore.getState();
     if (
-      cache.signature === connectionSignature(httpConnection) &&
+      cache.signature === connectionSignature(connection) &&
       cache.snapshot.status === "ready" &&
       cache.snapshot.diagnosticsStatus !== "loading" &&
-      isSqliteWorkerLoadedFor(httpConnection.id)
+      isSqliteWorkerLoadedFor(connection.id)
     ) {
       return;
     }
 
     let cancelled = false;
-    const activeConnection = httpConnection;
+    const activeConnection = connection;
 
     // Stamp the cache as reusable. Called only once diagnostics has reached a
     // terminal state (ready or error) — never mid-load — so an interrupted load
@@ -254,15 +257,16 @@ export function useDiagnosticsSnapshot() {
       // or disconnect instead.
     };
   }, [
-    httpConnection,
-    httpConnection?.apiKey,
-    httpConnection?.baseUrl,
-    httpConnection?.budgetSyncId,
-    httpConnection?.encryptionPassword,
-    httpConnection?.id,
+    connection,
+    connectionApiKey,
+    connectionServerPassword,
+    connection?.baseUrl,
+    connection?.budgetSyncId,
+    connection?.encryptionPassword,
+    connection?.id,
     reloadToken,
     setSnapshot,
   ]);
 
-  return { connection: httpConnection, snapshot, loadedAt, retry, runIntegrityCheck } as const;
+  return { connection, snapshot, loadedAt, retry, runIntegrityCheck } as const;
 }

--- a/src/features/budget-diagnostics/hooks/useDiagnosticsSnapshot.ts
+++ b/src/features/budget-diagnostics/hooks/useDiagnosticsSnapshot.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { selectActiveInstance, useConnectionStore } from "@/store/connection";
+import { selectActiveInstance, useConnectionStore, isHttpApiConnection } from "@/store/connection";
 import { exportSnapshot } from "../lib/exportSnapshot";
 import {
   getSqliteWorkerClient,
@@ -39,6 +39,7 @@ function getErrorMessage(error: unknown): string {
  */
 export function useDiagnosticsSnapshot() {
   const connection = useConnectionStore(selectActiveInstance);
+  const httpConnection = isHttpApiConnection(connection) ? connection : null;
   const [reloadToken, setReloadToken] = useState(0);
   const snapshot = useDiagnosticsCacheStore((s) => s.snapshot);
   const setSnapshot = useDiagnosticsCacheStore((s) => s.setSnapshot);
@@ -107,7 +108,7 @@ export function useDiagnosticsSnapshot() {
   }, [setSnapshot]);
 
   useEffect(() => {
-    if (!connection) {
+    if (!httpConnection) {
       integrityRunGeneration.current += 1;
       resetSqliteWorkerClient();
       useDiagnosticsCacheStore.getState().reset();
@@ -119,16 +120,16 @@ export function useDiagnosticsSnapshot() {
     // change, and disconnect all clear the cache, so a stale snapshot can't stick.
     const cache = useDiagnosticsCacheStore.getState();
     if (
-      cache.signature === connectionSignature(connection) &&
+      cache.signature === connectionSignature(httpConnection) &&
       cache.snapshot.status === "ready" &&
       cache.snapshot.diagnosticsStatus !== "loading" &&
-      isSqliteWorkerLoadedFor(connection.id)
+      isSqliteWorkerLoadedFor(httpConnection.id)
     ) {
       return;
     }
 
     let cancelled = false;
-    const activeConnection = connection;
+    const activeConnection = httpConnection;
 
     // Stamp the cache as reusable. Called only once diagnostics has reached a
     // terminal state (ready or error) — never mid-load — so an interrupted load
@@ -253,15 +254,15 @@ export function useDiagnosticsSnapshot() {
       // or disconnect instead.
     };
   }, [
-    connection,
-    connection?.apiKey,
-    connection?.baseUrl,
-    connection?.budgetSyncId,
-    connection?.encryptionPassword,
-    connection?.id,
+    httpConnection,
+    httpConnection?.apiKey,
+    httpConnection?.baseUrl,
+    httpConnection?.budgetSyncId,
+    httpConnection?.encryptionPassword,
+    httpConnection?.id,
     reloadToken,
     setSnapshot,
   ]);
 
-  return { connection, snapshot, loadedAt, retry, runIntegrityCheck } as const;
+  return { connection: httpConnection, snapshot, loadedAt, retry, runIntegrityCheck } as const;
 }

--- a/src/features/budget-diagnostics/lib/exportSnapshot.test.ts
+++ b/src/features/budget-diagnostics/lib/exportSnapshot.test.ts
@@ -1,0 +1,141 @@
+import { apiDownload, type DownloadResult } from "../../../lib/api/client";
+import { exportBrowserApiBudgetZip } from "../../../lib/actual/browser/runtime";
+import type { BrowserApiConnection, HttpApiConnection } from "@/store/connection";
+import type { LoadedSnapshotSummary, WorkerRequestInput, WorkerResultByKind } from "../types";
+import { exportSnapshot } from "./exportSnapshot";
+import { getSqliteWorkerClient, type SqliteWorkerClient } from "./sqliteWorkerClient";
+
+jest.mock("../../../lib/api/client", () => ({
+  apiDownload: jest.fn(),
+}));
+
+jest.mock("../../../lib/actual/browser/runtime", () => ({
+  exportBrowserApiBudgetZip: jest.fn(),
+}));
+
+jest.mock("./sqliteWorkerClient", () => ({
+  getSqliteWorkerClient: jest.fn(),
+}));
+
+const mockApiDownload = apiDownload as jest.MockedFunction<typeof apiDownload>;
+const mockExportBrowserApiBudgetZip = exportBrowserApiBudgetZip as jest.MockedFunction<
+  typeof exportBrowserApiBudgetZip
+>;
+const mockGetSqliteWorkerClient = getSqliteWorkerClient as jest.MockedFunction<
+  typeof getSqliteWorkerClient
+>;
+
+const httpConnection: HttpApiConnection = {
+  id: "http-1",
+  label: "HTTP Budget",
+  mode: "http-api",
+  baseUrl: "https://api.example.com",
+  apiKey: "api-key",
+  budgetSyncId: "budget-1",
+};
+
+const directConnection: BrowserApiConnection = {
+  id: "direct-1",
+  label: "Direct Household",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "server-password",
+  budgetSyncId: "budget-1",
+};
+
+const summary: LoadedSnapshotSummary = {
+  dbSizeBytes: 1024,
+  zipFilename: "budget.zip",
+  zipSizeBytes: 16,
+  hadMetadata: true,
+  metadata: { id: "budget-id", budgetName: "Household" },
+  tableCount: 12,
+  viewCount: 4,
+};
+
+function makeDownload(bytes: ArrayBuffer): DownloadResult {
+  return {
+    bytes,
+    filename: "http-budget.zip",
+    contentType: "application/zip",
+  };
+}
+
+function makeWorkerClient() {
+  const calls: Array<{
+    request: WorkerRequestInput;
+    options?: { onProgress?: unknown; transfer?: Transferable[] };
+  }> = [];
+
+  const client = {
+    call: jest.fn(
+      <K extends keyof WorkerResultByKind>(
+        request: Extract<WorkerRequestInput, { kind: K }>,
+        options?: { onProgress?: unknown; transfer?: Transferable[] }
+      ): Promise<WorkerResultByKind[K]> => {
+        calls.push({ request, options });
+        if (request.kind === "loadSnapshot") {
+          return Promise.resolve(summary as WorkerResultByKind[K]);
+        }
+        return Promise.resolve(undefined as unknown as WorkerResultByKind[K]);
+      }
+    ),
+  } as unknown as SqliteWorkerClient;
+
+  return { client, calls };
+}
+
+describe("exportSnapshot", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-04T12:00:00Z"));
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("downloads HTTP API snapshots through the proxy", async () => {
+    const { client, calls } = makeWorkerClient();
+    const bytes = new Uint8Array([1, 2, 3, 4]).buffer;
+    mockGetSqliteWorkerClient.mockReturnValue(client);
+    mockApiDownload.mockResolvedValue(makeDownload(bytes));
+
+    const result = await exportSnapshot(httpConnection);
+
+    expect(mockApiDownload).toHaveBeenCalledWith(httpConnection, "/export");
+    expect(mockExportBrowserApiBudgetZip).not.toHaveBeenCalled();
+    expect(result.download.filename).toBe("http-budget.zip");
+    expect(result.summary).toBe(summary);
+    expect(calls[0]?.request).toEqual({ kind: "init", wasmUrl: "/sqlite/sqlite3.wasm" });
+    expect(calls[1]?.request).toMatchObject({
+      kind: "loadSnapshot",
+      zipFilename: "http-budget.zip",
+      zipSizeBytes: 4,
+    });
+    expect(calls[1]?.options?.transfer).toHaveLength(1);
+  });
+
+  it("exports Direct snapshots from the Actual browser worker", async () => {
+    const { client, calls } = makeWorkerClient();
+    const bytes = new Uint8Array([5, 6, 7, 8]).buffer;
+    mockGetSqliteWorkerClient.mockReturnValue(client);
+    mockExportBrowserApiBudgetZip.mockResolvedValue(bytes);
+
+    const result = await exportSnapshot(directConnection);
+
+    expect(mockApiDownload).not.toHaveBeenCalled();
+    expect(mockExportBrowserApiBudgetZip).toHaveBeenCalledWith(directConnection);
+    expect(result.download).toMatchObject({
+      filename: "direct-household-2026-07-04.zip",
+      contentType: "application/zip",
+    });
+    expect(result.summary).toBe(summary);
+    expect(calls[1]?.request).toMatchObject({
+      kind: "loadSnapshot",
+      zipFilename: "direct-household-2026-07-04.zip",
+      zipSizeBytes: 4,
+    });
+    expect(calls[1]?.options?.transfer).toHaveLength(1);
+  });
+});

--- a/src/features/budget-diagnostics/lib/exportSnapshot.ts
+++ b/src/features/budget-diagnostics/lib/exportSnapshot.ts
@@ -1,6 +1,7 @@
-import { apiDownload } from "@/lib/api/client";
-import type { DownloadResult } from "@/lib/api/client";
-import type { ConnectionInstance } from "@/store/connection";
+import { apiDownload } from "../../../lib/api/client";
+import type { DownloadResult } from "../../../lib/api/client";
+import { exportBrowserApiBudgetZip } from "../../../lib/actual/browser/runtime";
+import { isBrowserApiConnection, type ConnectionInstance } from "@/store/connection";
 import type { ProgressStage, LoadedSnapshotSummary } from "../types";
 import { getSqliteWorkerClient } from "./sqliteWorkerClient";
 
@@ -9,12 +10,36 @@ export type ExportedSnapshot = {
   summary: LoadedSnapshotSummary;
 };
 
+function directExportFilename(connection: ConnectionInstance): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const safeLabel = connection.label
+    .trim()
+    .replace(/[^a-z0-9-_]+/gi, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+  return `${safeLabel || "direct-budget"}-${date}.zip`;
+}
+
+async function downloadSnapshotZip(
+  connection: ConnectionInstance
+): Promise<DownloadResult> {
+  if (!isBrowserApiConnection(connection)) {
+    return apiDownload(connection, "/export");
+  }
+
+  return {
+    bytes: await exportBrowserApiBudgetZip(connection),
+    filename: directExportFilename(connection),
+    contentType: "application/zip",
+  };
+}
+
 export async function exportSnapshot(
   connection: ConnectionInstance,
   onProgress?: (stage: ProgressStage) => void
 ): Promise<ExportedSnapshot> {
   onProgress?.("exporting");
-  const download = await apiDownload(connection, "/export");
+  const download = await downloadSnapshotZip(connection);
   const bytesForWorker = download.bytes.slice(0);
   const client = getSqliteWorkerClient();
 

--- a/src/features/budget-diagnostics/store/diagnosticsCache.ts
+++ b/src/features/budget-diagnostics/store/diagnosticsCache.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { DownloadResult } from "@/lib/api/client";
-import type { ConnectionInstance } from "@/store/connection";
+import { isHttpApiConnection, type ConnectionInstance } from "@/store/connection";
 import type { DiagnosticsPayload, OverviewPayload, ProgressStage } from "../types";
 
 /**
@@ -48,7 +48,7 @@ export function connectionSignature(connection: ConnectionInstance): string {
     connection.id,
     connection.baseUrl,
     connection.budgetSyncId ?? "",
-    connection.apiKey ?? "",
+    isHttpApiConnection(connection) ? connection.apiKey : "",
     connection.encryptionPassword ?? "",
   ].join("|");
 }

--- a/src/features/budget-diagnostics/store/diagnosticsCache.ts
+++ b/src/features/budget-diagnostics/store/diagnosticsCache.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 import type { DownloadResult } from "@/lib/api/client";
-import { isHttpApiConnection, type ConnectionInstance } from "@/store/connection";
+import {
+  isBrowserApiConnection,
+  isHttpApiConnection,
+  type ConnectionInstance,
+} from "@/store/connection";
 import type { DiagnosticsPayload, OverviewPayload, ProgressStage } from "../types";
 
 /**
@@ -46,9 +50,11 @@ export const INITIAL_SNAPSHOT_STATE: SnapshotState = {
 export function connectionSignature(connection: ConnectionInstance): string {
   return [
     connection.id,
+    connection.mode,
     connection.baseUrl,
     connection.budgetSyncId ?? "",
     isHttpApiConnection(connection) ? connection.apiKey : "",
+    isBrowserApiConnection(connection) ? connection.serverPassword : "",
     connection.encryptionPassword ?? "",
   ].join("|");
 }

--- a/src/features/budget-management/components/details/BudgetNoteSection.tsx
+++ b/src/features/budget-management/components/details/BudgetNoteSection.tsx
@@ -6,11 +6,6 @@ import { Button } from "@/components/ui/button";
 import { useAllNotes } from "@/hooks/useAllNotes";
 import { useNoteMutation, type EntityNoteKind } from "@/hooks/useNoteMutation";
 import { toAccountNoteId, toBudgetNoteId } from "@/lib/api/notes";
-import {
-  useConnectionStore,
-  selectActiveInstance,
-  isBrowserApiConnection,
-} from "@/store/connection";
 
 /** What the panel's note editor points at: the entity kind + its own id. */
 export type BudgetNoteTarget = { kind: EntityNoteKind; id: string };
@@ -34,8 +29,6 @@ function noteKeyFor({ kind, id }: BudgetNoteTarget): string {
  * set-state-in-effect rule forbids).
  */
 export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
-  const connection = useConnectionStore(selectActiveInstance);
-  const directReadOnly = isBrowserApiConnection(connection);
   const { data: allNotes } = useAllNotes();
   const note = allNotes?.get(noteKeyFor(target)) ?? "";
   const { save, remove } = useNoteMutation(target.kind, target.id);
@@ -52,7 +45,6 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
   const busy = save.isPending || remove.isPending;
 
   function enterEdit() {
-    if (directReadOnly) return;
     setDraft(note);
     save.reset();
     remove.reset();
@@ -66,7 +58,6 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
   }
 
   function handleSave() {
-    if (directReadOnly) return;
     // Blank draft on an entity that has no note: nothing to persist or clear, so
     // close without issuing a DELETE for a note that doesn't exist.
     if (!note && draft.trim() === "") {
@@ -77,7 +68,6 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
   }
 
   function handleClear() {
-    if (directReadOnly) return;
     remove.mutate(undefined, {
       onSuccess: () => {
         setDraft("");
@@ -98,8 +88,6 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
             size="xs"
             className="-mr-1 h-5 text-muted-foreground hover:text-foreground"
             onClick={enterEdit}
-            disabled={directReadOnly}
-            title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
           >
             <Pencil className="h-3 w-3" />
             Edit
@@ -131,8 +119,7 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
                 size="xs"
                 className="-ml-1 h-5 text-destructive hover:text-destructive"
                 onClick={handleClear}
-                disabled={busy || directReadOnly}
-                title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
+                disabled={busy}
               >
                 <Trash2 className="h-3 w-3" />
                 {remove.isPending ? "Clearing…" : "Clear"}
@@ -148,8 +135,7 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
                 size="xs"
                 className="h-5"
                 onClick={handleSave}
-                disabled={!dirty || busy || directReadOnly}
-                title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
+                disabled={!dirty || busy}
               >
                 {save.isPending ? (
                   <>
@@ -171,8 +157,6 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
           size="xs"
           className="-ml-1 h-5 text-muted-foreground hover:text-foreground"
           onClick={enterEdit}
-          disabled={directReadOnly}
-          title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
         >
           <Plus className="h-3 w-3" />
           Add note

--- a/src/features/budget-management/components/details/BudgetNoteSection.tsx
+++ b/src/features/budget-management/components/details/BudgetNoteSection.tsx
@@ -6,6 +6,11 @@ import { Button } from "@/components/ui/button";
 import { useAllNotes } from "@/hooks/useAllNotes";
 import { useNoteMutation, type EntityNoteKind } from "@/hooks/useNoteMutation";
 import { toAccountNoteId, toBudgetNoteId } from "@/lib/api/notes";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isBrowserApiConnection,
+} from "@/store/connection";
 
 /** What the panel's note editor points at: the entity kind + its own id. */
 export type BudgetNoteTarget = { kind: EntityNoteKind; id: string };
@@ -29,6 +34,8 @@ function noteKeyFor({ kind, id }: BudgetNoteTarget): string {
  * set-state-in-effect rule forbids).
  */
 export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
+  const connection = useConnectionStore(selectActiveInstance);
+  const directReadOnly = isBrowserApiConnection(connection);
   const { data: allNotes } = useAllNotes();
   const note = allNotes?.get(noteKeyFor(target)) ?? "";
   const { save, remove } = useNoteMutation(target.kind, target.id);
@@ -45,6 +52,7 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
   const busy = save.isPending || remove.isPending;
 
   function enterEdit() {
+    if (directReadOnly) return;
     setDraft(note);
     save.reset();
     remove.reset();
@@ -58,6 +66,7 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
   }
 
   function handleSave() {
+    if (directReadOnly) return;
     // Blank draft on an entity that has no note: nothing to persist or clear, so
     // close without issuing a DELETE for a note that doesn't exist.
     if (!note && draft.trim() === "") {
@@ -68,6 +77,7 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
   }
 
   function handleClear() {
+    if (directReadOnly) return;
     remove.mutate(undefined, {
       onSuccess: () => {
         setDraft("");
@@ -88,6 +98,8 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
             size="xs"
             className="-mr-1 h-5 text-muted-foreground hover:text-foreground"
             onClick={enterEdit}
+            disabled={directReadOnly}
+            title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
           >
             <Pencil className="h-3 w-3" />
             Edit
@@ -119,7 +131,8 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
                 size="xs"
                 className="-ml-1 h-5 text-destructive hover:text-destructive"
                 onClick={handleClear}
-                disabled={busy}
+                disabled={busy || directReadOnly}
+                title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
               >
                 <Trash2 className="h-3 w-3" />
                 {remove.isPending ? "Clearing…" : "Clear"}
@@ -131,7 +144,13 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
               <Button variant="ghost" size="xs" className="h-5" onClick={cancel} disabled={save.isPending}>
                 Cancel
               </Button>
-              <Button size="xs" className="h-5" onClick={handleSave} disabled={!dirty || busy}>
+              <Button
+                size="xs"
+                className="h-5"
+                onClick={handleSave}
+                disabled={!dirty || busy || directReadOnly}
+                title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
+              >
                 {save.isPending ? (
                   <>
                     <Loader2 className="h-3 w-3 animate-spin" />
@@ -152,6 +171,8 @@ export function BudgetNoteSection({ target }: { target: BudgetNoteTarget }) {
           size="xs"
           className="-ml-1 h-5 text-muted-foreground hover:text-foreground"
           onClick={enterEdit}
+          disabled={directReadOnly}
+          title={directReadOnly ? "Direct browser API mode is read-only" : undefined}
         >
           <Plus className="h-3 w-3" />
           Add note

--- a/src/features/budget-management/hooks/useAvailableMonths.ts
+++ b/src/features/budget-management/hooks/useAvailableMonths.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { apiRequest } from "@/lib/api/client";
+import { getTransport } from "@/lib/actual";
 
 /**
  * Fetches the list of available months from GET /months.
@@ -19,11 +19,8 @@ export function useAvailableMonths(): {
     queryKey: ["budget-months", connection?.id],
     queryFn: async () => {
       if (!connection) throw new Error("No active connection");
-      const result = await apiRequest<{ data: string[] }>(
-        connection,
-        "/months"
-      );
-      return [...result.data].sort();
+      const months = await getTransport(connection).getBudgetMonths();
+      return [...months].sort();
     },
     enabled: !!connection,
   });

--- a/src/features/budget-management/hooks/useBudgetSave.test.tsx
+++ b/src/features/budget-management/hooks/useBudgetSave.test.tsx
@@ -2,8 +2,14 @@ import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useBudgetSave } from "./useBudgetSave";
+import { useBudgetEditsStore } from "../../../store/budgetEdits";
 import type { ConnectionInstance } from "../../../store/connection";
-import type { BudgetCellKey, StagedBudgetEdit, StagedHold } from "../types";
+import type {
+  BudgetCellKey,
+  BudgetSaveResult,
+  StagedBudgetEdit,
+  StagedHold,
+} from "../types";
 
 const mockGetTransport = jest.fn();
 
@@ -64,15 +70,26 @@ function makeRawMonth() {
             balance: 100,
             carryover: false,
           },
+          {
+            id: "cat-2",
+            name: "Dining",
+            group_id: "group-1",
+            is_income: false,
+            hidden: false,
+            budgeted: 50,
+            spent: 0,
+            balance: 50,
+            carryover: false,
+          },
         ],
       },
     ],
   };
 }
 
-function makeTransport() {
+function makeTransport(mode: "http-api" | "browser-api" = "browser-api") {
   return {
-    mode: "browser-api",
+    mode,
     sync: jest.fn(() => Promise.resolve()),
     batchBudgetUpdates: jest.fn(async (operation: () => Promise<unknown>) => operation()),
     getBudgetMonths: jest.fn(() => Promise.resolve(["2026-01"])),
@@ -82,17 +99,21 @@ function makeTransport() {
     resetBudgetHold: jest.fn(() => Promise.resolve()),
     transferBudget: jest.fn(() => Promise.resolve()),
   } as {
+    mode: "http-api" | "browser-api";
     sync: jest.Mock;
     batchBudgetUpdates: jest.Mock;
     getBudgetMonths: jest.Mock;
     getBudgetMonth: jest.Mock;
     setBudgetAmount: jest.Mock;
     holdBudgetForNextMonth: jest.Mock;
+    resetBudgetHold: jest.Mock;
+    transferBudget: jest.Mock;
   };
 }
 
 describe("useBudgetSave", () => {
   beforeEach(() => {
+    useBudgetEditsStore.getState().discardAll();
     mockGetTransport.mockReset();
     mockActiveConnection = {
       id: "conn-1",
@@ -104,7 +125,11 @@ describe("useBudgetSave", () => {
     };
   });
 
-  it("saves Direct budget edits and holds through a transport budget batch then syncs", async () => {
+  afterEach(() => {
+    useBudgetEditsStore.getState().discardAll();
+  });
+
+  it("saves Direct budget edits and holds through a transport budget batch without an extra sync", async () => {
     const transport = makeTransport();
     mockGetTransport.mockReturnValue(transport);
     const client = new QueryClient();
@@ -135,6 +160,116 @@ describe("useBudgetSave", () => {
     expect(transport.getBudgetMonths).toHaveBeenCalledTimes(1);
     expect(transport.batchBudgetUpdates).toHaveBeenCalledTimes(1);
     expect(transport.holdBudgetForNextMonth).toHaveBeenCalledWith("2026-01", 25);
+    expect(transport.setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-1", 150);
+    expect(transport.sync).not.toHaveBeenCalled();
+  });
+
+  it("saves complete transfer pairs through transferBudget", async () => {
+    const transport = makeTransport();
+    mockGetTransport.mockReturnValue(transport);
+    const client = new QueryClient();
+    const { result } = renderHook(() => useBudgetSave(), {
+      wrapper: makeWrapper(client),
+    });
+
+    const src: StagedBudgetEdit = {
+      month: "2026-01",
+      categoryId: "cat-1",
+      previousBudgeted: 100,
+      nextBudgeted: 75,
+      source: "transfer",
+      transferGroupId: "transfer-1",
+    };
+    const dst: StagedBudgetEdit = {
+      month: "2026-01",
+      categoryId: "cat-2",
+      previousBudgeted: 50,
+      nextBudgeted: 75,
+      source: "transfer",
+      transferGroupId: "transfer-1",
+    };
+
+    let saveResults: BudgetSaveResult[] = [];
+    await act(async () => {
+      saveResults = await result.current.save({
+        ["2026-01:cat-1" as BudgetCellKey]: src,
+        ["2026-01:cat-2" as BudgetCellKey]: dst,
+      });
+    });
+
+    expect(transport.transferBudget).toHaveBeenCalledWith("2026-01", {
+      fromCategoryId: "cat-1",
+      toCategoryId: "cat-2",
+      amount: 25,
+    });
+    expect(transport.setBudgetAmount).not.toHaveBeenCalled();
+    expect(saveResults).toEqual([
+      { month: "2026-01", categoryId: "cat-1", status: "success" },
+      { month: "2026-01", categoryId: "cat-2", status: "success" },
+    ]);
+  });
+
+  it("keeps rejected staged edits in the store with a save error", async () => {
+    const transport = makeTransport();
+    transport.setBudgetAmount.mockRejectedValue(new Error("write failed"));
+    mockGetTransport.mockReturnValue(transport);
+    const client = new QueryClient();
+    const { result } = renderHook(() => useBudgetSave(), {
+      wrapper: makeWrapper(client),
+    });
+
+    const key = "2026-01:cat-1" as BudgetCellKey;
+    const edit: StagedBudgetEdit = {
+      month: "2026-01",
+      categoryId: "cat-1",
+      previousBudgeted: 100,
+      nextBudgeted: 150,
+      source: "manual",
+    };
+    useBudgetEditsStore.getState().stageEdit(edit);
+
+    let saveResults: BudgetSaveResult[] = [];
+    await act(async () => {
+      saveResults = await result.current.save(useBudgetEditsStore.getState().edits);
+    });
+
+    expect(saveResults).toEqual([
+      { month: "2026-01", categoryId: "cat-1", status: "error", message: "write failed" },
+    ]);
+    expect(useBudgetEditsStore.getState().edits[key]).toMatchObject({
+      nextBudgeted: 150,
+      saveError: "write failed",
+    });
+  });
+
+  it("does not sync after an HTTP API budget save", async () => {
+    mockActiveConnection = {
+      id: "conn-http",
+      label: "HTTP API",
+      mode: "http-api",
+      baseUrl: "https://api.example.com",
+      apiKey: "key",
+      budgetSyncId: "budget-1",
+    };
+    const transport = makeTransport("http-api");
+    mockGetTransport.mockReturnValue(transport);
+    const client = new QueryClient();
+    const { result } = renderHook(() => useBudgetSave(), {
+      wrapper: makeWrapper(client),
+    });
+
+    const edit: StagedBudgetEdit = {
+      month: "2026-01",
+      categoryId: "cat-1",
+      previousBudgeted: 100,
+      nextBudgeted: 150,
+      source: "manual",
+    };
+
+    await act(async () => {
+      await result.current.save({ ["2026-01:cat-1" as BudgetCellKey]: edit });
+    });
+
     expect(transport.setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-1", 150);
     expect(transport.sync).not.toHaveBeenCalled();
   });

--- a/src/features/budget-management/hooks/useBudgetSave.test.tsx
+++ b/src/features/budget-management/hooks/useBudgetSave.test.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useBudgetSave } from "./useBudgetSave";
+import type { ConnectionInstance } from "../../../store/connection";
+import type { BudgetCellKey, StagedBudgetEdit, StagedHold } from "../types";
+
+const mockGetTransport = jest.fn();
+
+jest.mock("../../../lib/actual", () => ({
+  getTransport: (connection: unknown) => (mockGetTransport as jest.Mock)(connection),
+}));
+
+let mockActiveConnection: ConnectionInstance = {
+  id: "conn-1",
+  label: "Direct",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "password",
+  budgetSyncId: "budget-1",
+};
+
+jest.mock("../../../store/connection", () => ({
+  useConnectionStore: jest.fn(() => mockActiveConnection),
+  selectActiveInstance: jest.fn(),
+}));
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function makeRawMonth() {
+  return {
+    month: "2026-01",
+    incomeAvailable: 0,
+    lastMonthOverspent: 0,
+    forNextMonth: 0,
+    totalBudgeted: 0,
+    toBudget: 0,
+    fromLastMonth: 0,
+    totalIncome: 0,
+    totalSpent: 0,
+    totalBalance: 0,
+    categoryGroups: [
+      {
+        id: "group-1",
+        name: "Expenses",
+        is_income: false as const,
+        hidden: false,
+        budgeted: 0,
+        spent: 0,
+        balance: 0,
+        categories: [
+          {
+            id: "cat-1",
+            name: "Groceries",
+            group_id: "group-1",
+            is_income: false,
+            hidden: false,
+            budgeted: 100,
+            spent: 0,
+            balance: 100,
+            carryover: false,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function makeTransport() {
+  return {
+    mode: "browser-api",
+    sync: jest.fn(() => Promise.resolve()),
+    batchBudgetUpdates: jest.fn(async (operation: () => Promise<unknown>) => operation()),
+    getBudgetMonths: jest.fn(() => Promise.resolve(["2026-01"])),
+    getBudgetMonth: jest.fn(() => Promise.resolve(makeRawMonth())),
+    setBudgetAmount: jest.fn(() => Promise.resolve()),
+    holdBudgetForNextMonth: jest.fn(() => Promise.resolve()),
+    resetBudgetHold: jest.fn(() => Promise.resolve()),
+    transferBudget: jest.fn(() => Promise.resolve()),
+  } as {
+    sync: jest.Mock;
+    batchBudgetUpdates: jest.Mock;
+    getBudgetMonths: jest.Mock;
+    getBudgetMonth: jest.Mock;
+    setBudgetAmount: jest.Mock;
+    holdBudgetForNextMonth: jest.Mock;
+  };
+}
+
+describe("useBudgetSave", () => {
+  beforeEach(() => {
+    mockGetTransport.mockReset();
+    mockActiveConnection = {
+      id: "conn-1",
+      label: "Direct",
+      mode: "browser-api",
+      baseUrl: "https://actual.example.com",
+      serverPassword: "password",
+      budgetSyncId: "budget-1",
+    };
+  });
+
+  it("saves Direct budget edits and holds through a transport budget batch then syncs", async () => {
+    const transport = makeTransport();
+    mockGetTransport.mockReturnValue(transport);
+    const client = new QueryClient();
+    const { result } = renderHook(() => useBudgetSave(), {
+      wrapper: makeWrapper(client),
+    });
+
+    const edit: StagedBudgetEdit = {
+      month: "2026-01",
+      categoryId: "cat-1",
+      previousBudgeted: 100,
+      nextBudgeted: 150,
+      source: "manual",
+    };
+    const hold: StagedHold = {
+      month: "2026-01",
+      previousAmount: 0,
+      nextAmount: 25,
+    };
+
+    await act(async () => {
+      await result.current.save(
+        { ["2026-01:cat-1" as BudgetCellKey]: edit },
+        { "2026-01": hold }
+      );
+    });
+
+    expect(transport.getBudgetMonths).toHaveBeenCalledTimes(1);
+    expect(transport.batchBudgetUpdates).toHaveBeenCalledTimes(1);
+    expect(transport.holdBudgetForNextMonth).toHaveBeenCalledWith("2026-01", 25);
+    expect(transport.setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-1", 150);
+    expect(transport.sync).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/budget-management/hooks/useBudgetSave.ts
+++ b/src/features/budget-management/hooks/useBudgetSave.ts
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { apiRequest } from "@/lib/api/client";
+import { getTransport } from "@/lib/actual";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { budgetMonthDataQueryOptions } from "./useMonthData";
 import { addMonths } from "@/lib/budget/monthMath";
@@ -101,14 +101,14 @@ export function useBudgetSave(): UseBudgetSaveReturn {
       holds: Record<string, StagedHold> = {}
     ): Promise<BudgetSaveResult[]> => {
       if (!connection) throw new Error("No active connection");
+      const transport = getTransport(connection);
 
       const entries = Object.entries(edits) as [BudgetCellKey, StagedBudgetEdit][];
       const holdEntries = Object.entries(holds) as [string, StagedHold][];
       if (entries.length === 0 && holdEntries.length === 0) return [];
 
-      // Pre-save guard: verify all target months still exist in GET /months.
-      const monthsResult = await apiRequest<{ data: string[] }>(connection, "/months");
-      const availableSet = new Set(monthsResult.data);
+      // Pre-save guard: verify all target months still exist.
+      const availableSet = new Set(await transport.getBudgetMonths());
 
       const monthValidEntries = entries.filter(([, edit]) => availableSet.has(edit.month));
       const monthInvalidEntries = entries.filter(([, edit]) => !availableSet.has(edit.month));
@@ -216,169 +216,158 @@ export function useBudgetSave(): UseBudgetSaveReturn {
       const successMonths = new Set<string>();
       let completedCalls = 0;
 
-      // ── 0. Staged holds ───────────────────────────────────────────────────────
-      for (const [month, hold] of holdEntries) {
-        if (!availableSet.has(month)) {
-          results.push({
-            month,
-            categoryId: "",
-            status: "error",
-            message: `Month ${month} is no longer available in this budget`,
-          });
-          continue;
+      await transport.batchBudgetUpdates(async () => {
+        // ── 0. Staged holds ─────────────────────────────────────────────────────
+        for (const [month, hold] of holdEntries) {
+          if (!availableSet.has(month)) {
+            results.push({
+              month,
+              categoryId: "",
+              status: "error",
+              message: `Month ${month} is no longer available in this budget`,
+            });
+            continue;
+          }
+
+          try {
+            if (hold.nextAmount === 0) {
+              await transport.resetBudgetHold(month);
+            } else {
+              // When the server already has a hold (previousAmount > 0), DELETE it
+              // first so the subsequent POST sets an absolute value rather than
+              // adding on top of whatever the server currently holds.
+              if (hold.previousAmount > 0) {
+                await transport.resetBudgetHold(month);
+              }
+              await transport.holdBudgetForNextMonth(month, hold.nextAmount);
+            }
+
+            // Optimistic cache update: apply the hold to the cached month state.
+            queryClient.setQueryData(
+              ["budget-month-data", connection.id, month],
+              (prev: LoadedMonthState | undefined) => {
+                if (!prev) return prev;
+                const holdDelta = hold.nextAmount - prev.summary.forNextMonth;
+                return {
+                  ...prev,
+                  summary: {
+                    ...prev.summary,
+                    forNextMonth: hold.nextAmount,
+                    toBudget: prev.summary.toBudget - holdDelta,
+                  },
+                };
+              }
+            );
+
+            succeededHoldMonths.push(month);
+            successMonths.add(month);
+            results.push({ month, categoryId: "", status: "success" });
+          } catch (err) {
+            const message =
+              err instanceof Error
+                ? err.message
+                : (err as { message?: string }).message ?? "Save failed";
+            setHoldSaveError(month, message);
+            results.push({ month, categoryId: "", status: "error", message });
+          }
+
+          completedCalls++;
+          setProgress({ completed: completedCalls, total: totalCalls });
         }
 
-        try {
-          if (hold.nextAmount === 0) {
-            // resetBudgetHold — DELETE /months/{month}/nextmonthbudgethold
-            await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
-              method: "DELETE",
+        // ── 1. Complete transfer pairs via atomic transfer ─────────────────────
+        for (const { src, dst } of completePairs) {
+          const [srcKey, srcEdit] = src;
+          const [dstKey, dstEdit] = dst;
+          const amount = dstEdit.nextBudgeted - dstEdit.previousBudgeted;
+          const month = srcEdit.month;
+
+          try {
+            await transport.transferBudget(month, {
+              fromCategoryId: srcEdit.categoryId,
+              toCategoryId: dstEdit.categoryId,
+              amount,
             });
-          } else {
-            // When the server already has a hold (previousAmount > 0), DELETE it
-            // first so the subsequent POST sets an absolute value rather than
-            // adding on top of whatever the server currently holds.
-            if (hold.previousAmount > 0) {
-              await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
-                method: "DELETE",
-              });
-            }
-            // holdBudgetForNextMonth — POST /months/{month}/nextmonthbudgethold
-            await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
-              method: "POST",
-              body: { amount: hold.nextAmount },
+
+            // BM-11: Optimistic cache update for both legs together.
+            queryClient.setQueryData(
+              ["budget-month-data", connection.id, month],
+              (prev: LoadedMonthState | undefined) => {
+                if (!prev) return prev;
+                let next = applyBudgetedToMonthState(prev, srcEdit.categoryId, srcEdit.nextBudgeted);
+                next = applyBudgetedToMonthState(next, dstEdit.categoryId, dstEdit.nextBudgeted);
+                return next;
+              }
+            );
+
+            succeededKeys.push(srcKey, dstKey);
+            successMonths.add(month);
+            results.push(
+              { month, categoryId: srcEdit.categoryId, status: "success" },
+              { month, categoryId: dstEdit.categoryId, status: "success" }
+            );
+          } catch (err) {
+            const message =
+              err instanceof Error
+                ? err.message
+                : (err as { message?: string }).message ?? "Save failed";
+            setSaveError(srcKey, message);
+            setSaveError(dstKey, message);
+            results.push(
+              { month, categoryId: srcEdit.categoryId, status: "error", message },
+              { month, categoryId: dstEdit.categoryId, status: "error", message }
+            );
+          }
+
+          completedCalls++;
+          setProgress({ completed: completedCalls, total: totalCalls });
+        }
+
+        // ── 2. Incomplete transfer legs + standalone edits ───────────────────
+        const patchEntries = [...incompleteLegs, ...nonTransferEntries];
+
+        for (const [key, edit] of patchEntries) {
+          try {
+            await transport.setBudgetAmount(edit.month, edit.categoryId, edit.nextBudgeted);
+
+            // BM-11: Optimistically update the cached month state so the grid
+            // clears the amber "staged" styling immediately, without waiting for
+            // the invalidation refetch round trip.
+            queryClient.setQueryData(
+              ["budget-month-data", connection.id, edit.month],
+              (prev: LoadedMonthState | undefined) =>
+                prev ? applyBudgetedToMonthState(prev, edit.categoryId, edit.nextBudgeted) : prev
+            );
+
+            succeededKeys.push(key);
+            successMonths.add(edit.month);
+            results.push({
+              month: edit.month,
+              categoryId: edit.categoryId,
+              status: "success",
+            });
+          } catch (err) {
+            const message =
+              err instanceof Error
+                ? err.message
+                : (err as { message?: string }).message ?? "Save failed";
+            setSaveError(key, message);
+            results.push({
+              month: edit.month,
+              categoryId: edit.categoryId,
+              status: "error",
+              message,
             });
           }
 
-          // Optimistic cache update: apply the hold to the cached month state.
-          queryClient.setQueryData(
-            ["budget-month-data", connection.id, month],
-            (prev: LoadedMonthState | undefined) => {
-              if (!prev) return prev;
-              const holdDelta = hold.nextAmount - prev.summary.forNextMonth;
-              return {
-                ...prev,
-                summary: {
-                  ...prev.summary,
-                  forNextMonth: hold.nextAmount,
-                  toBudget: prev.summary.toBudget - holdDelta,
-                },
-              };
-            }
-          );
-
-          succeededHoldMonths.push(month);
-          successMonths.add(month);
-          results.push({ month, categoryId: "", status: "success" });
-        } catch (err) {
-          const message =
-            err instanceof Error
-              ? err.message
-              : (err as { message?: string }).message ?? "Save failed";
-          setHoldSaveError(month, message);
-          results.push({ month, categoryId: "", status: "error", message });
+          completedCalls++;
+          setProgress({ completed: completedCalls, total: totalCalls });
         }
+      });
 
-        completedCalls++;
-        setProgress({ completed: completedCalls, total: totalCalls });
-      }
-
-      // ── 1. Complete transfer pairs via atomic POST ────────────────────────────
-      for (const { src, dst } of completePairs) {
-        const [srcKey, srcEdit] = src;
-        const [dstKey, dstEdit] = dst;
-        const amount = dstEdit.nextBudgeted - dstEdit.previousBudgeted;
-        const month = srcEdit.month;
-
-        try {
-          await apiRequest(connection, `/months/${month}/categorytransfers`, {
-            method: "POST",
-            body: {
-              categorytransfer: {
-                fromCategoryId: srcEdit.categoryId,
-                toCategoryId: dstEdit.categoryId,
-                amount,
-              },
-            },
-          });
-
-          // BM-11: Optimistic cache update for both legs together.
-          queryClient.setQueryData(
-            ["budget-month-data", connection.id, month],
-            (prev: LoadedMonthState | undefined) => {
-              if (!prev) return prev;
-              let next = applyBudgetedToMonthState(prev, srcEdit.categoryId, srcEdit.nextBudgeted);
-              next = applyBudgetedToMonthState(next, dstEdit.categoryId, dstEdit.nextBudgeted);
-              return next;
-            }
-          );
-
-          succeededKeys.push(srcKey, dstKey);
-          successMonths.add(month);
-          results.push(
-            { month, categoryId: srcEdit.categoryId, status: "success" },
-            { month, categoryId: dstEdit.categoryId, status: "success" }
-          );
-        } catch (err) {
-          const message =
-            err instanceof Error
-              ? err.message
-              : (err as { message?: string }).message ?? "Save failed";
-          setSaveError(srcKey, message);
-          setSaveError(dstKey, message);
-          results.push(
-            { month, categoryId: srcEdit.categoryId, status: "error", message },
-            { month, categoryId: dstEdit.categoryId, status: "error", message }
-          );
-        }
-
-        completedCalls++;
-        setProgress({ completed: completedCalls, total: totalCalls });
-      }
-
-      // ── 2. Incomplete transfer legs + standalone edits via PATCH ─────────────
-      const patchEntries = [...incompleteLegs, ...nonTransferEntries];
-
-      for (const [key, edit] of patchEntries) {
-        try {
-          await apiRequest(connection, `/months/${edit.month}/categories/${edit.categoryId}`, {
-            method: "PATCH",
-            body: { category: { budgeted: edit.nextBudgeted } },
-          });
-
-          // BM-11: Optimistically update the cached month state so the grid
-          // clears the amber "staged" styling immediately, without waiting for
-          // the invalidation refetch round trip.
-          queryClient.setQueryData(
-            ["budget-month-data", connection.id, edit.month],
-            (prev: LoadedMonthState | undefined) =>
-              prev ? applyBudgetedToMonthState(prev, edit.categoryId, edit.nextBudgeted) : prev
-          );
-
-          succeededKeys.push(key);
-          successMonths.add(edit.month);
-          results.push({
-            month: edit.month,
-            categoryId: edit.categoryId,
-            status: "success",
-          });
-        } catch (err) {
-          const message =
-            err instanceof Error
-              ? err.message
-              : (err as { message?: string }).message ?? "Save failed";
-          setSaveError(key, message);
-          results.push({
-            month: edit.month,
-            categoryId: edit.categoryId,
-            status: "error",
-            message,
-          });
-        }
-
-        completedCalls++;
-        setProgress({ completed: completedCalls, total: totalCalls });
-      }
+      // Direct budget batches schedule their own Actual sync after the batch
+      // message flush. Forcing an immediate sync here can race that flush and
+      // pull the old remote budget state back over the just-written values.
 
       // Clear succeeded hold months from the store.
       if (succeededHoldMonths.length > 0) {

--- a/src/features/budget-management/hooks/useCarryoverToggle.ts
+++ b/src/features/budget-management/hooks/useCarryoverToggle.ts
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import { getTransport } from "@/lib/actual";
 import { addMonths } from "@/lib/budget/monthMath";
 
 export type CarryoverToggleInput = {
@@ -66,21 +66,21 @@ export function useCarryoverToggle(): UseCarryoverToggleReturn {
       const results: CarryoverToggleResult[] = [];
       const successMonths = new Set<string>();
 
-      for (let i = 0; i < pairs.length; i++) {
-        const { catId, m } = pairs[i]!;
-        try {
-          await transport.setBudgetCarryover(m, catId, input.newValue);
-          successMonths.add(m);
-          results.push({ categoryId: catId, month: m, status: "success" });
-        } catch (err) {
-          const message =
-            err instanceof Error ? err.message : "Carryover update failed";
-          results.push({ categoryId: catId, month: m, status: "error", message });
+      await transport.batchBudgetUpdates(async () => {
+        for (let i = 0; i < pairs.length; i++) {
+          const { catId, m } = pairs[i]!;
+          try {
+            await transport.setBudgetCarryover(m, catId, input.newValue);
+            successMonths.add(m);
+            results.push({ categoryId: catId, month: m, status: "success" });
+          } catch (err) {
+            const message =
+              err instanceof Error ? err.message : "Carryover update failed";
+            results.push({ categoryId: catId, month: m, status: "error", message });
+          }
+          setProgress({ completed: i + 1, total: pairs.length });
         }
-        setProgress({ completed: i + 1, total: pairs.length });
-      }
-
-      await syncTransportAfterChanges(transport, successMonths.size > 0);
+      });
 
       if (successMonths.size > 0) {
         await Promise.all(

--- a/src/features/budget-management/hooks/useCarryoverToggle.ts
+++ b/src/features/budget-management/hooks/useCarryoverToggle.ts
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { apiRequest } from "@/lib/api/client";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import { addMonths } from "@/lib/budget/monthMath";
 
 export type CarryoverToggleInput = {
@@ -54,6 +54,7 @@ export function useCarryoverToggle(): UseCarryoverToggleReturn {
     async (input: CarryoverToggleInput): Promise<CarryoverToggleResult[]> => {
       if (!connection) throw new Error("No active connection");
       if (input.months.length === 0 || input.categoryIds.length === 0) return [];
+      const transport = getTransport(connection);
 
       const pairs = input.categoryIds.flatMap((catId) =>
         input.months.map((m) => ({ catId, m }))
@@ -68,14 +69,7 @@ export function useCarryoverToggle(): UseCarryoverToggleReturn {
       for (let i = 0; i < pairs.length; i++) {
         const { catId, m } = pairs[i]!;
         try {
-          await apiRequest(
-            connection,
-            `/months/${m}/categories/${catId}`,
-            {
-              method: "PATCH",
-              body: { category: { carryover: input.newValue } },
-            }
-          );
+          await transport.setBudgetCarryover(m, catId, input.newValue);
           successMonths.add(m);
           results.push({ categoryId: catId, month: m, status: "success" });
         } catch (err) {
@@ -85,6 +79,8 @@ export function useCarryoverToggle(): UseCarryoverToggleReturn {
         }
         setProgress({ completed: i + 1, total: pairs.length });
       }
+
+      await syncTransportAfterChanges(transport, successMonths.size > 0);
 
       if (successMonths.size > 0) {
         await Promise.all(

--- a/src/features/budget-management/hooks/useCategoryTransfer.ts
+++ b/src/features/budget-management/hooks/useCategoryTransfer.ts
@@ -6,7 +6,7 @@
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { apiRequest } from "@/lib/api/client";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import type { CategoryTransferInput } from "../types";
 
 type UseCategoryTransferReturn = {
@@ -18,9 +18,9 @@ type UseCategoryTransferReturn = {
 /**
  * Envelope-mode: immediate category-to-category budget transfer.
  *
- * Calls POST /months/{month}/categorytransfers directly — bypasses the staged
- * edits pipeline. On success, invalidates the affected month's TanStack Query
- * cache so the grid reloads with the updated balances.
+ * Routes through the active transport and bypasses the staged edits pipeline.
+ * On success, invalidates the affected month's TanStack Query cache so the grid
+ * reloads with the updated balances.
  *
  * This is an immediate action: it takes effect at the time the user confirms.
  * It does not go through the staged save panel.
@@ -40,14 +40,9 @@ export function useCategoryTransfer(): UseCategoryTransferReturn {
       setError(null);
 
       try {
-        await apiRequest(connection, `/months/${month}/categorytransfers`, {
-          method: "POST",
-          body: {
-            amount: input.amount,
-            categoryId: input.fromCategoryId,
-            transferCategoryId: input.toCategoryId,
-          },
-        });
+        const transport = getTransport(connection);
+        await transport.transferBudget(month, input);
+        await syncTransportAfterChanges(transport, true);
 
         await queryClient.invalidateQueries({
           queryKey: ["budget-month-data", connection.id, month],

--- a/src/features/budget-management/hooks/useIncomeBudgets.ts
+++ b/src/features/budget-management/hooks/useIncomeBudgets.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { apiRequest } from "@/lib/api/client";
+import { runQuery } from "@/lib/api/query";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -52,22 +52,15 @@ export function useIncomeBudgets(
     queryFn: async () => {
       if (!connection) throw new Error("No active connection");
 
-      const response = await apiRequest<RunQueryResponse>(
-        connection,
-        "/run-query",
-        {
-          method: "POST",
-          body: {
-            ActualQLquery: {
-              table: "reflect_budgets",
-              filter: {
-                category: { $oneof: sortedIds },
-              },
-              select: ["month", "category", "amount"],
-            },
+      const response = await runQuery<RunQueryResponse>(connection, {
+        ActualQLquery: {
+          table: "reflect_budgets",
+          filter: {
+            category: { $oneof: sortedIds },
           },
-        }
-      );
+          select: ["month", "category", "amount"],
+        },
+      });
 
       // Build a two-level Map: YYYY-MM → categoryId → amount.
       const result = new Map<string, Map<string, number>>();

--- a/src/features/budget-management/hooks/useNextMonthHold.ts
+++ b/src/features/budget-management/hooks/useNextMonthHold.ts
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { apiRequest } from "@/lib/api/client";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import type { NextMonthHoldInput } from "../types";
 
 type UseNextMonthHoldReturn = {
@@ -16,9 +16,8 @@ type UseNextMonthHoldReturn = {
 /**
  * Envelope-mode: immediate next-month budget hold management.
  *
- * setHold calls POST /months/{month}/nextmonthbudgethold.
- * clearHold calls DELETE /months/{month}/nextmonthbudgethold.
- * Both bypass the staged edits pipeline and take effect immediately on confirm.
+ * setHold and clearHold route through the active transport. They bypass
+ * the staged edits pipeline and take effect immediately on confirm.
  * Both invalidate the affected month's TanStack Query cache on success.
  */
 export function useNextMonthHold(): UseNextMonthHoldReturn {
@@ -46,10 +45,9 @@ export function useNextMonthHold(): UseNextMonthHoldReturn {
       setError(null);
 
       try {
-        await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
-          method: "POST",
-          body: { amount: input.amount },
-        });
+        const transport = getTransport(connection);
+        await transport.holdBudgetForNextMonth(month, input.amount);
+        await syncTransportAfterChanges(transport, true);
         await invalidateMonth(month);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Failed to set hold";
@@ -70,9 +68,9 @@ export function useNextMonthHold(): UseNextMonthHoldReturn {
       setError(null);
 
       try {
-        await apiRequest(connection, `/months/${month}/nextmonthbudgethold`, {
-          method: "DELETE",
-        });
+        const transport = getTransport(connection);
+        await transport.resetBudgetHold(month);
+        await syncTransportAfterChanges(transport, true);
         await invalidateMonth(month);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Failed to clear hold";

--- a/src/features/budget-management/lib/budgetTransactionsQuery.test.ts
+++ b/src/features/budget-management/lib/budgetTransactionsQuery.test.ts
@@ -15,6 +15,7 @@ const mockApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
 const connection: ConnectionInstance = {
   id: "conn-1",
   label: "Test",
+  mode: "http-api",
   baseUrl: "http://localhost:5006",
   apiKey: "test-key",
   budgetSyncId: "budget-1",

--- a/src/features/budget-management/lib/monthDataQuery.ts
+++ b/src/features/budget-management/lib/monthDataQuery.ts
@@ -1,11 +1,12 @@
 /**
- * Shared TanStack Query options for `GET /months/{month}`.
+ * Shared TanStack Query options for budget-month reads.
  *
  * Lives in `lib/` (no React deps) so both `useMonthData` and the
  * `MonthsDataProvider` context can import it without creating a cycle.
  */
 
-import { apiRequest } from "@/lib/api/client";
+import { getTransport } from "@/lib/actual";
+import type { TransportBudgetMonth } from "@/lib/actual/transport";
 import type { selectActiveInstance } from "@/store/connection";
 import type {
   BudgetMonthSummary,
@@ -13,58 +14,6 @@ import type {
   LoadedGroup,
   LoadedMonthState,
 } from "../types";
-
-type ApiMonthResponse = {
-  data: {
-    month: string;
-    incomeAvailable: number;
-    lastMonthOverspent: number;
-    forNextMonth: number;
-    totalBudgeted: number;
-    toBudget: number;
-    fromLastMonth: number;
-    totalIncome: number;
-    totalSpent: number;
-    totalBalance: number;
-    categoryGroups: Array<
-      | {
-          id: string;
-          name: string;
-          is_income: false;
-          hidden: boolean;
-          budgeted: number | null;
-          spent: number | null;
-          balance: number | null;
-          categories: Array<{
-            id: string;
-            name: string;
-            is_income: false;
-            hidden?: boolean;
-            group_id: string;
-            budgeted: number | null;
-            spent: number | null;
-            balance: number | null;
-            carryover?: boolean;
-          }>;
-        }
-      | {
-          id: string;
-          name: string;
-          is_income: true;
-          hidden: boolean;
-          received: number | null;
-          categories: Array<{
-            id: string;
-            name: string;
-            is_income: true;
-            hidden?: boolean;
-            group_id: string;
-            received: number | null;
-          }>;
-        }
-    >;
-  };
-};
 
 export function getMonthDataErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -90,6 +39,88 @@ export function isMissingBudgetMonthError(
   );
 }
 
+export function normalizeBudgetMonthData(
+  d: TransportBudgetMonth
+): LoadedMonthState {
+  const summary: BudgetMonthSummary = {
+    month: d.month,
+    incomeAvailable: d.incomeAvailable,
+    lastMonthOverspent: d.lastMonthOverspent,
+    forNextMonth: d.forNextMonth,
+    // Always store as non-positive: API may return positive or negative depending on version.
+    totalBudgeted: d.totalBudgeted > 0 ? -d.totalBudgeted : d.totalBudgeted,
+    toBudget: d.toBudget,
+    fromLastMonth: d.fromLastMonth,
+    totalIncome: d.totalIncome,
+    totalSpent: d.totalSpent,
+    totalBalance: d.totalBalance,
+  };
+
+  const groupsById: Record<string, LoadedGroup> = {};
+  const categoriesById: Record<string, LoadedCategory> = {};
+  const groupOrder: string[] = [];
+
+  for (const g of d.categoryGroups) {
+    const categoryIds: string[] = [];
+
+    for (const c of g.categories) {
+      const cat: LoadedCategory = g.is_income
+        ? {
+            id: c.id,
+            name: c.name,
+            groupId: g.id,
+            groupName: g.name,
+            isIncome: true,
+            hidden: c.hidden ?? false,
+            budgeted: c.budgeted ?? 0,
+            actuals: c.received ?? 0,
+            balance: c.balance ?? 0,
+            carryover: c.carryover ?? false,
+          }
+        : {
+            id: c.id,
+            name: c.name,
+            groupId: g.id,
+            groupName: g.name,
+            isIncome: false,
+            hidden: c.hidden ?? false,
+            budgeted: c.budgeted ?? 0,
+            actuals: c.spent ?? 0,
+            balance: c.balance ?? 0,
+            carryover: c.carryover ?? false,
+          };
+      categoriesById[c.id] = cat;
+      categoryIds.push(c.id);
+    }
+
+    const group: LoadedGroup = g.is_income
+      ? {
+          id: g.id,
+          name: g.name,
+          isIncome: true,
+          hidden: g.hidden,
+          categoryIds,
+          budgeted: g.budgeted ?? 0,
+          actuals: g.received ?? 0,
+          balance: g.balance ?? 0,
+        }
+      : {
+          id: g.id,
+          name: g.name,
+          isIncome: false,
+          hidden: g.hidden,
+          categoryIds,
+          budgeted: g.budgeted ?? 0,
+          actuals: g.spent ?? 0,
+          balance: g.balance ?? 0,
+        };
+    groupsById[g.id] = group;
+    groupOrder.push(g.id);
+  }
+
+  return { summary, groupsById, categoriesById, groupOrder } satisfies LoadedMonthState;
+}
+
 export function budgetMonthDataQueryOptions(
   connection: ReturnType<typeof selectActiveInstance>,
   month: string | null | undefined
@@ -100,89 +131,8 @@ export function budgetMonthDataQueryOptions(
       if (!connection) throw new Error("No active connection");
       if (!month) throw new Error("No month specified");
 
-      const response = await apiRequest<ApiMonthResponse>(
-        connection,
-        `/months/${month}`
-      );
-      const d = response.data;
-
-      const summary: BudgetMonthSummary = {
-        month: d.month,
-        incomeAvailable: d.incomeAvailable,
-        lastMonthOverspent: d.lastMonthOverspent,
-        forNextMonth: d.forNextMonth,
-        // Always store as non-positive: API may return positive or negative depending on version.
-        totalBudgeted: d.totalBudgeted > 0 ? -d.totalBudgeted : d.totalBudgeted,
-        toBudget: d.toBudget,
-        fromLastMonth: d.fromLastMonth,
-        totalIncome: d.totalIncome,
-        totalSpent: d.totalSpent,
-        totalBalance: d.totalBalance,
-      };
-
-      const groupsById: Record<string, LoadedGroup> = {};
-      const categoriesById: Record<string, LoadedCategory> = {};
-      const groupOrder: string[] = [];
-
-      for (const g of d.categoryGroups) {
-        const categoryIds: string[] = [];
-
-        for (const c of g.categories) {
-          const cat: LoadedCategory = g.is_income
-            ? {
-                id: c.id,
-                name: c.name,
-                groupId: g.id,
-                groupName: g.name,
-                isIncome: true,
-                hidden: c.hidden ?? false,
-                budgeted: 0,
-                actuals: (c as { received?: number | null }).received ?? 0,
-                balance: 0,
-                carryover: false,
-              }
-            : {
-                id: c.id,
-                name: c.name,
-                groupId: g.id,
-                groupName: g.name,
-                isIncome: false,
-                hidden: c.hidden ?? false,
-                budgeted: (c as { budgeted?: number | null }).budgeted ?? 0,
-                actuals: (c as { spent?: number | null }).spent ?? 0,
-                balance: (c as { balance?: number | null }).balance ?? 0,
-                carryover: (c as { carryover?: boolean }).carryover ?? false,
-              };
-          categoriesById[c.id] = cat;
-          categoryIds.push(c.id);
-        }
-
-        const group: LoadedGroup = g.is_income
-          ? {
-              id: g.id,
-              name: g.name,
-              isIncome: true,
-              hidden: g.hidden,
-              categoryIds,
-              budgeted: 0,
-              actuals: g.received ?? 0,
-              balance: 0,
-            }
-          : {
-              id: g.id,
-              name: g.name,
-              isIncome: false,
-              hidden: g.hidden,
-              categoryIds,
-              budgeted: g.budgeted ?? 0,
-              actuals: g.spent ?? 0,
-              balance: g.balance ?? 0,
-            };
-        groupsById[g.id] = group;
-        groupOrder.push(g.id);
-      }
-
-      return { summary, groupsById, categoriesById, groupOrder } satisfies LoadedMonthState;
+      const d = await getTransport(connection).getBudgetMonth(month);
+      return normalizeBudgetMonthData(d);
     },
     enabled: !!connection && !!month,
   };

--- a/src/features/categories/hooks/useCategoriesSave.ts
+++ b/src/features/categories/hooks/useCategoriesSave.ts
@@ -4,7 +4,11 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -37,15 +41,16 @@ export function useCategoriesSave() {
       // ── Creates (parallel) ──────────────────────────────────────────────────
       // Substitute any client-UUID groupId with the server-assigned group ID so
       // that new categories correctly reference newly created groups.
-      const createResults = await Promise.allSettled(
-        toCreate.map((c) =>
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (c) =>
           transport.createCategory({
             name: c.name,
             groupId: groupIdMap[c.groupId] ?? c.groupId,
             isIncome: c.isIncome,
             hidden: c.hidden,
           })
-        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
@@ -60,10 +65,10 @@ export function useCategoriesSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((c) =>
-          transport.updateCategory(c.id, { name: c.name, hidden: c.hidden })
-        )
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (c) => transport.updateCategory(c.id, { name: c.name, hidden: c.hidden })
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -76,8 +81,10 @@ export function useCategoriesSave() {
       }
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
-      const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => transport.deleteCategory(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        toDelete,
+        (id) => transport.deleteCategory(id)
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];

--- a/src/features/categories/hooks/useCategoriesSave.ts
+++ b/src/features/categories/hooks/useCategoriesSave.ts
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { createCategory, updateCategory, deleteCategory } from "@/lib/api/categories";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -27,6 +27,7 @@ export function useCategoriesSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const { toCreate, toUpdate, toDelete } = computeSaveOperations<Category>(staged);
       const succeeded: SaveResult[] = [];
       const failed: SaveResult[] = [];
@@ -38,18 +39,19 @@ export function useCategoriesSave() {
       // that new categories correctly reference newly created groups.
       const createResults = await Promise.allSettled(
         toCreate.map((c) =>
-          createCategory(connection, {
+          transport.createCategory({
             name: c.name,
             groupId: groupIdMap[c.groupId] ?? c.groupId,
+            isIncome: c.isIncome,
             hidden: c.hidden,
           })
         )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
-        const r  = createResults[i];
+        const r = createResults[i];
         if (r.status === "fulfilled") {
-          idMap[id] = r.value; // createCategory returns the server ID string
+          idMap[id] = r.value;
           succeeded.push({ status: "success", id });
           succeededCreateIds.add(id);
         } else {
@@ -60,12 +62,12 @@ export function useCategoriesSave() {
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
         toUpdate.map((c) =>
-          updateCategory(connection, c.id, { name: c.name, hidden: c.hidden })
+          transport.updateCategory(c.id, { name: c.name, hidden: c.hidden })
         )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
-        const r  = updateResults[i];
+        const r = updateResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -75,11 +77,11 @@ export function useCategoriesSave() {
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
       const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => deleteCategory(connection, id))
+        toDelete.map((id) => transport.deleteCategory(id))
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];
-        const r  = deleteResults[i];
+        const r = deleteResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -110,6 +112,8 @@ export function useCategoriesSave() {
         }
         useStagedStore.getState().setSaveErrors("categories", errors);
       }
+
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
 
       // Both entity types share one query key since they're loaded together
       await queryClient.invalidateQueries({ queryKey: ["categoryGroups", connection.id] });

--- a/src/features/categories/hooks/useCategoryGroups.ts
+++ b/src/features/categories/hooks/useCategoryGroups.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getCategoryGroups } from "@/lib/api/categoryGroups";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
@@ -22,7 +22,7 @@ export function useCategoryGroups(options: PreloadOptions = {}) {
     queryKey: ["categoryGroups", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getCategoryGroups(connection);
+      return getTransport(connection).getCategoryGroups();
     },
     enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.

--- a/src/features/categories/hooks/useCategoryGroupsSave.ts
+++ b/src/features/categories/hooks/useCategoryGroupsSave.ts
@@ -4,7 +4,11 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -35,10 +39,11 @@ export function useCategoryGroupsSave() {
       const idMap: Record<string, string> = {};
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
-      const createResults = await Promise.allSettled(
-        toCreate.map((g) =>
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (g) =>
           transport.createCategoryGroup({ name: g.name, isIncome: g.isIncome, hidden: g.hidden })
-        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
@@ -53,10 +58,10 @@ export function useCategoryGroupsSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((g) =>
-          transport.updateCategoryGroup(g.id, { name: g.name, hidden: g.hidden })
-        )
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (g) => transport.updateCategoryGroup(g.id, { name: g.name, hidden: g.hidden })
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -69,8 +74,10 @@ export function useCategoryGroupsSave() {
       }
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
-      const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => transport.deleteCategoryGroup(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        toDelete,
+        (id) => transport.deleteCategoryGroup(id)
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];

--- a/src/features/categories/hooks/useCategoryGroupsSave.ts
+++ b/src/features/categories/hooks/useCategoryGroupsSave.ts
@@ -4,11 +4,7 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import {
-  createCategoryGroup,
-  updateCategoryGroup,
-  deleteCategoryGroup,
-} from "@/lib/api/categoryGroups";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -31,6 +27,7 @@ export function useCategoryGroupsSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const { toCreate, toUpdate, toDelete } = computeSaveOperations<CategoryGroup>(staged);
       const succeeded: SaveResult[] = [];
       const failed: SaveResult[] = [];
@@ -40,14 +37,14 @@ export function useCategoryGroupsSave() {
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
         toCreate.map((g) =>
-          createCategoryGroup(connection, { name: g.name, isIncome: g.isIncome, hidden: g.hidden })
+          transport.createCategoryGroup({ name: g.name, isIncome: g.isIncome, hidden: g.hidden })
         )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
-        const r  = createResults[i];
+        const r = createResults[i];
         if (r.status === "fulfilled") {
-          idMap[id] = r.value; // createCategoryGroup returns the server ID string
+          idMap[id] = r.value;
           succeeded.push({ status: "success", id });
           succeededCreateIds.add(id);
         } else {
@@ -58,12 +55,12 @@ export function useCategoryGroupsSave() {
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
         toUpdate.map((g) =>
-          updateCategoryGroup(connection, g.id, { name: g.name, hidden: g.hidden })
+          transport.updateCategoryGroup(g.id, { name: g.name, hidden: g.hidden })
         )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
-        const r  = updateResults[i];
+        const r = updateResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -73,11 +70,11 @@ export function useCategoryGroupsSave() {
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
       const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => deleteCategoryGroup(connection, id))
+        toDelete.map((id) => transport.deleteCategoryGroup(id))
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];
-        const r  = deleteResults[i];
+        const r = deleteResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -108,6 +105,8 @@ export function useCategoryGroupsSave() {
         }
         useStagedStore.getState().setSaveErrors("categoryGroups", errors);
       }
+
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
 
       await queryClient.invalidateQueries({ queryKey: ["categoryGroups", connection.id] });
       await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "category", connection.id] });

--- a/src/features/overview/components/BudgetOverviewView.test.tsx
+++ b/src/features/overview/components/BudgetOverviewView.test.tsx
@@ -68,6 +68,7 @@ describe("BudgetOverviewView", () => {
         {
           id: "conn-1",
           label: "Household Budget",
+          mode: "http-api",
           baseUrl: "http://localhost:5006",
           apiKey: "key",
           budgetSyncId: "budget-1",

--- a/src/features/overview/lib/overviewQueries.test.ts
+++ b/src/features/overview/lib/overviewQueries.test.ts
@@ -30,6 +30,7 @@ const mockRunQuery = runQuery as jest.MockedFunction<typeof runQuery>;
 const connection: ConnectionInstance = {
   id: "conn-1",
   label: "Test Budget",
+  mode: "http-api",
   baseUrl: "http://localhost:5006",
   apiKey: "test-key",
   budgetSyncId: "budget-1",

--- a/src/features/payees/hooks/usePayees.ts
+++ b/src/features/payees/hooks/usePayees.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getPayees } from "@/lib/api/payees";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
@@ -22,7 +22,7 @@ export function usePayees(options: PreloadOptions = {}) {
     queryKey: ["payees", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getPayees(connection);
+      return getTransport(connection).getPayees();
     },
     enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.

--- a/src/features/payees/hooks/usePayeesSave.ts
+++ b/src/features/payees/hooks/usePayeesSave.ts
@@ -78,8 +78,17 @@ export function usePayeesSave() {
       if (unresolvedCreatedPayees.length > 0) {
         try {
           const freshPayees = await transport.getPayees();
-          const serverIdByName = new Map(freshPayees.map((p) => [p.name, p.id]));
+          const serverIdByName = new Map<string, string>();
+          const duplicateNames = new Set<string>();
+          for (const fresh of freshPayees) {
+            if (serverIdByName.has(fresh.name)) {
+              duplicateNames.add(fresh.name);
+            } else {
+              serverIdByName.set(fresh.name, fresh.id);
+            }
+          }
           for (const p of unresolvedCreatedPayees) {
+            if (duplicateNames.has(p.name)) continue;
             const serverId = serverIdByName.get(p.name);
             if (serverId) idMap[p.id] = serverId;
           }

--- a/src/features/payees/hooks/usePayeesSave.ts
+++ b/src/features/payees/hooks/usePayeesSave.ts
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { createPayee, updatePayee, deletePayee, getPayees, mergePayees } from "@/lib/api/payees";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -34,6 +34,7 @@ export function usePayeesSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const ops = computeSaveOperations<Payee>(staged);
       const toCreate = ops.toCreate.filter((p) => p.name.trim() !== "");
       const toUpdate = ops.toUpdate.filter((p) => p.name.trim() !== "");
@@ -47,45 +48,47 @@ export function usePayeesSave() {
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
-        toCreate.map((p) => createPayee(connection, { name: p.name }))
+        toCreate.map((p) => transport.createPayee({ name: p.name }))
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
-        const r  = createResults[i];
+        const r = createResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
           succeededCreateIds.add(id);
+          if (r.value.id) idMap[id] = r.value.id;
         } else {
           failed.push({ status: "error", id, message: extractMessage(r.reason, "Create failed") });
         }
       }
 
       // ── Resolve server IDs for created payees ───────────────────────────────
-      // The Actual HTTP API does not return the new payee's ID in the create
-      // response. Fetch the fresh list and match by name to build the mapping
-      // so that rules referencing newly created payees get the correct server ID.
-      if (succeededCreateIds.size > 0) {
+      // Some transports/API versions may not return the new payee ID in the
+      // create response. Fetch the fresh list and match by name to build the
+      // mapping so rules referencing new payees use the correct server ID.
+      const unresolvedCreatedPayees = toCreate.filter(
+        (p) => succeededCreateIds.has(p.id) && !idMap[p.id]
+      );
+      if (unresolvedCreatedPayees.length > 0) {
         try {
-          const freshPayees = await getPayees(connection);
+          const freshPayees = await transport.getPayees();
           const serverIdByName = new Map(freshPayees.map((p) => [p.name, p.id]));
-          for (const p of toCreate) {
-            if (succeededCreateIds.has(p.id)) {
-              const serverId = serverIdByName.get(p.name);
-              if (serverId) idMap[p.id] = serverId;
-            }
+          for (const p of unresolvedCreatedPayees) {
+            const serverId = serverIdByName.get(p.name);
+            if (serverId) idMap[p.id] = serverId;
           }
         } catch {
-          // idMap stays empty; rules will fall back to client UUIDs
+          // idMap stays partial; rules will fall back to client UUIDs
         }
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
-        toUpdate.map((p) => updatePayee(connection, p.id, { name: p.name }))
+        toUpdate.map((p) => transport.updatePayee(p.id, { name: p.name }))
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
-        const r  = updateResults[i];
+        const r = updateResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -95,11 +98,11 @@ export function usePayeesSave() {
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
       const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => deletePayee(connection, id))
+        toDelete.map((id) => transport.deletePayee(id))
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];
-        const r  = deleteResults[i];
+        const r = deleteResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -111,7 +114,7 @@ export function usePayeesSave() {
       const succeededMergeTargetIds: string[] = [];
       for (const { targetId, mergeIds } of pendingPayeeMerges) {
         try {
-          await mergePayees(connection, targetId, mergeIds);
+          await transport.mergePayees(targetId, mergeIds);
           succeededMergeTargetIds.push(targetId);
           for (const id of mergeIds) {
             succeeded.push({ status: "success", id });
@@ -150,6 +153,8 @@ export function usePayeesSave() {
       } else {
         useStagedStore.getState().setSaveErrors("payees", {});
       }
+
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
 
       await queryClient.invalidateQueries({ queryKey: ["payees", connection.id] });
       await queryClient.invalidateQueries({ queryKey: ["transactionCounts", "payee", connection.id] });

--- a/src/features/payees/hooks/usePayeesSave.ts
+++ b/src/features/payees/hooks/usePayeesSave.ts
@@ -4,7 +4,11 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -47,8 +51,10 @@ export function usePayeesSave() {
       const idMap: Record<string, string> = {};
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
-      const createResults = await Promise.allSettled(
-        toCreate.map((p) => transport.createPayee({ name: p.name }))
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (p) => transport.createPayee({ name: p.name })
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
@@ -83,8 +89,10 @@ export function usePayeesSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((p) => transport.updatePayee(p.id, { name: p.name }))
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (p) => transport.updatePayee(p.id, { name: p.name })
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -97,8 +105,10 @@ export function usePayeesSave() {
       }
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
-      const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => transport.deletePayee(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        toDelete,
+        (id) => transport.deletePayee(id)
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];

--- a/src/features/query/components/CopyCurlButton.tsx
+++ b/src/features/query/components/CopyCurlButton.tsx
@@ -34,11 +34,11 @@ export function CopyCurlButton({ lastRequest }: CopyCurlButtonProps) {
         size="sm"
         variant="ghost"
         onClick={copyDefaultCurl}
-        title="Copy a cURL command with secrets replaced by placeholders - safe to share"
+        title="Copy an actual-http-api cURL command with secrets replaced by placeholders - safe to share"
         className="gap-1.5 text-xs text-muted-foreground"
       >
         <Terminal className="h-3 w-3" />
-        Copy cURL
+        Copy HTTP cURL
       </Button>
 
       {/* Dangerous version - amber styling signals risk */}
@@ -46,7 +46,7 @@ export function CopyCurlButton({ lastRequest }: CopyCurlButtonProps) {
         size="sm"
         variant="ghost"
         onClick={copyFullCurl}
-        title="Copy a cURL command with real API key and credentials - do not share publicly"
+        title="Copy an actual-http-api cURL command with real API key and credentials - do not share publicly"
         className="gap-1.5 text-xs text-amber-600 hover:bg-amber-50 hover:text-amber-700 dark:text-amber-500 dark:hover:bg-amber-950/40 dark:hover:text-amber-400"
       >
         <ShieldAlert className="h-3 w-3" />

--- a/src/features/query/components/QueryReferenceDialog.tsx
+++ b/src/features/query/components/QueryReferenceDialog.tsx
@@ -134,7 +134,7 @@ function BasicsSection() {
     <div className="flex flex-col gap-4">
       <Para>
         ActualQL is a JSON-based query language for reading data from an Actual Budget.
-        All queries must be wrapped in <code className="font-mono text-[11px]">{"{ \"ActualQLquery\": { ... } }"}</code>.
+        The editor accepts bare query objects or the <code className="font-mono text-[11px]">{"{ \"ActualQLquery\": { ... } }"}</code> wrapper used by actual-http-api.
       </Para>
 
       <div>
@@ -156,7 +156,7 @@ function BasicsSection() {
       <div>
         <Heading>Minimal example</Heading>
         <Snippet
-          code={`{\n  "ActualQLquery": {\n    "table": "payees",\n    "limit": 10\n  }\n}`}
+          code={`{\n  "table": "payees",\n  "limit": 10\n}`}
         />
       </div>
     </div>
@@ -340,7 +340,7 @@ function TransactionsSection() {
         <Para>
           Querying <code className="font-mono text-[11px]">transactions</code> without a <code className="font-mono text-[11px]">limit</code>,
           <code className="font-mono text-[11px]">groupBy</code>, or <code className="font-mono text-[11px]">calculate</code> can return
-          thousands of rows and may time out (proxy enforces a 15-second limit).
+          thousands of rows and may time out. Add a limit before broad inspection queries.
         </Para>
       </div>
     </div>

--- a/src/features/query/components/QueryResults.tsx
+++ b/src/features/query/components/QueryResults.tsx
@@ -637,8 +637,8 @@ function ResultsActionBar({
           </Button>
         )}
 
-        {/* cURL buttons - safe first, secrets second (amber) */}
-        {lastRequest && <CopyCurlButton lastRequest={lastRequest} />}
+        {/* cURL commands target actual-http-api and only apply to HTTP API Server mode. */}
+        {lastRequest?.mode === "http-api" && <CopyCurlButton lastRequest={lastRequest} />}
       </div>
     </div>
   );

--- a/src/features/query/components/QueryWorkspace.test.tsx
+++ b/src/features/query/components/QueryWorkspace.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryWorkspace } from "./QueryWorkspace";
+import { useConnectionStore, type BrowserApiConnection } from "@/store/connection";
+
+jest.mock("sonner", () => ({
+  toast: Object.assign(jest.fn(), {
+    error: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    dismiss: jest.fn(),
+  }),
+}));
+
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => function DynamicStub() { return null; },
+}));
+
+const directConnection: BrowserApiConnection = {
+  id: "direct-1",
+  label: "Direct Budget",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "secret",
+  budgetSyncId: "budget-1",
+};
+
+describe("QueryWorkspace", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    useConnectionStore.setState({
+      instances: [directConnection],
+      activeInstanceId: directConnection.id,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useConnectionStore.setState({ instances: [], activeInstanceId: null });
+    jest.restoreAllMocks();
+  });
+
+  it("opens the ActualQL workspace for Direct connections", () => {
+    render(<QueryWorkspace />);
+
+    expect(screen.getByRole("heading", { name: "ActualQL Queries" })).toBeInTheDocument();
+    expect(
+      screen.queryByText("ActualQL Queries need HTTP API Server mode")
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
+  });
+});

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -3,8 +3,14 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import { toast } from "sonner";
-import { useConnectionStore, selectActiveInstance, isHttpApiConnection } from "@/store/connection";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isBrowserApiConnection,
+  isHttpApiConnection,
+} from "@/store/connection";
 import { useStagedStore, selectHasChanges } from "@/store/staged";
+import { DirectModeUnavailable } from "@/components/DirectModeUnavailable";
 import { runQuery } from "@/lib/api/query";
 import { cn } from "@/lib/utils";
 import { QueryEditor } from "./QueryEditor";
@@ -302,7 +308,7 @@ export function QueryWorkspace() {
         return;
       }
       if (!isHttpApiConnection(connection)) {
-        toast.error("Direct Actual Server transport is not active for queries yet.");
+        toast.error("ActualQL Queries require an HTTP API Server connection.");
         return;
       }
       // Prevent overlapping concurrent executions.
@@ -497,6 +503,16 @@ export function QueryWorkspace() {
   }
 
   // ─── Render ──────────────────────────────────────────────────────────────────
+
+  if (isBrowserApiConnection(connection)) {
+    return (
+      <DirectModeUnavailable
+        title="ActualQL Queries need HTTP API Server mode"
+        description="Direct mode currently supports only the internal query subset used by migrated app pages."
+        detail="Use an HTTP API Server connection for the generic query workspace."
+      />
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -6,11 +6,9 @@ import { toast } from "sonner";
 import {
   useConnectionStore,
   selectActiveInstance,
-  isBrowserApiConnection,
   isHttpApiConnection,
 } from "@/store/connection";
 import { useStagedStore, selectHasChanges } from "@/store/staged";
-import { DirectModeUnavailable } from "@/components/DirectModeUnavailable";
 import { runQuery } from "@/lib/api/query";
 import { cn } from "@/lib/utils";
 import { QueryEditor } from "./QueryEditor";
@@ -307,10 +305,6 @@ export function QueryWorkspace() {
         toast.error("No active connection.");
         return;
       }
-      if (!isHttpApiConnection(connection)) {
-        toast.error("ActualQL Queries require an HTTP API Server connection.");
-        return;
-      }
       // Prevent overlapping concurrent executions.
       if (isRunningRef.current) return;
 
@@ -329,16 +323,28 @@ export function QueryWorkspace() {
       // changes that occur while the request is in flight.
       const capturedBudgetId = connection.budgetSyncId;
 
-      // Snapshot the current request before the async gap so it is available
-      // for cURL generation on both the success and the error path.
-      setLastExecutedRequest({
-        query: parsed.inner,
-        rawQuery: queryString,
-        baseUrl: connection.baseUrl,
-        budgetSyncId: connection.budgetSyncId,
-        apiKey: connection.apiKey,
-        encryptionPassword: connection.encryptionPassword,
-      });
+      // Snapshot the current request before the async gap so result actions can
+      // use the executed query, even if the editor changes afterward.
+      setLastExecutedRequest(
+        isHttpApiConnection(connection)
+          ? {
+              mode: "http-api",
+              query: parsed.inner,
+              rawQuery: queryString,
+              baseUrl: connection.baseUrl,
+              budgetSyncId: connection.budgetSyncId,
+              apiKey: connection.apiKey,
+              encryptionPassword: connection.encryptionPassword,
+            }
+          : {
+              mode: "browser-api",
+              query: parsed.inner,
+              rawQuery: queryString,
+              baseUrl: connection.baseUrl,
+              budgetSyncId: connection.budgetSyncId,
+              encryptionPassword: connection.encryptionPassword,
+            }
+      );
 
       const start = Date.now();
       try {
@@ -503,16 +509,6 @@ export function QueryWorkspace() {
   }
 
   // ─── Render ──────────────────────────────────────────────────────────────────
-
-  if (isBrowserApiConnection(connection)) {
-    return (
-      <DirectModeUnavailable
-        title="ActualQL Queries need HTTP API Server mode"
-        description="Direct mode currently supports only the internal query subset used by migrated app pages."
-        detail="Use an HTTP API Server connection for the generic query workspace."
-      />
-    );
-  }
 
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import { toast } from "sonner";
-import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { useConnectionStore, selectActiveInstance, isHttpApiConnection } from "@/store/connection";
 import { useStagedStore, selectHasChanges } from "@/store/staged";
 import { runQuery } from "@/lib/api/query";
 import { cn } from "@/lib/utils";
@@ -299,6 +299,10 @@ export function QueryWorkspace() {
     async (queryString: string) => {
       if (!connection) {
         toast.error("No active connection.");
+        return;
+      }
+      if (!isHttpApiConnection(connection)) {
+        toast.error("Direct Actual Server transport is not active for queries yet.");
         return;
       }
       // Prevent overlapping concurrent executions.

--- a/src/features/query/lib/queryCurl.ts
+++ b/src/features/query/lib/queryCurl.ts
@@ -31,6 +31,10 @@ function buildCurl(
   req: LastExecutedRequest,
   sanitize: boolean
 ): string {
+  if (req.mode !== "http-api") {
+    throw new Error("cURL generation is only available for HTTP API Server connections.");
+  }
+
   const url = `${req.baseUrl.replace(/\/$/, "")}${ENDPOINT_PATH(req.budgetSyncId)}`;
   const body = JSON.stringify({ ActualQLquery: req.query }, null, 2);
   const apiKey = sanitize ? "{{API_KEY}}" : shellEscapeDoubleQuote(req.apiKey);

--- a/src/features/query/lib/queryExplain.ts
+++ b/src/features/query/lib/queryExplain.ts
@@ -5,7 +5,7 @@
  * Returns an ordered list of sentences that describe what the query does.
  */
 
-import type { ActualQLQuery } from "../types";
+import type { ActualQLExpression, ActualQLQuery } from "../types";
 
 export function explainQuery(query: ActualQLQuery): string[] {
   const lines: string[] = [];
@@ -24,8 +24,9 @@ export function explainQuery(query: ActualQLQuery): string[] {
   }
 
   // groupBy
-  if (query.groupBy && query.groupBy.length > 0) {
-    const fields = query.groupBy.map((f) => `\`${f}\``).join(", ");
+  const groupBy = toExpressionArray(query.groupBy);
+  if (groupBy.length > 0) {
+    const fields = groupBy.map(formatExpressionLabel).join(", ");
     lines.push(`Groups rows by ${fields}.`);
   }
 
@@ -35,8 +36,9 @@ export function explainQuery(query: ActualQLQuery): string[] {
   }
 
   // orderBy
-  if (query.orderBy && query.orderBy.length > 0) {
-    lines.push(describeOrderBy(query.orderBy));
+  const orderBy = toExpressionArray(query.orderBy);
+  if (orderBy.length > 0) {
+    lines.push(describeOrderBy(orderBy));
   }
 
   // limit / offset
@@ -48,20 +50,22 @@ export function explainQuery(query: ActualQLQuery): string[] {
   }
 
   // options.splits
-  if (query.options?.splits) {
+  const splitMode =
+    typeof query.options?.splits === "string" ? query.options.splits : undefined;
+  if (splitMode) {
     const splitDesc: Record<string, string> = {
       inline: "shows sub-transactions individually",
       grouped: "groups sub-transactions under their parent",
       all: "returns both parent and sub-transactions",
     };
-    const desc = splitDesc[query.options.splits] ?? query.options.splits;
-    lines.push(`Split behavior is set to \`${query.options.splits}\` - ${desc}.`);
+    const desc = splitDesc[splitMode] ?? splitMode;
+    lines.push(`Split behavior is set to \`${splitMode}\` - ${desc}.`);
   }
 
   // Result type summary
   if (query.calculate) {
     lines.push("Returns a single calculated value, not a list of rows.");
-  } else if (query.groupBy?.length) {
+  } else if (groupBy.length > 0) {
     lines.push("Returns one aggregated row per group.");
   } else {
     lines.push("Returns a list of rows.");
@@ -72,7 +76,23 @@ export function explainQuery(query: ActualQLQuery): string[] {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function describeFilter(filter: Record<string, unknown>): string {
+function toExpressionArray(
+  value: ActualQLExpression | ActualQLExpression[] | undefined
+): ActualQLExpression[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function formatExpressionLabel(value: ActualQLExpression): string {
+  return `\`${typeof value === "string" ? value : JSON.stringify(value)}\``;
+}
+
+function describeFilter(filter: Record<string, unknown> | Array<Record<string, unknown>>): string {
+  if (Array.isArray(filter)) {
+    if (filter.length === 0) return "No effective filter conditions.";
+    return `Applies ${filter.length} filter condition${filter.length !== 1 ? "s" : ""}.`;
+  }
+
   // Compound operators
   if ("$and" in filter && Array.isArray(filter["$and"])) {
     return `Filters rows where ALL of ${filter["$and"].length} conditions match ($and).`;
@@ -116,10 +136,13 @@ function describeFilter(filter: Record<string, unknown>): string {
 }
 
 function describeSelect(
-  select: Array<string | Record<string, unknown>> | Record<string, unknown>
+  select: "*" | ActualQLExpression | ActualQLExpression[]
 ): string {
+  if (select === "*") return "Selects all fields.";
   if (!Array.isArray(select)) {
-    return "Selects fields using an object expression.";
+    return typeof select === "string"
+      ? `Selects field \`${select}\`.`
+      : "Selects fields using an object expression.";
   }
 
   const simple: string[] = [];
@@ -151,7 +174,11 @@ function describeSelect(
   return `Selects ${parts.join(" and ")}.`;
 }
 
-function describeCalculate(calculate: Record<string, unknown>): string {
+function describeCalculate(calculate: ActualQLExpression): string {
+  if (typeof calculate === "string") {
+    return `Computes a scalar from \`${calculate}\`.`;
+  }
+
   const fn = Object.keys(calculate)[0];
   const operand = calculate[fn];
   const operandStr =
@@ -169,9 +196,7 @@ function describeCalculate(calculate: Record<string, unknown>): string {
   return `Computes a scalar - ${desc} \`${operandStr}\` across matching rows.`;
 }
 
-function describeOrderBy(
-  orderBy: Array<string | Record<string, "asc" | "desc">>
-): string {
+function describeOrderBy(orderBy: ActualQLExpression[]): string {
   const parts: string[] = [];
   for (const item of orderBy) {
     if (typeof item === "string") {

--- a/src/features/query/lib/queryValidation.ts
+++ b/src/features/query/lib/queryValidation.ts
@@ -1,7 +1,7 @@
 /**
  * Query parsing and lint rules for the ActualQL workspace.
  *
- * parseQuery: validates the full wrapped JSON string `{ "ActualQLquery": { ... } }`
+ * parseQuery: validates wrapped `{ "ActualQLquery": { ... } }` or bare query JSON
  * and returns { body, inner } or an Error describing why the input is invalid.
  * Called before every network request and displayed inline in the editor.
  *
@@ -37,9 +37,7 @@ export function parseQuery(input: string): ParsedQuery | Error {
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return new Error(
-      'Query must be a JSON object with an "ActualQLquery" key.'
-    );
+    return new Error("Query must be a JSON object.");
   }
 
   const obj = parsed as Record<string, unknown>;
@@ -78,20 +76,20 @@ export function parseQuery(input: string): ParsedQuery | Error {
 export function lintQuery(query: ActualQLQuery): LintWarning[] {
   const warnings: LintWarning[] = [];
 
-  // Unbounded transaction scan — the proxy enforces a 15-second timeout.
-  // A full transactions table can have thousands of rows. A query with any
-  // filter is considered scoped and does not trigger this warning.
+  // Unbounded transaction scan — HTTP mode has a proxy timeout, and Direct mode
+  // can still be expensive for large budgets. A query with any filter is
+  // considered scoped and does not trigger this warning.
   if (
     query.table === "transactions" &&
     !query.limit &&
-    !query.groupBy?.length &&
+    !hasQueryValue(query.groupBy) &&
     !query.calculate &&
-    (!query.filter || Object.keys(query.filter).length === 0)
+    !hasQueryValue(query.filter)
   ) {
     warnings.push({
       id: "unbounded-transactions",
       message:
-        'Unbounded transaction scan - may return thousands of rows and time out (15s proxy limit). Add "limit", "groupBy", or "calculate" to narrow the scope.',
+        'Unbounded transaction scan - may return thousands of rows and time out. Add "limit", "groupBy", or "calculate" to narrow the scope.',
     });
   }
 
@@ -107,7 +105,7 @@ export function lintQuery(query: ActualQLQuery): LintWarning[] {
   // groupBy without an aggregate in select — every group will return its
   // raw rows, which is rarely what the user intends
   if (
-    query.groupBy?.length &&
+    hasQueryValue(query.groupBy) &&
     !query.calculate &&
     Array.isArray(query.select)
   ) {
@@ -140,7 +138,15 @@ export function lintQuery(query: ActualQLQuery): LintWarning[] {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+function hasQueryValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (value && typeof value === "object") return Object.keys(value).length > 0;
+  return value !== undefined && value !== null;
+}
+
 function hasEmptyOneof(filter: unknown): boolean {
+  if (Array.isArray(filter)) return filter.some((item) => hasEmptyOneof(item));
   if (!filter || typeof filter !== "object") return false;
   const obj = filter as Record<string, unknown>;
 

--- a/src/features/query/types.ts
+++ b/src/features/query/types.ts
@@ -4,18 +4,22 @@
 // Dotted paths, aggregate expressions, $oneof, $transform, options.splits, etc.
 // all pass through as-is.
 
+export type ActualQLExpression = string | Record<string, unknown>;
+
 export type ActualQLQuery = {
   table: string;
-  filter?: Record<string, unknown>;
-  select?: Array<string | Record<string, unknown>> | Record<string, unknown>;
-  groupBy?: string[];
-  calculate?: Record<string, unknown>;
-  orderBy?: Array<string | Record<string, "asc" | "desc">>;
+  filter?: Record<string, unknown> | Array<Record<string, unknown>>;
+  select?: "*" | ActualQLExpression | ActualQLExpression[];
+  groupBy?: ActualQLExpression | ActualQLExpression[];
+  calculate?: ActualQLExpression;
+  orderBy?: ActualQLExpression | ActualQLExpression[];
   limit?: number;
   offset?: number;
-  options?: {
-    splits?: "inline" | "grouped" | "all";
-  };
+  options?: Record<string, unknown>;
+  unfilter?: string | string[];
+  raw?: boolean;
+  withDead?: boolean;
+  withoutValidatedRefs?: boolean;
 };
 
 // ─── Saved query ──────────────────────────────────────────────────────────────
@@ -50,17 +54,20 @@ export type QueryHistoryEntry = {
 
 export type QueryResultMode = "table" | "raw" | "scalar" | "tree";
 
-// ─── Last executed request (for cURL generation in Phase 2) ──────────────────
+// ─── Last executed request ───────────────────────────────────────────────────
 
 export type LastExecutedRequest = {
   query: ActualQLQuery;
-  /** Full wrapped editor string at execution time — used for "Copy query JSON". */
+  /** Full editor string at execution time — preserved for copy/replay flows. */
   rawQuery: string;
+  mode: "http-api" | "browser-api";
   baseUrl: string;
   budgetSyncId: string;
-  apiKey: string;
   encryptionPassword?: string;
-};
+} & (
+  | { mode: "http-api"; apiKey: string }
+  | { mode: "browser-api"; apiKey?: never }
+);
 
 // ─── Lint warning ─────────────────────────────────────────────────────────────
 

--- a/src/features/rules/hooks/useRules.ts
+++ b/src/features/rules/hooks/useRules.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getRules } from "@/lib/api/rules";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
@@ -18,7 +18,7 @@ export function useRules(options: PreloadOptions = {}) {
     queryKey: ["rules", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getRules(connection);
+      return getTransport(connection).getRules();
     },
     enabled: !!connection && (options.enabled ?? true),
     // staleTime/gcTime/refetchOn* are set globally in queryClient.ts.

--- a/src/features/rules/hooks/useRulesSave.ts
+++ b/src/features/rules/hooks/useRulesSave.ts
@@ -4,75 +4,15 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { createRule, updateRule, deleteRule } from "@/lib/api/rules";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import { applyRuleEntityIdMap } from "@/lib/actual/ruleMutation";
 import {
   extractMessage,
   computeSaveOperations,
   hasPendingStagedChanges,
 } from "@/lib/saveUtils";
-import { CONDITION_FIELDS, ACTION_FIELDS } from "../utils/ruleFields";
 import type { SaveResult, SaveSummary } from "@/types/diff";
-import type { Rule, ConditionOrAction, AmountRange } from "@/types/entities";
-
-/** Fields whose values are entity IDs that may need client→server substitution */
-const ENTITY_REF_FIELDS = new Set(["payee", "account", "category", "category_group", "categoryGroup"]);
-
-/**
- * Substitute any client-generated UUID in entity reference fields with the
- * server-assigned ID, so that rules referencing new payees/accounts/categories
- * are saved with the correct IDs.
- */
-function applyEntityIdMap(
-  parts: ConditionOrAction[],
-  idMap: Record<string, string>
-): ConditionOrAction[] {
-  if (Object.keys(idMap).length === 0) return parts;
-  return parts.map((p) => {
-    if (!p.field || !ENTITY_REF_FIELDS.has(p.field)) return p;
-    const v = p.value;
-    if (typeof v === "string" && idMap[v]) return { ...p, value: idMap[v] };
-    if (Array.isArray(v)) {
-      const mapped = v.map((x) => (typeof x === "string" && idMap[x] ? idMap[x] : x));
-      return { ...p, value: mapped };
-    }
-    return p;
-  });
-}
-
-/**
- * Prepare condition/action values for the API:
- *  1. Coerce any string typed by the user in a number input to a JS number.
- *  2. Scale display-unit amounts back to Actual's internal ×100 representation.
- */
-function coerceParts(parts: ConditionOrAction[]): ConditionOrAction[] {
-  return parts.map((p) => {
-    const def = CONDITION_FIELDS[p.field ?? ""] ?? ACTION_FIELDS[p.field ?? ""];
-    if (def?.type !== "number") return p;
-
-    let value: ConditionOrAction["value"] = p.value;
-
-    // 1. Coerce string → number (HTML number inputs always yield strings)
-    if (typeof value === "string" && value !== "") value = Number(value);
-
-    // 2. Multiply by 100 to convert display units → Actual's internal format
-    if (typeof value === "number") {
-      value = Math.round(value * 100);
-    } else if (typeof value === "object" && value !== null && "num1" in value) {
-      const r = value as AmountRange;
-      value = { num1: Math.round(r.num1 * 100), num2: Math.round(r.num2 * 100) };
-    }
-
-    return { ...p, value };
-  });
-}
-
-function coerceRule(rule: Rule): Rule {
-  return {
-    ...rule,
-    conditions: coerceParts(rule.conditions),
-    actions: coerceParts(rule.actions),
-  };
-}
+import type { Rule } from "@/types/entities";
 
 export function useRulesSave() {
   const [isSaving, setIsSaving] = useState(false);
@@ -88,6 +28,7 @@ export function useRulesSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const { toCreate, toUpdate, toDelete } = computeSaveOperations<Rule>(staged);
       const mergeDeps = useStagedStore.getState().mergeDependencies;
 
@@ -100,19 +41,18 @@ export function useRulesSave() {
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
-        toCreate.map((raw) => {
-          const rule = coerceRule(raw);
-          return createRule(connection, {
+        toCreate.map((rule) =>
+          transport.createRule({
             stage: rule.stage,
             conditionsOp: rule.conditionsOp,
-            conditions: applyEntityIdMap(rule.conditions, entityIdMap),
-            actions: applyEntityIdMap(rule.actions, entityIdMap),
-          });
-        })
+            conditions: applyRuleEntityIdMap(rule.conditions, entityIdMap),
+            actions: applyRuleEntityIdMap(rule.actions, entityIdMap),
+          })
+        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
-        const r  = createResults[i];
+        const r = createResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
           succeededCreateIds.add(id);
@@ -123,19 +63,18 @@ export function useRulesSave() {
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
-        toUpdate.map((raw) => {
-          const rule = coerceRule(raw);
-          return updateRule(connection, rule.id, {
+        toUpdate.map((rule) =>
+          transport.updateRule(rule.id, {
             stage: rule.stage,
             conditionsOp: rule.conditionsOp,
-            conditions: applyEntityIdMap(rule.conditions, entityIdMap),
-            actions: applyEntityIdMap(rule.actions, entityIdMap),
-          });
-        })
+            conditions: applyRuleEntityIdMap(rule.conditions, entityIdMap),
+            actions: applyRuleEntityIdMap(rule.actions, entityIdMap),
+          })
+        )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
-        const r  = updateResults[i];
+        const r = updateResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -167,11 +106,11 @@ export function useRulesSave() {
       }
 
       const deleteResults = await Promise.allSettled(
-        safeToDelete.map((id) => deleteRule(connection, id))
+        safeToDelete.map((id) => transport.deleteRule(id))
       );
       for (let i = 0; i < safeToDelete.length; i++) {
         const id = safeToDelete[i];
-        const r  = deleteResults[i];
+        const r = deleteResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -215,6 +154,8 @@ export function useRulesSave() {
         }
         useStagedStore.getState().setSaveErrors("rules", errors);
       }
+
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
 
       await queryClient.invalidateQueries({ queryKey: ["rules", connection.id] });
       await queryClient.invalidateQueries({ queryKey: ["budget-overview", connection.id] });

--- a/src/features/rules/hooks/useRulesSave.ts
+++ b/src/features/rules/hooks/useRulesSave.ts
@@ -4,7 +4,11 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import { applyRuleEntityIdMap } from "@/lib/actual/ruleMutation";
 import {
   extractMessage,
@@ -40,15 +44,16 @@ export function useRulesSave() {
       const succeededCreateIds = new Set<string>();
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
-      const createResults = await Promise.allSettled(
-        toCreate.map((rule) =>
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (rule) =>
           transport.createRule({
             stage: rule.stage,
             conditionsOp: rule.conditionsOp,
             conditions: applyRuleEntityIdMap(rule.conditions, entityIdMap),
             actions: applyRuleEntityIdMap(rule.actions, entityIdMap),
           })
-        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
@@ -62,15 +67,16 @@ export function useRulesSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((rule) =>
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (rule) =>
           transport.updateRule(rule.id, {
             stage: rule.stage,
             conditionsOp: rule.conditionsOp,
             conditions: applyRuleEntityIdMap(rule.conditions, entityIdMap),
             actions: applyRuleEntityIdMap(rule.actions, entityIdMap),
           })
-        )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -105,8 +111,10 @@ export function useRulesSave() {
         }
       }
 
-      const deleteResults = await Promise.allSettled(
-        safeToDelete.map((id) => transport.deleteRule(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        safeToDelete,
+        (id) => transport.deleteRule(id)
       );
       for (let i = 0; i < safeToDelete.length; i++) {
         const id = safeToDelete[i];

--- a/src/features/schedules/hooks/useSchedules.ts
+++ b/src/features/schedules/hooks/useSchedules.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getSchedules } from "@/lib/api/schedules";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
@@ -18,7 +18,7 @@ export function useSchedules(options: PreloadOptions = {}) {
     queryKey: ["schedules", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getSchedules(connection);
+      return getTransport(connection).getSchedules();
     },
     enabled: !!connection && (options.enabled ?? true),
   });

--- a/src/features/schedules/hooks/useSchedulesSave.ts
+++ b/src/features/schedules/hooks/useSchedulesSave.ts
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { createSchedule, updateSchedule, deleteSchedule, getSchedules } from "@/lib/api/schedules";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -31,6 +31,7 @@ export function useSchedulesSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const ops = computeSaveOperations<Schedule>(staged);
       // Skip incomplete schedules (no date set)
       const toCreate = ops.toCreate.filter((s) => !!s.date);
@@ -45,7 +46,7 @@ export function useSchedulesSave() {
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
         toCreate.map((s) =>
-          createSchedule(connection, {
+          transport.createSchedule({
             name: s.name,
             postsTransaction: s.postsTransaction,
             payeeId: s.payeeId,
@@ -77,7 +78,7 @@ export function useSchedulesSave() {
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
         toUpdate.map((s) =>
-          updateSchedule(connection, s.id, {
+          transport.updateSchedule(s.id, {
             name: s.name,
             postsTransaction: s.postsTransaction,
             payeeId: s.payeeId,
@@ -104,7 +105,7 @@ export function useSchedulesSave() {
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
       const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => deleteSchedule(connection, id))
+        toDelete.map((id) => transport.deleteSchedule(id))
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];
@@ -148,6 +149,8 @@ export function useSchedulesSave() {
         store.setSaveErrors("schedules", {});
       }
 
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
+
       const requiredVisibleIds = new Set<string>([
         ...succeededUpdatedIds,
         ...Object.values(idMap),
@@ -155,7 +158,7 @@ export function useSchedulesSave() {
 
       let refreshedSchedules: Schedule[] | null = null;
       for (let attempt = 0; attempt < 3; attempt++) {
-        const freshSchedules = await getSchedules(connection);
+        const freshSchedules = await transport.getSchedules();
         const freshIds = new Set(freshSchedules.map((schedule) => schedule.id));
         const hasAllRequiredRows = [...requiredVisibleIds].every((id) => freshIds.has(id));
 

--- a/src/features/schedules/hooks/useSchedulesSave.ts
+++ b/src/features/schedules/hooks/useSchedulesSave.ts
@@ -4,7 +4,11 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -44,8 +48,10 @@ export function useSchedulesSave() {
       const idMap: Record<string, string> = {};
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
-      const createResults = await Promise.allSettled(
-        toCreate.map((s) =>
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (s) =>
           transport.createSchedule({
             name: s.name,
             postsTransaction: s.postsTransaction,
@@ -55,7 +61,6 @@ export function useSchedulesSave() {
             amountOp: s.amountOp,
             date: s.date,
           })
-        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const stagedId = toCreate[i].id;
@@ -76,8 +81,10 @@ export function useSchedulesSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((s) =>
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (s) =>
           transport.updateSchedule(s.id, {
             name: s.name,
             postsTransaction: s.postsTransaction,
@@ -87,7 +94,6 @@ export function useSchedulesSave() {
             amountOp: s.amountOp,
             date: s.date,
           })
-        )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -104,8 +110,10 @@ export function useSchedulesSave() {
       }
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
-      const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => transport.deleteSchedule(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        toDelete,
+        (id) => transport.deleteSchedule(id)
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getTags } from "@/lib/api/tags";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useStagedStore } from "@/store/staged";
 
@@ -18,7 +18,7 @@ export function useTags(options: PreloadOptions = {}) {
     queryKey: ["tags", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getTags(connection);
+      return getTransport(connection).getTags();
     },
     enabled: !!connection && (options.enabled ?? true),
   });

--- a/src/features/tags/hooks/useTagsSave.ts
+++ b/src/features/tags/hooks/useTagsSave.ts
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { createTag, updateTag, deleteTag, getTags } from "@/lib/api/tags";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -31,6 +31,7 @@ export function useTagsSave() {
     setIsSaving(true);
 
     try {
+      const transport = getTransport(connection);
       const ops = computeSaveOperations<Tag>(staged);
       const toCreate = ops.toCreate.filter((t) => t.name.trim() !== "");
       const toUpdate = ops.toUpdate.filter((t) => t.name.trim() !== "");
@@ -42,11 +43,13 @@ export function useTagsSave() {
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
       const createResults = await Promise.allSettled(
-        toCreate.map((t) => createTag(connection, { name: t.name, color: t.color, description: t.description }))
+        toCreate.map((t) =>
+          transport.createTag({ name: t.name, color: t.color, description: t.description })
+        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
-        const r  = createResults[i];
+        const r = createResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
           succeededCreateIds.add(id);
@@ -61,7 +64,7 @@ export function useTagsSave() {
       const unresolved = toCreate.filter((t) => succeededCreateIds.has(t.id) && !idMap[t.id]);
       if (unresolved.length > 0) {
         try {
-          const freshTags = await getTags(connection);
+          const freshTags = await transport.getTags();
           const serverIdByName = new Map(freshTags.map((t) => [t.name, t.id]));
           for (const t of unresolved) {
             const serverId = serverIdByName.get(t.name);
@@ -74,11 +77,13 @@ export function useTagsSave() {
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
       const updateResults = await Promise.allSettled(
-        toUpdate.map((t) => updateTag(connection, t.id, { name: t.name, color: t.color, description: t.description }))
+        toUpdate.map((t) =>
+          transport.updateTag(t.id, { name: t.name, color: t.color, description: t.description })
+        )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
-        const r  = updateResults[i];
+        const r = updateResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -88,11 +93,11 @@ export function useTagsSave() {
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
       const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => deleteTag(connection, id))
+        toDelete.map((id) => transport.deleteTag(id))
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];
-        const r  = deleteResults[i];
+        const r = deleteResults[i];
         if (r.status === "fulfilled") {
           succeeded.push({ status: "success", id });
         } else {
@@ -122,6 +127,8 @@ export function useTagsSave() {
       } else {
         store.setSaveErrors("tags", {});
       }
+
+      await syncTransportAfterChanges(transport, succeeded.length > 0);
 
       await queryClient.invalidateQueries({ queryKey: ["tags", connection.id] });
       return { succeeded, failed, idMap };

--- a/src/features/tags/hooks/useTagsSave.ts
+++ b/src/features/tags/hooks/useTagsSave.ts
@@ -4,7 +4,11 @@ import { useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStagedStore } from "@/store/staged";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
-import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import {
+  getTransport,
+  settleTransportWrites,
+  syncTransportAfterChanges,
+} from "@/lib/actual";
 import {
   extractMessage,
   computeSaveOperations,
@@ -42,10 +46,11 @@ export function useTagsSave() {
       const idMap: Record<string, string> = {};
 
       // ── Creates (parallel) ──────────────────────────────────────────────────
-      const createResults = await Promise.allSettled(
-        toCreate.map((t) =>
+      const createResults = await settleTransportWrites(
+        transport,
+        toCreate,
+        (t) =>
           transport.createTag({ name: t.name, color: t.color, description: t.description })
-        )
       );
       for (let i = 0; i < toCreate.length; i++) {
         const id = toCreate[i].id;
@@ -76,10 +81,11 @@ export function useTagsSave() {
       }
 
       // ── Updates (parallel) ──────────────────────────────────────────────────
-      const updateResults = await Promise.allSettled(
-        toUpdate.map((t) =>
+      const updateResults = await settleTransportWrites(
+        transport,
+        toUpdate,
+        (t) =>
           transport.updateTag(t.id, { name: t.name, color: t.color, description: t.description })
-        )
       );
       for (let i = 0; i < toUpdate.length; i++) {
         const id = toUpdate[i].id;
@@ -92,8 +98,10 @@ export function useTagsSave() {
       }
 
       // ── Deletes (parallel) ──────────────────────────────────────────────────
-      const deleteResults = await Promise.allSettled(
-        toDelete.map((id) => transport.deleteTag(id))
+      const deleteResults = await settleTransportWrites(
+        transport,
+        toDelete,
+        (id) => transport.deleteTag(id)
       );
       for (let i = 0; i < toDelete.length; i++) {
         const id = toDelete[i];

--- a/src/hooks/useAllNotes.ts
+++ b/src/hooks/useAllNotes.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { getAllNotes } from "@/lib/api/notes";
+import { getTransport } from "@/lib/actual";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 
 export function useAllNotes() {
@@ -11,7 +11,7 @@ export function useAllNotes() {
     queryKey: ["allNotes", connection?.id],
     queryFn: () => {
       if (!connection) throw new Error("No active connection");
-      return getAllNotes(connection);
+      return getTransport(connection).getAllNotes();
     },
     enabled: !!connection,
     staleTime: 300_000,

--- a/src/hooks/useBudgetPreferences.ts
+++ b/src/hooks/useBudgetPreferences.ts
@@ -4,7 +4,6 @@ import { useQuery } from "@tanstack/react-query";
 import {
   useConnectionStore,
   selectActiveInstance,
-  isHttpApiConnection,
 } from "@/store/connection";
 import { fetchBudgetPreferences } from "@/lib/api/preferences";
 import type { BudgetPreferences } from "@/lib/api/preferences";
@@ -24,15 +23,14 @@ const REFETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
  */
 export function useBudgetPreferences(): BudgetPreferences {
   const connection = useConnectionStore(selectActiveInstance);
-  const httpConnection = isHttpApiConnection(connection) ? connection : null;
 
   const { data } = useQuery({
-    queryKey: ["budgetPreferences", httpConnection?.id],
+    queryKey: ["budgetPreferences", connection?.id],
     queryFn: () => {
-      if (!httpConnection) throw new Error("No active Classic connection");
-      return fetchBudgetPreferences(httpConnection);
+      if (!connection) throw new Error("No active connection");
+      return fetchBudgetPreferences(connection);
     },
-    enabled: !!httpConnection,
+    enabled: !!connection,
     staleTime: REFETCH_INTERVAL,
     gcTime: REFETCH_INTERVAL * 2,
     refetchInterval: REFETCH_INTERVAL,

--- a/src/hooks/useBudgetPreferences.ts
+++ b/src/hooks/useBudgetPreferences.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isHttpApiConnection,
+} from "@/store/connection";
 import { fetchBudgetPreferences } from "@/lib/api/preferences";
 import type { BudgetPreferences } from "@/lib/api/preferences";
 
@@ -20,14 +24,15 @@ const REFETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
  */
 export function useBudgetPreferences(): BudgetPreferences {
   const connection = useConnectionStore(selectActiveInstance);
+  const httpConnection = isHttpApiConnection(connection) ? connection : null;
 
   const { data } = useQuery({
-    queryKey: ["budgetPreferences", connection?.id],
+    queryKey: ["budgetPreferences", httpConnection?.id],
     queryFn: () => {
-      if (!connection) throw new Error("No active connection");
-      return fetchBudgetPreferences(connection);
+      if (!httpConnection) throw new Error("No active Classic connection");
+      return fetchBudgetPreferences(httpConnection);
     },
-    enabled: !!connection,
+    enabled: !!httpConnection,
     staleTime: REFETCH_INTERVAL,
     gcTime: REFETCH_INTERVAL * 2,
     refetchInterval: REFETCH_INTERVAL,

--- a/src/hooks/useConnectionHealth.test.tsx
+++ b/src/hooks/useConnectionHealth.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { useConnectionHealth } from "./useConnectionHealth";
+import { useConnectionStore, type BrowserApiConnection } from "@/store/connection";
+
+const directConnection: BrowserApiConnection = {
+  id: "direct-1",
+  label: "Direct Budget",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "secret",
+  budgetSyncId: "budget-1",
+};
+
+function Probe() {
+  const health = useConnectionHealth();
+  return <div>{health.status}</div>;
+}
+
+describe("useConnectionHealth", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    useConnectionStore.setState({
+      instances: [directConnection],
+      activeInstanceId: directConnection.id,
+    });
+    global.fetch = jest.fn() as jest.Mock;
+  });
+
+  afterEach(() => {
+    useConnectionStore.setState({ instances: [], activeInstanceId: null });
+    jest.restoreAllMocks();
+  });
+
+  it("reports Direct sessions without pinging the HTTP API proxy", () => {
+    render(<Probe />);
+
+    expect(screen.getByText("direct")).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useConnectionHealth.ts
+++ b/src/hooks/useConnectionHealth.ts
@@ -1,9 +1,20 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback, createContext, useContext } from "react";
-import { useConnectionStore, selectActiveInstance, isHttpApiConnection } from "@/store/connection";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isBrowserApiConnection,
+  isHttpApiConnection,
+} from "@/store/connection";
 
-export type HealthStatus = "unknown" | "checking" | "healthy" | "degraded" | "offline";
+export type HealthStatus =
+  | "unknown"
+  | "checking"
+  | "healthy"
+  | "degraded"
+  | "offline"
+  | "direct";
 
 export type ConnectionHealthState = {
   status: HealthStatus;
@@ -123,6 +134,12 @@ export function useConnectionHealth(): ConnectionHealthState {
 
   // When no connection is active derive the reset values during render rather
   // than calling setState in the effect body (which triggers cascading renders).
-  if (!activeInstance || !isHttpApiConnection(activeInstance)) return { status: "unknown", latencyMs: null, showBanner: false };
+  if (!activeInstance) return { status: "unknown", latencyMs: null, showBanner: false };
+  if (isBrowserApiConnection(activeInstance)) {
+    return { status: "direct", latencyMs: null, showBanner: false };
+  }
+  if (!isHttpApiConnection(activeInstance)) {
+    return { status: "unknown", latencyMs: null, showBanner: false };
+  }
   return { status, latencyMs, showBanner };
 }

--- a/src/hooks/useConnectionHealth.ts
+++ b/src/hooks/useConnectionHealth.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback, createContext, useContext } from "react";
-import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { useConnectionStore, selectActiveInstance, isHttpApiConnection } from "@/store/connection";
 
 export type HealthStatus = "unknown" | "checking" | "healthy" | "degraded" | "offline";
 
@@ -84,7 +84,7 @@ export function useConnectionHealth(): ConnectionHealthState {
     consecutiveFailures.current = 0;
     isChecking.current = false;
 
-    if (!activeInstance) return;
+    if (!activeInstance || !isHttpApiConnection(activeInstance)) return;
 
     const { baseUrl, apiKey } = activeInstance;
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -123,6 +123,6 @@ export function useConnectionHealth(): ConnectionHealthState {
 
   // When no connection is active derive the reset values during render rather
   // than calling setState in the effect body (which triggers cascading renders).
-  if (!activeInstance) return { status: "unknown", latencyMs: null, showBanner: false };
+  if (!activeInstance || !isHttpApiConnection(activeInstance)) return { status: "unknown", latencyMs: null, showBanner: false };
   return { status, latencyMs, showBanner };
 }

--- a/src/hooks/useNoteMutation.test.tsx
+++ b/src/hooks/useNoteMutation.test.tsx
@@ -17,6 +17,7 @@ jest.mock("../lib/api/notes", () => ({
 jest.mock("../store/connection", () => ({
   useConnectionStore: jest.fn(() => ({ id: "conn-1" })),
   selectActiveInstance: jest.fn(),
+  isBrowserApiConnection: jest.fn((connection) => connection?.mode === "browser-api"),
 }));
 
 const notes = jest.requireMock("../lib/api/notes") as {

--- a/src/hooks/useNoteMutation.test.tsx
+++ b/src/hooks/useNoteMutation.test.tsx
@@ -4,26 +4,30 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useNoteMutation } from "./useNoteMutation";
 import { toAccountNoteId } from "../lib/api/notes";
 
-// Relative paths resolve to the same module the hook imports via `@/…`, so these
-// mocks intercept it. Keep the real id helpers (the hook derives the cache key
-// from them); only stub the network writers so we can assert on the DELETE.
-jest.mock("../lib/api/notes", () => ({
-  ...jest.requireActual("../lib/api/notes"),
+const mockTransport = {
+  mode: "http-api",
   setAccountNote: jest.fn(() => Promise.resolve()),
   deleteAccountNote: jest.fn(() => Promise.resolve()),
-}));
-
-// Pin an active connection so the hook builds a stable cache key.
-jest.mock("../store/connection", () => ({
-  useConnectionStore: jest.fn(() => ({ id: "conn-1" })),
-  selectActiveInstance: jest.fn(),
-  isBrowserApiConnection: jest.fn((connection) => connection?.mode === "browser-api"),
-}));
-
-const notes = jest.requireMock("../lib/api/notes") as {
-  setAccountNote: jest.Mock;
-  deleteAccountNote: jest.Mock;
 };
+
+const mockGetTransport = jest.fn(() => mockTransport);
+const mockSyncTransportAfterChanges = jest.fn(() => Promise.resolve());
+
+jest.mock("../lib/actual", () => ({
+  getTransport: (connection: unknown) => (mockGetTransport as jest.Mock)(connection),
+  syncTransportAfterChanges: (transport: unknown, changed: unknown) =>
+    (mockSyncTransportAfterChanges as jest.Mock)(transport, changed),
+}));
+
+let mockActiveConnection: { id: string; mode: "http-api" | "browser-api" } = {
+  id: "conn-1",
+  mode: "http-api",
+};
+
+jest.mock("../store/connection", () => ({
+  useConnectionStore: jest.fn(() => mockActiveConnection),
+  selectActiveInstance: jest.fn(),
+}));
 
 function makeWrapper(client: QueryClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -40,7 +44,6 @@ function renderWithNotes(entries: Array<[string, string]>) {
 }
 
 function renderColdCache() {
-  // The allNotes query is never populated, so getQueryState() is undefined.
   const client = new QueryClient();
   return renderHook(() => useNoteMutation("account", "acc-1"), {
     wrapper: makeWrapper(client),
@@ -49,36 +52,48 @@ function renderColdCache() {
 
 describe("useNoteMutation", () => {
   beforeEach(() => {
-    notes.setAccountNote.mockClear();
-    notes.deleteAccountNote.mockClear();
+    mockActiveConnection = { id: "conn-1", mode: "http-api" };
+    mockGetTransport.mockClear();
+    mockSyncTransportAfterChanges.mockClear();
+    mockTransport.setAccountNote.mockClear();
+    mockTransport.deleteAccountNote.mockClear();
   });
 
   it("skips the DELETE when an empty save clears a note that never existed", async () => {
-    const { result } = renderWithNotes([]); // nothing in the notes cache
+    const { result } = renderWithNotes([]);
     await act(async () => {
-      // Whitespace-only content routes to the clear path; with no note present
-      // it must resolve as a no-op rather than firing a DELETE (a possible 404).
       await result.current.save.mutateAsync("   ");
     });
-    expect(notes.deleteAccountNote).not.toHaveBeenCalled();
-    expect(notes.setAccountNote).not.toHaveBeenCalled();
+    expect(mockTransport.deleteAccountNote).not.toHaveBeenCalled();
+    expect(mockTransport.setAccountNote).not.toHaveBeenCalled();
+    expect(mockSyncTransportAfterChanges).not.toHaveBeenCalled();
   });
 
-  it("sends the DELETE when clearing a note that exists", async () => {
+  it("sends the DELETE through the active transport when clearing a note that exists", async () => {
     const { result } = renderWithNotes([[toAccountNoteId("acc-1"), "existing"]]);
     await act(async () => {
       await result.current.remove.mutateAsync();
     });
-    expect(notes.deleteAccountNote).toHaveBeenCalledWith({ id: "conn-1" }, "acc-1");
+    expect(mockGetTransport).toHaveBeenCalledWith(mockActiveConnection);
+    expect(mockTransport.deleteAccountNote).toHaveBeenCalledWith("acc-1");
+    expect(mockSyncTransportAfterChanges).toHaveBeenCalledWith(mockTransport, true);
   });
 
-  it("sends the DELETE when the notes cache is cold (absence unconfirmed)", async () => {
-    // A cold cache is not proof the note is absent: skipping the DELETE here
-    // would silently fail to clear a note that exists server-side.
+  it("sends the DELETE when the notes cache is cold", async () => {
     const { result } = renderColdCache();
     await act(async () => {
       await result.current.remove.mutateAsync();
     });
-    expect(notes.deleteAccountNote).toHaveBeenCalledWith({ id: "conn-1" }, "acc-1");
+    expect(mockTransport.deleteAccountNote).toHaveBeenCalledWith("acc-1");
+  });
+
+  it("syncs after Direct note writes through the transport", async () => {
+    mockActiveConnection = { id: "conn-1", mode: "browser-api" };
+    const { result } = renderWithNotes([[toAccountNoteId("acc-1"), "existing"]]);
+    await act(async () => {
+      await result.current.save.mutateAsync("updated");
+    });
+    expect(mockTransport.setAccountNote).toHaveBeenCalledWith("acc-1", "updated");
+    expect(mockSyncTransportAfterChanges).toHaveBeenCalledWith(mockTransport, true);
   });
 });

--- a/src/hooks/useNoteMutation.ts
+++ b/src/hooks/useNoteMutation.ts
@@ -11,7 +11,11 @@ import {
   toAccountNoteId,
   toBudgetNoteId,
 } from "@/lib/api/notes";
-import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import {
+  useConnectionStore,
+  selectActiveInstance,
+  isBrowserApiConnection,
+} from "@/store/connection";
 
 export type EntityNoteKind = "account" | "category" | "budgetMonth";
 
@@ -54,12 +58,20 @@ export function useNoteMutation(kind: EntityNoteKind, id: string) {
     void queryClient.invalidateQueries({ queryKey: ["allNotes", connection?.id] });
   }
 
-  function writeNote(note: string) {
+  function requireWritableConnection() {
     if (!connection) throw new Error("No active connection");
+    if (isBrowserApiConnection(connection)) {
+      throw new Error("Direct browser API mode is read-only in this milestone.");
+    }
+    return connection;
+  }
+
+  function writeNote(note: string) {
+    const writableConnection = requireWritableConnection();
     if (note.trim() === "") return clearNote();
-    if (kind === "account") return setAccountNote(connection, id, note);
-    if (kind === "budgetMonth") return setBudgetMonthNote(connection, id, note);
-    return setCategoryNote(connection, id, note);
+    if (kind === "account") return setAccountNote(writableConnection, id, note);
+    if (kind === "budgetMonth") return setBudgetMonthNote(writableConnection, id, note);
+    return setCategoryNote(writableConnection, id, note);
   }
 
   // The notes-table key for this entity, matching how getAllNotes indexes them.
@@ -83,14 +95,14 @@ export function useNoteMutation(kind: EntityNoteKind, id: string) {
   }
 
   function clearNote(): Promise<void> {
-    if (!connection) throw new Error("No active connection");
+    const writableConnection = requireWritableConnection();
     // Skip the DELETE only when the cache positively confirms there's nothing to
     // clear; an unguarded DELETE on a never-created note can 404 and surface a
     // false "could not clear" error. A cold cache isn't confirmation, so delete.
     if (noteKnownAbsent()) return Promise.resolve();
-    if (kind === "account") return deleteAccountNote(connection, id);
-    if (kind === "budgetMonth") return deleteBudgetMonthNote(connection, id);
-    return deleteCategoryNote(connection, id);
+    if (kind === "account") return deleteAccountNote(writableConnection, id);
+    if (kind === "budgetMonth") return deleteBudgetMonthNote(writableConnection, id);
+    return deleteCategoryNote(writableConnection, id);
   }
 
   const save = useMutation({ mutationFn: writeNote, onSuccess: invalidate });

--- a/src/hooks/useNoteMutation.ts
+++ b/src/hooks/useNoteMutation.ts
@@ -1,21 +1,9 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  setAccountNote,
-  deleteAccountNote,
-  setCategoryNote,
-  deleteCategoryNote,
-  setBudgetMonthNote,
-  deleteBudgetMonthNote,
-  toAccountNoteId,
-  toBudgetNoteId,
-} from "@/lib/api/notes";
-import {
-  useConnectionStore,
-  selectActiveInstance,
-  isBrowserApiConnection,
-} from "@/store/connection";
+import { toAccountNoteId, toBudgetNoteId } from "@/lib/api/notes";
+import { getTransport, syncTransportAfterChanges } from "@/lib/actual";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 
 export type EntityNoteKind = "account" | "category" | "budgetMonth";
 
@@ -26,7 +14,7 @@ export type EntityNoteKind = "account" | "category" | "budgetMonth";
  * is "stage every mutation (stageNew/stageUpdate/stageDelete); nothing writes
  * until the user clicks Save." Notes are deliberately exempt: they live in their
  * own key-value table, orthogonal to entity dirty-state, with a self-contained
- * popover/panel editor. So Save/Clear here issue an immediate PUT/DELETE and
+ * popover/panel editor. So Save/Clear here issue an immediate write/delete and
  * invalidate the note caches rather than routing through staged.ts /
  * budgetEdits.ts — don't "fix" this back onto the staged stores.
  *
@@ -58,20 +46,21 @@ export function useNoteMutation(kind: EntityNoteKind, id: string) {
     void queryClient.invalidateQueries({ queryKey: ["allNotes", connection?.id] });
   }
 
-  function requireWritableConnection() {
+  function requireConnection() {
     if (!connection) throw new Error("No active connection");
-    if (isBrowserApiConnection(connection)) {
-      throw new Error("Direct browser API mode is read-only in this milestone.");
-    }
     return connection;
   }
 
-  function writeNote(note: string) {
-    const writableConnection = requireWritableConnection();
+  async function writeNote(note: string) {
+    const activeConnection = requireConnection();
     if (note.trim() === "") return clearNote();
-    if (kind === "account") return setAccountNote(writableConnection, id, note);
-    if (kind === "budgetMonth") return setBudgetMonthNote(writableConnection, id, note);
-    return setCategoryNote(writableConnection, id, note);
+
+    const transport = getTransport(activeConnection);
+    if (kind === "account") await transport.setAccountNote(id, note);
+    else if (kind === "budgetMonth") await transport.setBudgetMonthNote(id, note);
+    else await transport.setCategoryNote(id, note);
+
+    await syncTransportAfterChanges(transport, true);
   }
 
   // The notes-table key for this entity, matching how getAllNotes indexes them.
@@ -94,15 +83,19 @@ export function useNoteMutation(kind: EntityNoteKind, id: string) {
     return (state.data?.get(noteCacheKey())?.trim().length ?? 0) === 0;
   }
 
-  function clearNote(): Promise<void> {
-    const writableConnection = requireWritableConnection();
+  async function clearNote(): Promise<void> {
+    const activeConnection = requireConnection();
     // Skip the DELETE only when the cache positively confirms there's nothing to
     // clear; an unguarded DELETE on a never-created note can 404 and surface a
     // false "could not clear" error. A cold cache isn't confirmation, so delete.
-    if (noteKnownAbsent()) return Promise.resolve();
-    if (kind === "account") return deleteAccountNote(writableConnection, id);
-    if (kind === "budgetMonth") return deleteBudgetMonthNote(writableConnection, id);
-    return deleteCategoryNote(writableConnection, id);
+    if (noteKnownAbsent()) return;
+
+    const transport = getTransport(activeConnection);
+    if (kind === "account") await transport.deleteAccountNote(id);
+    else if (kind === "budgetMonth") await transport.deleteBudgetMonthNote(id);
+    else await transport.deleteCategoryNote(id);
+
+    await syncTransportAfterChanges(transport, true);
   }
 
   const save = useMutation({ mutationFn: writeNote, onSuccess: invalidate });

--- a/src/lib/actual/browser/environment.ts
+++ b/src/lib/actual/browser/environment.ts
@@ -1,0 +1,12 @@
+export function assertDirectBrowserApiEnvironment(): void {
+  if (typeof window === "undefined") {
+    throw new Error("Direct browser API transport can only run in the browser.");
+  }
+
+  if (window.crossOriginIsolated !== true) {
+    throw new Error(
+      "Direct Actual Server mode requires cross-origin isolation (COOP/COEP). " +
+        "Enable Direct mode headers for Actual Bench, or use HTTP API Server mode."
+    );
+  }
+}

--- a/src/lib/actual/browser/labRuntime.ts
+++ b/src/lib/actual/browser/labRuntime.ts
@@ -1,0 +1,352 @@
+"use client";
+
+export type BrowserApiLabInput = {
+  serverUrl: string;
+  serverPassword: string;
+  budgetSyncId: string;
+  encryptionPassword?: string;
+};
+
+export type BrowserApiLabBudget = {
+  cloudFileId?: string;
+  name?: string;
+  state?: string;
+  groupId?: string;
+  encryptKeyId?: string | null;
+  hasKey?: boolean;
+  owner?: string;
+};
+
+export type BrowserApiLabAccount = {
+  id: string;
+  name: string;
+  closed?: boolean;
+  offbudget?: boolean;
+};
+
+export type BrowserApiLabResult = {
+  serverUrl: string;
+  budgetCount: number;
+  selectedBudgetName: string | null;
+  selectedBudgetSyncId: string;
+  accounts: BrowserApiLabAccount[];
+};
+
+export type BrowserApiLabStepId =
+  | "load"
+  | "init"
+  | "budgets"
+  | "download"
+  | "accounts"
+  | "sync"
+  | "shutdown";
+
+export type BrowserApiLabStepStatus = "running" | "success" | "error";
+
+const DEFAULT_STEP_TIMEOUT_MS = 45_000;
+const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
+
+export type BrowserApiLabStepUpdate = {
+  id: BrowserApiLabStepId;
+  status: BrowserApiLabStepStatus;
+  detail?: string;
+};
+
+type ActualBudget = {
+  cloudFileId?: string;
+  name?: string;
+  state?: string;
+  groupId?: string;
+  encryptKeyId?: string | null;
+  hasKey?: boolean;
+  owner?: string;
+};
+
+type ActualAccount = {
+  id?: string;
+  name?: string;
+  closed?: boolean;
+  offbudget?: boolean;
+};
+
+type ActualApiModule = {
+  init(config: {
+    dataDir?: string;
+    serverURL: string;
+    password: string;
+    verbose?: boolean;
+  }): Promise<unknown>;
+  getBudgets(): Promise<ActualBudget[]>;
+  downloadBudget(syncId: string, options?: { password?: string }): Promise<unknown>;
+  getAccounts(): Promise<ActualAccount[]>;
+  sync(): Promise<unknown>;
+  shutdown(): Promise<unknown>;
+};
+
+type WorkerInitMessage = {
+  name?: unknown;
+  args?: unknown;
+};
+
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function normalizeBudget(budget: ActualBudget): BrowserApiLabBudget {
+  return {
+    cloudFileId: budget.cloudFileId,
+    name: budget.name,
+    state: budget.state,
+    groupId: budget.groupId,
+    encryptKeyId: budget.encryptKeyId,
+    hasKey: budget.hasKey,
+    owner: budget.owner,
+  };
+}
+
+function normalizeAccount(account: ActualAccount): BrowserApiLabAccount | null {
+  if (!account.id || !account.name) return null;
+  return {
+    id: account.id,
+    name: account.name,
+    closed: account.closed,
+    offbudget: account.offbudget,
+  };
+}
+
+function redactMessage(message: string, input: BrowserApiLabInput): string {
+  let redacted = message;
+  for (const secret of [input.serverPassword, input.encryptionPassword]) {
+    if (!secret) continue;
+    redacted = redacted.split(secret).join("[redacted]");
+  }
+  return redacted;
+}
+
+function toErrorMessage(error: unknown, input: BrowserApiLabInput): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : typeof error === "object" &&
+            error !== null &&
+            "message" in error &&
+            typeof error.message === "string"
+          ? error.message
+          : "Unknown browser API error";
+  return redactMessage(message, input);
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  stepLabel: string,
+  timeoutMs = DEFAULT_STEP_TIMEOUT_MS
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new Error(
+          stepLabel +
+            " did not finish within " +
+            Math.round(timeoutMs / 1000) +
+            " seconds."
+        )
+      );
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}
+
+function getActualAssetsBaseUrl(): string {
+  if (typeof window === "undefined") return "/actual-api-assets/";
+  return new URL("/actual-api-assets/", window.location.origin).href;
+}
+
+function isWorkerInitMessage(message: unknown): message is WorkerInitMessage {
+  return typeof message === "object" && message !== null && "name" in message;
+}
+
+function rewriteActualInitMessage(message: unknown, assetsBaseUrl: string): unknown {
+  if (!isWorkerInitMessage(message) || message.name !== "api-browser/init") {
+    return message;
+  }
+
+  const args =
+    typeof message.args === "object" && message.args !== null ? message.args : {};
+
+  return {
+    ...message,
+    args: {
+      ...args,
+      assetsBaseUrl,
+    },
+  };
+}
+
+async function initializeActualApi(
+  actual: ActualApiModule,
+  config: Parameters<ActualApiModule["init"]>[0]
+): Promise<unknown> {
+  const NativeWorker = window.Worker;
+  const assetsBaseUrl = getActualAssetsBaseUrl();
+  let redirectedBackendWorker = false;
+
+  window.Worker = class ActualBenchWorker extends NativeWorker {
+    constructor(scriptURL: string | URL, options?: WorkerOptions) {
+      const actualBackendWorkerUrl = redirectedBackendWorker
+        ? scriptURL
+        : assetsBaseUrl + "worker.js";
+
+      redirectedBackendWorker = true;
+      super(actualBackendWorkerUrl, options);
+    }
+
+    postMessage(message: unknown, transfer: Transferable[]): void;
+    postMessage(message: unknown, options?: StructuredSerializeOptions): void;
+    postMessage(
+      message: unknown,
+      options?: Transferable[] | StructuredSerializeOptions
+    ): void {
+      const rewrittenMessage = rewriteActualInitMessage(message, assetsBaseUrl);
+
+      if (options === undefined) {
+        super.postMessage(rewrittenMessage);
+      } else if (Array.isArray(options)) {
+        super.postMessage(rewrittenMessage, options);
+      } else {
+        super.postMessage(rewrittenMessage, options);
+      }
+    }
+  } as typeof Worker;
+
+  try {
+    return await actual.init(config);
+  } finally {
+    window.Worker = NativeWorker;
+  }
+}
+
+async function loadActualApi(): Promise<ActualApiModule> {
+  const actual = await import("@actual-app/api");
+  return actual as unknown as ActualApiModule;
+}
+
+export async function runBrowserApiLab(
+  input: BrowserApiLabInput,
+  onStep: (update: BrowserApiLabStepUpdate) => void
+): Promise<BrowserApiLabResult> {
+  const serverUrl = normalizeUrl(input.serverUrl);
+  const budgetSyncId = input.budgetSyncId.trim();
+  const serverPassword = input.serverPassword;
+  const encryptionPassword = input.encryptionPassword?.trim() || undefined;
+
+  if (!serverUrl) throw new Error("Actual Server URL is required.");
+  if (!serverPassword) throw new Error("Actual Server password is required.");
+  if (!budgetSyncId) throw new Error("Budget Sync ID is required.");
+
+  let actual: ActualApiModule | null = null;
+  let initialized = false;
+  let result: BrowserApiLabResult | null = null;
+  let activeStep: BrowserApiLabStepId | null = null;
+
+  function startStep(id: BrowserApiLabStepId) {
+    activeStep = id;
+    onStep({ id, status: "running" });
+  }
+
+  function completeStep(id: BrowserApiLabStepId, detail?: string) {
+    if (activeStep === id) activeStep = null;
+    onStep({ id, status: "success", detail });
+  }
+
+  try {
+    startStep("load");
+    actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
+    completeStep("load", "Browser API module loaded.");
+
+    startStep("init");
+    await withTimeout(
+      initializeActualApi(actual, {
+        dataDir: "/documents",
+        serverURL: serverUrl,
+        password: serverPassword,
+        verbose: true,
+      }),
+      "Initializing browser API worker"
+    );
+    initialized = true;
+    completeStep("init", "Worker runtime initialized.");
+
+    startStep("budgets");
+    const budgets = (await withTimeout(actual.getBudgets(), "Listing budgets")).map(normalizeBudget);
+    completeStep(
+      "budgets",
+      budgets.length + " budget" + (budgets.length === 1 ? "" : "s") + " returned."
+    );
+
+    const selectedBudget = budgets.find((budget) => budget.groupId === budgetSyncId);
+
+    startStep("download");
+    await withTimeout(
+      actual.downloadBudget(budgetSyncId, { password: encryptionPassword }),
+      "Downloading budget"
+    );
+    completeStep(
+      "download",
+      selectedBudget?.name
+        ? "Downloaded " + selectedBudget.name + "."
+        : "Downloaded selected budget."
+    );
+
+    startStep("accounts");
+    const accounts = (await withTimeout(actual.getAccounts(), "Reading accounts"))
+      .map(normalizeAccount)
+      .filter((account): account is BrowserApiLabAccount => account !== null);
+    completeStep(
+      "accounts",
+      accounts.length + " account" + (accounts.length === 1 ? "" : "s") + " returned."
+    );
+
+    startStep("sync");
+    await withTimeout(actual.sync(), "Syncing budget");
+    completeStep("sync", "Sync completed.");
+
+    result = {
+      serverUrl,
+      budgetCount: budgets.length,
+      selectedBudgetName: selectedBudget?.name ?? null,
+      selectedBudgetSyncId: budgetSyncId,
+      accounts,
+    };
+    return result;
+  } catch (error) {
+    const detail = toErrorMessage(error, input);
+    if (activeStep) {
+      onStep({ id: activeStep, status: "error", detail });
+      activeStep = null;
+    }
+    throw new Error(detail);
+  } finally {
+    if (actual && initialized) {
+      onStep({ id: "shutdown", status: "running" });
+      try {
+        await withTimeout(
+          actual.shutdown(),
+          "Shutting down browser API",
+          SHUTDOWN_STEP_TIMEOUT_MS
+        );
+        onStep({ id: "shutdown", status: "success", detail: "Runtime shut down." });
+      } catch (error) {
+        const detail = toErrorMessage(error, input);
+        onStep({ id: "shutdown", status: "error", detail });
+        if (result) throw new Error(detail);
+      }
+    }
+  }
+}

--- a/src/lib/actual/browser/labRuntime.ts
+++ b/src/lib/actual/browser/labRuntime.ts
@@ -7,6 +7,11 @@ export type BrowserApiLabInput = {
   encryptionPassword?: string;
 };
 
+export type BrowserApiBudgetListInput = {
+  serverUrl: string;
+  serverPassword: string;
+};
+
 export type BrowserApiLabBudget = {
   cloudFileId?: string;
   name?: string;
@@ -114,7 +119,21 @@ function normalizeAccount(account: ActualAccount): BrowserApiLabAccount | null {
   };
 }
 
-function redactMessage(message: string, input: BrowserApiLabInput): string {
+function filterRemoteBudgets(budgets: BrowserApiLabBudget[]): BrowserApiLabBudget[] {
+  const seen = new Set<string>();
+  return budgets.filter((budget) => {
+    if (budget.state !== "remote") return false;
+    if (!budget.groupId) return false;
+    if (seen.has(budget.groupId)) return false;
+    seen.add(budget.groupId);
+    return true;
+  });
+}
+
+function redactMessage(
+  message: string,
+  input: { serverPassword?: string; encryptionPassword?: string }
+): string {
   let redacted = message;
   for (const secret of [input.serverPassword, input.encryptionPassword]) {
     if (!secret) continue;
@@ -123,7 +142,10 @@ function redactMessage(message: string, input: BrowserApiLabInput): string {
   return redacted;
 }
 
-function toErrorMessage(error: unknown, input: BrowserApiLabInput): string {
+function toErrorMessage(
+  error: unknown,
+  input: { serverPassword?: string; encryptionPassword?: string }
+): string {
   const message =
     error instanceof Error
       ? error.message
@@ -237,6 +259,47 @@ async function loadActualApi(): Promise<ActualApiModule> {
   return actual as unknown as ActualApiModule;
 }
 
+export async function listBrowserApiBudgets(
+  input: BrowserApiBudgetListInput
+): Promise<BrowserApiLabBudget[]> {
+  const serverUrl = normalizeUrl(input.serverUrl);
+  const serverPassword = input.serverPassword;
+
+  if (!serverUrl) throw new Error("Actual Server URL is required.");
+  if (!serverPassword) throw new Error("Actual Server password is required.");
+
+  let actual: ActualApiModule | null = null;
+  let initialized = false;
+
+  try {
+    actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
+    await withTimeout(
+      initializeActualApi(actual, {
+        dataDir: "/documents",
+        serverURL: serverUrl,
+        password: serverPassword,
+        verbose: false,
+      }),
+      "Initializing browser API worker"
+    );
+    initialized = true;
+
+    const budgets = (await withTimeout(actual.getBudgets(), "Listing budgets"))
+      .map(normalizeBudget);
+    return filterRemoteBudgets(budgets);
+  } catch (error) {
+    throw new Error(toErrorMessage(error, input));
+  } finally {
+    if (actual && initialized) {
+      await withTimeout(
+        actual.shutdown(),
+        "Shutting down browser API",
+        SHUTDOWN_STEP_TIMEOUT_MS
+      ).catch(() => undefined);
+    }
+  }
+}
+
 export async function runBrowserApiLab(
   input: BrowserApiLabInput,
   onStep: (update: BrowserApiLabStepUpdate) => void
@@ -284,7 +347,9 @@ export async function runBrowserApiLab(
     completeStep("init", "Worker runtime initialized.");
 
     startStep("budgets");
-    const budgets = (await withTimeout(actual.getBudgets(), "Listing budgets")).map(normalizeBudget);
+    const budgets = filterRemoteBudgets(
+      (await withTimeout(actual.getBudgets(), "Listing budgets")).map(normalizeBudget)
+    );
     completeStep(
       "budgets",
       budgets.length + " budget" + (budgets.length === 1 ? "" : "s") + " returned."

--- a/src/lib/actual/browser/labRuntime.ts
+++ b/src/lib/actual/browser/labRuntime.ts
@@ -22,6 +22,11 @@ export type BrowserApiLabBudget = {
   owner?: string;
 };
 
+export type BrowserApiBudgetListResult = {
+  budgets: BrowserApiLabBudget[];
+  serverVersion: string | null;
+};
+
 export type BrowserApiLabAccount = {
   id: string;
   name: string;
@@ -82,6 +87,7 @@ type ActualApiModule = {
     verbose?: boolean;
   }): Promise<unknown>;
   getBudgets(): Promise<ActualBudget[]>;
+  getServerVersion?(): Promise<{ version: string } | { error: string }>;
   downloadBudget(syncId: string, options?: { password?: string }): Promise<unknown>;
   getAccounts(): Promise<ActualAccount[]>;
   sync(): Promise<unknown>;
@@ -263,9 +269,9 @@ async function loadActualApi(): Promise<ActualApiModule> {
   return actual as unknown as ActualApiModule;
 }
 
-export async function listBrowserApiBudgets(
+export async function loadBrowserApiBudgetList(
   input: BrowserApiBudgetListInput
-): Promise<BrowserApiLabBudget[]> {
+): Promise<BrowserApiBudgetListResult> {
   const serverUrl = normalizeUrl(input.serverUrl);
   const serverPassword = input.serverPassword;
 
@@ -287,7 +293,19 @@ export async function listBrowserApiBudgets(
 
     const budgets = (await withTimeout(actual.getBudgets(), "Listing budgets"))
       .map(normalizeBudget);
-    return filterRemoteBudgets(budgets);
+    const versionResult = actual.getServerVersion
+      ? await withTimeout(
+          actual.getServerVersion(),
+          "Reading Actual Server version",
+          10_000
+        ).catch(() => null)
+      : null;
+
+    return {
+      budgets: filterRemoteBudgets(budgets),
+      serverVersion:
+        versionResult && "version" in versionResult ? versionResult.version : null,
+    };
   } catch (error) {
     throw new Error(toErrorMessage(error, input));
   } finally {
@@ -299,6 +317,12 @@ export async function listBrowserApiBudgets(
       ).catch(() => undefined);
     }
   }
+}
+
+export async function listBrowserApiBudgets(
+  input: BrowserApiBudgetListInput
+): Promise<BrowserApiLabBudget[]> {
+  return (await loadBrowserApiBudgetList(input)).budgets;
 }
 
 export async function runBrowserApiLab(

--- a/src/lib/actual/browser/labRuntime.ts
+++ b/src/lib/actual/browser/labRuntime.ts
@@ -1,6 +1,13 @@
 "use client";
 
 import { assertDirectBrowserApiEnvironment } from "./environment";
+import {
+  SHUTDOWN_STEP_TIMEOUT_MS,
+  initializeActualApi,
+  loadActualApi,
+  normalizeUrl,
+  withTimeout,
+} from "./setup";
 
 export type BrowserApiLabInput = {
   serverUrl: string;
@@ -15,6 +22,7 @@ export type BrowserApiBudgetListInput = {
 };
 
 export type BrowserApiLabBudget = {
+  id?: string;
   cloudFileId?: string;
   name?: string;
   state?: string;
@@ -55,9 +63,6 @@ export type BrowserApiLabStepId =
 
 export type BrowserApiLabStepStatus = "running" | "success" | "error";
 
-const DEFAULT_STEP_TIMEOUT_MS = 45_000;
-const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
-
 export type BrowserApiLabStepUpdate = {
   id: BrowserApiLabStepId;
   status: BrowserApiLabStepStatus;
@@ -65,6 +70,7 @@ export type BrowserApiLabStepUpdate = {
 };
 
 type ActualBudget = {
+  id?: string;
   cloudFileId?: string;
   name?: string;
   state?: string;
@@ -96,17 +102,9 @@ type ActualApiModule = {
   shutdown(): Promise<unknown>;
 };
 
-type WorkerInitMessage = {
-  name?: unknown;
-  args?: unknown;
-};
-
-function normalizeUrl(url: string): string {
-  return url.trim().replace(/\/+$/, "");
-}
-
 function normalizeBudget(budget: ActualBudget): BrowserApiLabBudget {
   return {
+    id: budget.id,
     cloudFileId: budget.cloudFileId,
     name: budget.name,
     state: budget.state,
@@ -131,11 +129,16 @@ function filterRemoteBudgets(budgets: BrowserApiLabBudget[]): BrowserApiLabBudge
   const seen = new Set<string>();
   return budgets.filter((budget) => {
     if (budget.state !== "remote") return false;
-    if (!budget.groupId) return false;
-    if (seen.has(budget.groupId)) return false;
-    seen.add(budget.groupId);
+    const syncId = getBudgetSyncId(budget);
+    if (!syncId) return false;
+    if (seen.has(syncId)) return false;
+    seen.add(syncId);
     return true;
   });
+}
+
+function getBudgetSyncId(budget: BrowserApiLabBudget): string | undefined {
+  return budget.groupId ?? budget.id;
 }
 
 function redactMessage(
@@ -168,109 +171,6 @@ function toErrorMessage(
   return redactMessage(message, input);
 }
 
-function withTimeout<T>(
-  promise: Promise<T>,
-  stepLabel: string,
-  timeoutMs = DEFAULT_STEP_TIMEOUT_MS
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(() => {
-      reject(
-        new Error(
-          stepLabel +
-            " did not finish within " +
-            Math.round(timeoutMs / 1000) +
-            " seconds."
-        )
-      );
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) clearTimeout(timeoutId);
-  });
-}
-
-function getActualAssetsBaseUrl(): string {
-  if (typeof window === "undefined") return "/actual-api-assets/";
-  return new URL("/actual-api-assets/", window.location.origin).href;
-}
-
-function isWorkerInitMessage(message: unknown): message is WorkerInitMessage {
-  return typeof message === "object" && message !== null && "name" in message;
-}
-
-function rewriteActualInitMessage(message: unknown, assetsBaseUrl: string): unknown {
-  if (!isWorkerInitMessage(message) || message.name !== "api-browser/init") {
-    return message;
-  }
-
-  const args =
-    typeof message.args === "object" && message.args !== null ? message.args : {};
-
-  return {
-    ...message,
-    args: {
-      ...args,
-      assetsBaseUrl,
-    },
-  };
-}
-
-async function initializeActualApi(
-  actual: ActualApiModule,
-  config: Parameters<ActualApiModule["init"]>[0]
-): Promise<unknown> {
-  const NativeWorker = window.Worker;
-  const assetsBaseUrl = getActualAssetsBaseUrl();
-  let redirectedBackendWorker = false;
-
-  const ActualBenchWorker = class extends NativeWorker {
-    constructor(scriptURL: string | URL, options?: WorkerOptions) {
-      const actualBackendWorkerUrl = redirectedBackendWorker
-        ? scriptURL
-        : assetsBaseUrl + "worker.js";
-
-      redirectedBackendWorker = true;
-      super(actualBackendWorkerUrl, options);
-    }
-
-    postMessage(message: unknown, transfer: Transferable[]): void;
-    postMessage(message: unknown, options?: StructuredSerializeOptions): void;
-    postMessage(
-      message: unknown,
-      options?: Transferable[] | StructuredSerializeOptions
-    ): void {
-      const rewrittenMessage = rewriteActualInitMessage(message, assetsBaseUrl);
-
-      if (options === undefined) {
-        super.postMessage(rewrittenMessage);
-      } else if (Array.isArray(options)) {
-        super.postMessage(rewrittenMessage, options);
-      } else {
-        super.postMessage(rewrittenMessage, options);
-      }
-    }
-  };
-
-  window.Worker = ActualBenchWorker as typeof Worker;
-
-  try {
-    return await withTimeout(actual.init(config), "Initializing browser API worker");
-  } finally {
-    if (window.Worker === (ActualBenchWorker as typeof Worker)) {
-      window.Worker = NativeWorker;
-    }
-  }
-}
-
-async function loadActualApi(): Promise<ActualApiModule> {
-  const actual = await import("@actual-app/api");
-  return actual as unknown as ActualApiModule;
-}
-
 export async function loadBrowserApiBudgetList(
   input: BrowserApiBudgetListInput
 ): Promise<BrowserApiBudgetListResult> {
@@ -285,7 +185,10 @@ export async function loadBrowserApiBudgetList(
   let initialized = false;
 
   try {
-    actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
+    actual = await withTimeout(
+      loadActualApi<ActualApiModule>(),
+      "Loading @actual-app/api"
+    );
     await initializeActualApi(actual, {
       dataDir: "/documents",
       serverURL: serverUrl,
@@ -359,7 +262,10 @@ export async function runBrowserApiLab(
 
   try {
     startStep("load");
-    actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
+    actual = await withTimeout(
+      loadActualApi<ActualApiModule>(),
+      "Loading @actual-app/api"
+    );
     completeStep("load", "Browser API module loaded.");
 
     startStep("init");
@@ -381,7 +287,9 @@ export async function runBrowserApiLab(
       budgets.length + " budget" + (budgets.length === 1 ? "" : "s") + " returned."
     );
 
-    const selectedBudget = budgets.find((budget) => budget.groupId === budgetSyncId);
+    const selectedBudget = budgets.find(
+      (budget) => getBudgetSyncId(budget) === budgetSyncId
+    );
 
     startStep("download");
     await withTimeout(
@@ -415,7 +323,6 @@ export async function runBrowserApiLab(
       selectedBudgetSyncId: budgetSyncId,
       accounts,
     };
-    return result;
   } catch (error) {
     const detail = toErrorMessage(error, input);
     if (activeStep) {
@@ -423,21 +330,24 @@ export async function runBrowserApiLab(
       activeStep = null;
     }
     throw new Error(detail);
-  } finally {
-    if (actual && initialized) {
-      onStep({ id: "shutdown", status: "running" });
-      try {
-        await withTimeout(
-          actual.shutdown(),
-          "Shutting down browser API",
-          SHUTDOWN_STEP_TIMEOUT_MS
-        );
-        onStep({ id: "shutdown", status: "success", detail: "Runtime shut down." });
-      } catch (error) {
-        const detail = toErrorMessage(error, input);
-        onStep({ id: "shutdown", status: "error", detail });
-        if (result) throw new Error(detail);
-      }
+  }
+
+  if (actual && initialized) {
+    onStep({ id: "shutdown", status: "running" });
+    try {
+      await withTimeout(
+        actual.shutdown(),
+        "Shutting down browser API",
+        SHUTDOWN_STEP_TIMEOUT_MS
+      );
+      onStep({ id: "shutdown", status: "success", detail: "Runtime shut down." });
+    } catch (error) {
+      const detail = toErrorMessage(error, input);
+      onStep({ id: "shutdown", status: "error", detail });
+      throw new Error(detail);
     }
   }
+
+  if (!result) throw new Error("Browser API lab did not produce a result.");
+  return result;
 }

--- a/src/lib/actual/browser/labRuntime.ts
+++ b/src/lib/actual/browser/labRuntime.ts
@@ -219,7 +219,7 @@ async function initializeActualApi(
   const assetsBaseUrl = getActualAssetsBaseUrl();
   let redirectedBackendWorker = false;
 
-  window.Worker = class ActualBenchWorker extends NativeWorker {
+  const ActualBenchWorker = class extends NativeWorker {
     constructor(scriptURL: string | URL, options?: WorkerOptions) {
       const actualBackendWorkerUrl = redirectedBackendWorker
         ? scriptURL
@@ -245,12 +245,16 @@ async function initializeActualApi(
         super.postMessage(rewrittenMessage, options);
       }
     }
-  } as typeof Worker;
+  };
+
+  window.Worker = ActualBenchWorker as typeof Worker;
 
   try {
-    return await actual.init(config);
+    return await withTimeout(actual.init(config), "Initializing browser API worker");
   } finally {
-    window.Worker = NativeWorker;
+    if (window.Worker === (ActualBenchWorker as typeof Worker)) {
+      window.Worker = NativeWorker;
+    }
   }
 }
 
@@ -273,15 +277,12 @@ export async function listBrowserApiBudgets(
 
   try {
     actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
-    await withTimeout(
-      initializeActualApi(actual, {
-        dataDir: "/documents",
-        serverURL: serverUrl,
-        password: serverPassword,
-        verbose: false,
-      }),
-      "Initializing browser API worker"
-    );
+    await initializeActualApi(actual, {
+      dataDir: "/documents",
+      serverURL: serverUrl,
+      password: serverPassword,
+      verbose: false,
+    });
     initialized = true;
 
     const budgets = (await withTimeout(actual.getBudgets(), "Listing budgets"))
@@ -334,15 +335,12 @@ export async function runBrowserApiLab(
     completeStep("load", "Browser API module loaded.");
 
     startStep("init");
-    await withTimeout(
-      initializeActualApi(actual, {
-        dataDir: "/documents",
-        serverURL: serverUrl,
-        password: serverPassword,
-        verbose: true,
-      }),
-      "Initializing browser API worker"
-    );
+    await initializeActualApi(actual, {
+      dataDir: "/documents",
+      serverURL: serverUrl,
+      password: serverPassword,
+      verbose: true,
+    });
     initialized = true;
     completeStep("init", "Worker runtime initialized.");
 

--- a/src/lib/actual/browser/labRuntime.ts
+++ b/src/lib/actual/browser/labRuntime.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { assertDirectBrowserApiEnvironment } from "./environment";
+
 export type BrowserApiLabInput = {
   serverUrl: string;
   serverPassword: string;
@@ -277,6 +279,7 @@ export async function loadBrowserApiBudgetList(
 
   if (!serverUrl) throw new Error("Actual Server URL is required.");
   if (!serverPassword) throw new Error("Actual Server password is required.");
+  assertDirectBrowserApiEnvironment();
 
   let actual: ActualApiModule | null = null;
   let initialized = false;
@@ -337,6 +340,7 @@ export async function runBrowserApiLab(
   if (!serverUrl) throw new Error("Actual Server URL is required.");
   if (!serverPassword) throw new Error("Actual Server password is required.");
   if (!budgetSyncId) throw new Error("Budget Sync ID is required.");
+  assertDirectBrowserApiEnvironment();
 
   let actual: ActualApiModule | null = null;
   let initialized = false;

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -12,6 +12,13 @@ import type {
 import type { BrowserApiConnection } from "@/store/connection";
 import type { NoteRow } from "@/lib/api/notes";
 import { assertDirectBrowserApiEnvironment } from "./environment";
+import {
+  SHUTDOWN_STEP_TIMEOUT_MS,
+  initializeActualApi,
+  loadActualApi,
+  normalizeUrl,
+  withTimeout,
+} from "./setup";
 
 export type ActualQueryBuilder = {
   filter(expr: unknown): ActualQueryBuilder;
@@ -96,11 +103,6 @@ export type ActualBrowserApi = {
   shutdown(): Promise<unknown>;
 };
 
-type WorkerInitMessage = {
-  name?: unknown;
-  args?: unknown;
-};
-
 export type ActualBrowserApiRuntime = ActualBrowserApi & {
   send: ActualBrowserApiSend;
 };
@@ -110,15 +112,8 @@ type ActiveRuntime = {
   promise: Promise<ActualBrowserApiRuntime>;
 };
 
-const DEFAULT_STEP_TIMEOUT_MS = 45_000;
-const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
-
 let activeRuntime: ActiveRuntime | null = null;
 let syncQueue = Promise.resolve();
-
-function normalizeUrl(url: string): string {
-  return url.trim().replace(/\/+$/, "");
-}
 
 function runtimeKey(connection: BrowserApiConnection): string {
   return JSON.stringify({
@@ -128,109 +123,6 @@ function runtimeKey(connection: BrowserApiConnection): string {
     serverPassword: connection.serverPassword,
     encryptionPassword: connection.encryptionPassword ?? "",
   });
-}
-
-function getActualAssetsBaseUrl(): string {
-  if (typeof window === "undefined") return "/actual-api-assets/";
-  return new URL("/actual-api-assets/", window.location.origin).href;
-}
-
-function isWorkerInitMessage(message: unknown): message is WorkerInitMessage {
-  return typeof message === "object" && message !== null && "name" in message;
-}
-
-function rewriteActualInitMessage(message: unknown, assetsBaseUrl: string): unknown {
-  if (!isWorkerInitMessage(message) || message.name !== "api-browser/init") {
-    return message;
-  }
-
-  const args =
-    typeof message.args === "object" && message.args !== null ? message.args : {};
-
-  return {
-    ...message,
-    args: {
-      ...args,
-      assetsBaseUrl,
-    },
-  };
-}
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  stepLabel: string,
-  timeoutMs = DEFAULT_STEP_TIMEOUT_MS
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(() => {
-      reject(
-        new Error(
-          stepLabel +
-            " did not finish within " +
-            Math.round(timeoutMs / 1000) +
-            " seconds."
-        )
-      );
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) clearTimeout(timeoutId);
-  });
-}
-
-async function initializeActualApi(
-  actual: ActualBrowserApi,
-  config: Parameters<ActualBrowserApi["init"]>[0]
-): Promise<ActualBrowserApiInitResult> {
-  const NativeWorker = window.Worker;
-  const assetsBaseUrl = getActualAssetsBaseUrl();
-  let redirectedBackendWorker = false;
-
-  const ActualBenchWorker = class extends NativeWorker {
-    constructor(scriptURL: string | URL, options?: WorkerOptions) {
-      const actualBackendWorkerUrl = redirectedBackendWorker
-        ? scriptURL
-        : assetsBaseUrl + "worker.js";
-
-      redirectedBackendWorker = true;
-      super(actualBackendWorkerUrl, options);
-    }
-
-    postMessage(message: unknown, transfer: Transferable[]): void;
-    postMessage(message: unknown, options?: StructuredSerializeOptions): void;
-    postMessage(
-      message: unknown,
-      options?: Transferable[] | StructuredSerializeOptions
-    ): void {
-      const rewrittenMessage = rewriteActualInitMessage(message, assetsBaseUrl);
-
-      if (options === undefined) {
-        super.postMessage(rewrittenMessage);
-      } else if (Array.isArray(options)) {
-        super.postMessage(rewrittenMessage, options);
-      } else {
-        super.postMessage(rewrittenMessage, options);
-      }
-    }
-  };
-
-  window.Worker = ActualBenchWorker as typeof Worker;
-
-  try {
-    return await withTimeout(actual.init(config), "Initializing browser API worker");
-  } finally {
-    if (window.Worker === (ActualBenchWorker as typeof Worker)) {
-      window.Worker = NativeWorker;
-    }
-  }
-}
-
-async function loadActualApi(): Promise<ActualBrowserApi> {
-  const actual = await import("@actual-app/api");
-  return actual as unknown as ActualBrowserApi;
 }
 
 async function shutdownRuntime(runtime: ActiveRuntime): Promise<void> {
@@ -338,7 +230,10 @@ export async function getBrowserApiRuntime(
   const promise = (async () => {
     if (previousRuntime) await shutdownRuntime(previousRuntime);
 
-    const actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
+    const actual = await withTimeout(
+      loadActualApi<ActualBrowserApi>(),
+      "Loading @actual-app/api"
+    );
     const initResult = await initializeActualApi(actual, {
       dataDir: "/documents",
       serverURL: serverUrl,

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -13,7 +13,14 @@ import type { BrowserApiConnection } from "@/store/connection";
 import type { NoteRow } from "@/lib/api/notes";
 
 export type ActualQueryBuilder = {
-  select(exprs?: unknown): unknown;
+  filter(expr: unknown): ActualQueryBuilder;
+  select(exprs?: unknown): ActualQueryBuilder;
+  calculate(expr: unknown): ActualQueryBuilder;
+  groupBy(exprs: unknown): ActualQueryBuilder;
+  orderBy(exprs: unknown): ActualQueryBuilder;
+  limit(num: number): ActualQueryBuilder;
+  offset(num: number): ActualQueryBuilder;
+  options(opts: Record<string, unknown>): ActualQueryBuilder;
 };
 
 export type ActualBrowserApi = {
@@ -26,6 +33,13 @@ export type ActualBrowserApi = {
   getBudgets(): Promise<unknown[]>;
   downloadBudget(syncId: string, options?: { password?: string }): Promise<unknown>;
   sync(): Promise<unknown>;
+  batchBudgetUpdates(func: () => Promise<void>): Promise<void>;
+  getBudgetMonths(): Promise<string[]>;
+  getBudgetMonth(month: string): Promise<unknown>;
+  setBudgetAmount(month: string, categoryId: string, value: number): Promise<void>;
+  setBudgetCarryover(month: string, categoryId: string, flag: boolean): Promise<void>;
+  holdBudgetForNextMonth(month: string, amount: number): Promise<boolean>;
+  resetBudgetHold(month: string): Promise<void>;
   getAccounts(): Promise<ApiAccount[]>;
   createAccount(account: Omit<ApiAccount, "id">, initialBalance?: number): Promise<string>;
   updateAccount(accountId: string, fields: Partial<ApiAccount>): Promise<void>;

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -1,0 +1,233 @@
+"use client";
+
+import type {
+  ApiAccount,
+  ApiCategory,
+  ApiCategoryGroup,
+  ApiPayee,
+  ApiRule,
+  ApiSchedule,
+  ApiTag,
+} from "@/types/api";
+import type { BrowserApiConnection } from "@/store/connection";
+import type { NoteRow } from "@/lib/api/notes";
+
+export type ActualQueryBuilder = {
+  select(exprs?: unknown): unknown;
+};
+
+export type ActualBrowserApi = {
+  init(config: {
+    dataDir?: string;
+    serverURL: string;
+    password: string;
+    verbose?: boolean;
+  }): Promise<unknown>;
+  getBudgets(): Promise<unknown[]>;
+  downloadBudget(syncId: string, options?: { password?: string }): Promise<unknown>;
+  sync(): Promise<unknown>;
+  getAccounts(): Promise<ApiAccount[]>;
+  getAccountBalance(accountId: string): Promise<number>;
+  getCategoryGroups(options?: { hidden?: boolean }): Promise<ApiCategoryGroup[]>;
+  getCategories(options?: { hidden?: boolean }): Promise<Array<ApiCategory | ApiCategoryGroup>>;
+  getPayees(): Promise<ApiPayee[]>;
+  getTags(): Promise<ApiTag[]>;
+  getRules(): Promise<ApiRule[]>;
+  getSchedules(): Promise<ApiSchedule[]>;
+  getNote(id: string): Promise<NoteRow | null>;
+  q?(table: string): ActualQueryBuilder;
+  runQuery?(query: unknown): Promise<unknown>;
+  aqlQuery?(query: unknown): Promise<unknown>;
+  getServerVersion?(): Promise<{ version: string } | { error: string }>;
+  shutdown(): Promise<unknown>;
+};
+
+type WorkerInitMessage = {
+  name?: unknown;
+  args?: unknown;
+};
+
+type ActiveRuntime = {
+  key: string;
+  promise: Promise<ActualBrowserApi>;
+};
+
+const DEFAULT_STEP_TIMEOUT_MS = 45_000;
+const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
+
+let activeRuntime: ActiveRuntime | null = null;
+
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function runtimeKey(connection: BrowserApiConnection): string {
+  return JSON.stringify({
+    id: connection.id,
+    baseUrl: normalizeUrl(connection.baseUrl),
+    budgetSyncId: connection.budgetSyncId,
+    serverPassword: connection.serverPassword,
+    encryptionPassword: connection.encryptionPassword ?? "",
+  });
+}
+
+function getActualAssetsBaseUrl(): string {
+  if (typeof window === "undefined") return "/actual-api-assets/";
+  return new URL("/actual-api-assets/", window.location.origin).href;
+}
+
+function isWorkerInitMessage(message: unknown): message is WorkerInitMessage {
+  return typeof message === "object" && message !== null && "name" in message;
+}
+
+function rewriteActualInitMessage(message: unknown, assetsBaseUrl: string): unknown {
+  if (!isWorkerInitMessage(message) || message.name !== "api-browser/init") {
+    return message;
+  }
+
+  const args =
+    typeof message.args === "object" && message.args !== null ? message.args : {};
+
+  return {
+    ...message,
+    args: {
+      ...args,
+      assetsBaseUrl,
+    },
+  };
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  stepLabel: string,
+  timeoutMs = DEFAULT_STEP_TIMEOUT_MS
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new Error(
+          stepLabel +
+            " did not finish within " +
+            Math.round(timeoutMs / 1000) +
+            " seconds."
+        )
+      );
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}
+
+async function initializeActualApi(
+  actual: ActualBrowserApi,
+  config: Parameters<ActualBrowserApi["init"]>[0]
+): Promise<unknown> {
+  const NativeWorker = window.Worker;
+  const assetsBaseUrl = getActualAssetsBaseUrl();
+  let redirectedBackendWorker = false;
+
+  window.Worker = class ActualBenchWorker extends NativeWorker {
+    constructor(scriptURL: string | URL, options?: WorkerOptions) {
+      const actualBackendWorkerUrl = redirectedBackendWorker
+        ? scriptURL
+        : assetsBaseUrl + "worker.js";
+
+      redirectedBackendWorker = true;
+      super(actualBackendWorkerUrl, options);
+    }
+
+    postMessage(message: unknown, transfer: Transferable[]): void;
+    postMessage(message: unknown, options?: StructuredSerializeOptions): void;
+    postMessage(
+      message: unknown,
+      options?: Transferable[] | StructuredSerializeOptions
+    ): void {
+      const rewrittenMessage = rewriteActualInitMessage(message, assetsBaseUrl);
+
+      if (options === undefined) {
+        super.postMessage(rewrittenMessage);
+      } else if (Array.isArray(options)) {
+        super.postMessage(rewrittenMessage, options);
+      } else {
+        super.postMessage(rewrittenMessage, options);
+      }
+    }
+  } as typeof Worker;
+
+  try {
+    return await actual.init(config);
+  } finally {
+    window.Worker = NativeWorker;
+  }
+}
+
+async function loadActualApi(): Promise<ActualBrowserApi> {
+  const actual = await import("@actual-app/api");
+  return actual as unknown as ActualBrowserApi;
+}
+
+async function shutdownRuntime(runtime: ActiveRuntime): Promise<void> {
+  try {
+    const actual = await runtime.promise;
+    await withTimeout(
+      actual.shutdown(),
+      "Shutting down browser API",
+      SHUTDOWN_STEP_TIMEOUT_MS
+    );
+  } catch {
+    // Best-effort cleanup only. The next initialization will surface real errors.
+  }
+}
+
+export function clearBrowserApiRuntimeCache(): void {
+  const runtime = activeRuntime;
+  activeRuntime = null;
+  if (runtime) void shutdownRuntime(runtime);
+}
+
+export async function getBrowserApiRuntime(
+  connection: BrowserApiConnection
+): Promise<ActualBrowserApi> {
+  if (typeof window === "undefined") {
+    throw new Error("Direct browser API transport can only run in the browser.");
+  }
+
+  const key = runtimeKey(connection);
+  if (activeRuntime?.key === key) return activeRuntime.promise;
+
+  const previousRuntime = activeRuntime;
+  const serverUrl = normalizeUrl(connection.baseUrl);
+  const encryptionPassword = connection.encryptionPassword?.trim() || undefined;
+
+  const promise = (async () => {
+    if (previousRuntime) await shutdownRuntime(previousRuntime);
+
+    const actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
+    await withTimeout(
+      initializeActualApi(actual, {
+        dataDir: "/documents",
+        serverURL: serverUrl,
+        password: connection.serverPassword,
+        verbose: false,
+      }),
+      "Initializing browser API worker"
+    );
+    await withTimeout(
+      actual.downloadBudget(connection.budgetSyncId, { password: encryptionPassword }),
+      "Opening budget"
+    );
+    await withTimeout(actual.sync(), "Syncing budget");
+    return actual;
+  })();
+
+  activeRuntime = { key, promise };
+  promise.catch(() => {
+    if (activeRuntime?.key === key) activeRuntime = null;
+  });
+
+  return promise;
+}

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -27,14 +27,39 @@ export type ActualBrowserApi = {
   downloadBudget(syncId: string, options?: { password?: string }): Promise<unknown>;
   sync(): Promise<unknown>;
   getAccounts(): Promise<ApiAccount[]>;
+  createAccount(account: Omit<ApiAccount, "id">, initialBalance?: number): Promise<string>;
+  updateAccount(accountId: string, fields: Partial<ApiAccount>): Promise<void>;
+  closeAccount(accountId: string): Promise<void>;
+  reopenAccount(accountId: string): Promise<void>;
+  deleteAccount(accountId: string): Promise<void>;
   getAccountBalance(accountId: string): Promise<number>;
   getCategoryGroups(options?: { hidden?: boolean }): Promise<ApiCategoryGroup[]>;
+  createCategoryGroup(group: Omit<ApiCategoryGroup, "id">): Promise<string>;
+  updateCategoryGroup(groupId: string, fields: Partial<ApiCategoryGroup>): Promise<void>;
+  deleteCategoryGroup(groupId: string): Promise<void>;
   getCategories(options?: { hidden?: boolean }): Promise<Array<ApiCategory | ApiCategoryGroup>>;
+  createCategory(category: Omit<ApiCategory, "id">): Promise<string>;
+  updateCategory(categoryId: string, fields: Partial<ApiCategory>): Promise<void>;
+  deleteCategory(categoryId: string): Promise<void>;
   getPayees(): Promise<ApiPayee[]>;
+  createPayee(payee: Omit<ApiPayee, "id">): Promise<string>;
+  updatePayee(payeeId: string, fields: Partial<ApiPayee>): Promise<void>;
+  deletePayee(payeeId: string): Promise<void>;
+  mergePayees(targetId: string, mergeIds: string[]): Promise<void>;
   getTags(): Promise<ApiTag[]>;
+  createTag(tag: Omit<ApiTag, "id">): Promise<string>;
+  updateTag(tagId: string, fields: Partial<Omit<ApiTag, "id">>): Promise<void>;
+  deleteTag(tagId: string): Promise<void>;
   getRules(): Promise<ApiRule[]>;
+  createRule(rule: Omit<ApiRule, "id">): Promise<ApiRule>;
+  updateRule(rule: ApiRule): Promise<ApiRule>;
+  deleteRule(ruleId: string): Promise<boolean>;
   getSchedules(): Promise<ApiSchedule[]>;
+  createSchedule(schedule: Omit<ApiSchedule, "id">): Promise<string>;
+  updateSchedule(scheduleId: string, fields: Partial<ApiSchedule>): Promise<string>;
+  deleteSchedule(scheduleId: string): Promise<void>;
   getNote(id: string): Promise<NoteRow | null>;
+  updateNote(id: string, note: string | null): Promise<void>;
   q?(table: string): ActualQueryBuilder;
   runQuery?(query: unknown): Promise<unknown>;
   aqlQuery?(query: unknown): Promise<unknown>;
@@ -56,6 +81,7 @@ const DEFAULT_STEP_TIMEOUT_MS = 45_000;
 const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
 
 let activeRuntime: ActiveRuntime | null = null;
+let syncQueue = Promise.resolve();
 
 function normalizeUrl(url: string): string {
   return url.trim().replace(/\/+$/, "");
@@ -130,7 +156,7 @@ async function initializeActualApi(
   const assetsBaseUrl = getActualAssetsBaseUrl();
   let redirectedBackendWorker = false;
 
-  window.Worker = class ActualBenchWorker extends NativeWorker {
+  const ActualBenchWorker = class extends NativeWorker {
     constructor(scriptURL: string | URL, options?: WorkerOptions) {
       const actualBackendWorkerUrl = redirectedBackendWorker
         ? scriptURL
@@ -156,12 +182,16 @@ async function initializeActualApi(
         super.postMessage(rewrittenMessage, options);
       }
     }
-  } as typeof Worker;
+  };
+
+  window.Worker = ActualBenchWorker as typeof Worker;
 
   try {
-    return await actual.init(config);
+    return await withTimeout(actual.init(config), "Initializing browser API worker");
   } finally {
-    window.Worker = NativeWorker;
+    if (window.Worker === (ActualBenchWorker as typeof Worker)) {
+      window.Worker = NativeWorker;
+    }
   }
 }
 
@@ -189,6 +219,17 @@ export function clearBrowserApiRuntimeCache(): void {
   if (runtime) void shutdownRuntime(runtime);
 }
 
+export async function syncBrowserApiRuntime(
+  connection: BrowserApiConnection
+): Promise<void> {
+  const nextSync = syncQueue.then(async () => {
+    const actual = await getBrowserApiRuntime(connection);
+    await withTimeout(actual.sync(), "Syncing budget");
+  });
+  syncQueue = nextSync.catch(() => undefined);
+  return nextSync;
+}
+
 export async function getBrowserApiRuntime(
   connection: BrowserApiConnection
 ): Promise<ActualBrowserApi> {
@@ -207,15 +248,12 @@ export async function getBrowserApiRuntime(
     if (previousRuntime) await shutdownRuntime(previousRuntime);
 
     const actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
-    await withTimeout(
-      initializeActualApi(actual, {
-        dataDir: "/documents",
-        serverURL: serverUrl,
-        password: connection.serverPassword,
-        verbose: false,
-      }),
-      "Initializing browser API worker"
-    );
+    await initializeActualApi(actual, {
+      dataDir: "/documents",
+      serverURL: serverUrl,
+      password: connection.serverPassword,
+      verbose: false,
+    });
     await withTimeout(
       actual.downloadBudget(connection.budgetSyncId, { password: encryptionPassword }),
       "Opening budget"

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -14,12 +14,16 @@ import type { NoteRow } from "@/lib/api/notes";
 
 export type ActualQueryBuilder = {
   filter(expr: unknown): ActualQueryBuilder;
+  unfilter(exprs?: unknown): ActualQueryBuilder;
   select(exprs?: unknown): ActualQueryBuilder;
   calculate(expr: unknown): ActualQueryBuilder;
   groupBy(exprs: unknown): ActualQueryBuilder;
   orderBy(exprs: unknown): ActualQueryBuilder;
   limit(num: number): ActualQueryBuilder;
   offset(num: number): ActualQueryBuilder;
+  raw(): ActualQueryBuilder;
+  withDead(): ActualQueryBuilder;
+  withoutValidatedRefs(): ActualQueryBuilder;
   options(opts: Record<string, unknown>): ActualQueryBuilder;
 };
 

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/types/api";
 import type { BrowserApiConnection } from "@/store/connection";
 import type { NoteRow } from "@/lib/api/notes";
+import { assertDirectBrowserApiEnvironment } from "./environment";
 
 export type ActualQueryBuilder = {
   filter(expr: unknown): ActualQueryBuilder;
@@ -316,12 +317,16 @@ export async function exportBrowserApiBudgetZip(
   return exportedZipToArrayBuffer(result.data);
 }
 
+export async function ensureBrowserApiBudgetOpen(
+  connection: BrowserApiConnection
+): Promise<void> {
+  await getBrowserApiRuntime(connection);
+}
+
 export async function getBrowserApiRuntime(
   connection: BrowserApiConnection
 ): Promise<ActualBrowserApiRuntime> {
-  if (typeof window === "undefined") {
-    throw new Error("Direct browser API transport can only run in the browser.");
-  }
+  assertDirectBrowserApiEnvironment();
 
   const key = runtimeKey(connection);
   if (activeRuntime?.key === key) return activeRuntime.promise;

--- a/src/lib/actual/browser/runtime.ts
+++ b/src/lib/actual/browser/runtime.ts
@@ -23,13 +23,23 @@ export type ActualQueryBuilder = {
   options(opts: Record<string, unknown>): ActualQueryBuilder;
 };
 
+export type ActualBrowserApiSend = <T = unknown>(
+  name: string,
+  args?: unknown,
+  options?: { catchErrors?: boolean }
+) => Promise<T>;
+
+export type ActualBrowserApiInitResult = {
+  send: ActualBrowserApiSend;
+};
+
 export type ActualBrowserApi = {
   init(config: {
     dataDir?: string;
     serverURL: string;
     password: string;
     verbose?: boolean;
-  }): Promise<unknown>;
+  }): Promise<ActualBrowserApiInitResult>;
   getBudgets(): Promise<unknown[]>;
   downloadBudget(syncId: string, options?: { password?: string }): Promise<unknown>;
   sync(): Promise<unknown>;
@@ -86,9 +96,13 @@ type WorkerInitMessage = {
   args?: unknown;
 };
 
+export type ActualBrowserApiRuntime = ActualBrowserApi & {
+  send: ActualBrowserApiSend;
+};
+
 type ActiveRuntime = {
   key: string;
-  promise: Promise<ActualBrowserApi>;
+  promise: Promise<ActualBrowserApiRuntime>;
 };
 
 const DEFAULT_STEP_TIMEOUT_MS = 45_000;
@@ -165,7 +179,7 @@ function withTimeout<T>(
 async function initializeActualApi(
   actual: ActualBrowserApi,
   config: Parameters<ActualBrowserApi["init"]>[0]
-): Promise<unknown> {
+): Promise<ActualBrowserApiInitResult> {
   const NativeWorker = window.Worker;
   const assetsBaseUrl = getActualAssetsBaseUrl();
   let redirectedBackendWorker = false;
@@ -244,9 +258,63 @@ export async function syncBrowserApiRuntime(
   return nextSync;
 }
 
+type ActualExportBudgetResult = {
+  data?: unknown;
+  error?: string;
+};
+
+function exportedZipToArrayBuffer(data: unknown): ArrayBuffer {
+  if (data instanceof ArrayBuffer) return data.slice(0);
+
+  if (ArrayBuffer.isView(data)) {
+    return data.buffer.slice(
+      data.byteOffset,
+      data.byteOffset + data.byteLength
+    ) as ArrayBuffer;
+  }
+
+  if (Array.isArray(data)) {
+    return Uint8Array.from(data).buffer as ArrayBuffer;
+  }
+
+  if (
+    data &&
+    typeof data === "object" &&
+    "type" in data &&
+    (data as { type?: unknown }).type === "Buffer" &&
+    "data" in data &&
+    Array.isArray((data as { data?: unknown }).data)
+  ) {
+    return Uint8Array.from((data as { data: number[] }).data).buffer as ArrayBuffer;
+  }
+
+  throw new Error("Direct budget export returned an unsupported byte payload.");
+}
+
+export async function exportBrowserApiBudgetZip(
+  connection: BrowserApiConnection
+): Promise<ArrayBuffer> {
+  const actual = await getBrowserApiRuntime(connection);
+  await withTimeout(actual.sync(), "Syncing budget");
+  const result = await withTimeout(
+    actual.send<ActualExportBudgetResult | null>("export-budget"),
+    "Exporting budget snapshot"
+  );
+
+  if (!result) {
+    throw new Error("Direct budget export returned no data.");
+  }
+
+  if (result.error) {
+    throw new Error("Direct budget export failed: " + result.error);
+  }
+
+  return exportedZipToArrayBuffer(result.data);
+}
+
 export async function getBrowserApiRuntime(
   connection: BrowserApiConnection
-): Promise<ActualBrowserApi> {
+): Promise<ActualBrowserApiRuntime> {
   if (typeof window === "undefined") {
     throw new Error("Direct browser API transport can only run in the browser.");
   }
@@ -262,18 +330,19 @@ export async function getBrowserApiRuntime(
     if (previousRuntime) await shutdownRuntime(previousRuntime);
 
     const actual = await withTimeout(loadActualApi(), "Loading @actual-app/api");
-    await initializeActualApi(actual, {
+    const initResult = await initializeActualApi(actual, {
       dataDir: "/documents",
       serverURL: serverUrl,
       password: connection.serverPassword,
       verbose: false,
     });
+    const runtime: ActualBrowserApiRuntime = { ...actual, send: initResult.send };
     await withTimeout(
-      actual.downloadBudget(connection.budgetSyncId, { password: encryptionPassword }),
+      runtime.downloadBudget(connection.budgetSyncId, { password: encryptionPassword }),
       "Opening budget"
     );
-    await withTimeout(actual.sync(), "Syncing budget");
-    return actual;
+    await withTimeout(runtime.sync(), "Syncing budget");
+    return runtime;
   })();
 
   activeRuntime = { key, promise };

--- a/src/lib/actual/browser/setup.test.ts
+++ b/src/lib/actual/browser/setup.test.ts
@@ -1,0 +1,139 @@
+import { initializeActualApi } from "./setup";
+
+type WorkerRecord = {
+  scriptURL: string | URL;
+  options?: WorkerOptions;
+  messages: unknown[];
+};
+
+const originalWorker = window.Worker;
+
+class MockNativeWorker {
+  static instances: WorkerRecord[] = [];
+
+  private record: WorkerRecord;
+
+  constructor(scriptURL: string | URL, options?: WorkerOptions) {
+    this.record = { scriptURL, options, messages: [] };
+    MockNativeWorker.instances.push(this.record);
+  }
+
+  postMessage(message: unknown): void {
+    this.record.messages.push(message);
+  }
+}
+
+function installMockWorker() {
+  MockNativeWorker.instances = [];
+  Object.defineProperty(window, "Worker", {
+    configurable: true,
+    writable: true,
+    value: MockNativeWorker,
+  });
+}
+
+function restoreWorker() {
+  Object.defineProperty(window, "Worker", {
+    configurable: true,
+    writable: true,
+    value: originalWorker,
+  });
+}
+
+describe("initializeActualApi", () => {
+  beforeEach(() => {
+    installMockWorker();
+  });
+
+  afterEach(() => {
+    restoreWorker();
+  });
+
+  it("redirects only Actual backend worker URLs through the asset route", async () => {
+    const unrelatedWorkerUrl = new URL("https://cdn.example.com/other-worker.js");
+    const actual = {
+      init: jest.fn(async () => {
+        const ActualWorker = window.Worker;
+        const backend = new ActualWorker(
+          new URL("https://cdn.example.com/@actual-app/api/dist/worker.js"),
+          { type: "module" }
+        );
+        const unrelated = new ActualWorker(unrelatedWorkerUrl);
+        const plainWorker = new ActualWorker(new URL("https://cdn.example.com/worker.js"));
+
+        backend.postMessage({ name: "api-browser/init", args: { config: true } });
+        unrelated.postMessage({ name: "other/init" });
+        plainWorker.postMessage({ name: "plain/init" });
+        return "ready";
+      }),
+    };
+
+    await expect(
+      initializeActualApi(actual, {
+        serverURL: "https://actual.example.com",
+        password: "password",
+      })
+    ).resolves.toBe("ready");
+
+    expect(MockNativeWorker.instances).toHaveLength(3);
+    expect(String(MockNativeWorker.instances[0].scriptURL)).toBe(
+      "http://localhost/actual-api-assets/worker.js"
+    );
+    expect(MockNativeWorker.instances[0].options).toEqual({ type: "module" });
+    expect(MockNativeWorker.instances[0].messages[0]).toEqual({
+      name: "api-browser/init",
+      args: {
+        config: true,
+        assetsBaseUrl: "http://localhost/actual-api-assets/",
+      },
+    });
+    expect(MockNativeWorker.instances[1].scriptURL).toBe(unrelatedWorkerUrl);
+    expect(MockNativeWorker.instances[1].messages[0]).toEqual({ name: "other/init" });
+    expect(String(MockNativeWorker.instances[2].scriptURL)).toBe(
+      "https://cdn.example.com/worker.js"
+    );
+    expect(MockNativeWorker.instances[2].messages[0]).toEqual({ name: "plain/init" });
+    expect(window.Worker).toBe(MockNativeWorker);
+  });
+
+  it("serializes overlapping init calls so Worker restore order stays stable", async () => {
+    const events: string[] = [];
+    let finishFirst!: () => void;
+
+    const first = {
+      init: jest.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            events.push("first-start");
+            finishFirst = () => resolve("first-ready");
+          })
+      ),
+    };
+    const second = {
+      init: jest.fn(async () => {
+        events.push("second-start");
+        return "second-ready";
+      }),
+    };
+
+    const firstResult = initializeActualApi(first, {
+      serverURL: "https://actual.example.com",
+      password: "password",
+    });
+    const secondResult = initializeActualApi(second, {
+      serverURL: "https://actual.example.com",
+      password: "password",
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(["first-start"]);
+    expect(second.init).not.toHaveBeenCalled();
+
+    finishFirst();
+
+    await expect(firstResult).resolves.toBe("first-ready");
+    await expect(secondResult).resolves.toBe("second-ready");
+    expect(events).toEqual(["first-start", "second-start"]);
+    expect(window.Worker).toBe(MockNativeWorker);
+  });
+});

--- a/src/lib/actual/browser/setup.ts
+++ b/src/lib/actual/browser/setup.ts
@@ -1,0 +1,133 @@
+"use client";
+
+type ActualInitConfig = {
+  dataDir?: string;
+  serverURL: string;
+  password: string;
+  verbose?: boolean;
+};
+
+type ActualInitCapable = {
+  init(config: ActualInitConfig): Promise<unknown>;
+};
+
+type WorkerInitMessage = {
+  name?: unknown;
+  args?: unknown;
+};
+
+export const DEFAULT_STEP_TIMEOUT_MS = 45_000;
+export const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
+
+export function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  stepLabel: string,
+  timeoutMs = DEFAULT_STEP_TIMEOUT_MS
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(
+        new Error(
+          stepLabel +
+            " did not finish within " +
+            Math.round(timeoutMs / 1000) +
+            " seconds."
+        )
+      );
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId) clearTimeout(timeoutId);
+  });
+}
+
+function getActualAssetsBaseUrl(): string {
+  if (typeof window === "undefined") return "/actual-api-assets/";
+  return new URL("/actual-api-assets/", window.location.origin).href;
+}
+
+function isWorkerInitMessage(message: unknown): message is WorkerInitMessage {
+  return typeof message === "object" && message !== null && "name" in message;
+}
+
+function rewriteActualInitMessage(message: unknown, assetsBaseUrl: string): unknown {
+  if (!isWorkerInitMessage(message) || message.name !== "api-browser/init") {
+    return message;
+  }
+
+  const args =
+    typeof message.args === "object" && message.args !== null ? message.args : {};
+
+  return {
+    ...message,
+    args: {
+      ...args,
+      assetsBaseUrl,
+    },
+  };
+}
+
+export async function initializeActualApi<TActual extends ActualInitCapable>(
+  actual: TActual,
+  config: ActualInitConfig
+): Promise<Awaited<ReturnType<TActual["init"]>>> {
+  const NativeWorker = window.Worker;
+  const assetsBaseUrl = getActualAssetsBaseUrl();
+  let redirectedBackendWorker = false;
+
+  const ActualBenchWorker = class extends NativeWorker {
+    constructor(scriptURL: string | URL, options?: WorkerOptions) {
+      const actualBackendWorkerUrl = redirectedBackendWorker
+        ? scriptURL
+        : assetsBaseUrl + "worker.js";
+
+      redirectedBackendWorker = true;
+      super(actualBackendWorkerUrl, options);
+    }
+
+    postMessage(message: unknown, transfer: Transferable[]): void;
+    postMessage(message: unknown, options?: StructuredSerializeOptions): void;
+    postMessage(
+      message: unknown,
+      options?: Transferable[] | StructuredSerializeOptions
+    ): void {
+      const rewrittenMessage = rewriteActualInitMessage(message, assetsBaseUrl);
+
+      if (options === undefined) {
+        super.postMessage(rewrittenMessage);
+      } else if (Array.isArray(options)) {
+        super.postMessage(rewrittenMessage, options);
+      } else {
+        super.postMessage(rewrittenMessage, options);
+      }
+    }
+  };
+
+  // Next/Turbopack cannot load the first Actual backend worker directly from
+  // node_modules, so this temporary shim redirects it to our asset route. The
+  // native Worker constructor is restored in the finally block below.
+  window.Worker = ActualBenchWorker as typeof Worker;
+
+  try {
+    return (await withTimeout(
+      actual.init(config),
+      "Initializing browser API worker"
+    )) as Awaited<ReturnType<TActual["init"]>>;
+  } finally {
+    if (window.Worker === (ActualBenchWorker as typeof Worker)) {
+      window.Worker = NativeWorker;
+    }
+  }
+}
+
+export async function loadActualApi<TActual>(): Promise<TActual> {
+  const actual = await import("@actual-app/api");
+  return actual as unknown as TActual;
+}

--- a/src/lib/actual/browser/setup.ts
+++ b/src/lib/actual/browser/setup.ts
@@ -16,6 +16,8 @@ type WorkerInitMessage = {
   args?: unknown;
 };
 
+let initializeActualApiTail: Promise<unknown> = Promise.resolve();
+
 export const DEFAULT_STEP_TIMEOUT_MS = 45_000;
 export const SHUTDOWN_STEP_TIMEOUT_MS = 15_000;
 
@@ -74,22 +76,41 @@ function rewriteActualInitMessage(message: unknown, assetsBaseUrl: string): unkn
   };
 }
 
-export async function initializeActualApi<TActual extends ActualInitCapable>(
+function isActualBackendWorkerUrl(
+  scriptURL: string | URL,
+  options?: WorkerOptions
+): boolean {
+  return (
+    scriptURL instanceof URL &&
+    options?.type === "module" &&
+    scriptURL.pathname.endsWith("/worker.js")
+  );
+}
+
+export function initializeActualApi<TActual extends ActualInitCapable>(
+  actual: TActual,
+  config: ActualInitConfig
+): Promise<Awaited<ReturnType<TActual["init"]>>> {
+  const run = () => initializeActualApiWithWorkerShim(actual, config);
+  const result = initializeActualApiTail.then(run, run);
+  initializeActualApiTail = result.catch(() => undefined);
+  return result;
+}
+
+async function initializeActualApiWithWorkerShim<TActual extends ActualInitCapable>(
   actual: TActual,
   config: ActualInitConfig
 ): Promise<Awaited<ReturnType<TActual["init"]>>> {
   const NativeWorker = window.Worker;
   const assetsBaseUrl = getActualAssetsBaseUrl();
-  let redirectedBackendWorker = false;
-
   const ActualBenchWorker = class extends NativeWorker {
     constructor(scriptURL: string | URL, options?: WorkerOptions) {
-      const actualBackendWorkerUrl = redirectedBackendWorker
-        ? scriptURL
-        : assetsBaseUrl + "worker.js";
-
-      redirectedBackendWorker = true;
-      super(actualBackendWorkerUrl, options);
+      super(
+        isActualBackendWorkerUrl(scriptURL, options)
+          ? assetsBaseUrl + "worker.js"
+          : scriptURL,
+        options
+      );
     }
 
     postMessage(message: unknown, transfer: Transferable[]): void;
@@ -110,8 +131,9 @@ export async function initializeActualApi<TActual extends ActualInitCapable>(
     }
   };
 
-  // Next/Turbopack cannot load the first Actual backend worker directly from
-  // node_modules, so this temporary shim redirects it to our asset route. The
+  // Next/Turbopack cannot load Actual's backend worker directly from
+  // node_modules, so this temporary shim redirects that worker URL to our asset
+  // route. Other Worker URLs pass through to the native constructor, and the
   // native Worker constructor is restored in the finally block below.
   window.Worker = ActualBenchWorker as typeof Worker;
 

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -1,13 +1,278 @@
+import { normalizeAccount } from "../api/accounts";
+import {
+  normalizeCategory,
+  normalizeCategoryGroup,
+  type CategoryGroupsResponse,
+} from "../api/categoryGroups";
+import {
+  extractNote,
+  parseNotesIndexIds,
+  toAccountNoteId,
+  type NoteRow,
+} from "../api/notes";
+import { normalizePayee } from "../api/payees";
+import { normalizeRule } from "../api/rules";
+import { normalizeSchedule } from "../api/schedules";
+import { normalizeTag } from "../api/tags";
 import type { BrowserApiConnection } from "@/store/connection";
+import type {
+  ApiAccount,
+  ApiCategory,
+  ApiCategoryGroup,
+  ApiPayee,
+  ApiRule,
+  ApiSchedule,
+  ApiTag,
+} from "@/types/api";
+import type { Account, Payee, Rule, Schedule, Tag } from "@/types/entities";
+import { getBrowserApiRuntime, type ActualBrowserApi } from "./browser/runtime";
 import type { ActualBenchTransport } from "./transport";
-import { unsupportedTransportOperation } from "./transport";
+
+type RecordLike = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordLike {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function normalizeDirectAccount(raw: unknown): Account | null {
+  if (!isRecord(raw)) return null;
+  const id = asString(raw.id);
+  const name = asString(raw.name);
+  if (!id || !name) return null;
+
+  return normalizeAccount({
+    id,
+    name,
+    offbudget: asBoolean(raw.offbudget),
+    closed: asBoolean(raw.closed),
+  } satisfies ApiAccount);
+}
+
+function normalizeDirectPayee(raw: unknown): Payee | null {
+  if (!isRecord(raw)) return null;
+  const id = asString(raw.id);
+  const name = asString(raw.name);
+  if (!id || !name) return null;
+
+  return normalizePayee({
+    id,
+    name,
+    category: asString(raw.category),
+    transfer_acct: asString(raw.transfer_acct),
+  } satisfies ApiPayee);
+}
+
+function normalizeDirectTag(raw: unknown): Tag | null {
+  if (!isRecord(raw)) return null;
+  const id = asString(raw.id);
+  const tag = asString(raw.tag) ?? asString(raw.name);
+  if (!id || !tag) return null;
+
+  return normalizeTag({
+    id,
+    tag,
+    color: asString(raw.color) ?? null,
+    description: asString(raw.description) ?? null,
+  } satisfies ApiTag);
+}
+
+function normalizeDirectRule(raw: unknown): Rule | null {
+  if (!isRecord(raw) || !asString(raw.id)) return null;
+  return normalizeRule(raw as ApiRule);
+}
+
+function normalizeDirectSchedule(raw: unknown): Schedule | null {
+  if (!isRecord(raw) || !asString(raw.id)) return null;
+  return normalizeSchedule(raw as ApiSchedule);
+}
+
+function toDirectCategory(raw: unknown, fallbackGroupId?: string): ApiCategory | null {
+  if (!isRecord(raw)) return null;
+  const id = asString(raw.id);
+  const name = asString(raw.name);
+  const groupId = asString(raw.group_id) ?? asString(raw.group) ?? fallbackGroupId;
+  if (!id || !name || !groupId) return null;
+
+  return {
+    id,
+    name,
+    group_id: groupId,
+    is_income: asBoolean(raw.is_income),
+    hidden: asBoolean(raw.hidden),
+  } satisfies ApiCategory;
+}
+
+function toDirectCategoryGroup(raw: unknown): ApiCategoryGroup | null {
+  if (!isRecord(raw)) return null;
+  const id = asString(raw.id);
+  const name = asString(raw.name);
+  if (!id || !name) return null;
+
+  const categories = Array.isArray(raw.categories)
+    ? raw.categories
+        .map((category) => toDirectCategory(category, id))
+        .filter((category): category is ApiCategory => category !== null)
+    : undefined;
+
+  return {
+    id,
+    name,
+    is_income: asBoolean(raw.is_income),
+    hidden: asBoolean(raw.hidden),
+    ...(categories ? { categories } : {}),
+  } satisfies ApiCategoryGroup;
+}
+
+function responseRows<T>(response: unknown): T[] {
+  if (Array.isArray(response)) return response as T[];
+  if (isRecord(response) && Array.isArray(response.data)) return response.data as T[];
+  return [];
+}
+
+function buildActualQuery(
+  api: ActualBrowserApi,
+  table: string,
+  select: "*" | string
+): unknown {
+  if (typeof api.q === "function") {
+    return api.q(table).select(select);
+  }
+
+  return { table, select };
+}
+
+async function getBrowserAccounts(
+  connection: BrowserApiConnection
+): Promise<Account[]> {
+  const api = await getBrowserApiRuntime(connection);
+  return (await api.getAccounts())
+    .map(normalizeDirectAccount)
+    .filter((account): account is Account => account !== null);
+}
+
+async function getBrowserAccountBalances(
+  connection: BrowserApiConnection
+): Promise<Map<string, number>> {
+  const api = await getBrowserApiRuntime(connection);
+  const accounts = await getBrowserAccounts(connection);
+  const entries = await Promise.all(
+    accounts.map(async (account) => {
+      const balance = await api.getAccountBalance(account.id);
+      return [account.id, balance / 100] as const;
+    })
+  );
+
+  return new Map(entries);
+}
+
+async function getBrowserCategoryGroups(
+  connection: BrowserApiConnection
+): Promise<CategoryGroupsResponse> {
+  const api = await getBrowserApiRuntime(connection);
+  const groupRows = (await api.getCategoryGroups())
+    .map(toDirectCategoryGroup)
+    .filter((group): group is ApiCategoryGroup => group !== null);
+
+  let categoryRows = groupRows.flatMap((group) => group.categories ?? []);
+  const hasGroupsWithoutNestedCategories = groupRows.some(
+    (group) => (group.categories?.length ?? 0) === 0
+  );
+
+  if (hasGroupsWithoutNestedCategories) {
+    const categoriesFromApi = (await api.getCategories().catch(() => []))
+      .map((category) => toDirectCategory(category))
+      .filter((category): category is ApiCategory => category !== null);
+    if (categoriesFromApi.length > 0) categoryRows = categoriesFromApi;
+  }
+
+  const groups = groupRows.map((group) => {
+    const categoriesForGroup = categoryRows.filter(
+      (category) => category.group_id === group.id
+    );
+    return normalizeCategoryGroup({ ...group, categories: categoriesForGroup });
+  });
+  const categories = categoryRows.map((category) =>
+    normalizeCategory(category, category.group_id)
+  );
+
+  return { groups, categories };
+}
+
+async function getBrowserAllNotes(
+  connection: BrowserApiConnection
+): Promise<Map<string, string>> {
+  const api = await getBrowserApiRuntime(connection);
+  const query = buildActualQuery(api, "notes", "*");
+  const runner = api.aqlQuery ?? api.runQuery;
+  const rows = runner
+    ? responseRows<NoteRow>(await runner(query).catch(() => []))
+    : [];
+
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    if (row.id && row.note) map.set(row.id, row.note);
+  }
+  return map;
+}
 
 export function createBrowserApiTransport(
   connection: BrowserApiConnection
 ): ActualBenchTransport {
   return {
     mode: connection.mode,
-    getAccounts: () =>
-      Promise.reject(unsupportedTransportOperation(connection.mode, "getAccounts")),
+    getServerVersion: async () => {
+      const api = await getBrowserApiRuntime(connection);
+      if (typeof api.getServerVersion !== "function") return null;
+      const result = await api.getServerVersion().catch(() => null);
+      return result && "version" in result ? result.version : null;
+    },
+    getAccounts: () => getBrowserAccounts(connection),
+    getAccountBalances: () => getBrowserAccountBalances(connection),
+    getPayees: async () => {
+      const api = await getBrowserApiRuntime(connection);
+      return (await api.getPayees())
+        .map(normalizeDirectPayee)
+        .filter((payee): payee is Payee => payee !== null);
+    },
+    getCategoryGroups: () => getBrowserCategoryGroups(connection),
+    getTags: async () => {
+      const api = await getBrowserApiRuntime(connection);
+      return (await api.getTags())
+        .map(normalizeDirectTag)
+        .filter((tag): tag is Tag => tag !== null);
+    },
+    getRules: async () => {
+      const api = await getBrowserApiRuntime(connection);
+      return (await api.getRules())
+        .map(normalizeDirectRule)
+        .filter((rule): rule is Rule => rule !== null);
+    },
+    getSchedules: async () => {
+      const api = await getBrowserApiRuntime(connection);
+      return (await api.getSchedules())
+        .map(normalizeDirectSchedule)
+        .filter((schedule): schedule is Schedule => schedule !== null);
+    },
+    getNotesIndex: async () => {
+      const notes = await getBrowserAllNotes(connection);
+      return parseNotesIndexIds([...notes.keys()]);
+    },
+    getAccountNote: async (accountId) => {
+      const api = await getBrowserApiRuntime(connection);
+      return extractNote(await api.getNote(toAccountNoteId(accountId)));
+    },
+    getAllNotes: () => getBrowserAllNotes(connection),
+    getCategoryLikeNote: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      return extractNote(await api.getNote(id));
+    },
   };
 }

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -36,6 +36,7 @@ import {
   getBrowserApiRuntime,
   syncBrowserApiRuntime,
   type ActualBrowserApi,
+  type ActualQueryBuilder,
 } from "./browser/runtime";
 import { prepareRuleForTransport, prepareRulePatchForTransport } from "./ruleMutation";
 import { unsupportedTransportOperation, type ActualBenchTransport, type ScheduleWriteInput, type TransportBudgetMonth } from "./transport";
@@ -156,9 +157,92 @@ function assertRecord(value: unknown, label: string): RecordLike {
   return value;
 }
 
-function getWrappedActualQuery(body: object): RecordLike {
-  const wrapped = assertRecord(body, "the query body");
-  return assertRecord(wrapped.ActualQLquery, "ActualQLquery");
+function getActualQueryInput(body: object): RecordLike {
+  const parsed = assertRecord(body, "the query body");
+  if ("ActualQLquery" in parsed) {
+    return assertRecord(parsed.ActualQLquery, "ActualQLquery");
+  }
+  if ("table" in parsed) return parsed;
+
+  throw new Error(
+    'Direct browser API query adapter requires a query object with "table" or an "ActualQLquery" wrapper.'
+  );
+}
+
+function assertQueryBuilderMethod(
+  query: ActualQueryBuilder,
+  method: keyof ActualQueryBuilder
+): void {
+  if (typeof query[method] !== "function") {
+    throw new Error(
+      "Direct browser API query adapter cannot apply ActualQL field because the installed Actual API query builder does not expose " +
+        method +
+        "()."
+    );
+  }
+}
+
+function toRepeatedValues(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function applyRepeatedBuilderMethod(
+  query: ActualQueryBuilder,
+  method: "filter" | "groupBy" | "orderBy",
+  value: unknown
+): ActualQueryBuilder {
+  if (value === undefined) return query;
+
+  assertQueryBuilderMethod(query, method);
+  let nextQuery = query;
+  for (const item of toRepeatedValues(value)) {
+    if (method === "filter") {
+      nextQuery = nextQuery.filter(assertRecord(item, "ActualQLquery.filter item"));
+    } else {
+      nextQuery = nextQuery[method](item);
+    }
+  }
+  return nextQuery;
+}
+
+function getSafeInteger(value: unknown, field: "limit" | "offset"): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < 0
+  ) {
+    throw new Error(
+      "Direct browser API query adapter requires ActualQLquery." +
+        field +
+        " to be a non-negative safe integer."
+    );
+  }
+  return value;
+}
+
+function getBooleanFlag(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(
+      "Direct browser API query adapter requires ActualQLquery." +
+        field +
+        " to be a boolean when provided."
+    );
+  }
+  return value;
+}
+
+function getUnfilterValue(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return [value];
+  if (
+    Array.isArray(value) &&
+    value.every((item): item is string => typeof item === "string")
+  ) {
+    return value;
+  }
+  throw new Error(
+    "Direct browser API query adapter requires ActualQLquery.unfilter to be a string or string array."
+  );
 }
 
 function createBrowserQuery(api: ActualBrowserApi, body: object): unknown {
@@ -166,7 +250,7 @@ function createBrowserQuery(api: ActualBrowserApi, body: object): unknown {
     throw unsupportedTransportOperation("browser-api", "ActualQL queries");
   }
 
-  const query = getWrappedActualQuery(body);
+  const query = getActualQueryInput(body);
   const supportedKeys = new Set([
     "table",
     "options",
@@ -177,6 +261,10 @@ function createBrowserQuery(api: ActualBrowserApi, body: object): unknown {
     "orderBy",
     "limit",
     "offset",
+    "unfilter",
+    "raw",
+    "withDead",
+    "withoutValidatedRefs",
   ]);
   for (const key of Object.keys(query)) {
     if (!supportedKeys.has(key)) {
@@ -195,9 +283,7 @@ function createBrowserQuery(api: ActualBrowserApi, body: object): unknown {
   if (query.options !== undefined) {
     browserQuery = browserQuery.options(assertRecord(query.options, "ActualQLquery.options"));
   }
-  if (query.filter !== undefined) {
-    browserQuery = browserQuery.filter(assertRecord(query.filter, "ActualQLquery.filter"));
-  }
+  browserQuery = applyRepeatedBuilderMethod(browserQuery, "filter", query.filter);
   if (query.calculate !== undefined) {
     if (query.select !== undefined) {
       throw new Error(
@@ -208,24 +294,56 @@ function createBrowserQuery(api: ActualBrowserApi, body: object): unknown {
   } else if (query.select !== undefined) {
     browserQuery = browserQuery.select(query.select);
   }
-  if (query.groupBy !== undefined) browserQuery = browserQuery.groupBy(query.groupBy);
-  if (query.orderBy !== undefined) browserQuery = browserQuery.orderBy(query.orderBy);
+  browserQuery = applyRepeatedBuilderMethod(browserQuery, "groupBy", query.groupBy);
+  browserQuery = applyRepeatedBuilderMethod(browserQuery, "orderBy", query.orderBy);
   if (query.limit !== undefined) {
-    const limit = query.limit;
-    if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 0) {
-      throw new Error("Direct browser API query adapter requires a non-negative integer limit.");
-    }
-    browserQuery = browserQuery.limit(limit);
+    browserQuery = browserQuery.limit(getSafeInteger(query.limit, "limit"));
   }
   if (query.offset !== undefined) {
-    const offset = query.offset;
-    if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) {
-      throw new Error("Direct browser API query adapter requires a non-negative integer offset.");
-    }
-    browserQuery = browserQuery.offset(offset);
+    browserQuery = browserQuery.offset(getSafeInteger(query.offset, "offset"));
+  }
+
+  const unfilter = getUnfilterValue(query.unfilter);
+  if (unfilter !== undefined) {
+    assertQueryBuilderMethod(browserQuery, "unfilter");
+    browserQuery = browserQuery.unfilter(unfilter);
+  }
+
+  // Do not inject Direct-only default limits here. The workspace already warns
+  // about risky unbounded reads, and silently changing Direct semantics would
+  // make the same saved query return different data by connection mode.
+  if (query.raw !== undefined && getBooleanFlag(query.raw, "raw")) {
+    assertQueryBuilderMethod(browserQuery, "raw");
+    browserQuery = browserQuery.raw();
+  }
+  if (query.withDead !== undefined && getBooleanFlag(query.withDead, "withDead")) {
+    assertQueryBuilderMethod(browserQuery, "withDead");
+    browserQuery = browserQuery.withDead();
+  }
+  if (
+    query.withoutValidatedRefs !== undefined &&
+    getBooleanFlag(query.withoutValidatedRefs, "withoutValidatedRefs")
+  ) {
+    assertQueryBuilderMethod(browserQuery, "withoutValidatedRefs");
+    browserQuery = browserQuery.withoutValidatedRefs();
   }
 
   return browserQuery;
+}
+
+function getErrorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (isRecord(value) && typeof value.message === "string") return value.message;
+  return String(value || "Direct ActualQL query failed.");
+}
+
+function cleanBrowserQueryError(value: unknown): Error {
+  const firstLine = getErrorMessage(value).split("\n")[0]?.trim();
+  return new Error(
+    firstLine
+      ? "Direct ActualQL query failed: " + firstLine
+      : "Direct ActualQL query failed."
+  );
 }
 
 async function runBrowserQuery<T>(
@@ -233,9 +351,15 @@ async function runBrowserQuery<T>(
   body: object
 ): Promise<T> {
   const api = await getBrowserApiRuntime(connection);
-  const runner = api.aqlQuery ?? api.runQuery;
+  const runner = api.aqlQuery?.bind(api) ?? api.runQuery?.bind(api);
   if (!runner) throw unsupportedTransportOperation("browser-api", "ActualQL queries");
-  return (await runner(createBrowserQuery(api, body))) as T;
+
+  const query = createBrowserQuery(api, body);
+  try {
+    return (await runner(query)) as T;
+  } catch (err) {
+    throw cleanBrowserQueryError(err);
+  }
 }
 
 function toBudgetAmount(amount: number): number {

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -42,6 +42,7 @@ import { prepareRuleForTransport, prepareRulePatchForTransport } from "./ruleMut
 import { unsupportedTransportOperation, type ActualBenchTransport, type ScheduleWriteInput, type TransportBudgetMonth } from "./transport";
 
 type RecordLike = Record<string, unknown>;
+type ApiCategoryGroupWithId = ApiCategoryGroup & { id: string };
 
 function isRecord(value: unknown): value is RecordLike {
   return typeof value === "object" && value !== null;
@@ -461,17 +462,35 @@ async function getBrowserAccounts(
     .filter((account): account is Account => account !== null);
 }
 
+async function mapWithConcurrency<TInput, TResult>(
+  inputs: TInput[],
+  limit: number,
+  mapper: (input: TInput) => Promise<TResult>
+): Promise<TResult[]> {
+  const results = new Array<TResult>(inputs.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < inputs.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(inputs[index]);
+    }
+  }
+
+  const workerCount = Math.min(limit, inputs.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 async function getBrowserAccountBalances(
   connection: BrowserApiConnection
 ): Promise<Map<string, number>> {
   const api = await getBrowserApiRuntime(connection);
   const accounts = await getBrowserAccounts(connection);
-  const entries = await Promise.all(
-    accounts.map(async (account) => {
-      const balance = await api.getAccountBalance(account.id);
-      return [account.id, balance / 100] as const;
-    })
-  );
+  const entries = await mapWithConcurrency(accounts, 6, async (account) => {
+    const balance = await api.getAccountBalance(account.id);
+    return [account.id, balance / 100] as const;
+  });
 
   return new Map(entries);
 }
@@ -482,7 +501,10 @@ async function getBrowserCategoryGroups(
   const api = await getBrowserApiRuntime(connection);
   const groupRows = (await api.getCategoryGroups())
     .map(toDirectCategoryGroup)
-    .filter((group): group is ApiCategoryGroup => group !== null);
+    .filter(
+      (group): group is ApiCategoryGroupWithId =>
+        group !== null && typeof group.id === "string"
+    );
 
   let categoryRows = groupRows.flatMap((group) => group.categories ?? []);
   const hasGroupsWithoutNestedCategories = groupRows.some(
@@ -496,15 +518,27 @@ async function getBrowserCategoryGroups(
     if (categoriesFromApi.length > 0) categoryRows = categoriesFromApi;
   }
 
-  const groups = groupRows.map((group) => {
-    const categoriesForGroup = categoryRows.filter(
-      (category) => category.group_id === group.id
-    );
-    return normalizeCategoryGroup({ ...group, categories: categoriesForGroup });
-  });
-  const categories = categoryRows.map((category) =>
-    normalizeCategory(category, category.group_id)
+  const categoriesByGroupId = new Map<string, ApiCategory[]>();
+  for (const category of categoryRows) {
+    const groupCategories = categoriesByGroupId.get(category.group_id);
+    if (groupCategories) {
+      groupCategories.push(category);
+    } else {
+      categoriesByGroupId.set(category.group_id, [category]);
+    }
+  }
+
+  const groups = groupRows.map((group) =>
+    normalizeCategoryGroup({
+      ...group,
+      categories: categoriesByGroupId.get(group.id) ?? [],
+    })
   );
+  const categories = categoryRows
+    .filter((category): category is ApiCategory & { group_id: string } =>
+      typeof category.group_id === "string"
+    )
+    .map((category) => normalizeCategory(category, category.group_id));
 
   return { groups, categories };
 }
@@ -514,7 +548,7 @@ async function getBrowserAllNotes(
 ): Promise<Map<string, string>> {
   const api = await getBrowserApiRuntime(connection);
   const query = buildActualQuery(api, "notes", "*");
-  const runner = api.aqlQuery ?? api.runQuery;
+  const runner = api.aqlQuery?.bind(api) ?? api.runQuery?.bind(api);
   const rows = runner
     ? responseRows<NoteRow>(await runner(query).catch(() => []))
     : [];

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -8,6 +8,7 @@ import {
   extractNote,
   parseNotesIndexIds,
   toAccountNoteId,
+  toBudgetNoteId,
   type NoteRow,
 } from "../api/notes";
 import { normalizePayee } from "../api/payees";
@@ -24,9 +25,20 @@ import type {
   ApiSchedule,
   ApiTag,
 } from "@/types/api";
-import type { Account, Payee, Rule, Schedule, Tag } from "@/types/entities";
-import { getBrowserApiRuntime, type ActualBrowserApi } from "./browser/runtime";
-import type { ActualBenchTransport } from "./transport";
+import type {
+  Account,
+  Payee,
+  Rule,
+  Schedule,
+  Tag,
+} from "@/types/entities";
+import {
+  getBrowserApiRuntime,
+  syncBrowserApiRuntime,
+  type ActualBrowserApi,
+} from "./browser/runtime";
+import { prepareRuleForTransport, prepareRulePatchForTransport } from "./ruleMutation";
+import type { ActualBenchTransport, ScheduleWriteInput } from "./transport";
 
 type RecordLike = Record<string, unknown>;
 
@@ -149,6 +161,48 @@ function buildActualQuery(
   return { table, select };
 }
 
+function denormalizeSchedule(input: ScheduleWriteInput): Omit<ApiSchedule, "id"> {
+  if (input.date == null) throw new Error("Schedule date is required but was missing");
+
+  const schedule: Omit<ApiSchedule, "id"> = {
+    date: input.date,
+    posts_transaction: input.postsTransaction,
+    payee: input.payeeId ?? null,
+    account: input.accountId ?? null,
+  };
+  if (input.name !== undefined) schedule.name = input.name;
+  if (input.amount !== undefined) schedule.amount = input.amount;
+  if (input.amountOp !== undefined) schedule.amountOp = input.amountOp;
+  return schedule;
+}
+
+type BrowserRuleStage = "pre" | "post" | null;
+type BrowserRule = Omit<ApiRule, "stage"> & { stage: BrowserRuleStage };
+
+function toBrowserRuleStage(stage: Rule["stage"]): BrowserRuleStage {
+  return stage === "default" ? null : stage;
+}
+
+function denormalizeRuleForBrowser(input: Omit<Rule, "id">): Omit<BrowserRule, "id"> {
+  const rule = prepareRuleForTransport(input);
+  return {
+    ...rule,
+    stage: toBrowserRuleStage(rule.stage),
+  } as unknown as Omit<BrowserRule, "id">;
+}
+
+function denormalizeRulePatchForBrowser(
+  id: string,
+  patch: Partial<Omit<Rule, "id">>
+): BrowserRule {
+  const rule = prepareRulePatchForTransport(patch);
+  return {
+    id,
+    ...rule,
+    ...(rule.stage !== undefined ? { stage: toBrowserRuleStage(rule.stage) } : {}),
+  } as unknown as BrowserRule;
+}
+
 async function getBrowserAccounts(
   connection: BrowserApiConnection
 ): Promise<Account[]> {
@@ -228,6 +282,7 @@ export function createBrowserApiTransport(
 ): ActualBenchTransport {
   return {
     mode: connection.mode,
+    sync: () => syncBrowserApiRuntime(connection),
     getServerVersion: async () => {
       const api = await getBrowserApiRuntime(connection);
       if (typeof api.getServerVersion !== "function") return null;
@@ -236,31 +291,175 @@ export function createBrowserApiTransport(
     },
     getAccounts: () => getBrowserAccounts(connection),
     getAccountBalances: () => getBrowserAccountBalances(connection),
+    createAccount: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      const id = await api.createAccount(
+        {
+          name: input.name,
+          offbudget: input.offBudget,
+          closed: false,
+        },
+        input.initialBalance !== undefined
+          ? Math.round(input.initialBalance * 100)
+          : undefined
+      );
+      if (input.closed) await api.closeAccount(id);
+      return { id, ...input };
+    },
+    updateAccount: async (id, patch) => {
+      const api = await getBrowserApiRuntime(connection);
+      const fields: Partial<ApiAccount> = {};
+      if (patch.name !== undefined) fields.name = patch.name;
+      if (patch.offBudget !== undefined) fields.offbudget = patch.offBudget;
+      if (Object.keys(fields).length > 0) await api.updateAccount(id, fields);
+      if (patch.closed === true) await api.closeAccount(id);
+      if (patch.closed === false) await api.reopenAccount(id);
+    },
+    deleteAccount: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deleteAccount(id);
+    },
+
     getPayees: async () => {
       const api = await getBrowserApiRuntime(connection);
       return (await api.getPayees())
         .map(normalizeDirectPayee)
         .filter((payee): payee is Payee => payee !== null);
     },
+    createPayee: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      const id = await api.createPayee({ name: input.name });
+      return { id, name: input.name };
+    },
+    updatePayee: async (id, patch) => {
+      const api = await getBrowserApiRuntime(connection);
+      const fields: Partial<ApiPayee> = {};
+      if (patch.name !== undefined) fields.name = patch.name;
+      await api.updatePayee(id, fields);
+    },
+    deletePayee: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deletePayee(id);
+    },
+    mergePayees: async (targetId, mergeIds) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.mergePayees(targetId, mergeIds);
+    },
+
     getCategoryGroups: () => getBrowserCategoryGroups(connection),
+    createCategoryGroup: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      return api.createCategoryGroup({
+        name: input.name,
+        is_income: input.isIncome,
+        hidden: input.hidden,
+      });
+    },
+    updateCategoryGroup: async (id, patch) => {
+      const api = await getBrowserApiRuntime(connection);
+      const fields: Partial<ApiCategoryGroup> = {};
+      if (patch.name !== undefined) fields.name = patch.name;
+      if (patch.hidden !== undefined) fields.hidden = patch.hidden;
+      await api.updateCategoryGroup(id, fields);
+    },
+    deleteCategoryGroup: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deleteCategoryGroup(id);
+    },
+    createCategory: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      return api.createCategory({
+        name: input.name,
+        group_id: input.groupId,
+        is_income: input.isIncome,
+        hidden: input.hidden,
+      });
+    },
+    updateCategory: async (id, patch) => {
+      const api = await getBrowserApiRuntime(connection);
+      const fields: Partial<ApiCategory> = {};
+      if (patch.name !== undefined) fields.name = patch.name;
+      if (patch.hidden !== undefined) fields.hidden = patch.hidden;
+      await api.updateCategory(id, fields);
+    },
+    deleteCategory: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deleteCategory(id);
+    },
+
     getTags: async () => {
       const api = await getBrowserApiRuntime(connection);
       return (await api.getTags())
         .map(normalizeDirectTag)
         .filter((tag): tag is Tag => tag !== null);
     },
+    createTag: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      const id = await api.createTag({
+        tag: input.name,
+        color: input.color ?? null,
+        description: input.description ?? null,
+      });
+      return { id, name: input.name, color: input.color, description: input.description };
+    },
+    updateTag: async (id, patch) => {
+      const api = await getBrowserApiRuntime(connection);
+      const fields: Partial<Omit<ApiTag, "id">> = {};
+      if (patch.name !== undefined) fields.tag = patch.name;
+      if ("color" in patch) fields.color = patch.color ?? null;
+      if ("description" in patch) fields.description = patch.description ?? null;
+      await api.updateTag(id, fields);
+    },
+    deleteTag: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deleteTag(id);
+    },
+
     getRules: async () => {
       const api = await getBrowserApiRuntime(connection);
       return (await api.getRules())
         .map(normalizeDirectRule)
         .filter((rule): rule is Rule => rule !== null);
     },
+    createRule: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      return normalizeRule(
+        await api.createRule(denormalizeRuleForBrowser(input) as unknown as Omit<ApiRule, "id">)
+      );
+    },
+    updateRule: async (id, patch) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateRule(denormalizeRulePatchForBrowser(id, patch) as unknown as ApiRule);
+    },
+    deleteRule: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deleteRule(id);
+    },
+
     getSchedules: async () => {
       const api = await getBrowserApiRuntime(connection);
       return (await api.getSchedules())
         .map(normalizeDirectSchedule)
         .filter((schedule): schedule is Schedule => schedule !== null);
     },
+    createSchedule: async (input) => {
+      const api = await getBrowserApiRuntime(connection);
+      const id = await api.createSchedule(denormalizeSchedule(input));
+      return {
+        id,
+        completed: false,
+        ...input,
+      };
+    },
+    updateSchedule: async (id, input) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateSchedule(id, denormalizeSchedule(input));
+    },
+    deleteSchedule: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.deleteSchedule(id);
+    },
+
     getNotesIndex: async () => {
       const notes = await getBrowserAllNotes(connection);
       return parseNotesIndexIds([...notes.keys()]);
@@ -273,6 +472,30 @@ export function createBrowserApiTransport(
     getCategoryLikeNote: async (id) => {
       const api = await getBrowserApiRuntime(connection);
       return extractNote(await api.getNote(id));
+    },
+    setAccountNote: async (accountId, note) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateNote(toAccountNoteId(accountId), note);
+    },
+    deleteAccountNote: async (accountId) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateNote(toAccountNoteId(accountId), null);
+    },
+    setCategoryNote: async (id, note) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateNote(id, note);
+    },
+    deleteCategoryNote: async (id) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateNote(id, null);
+    },
+    setBudgetMonthNote: async (month, note) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateNote(toBudgetNoteId(month), note);
+    },
+    deleteBudgetMonthNote: async (month) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.updateNote(toBudgetNoteId(month), null);
     },
   };
 }

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -38,7 +38,7 @@ import {
   type ActualBrowserApi,
 } from "./browser/runtime";
 import { prepareRuleForTransport, prepareRulePatchForTransport } from "./ruleMutation";
-import type { ActualBenchTransport, ScheduleWriteInput } from "./transport";
+import { unsupportedTransportOperation, type ActualBenchTransport, type ScheduleWriteInput, type TransportBudgetMonth } from "./transport";
 
 type RecordLike = Record<string, unknown>;
 
@@ -147,6 +147,131 @@ function responseRows<T>(response: unknown): T[] {
   if (Array.isArray(response)) return response as T[];
   if (isRecord(response) && Array.isArray(response.data)) return response.data as T[];
   return [];
+}
+
+function assertRecord(value: unknown, label: string): RecordLike {
+  if (!isRecord(value)) {
+    throw new Error("Direct browser API query adapter expected " + label + " to be an object.");
+  }
+  return value;
+}
+
+function getWrappedActualQuery(body: object): RecordLike {
+  const wrapped = assertRecord(body, "the query body");
+  return assertRecord(wrapped.ActualQLquery, "ActualQLquery");
+}
+
+function createBrowserQuery(api: ActualBrowserApi, body: object): unknown {
+  if (typeof api.q !== "function") {
+    throw unsupportedTransportOperation("browser-api", "ActualQL queries");
+  }
+
+  const query = getWrappedActualQuery(body);
+  const supportedKeys = new Set([
+    "table",
+    "options",
+    "filter",
+    "select",
+    "calculate",
+    "groupBy",
+    "orderBy",
+    "limit",
+    "offset",
+  ]);
+  for (const key of Object.keys(query)) {
+    if (!supportedKeys.has(key)) {
+      throw new Error(
+        "Direct browser API query adapter does not support ActualQL field: " + key
+      );
+    }
+  }
+
+  const table = asString(query.table);
+  if (!table) {
+    throw new Error("Direct browser API query adapter requires ActualQLquery.table.");
+  }
+
+  let browserQuery = api.q(table);
+  if (query.options !== undefined) {
+    browserQuery = browserQuery.options(assertRecord(query.options, "ActualQLquery.options"));
+  }
+  if (query.filter !== undefined) {
+    browserQuery = browserQuery.filter(assertRecord(query.filter, "ActualQLquery.filter"));
+  }
+  if (query.calculate !== undefined) {
+    if (query.select !== undefined) {
+      throw new Error(
+        "Direct browser API query adapter does not support using select and calculate together."
+      );
+    }
+    browserQuery = browserQuery.calculate(query.calculate);
+  } else if (query.select !== undefined) {
+    browserQuery = browserQuery.select(query.select);
+  }
+  if (query.groupBy !== undefined) browserQuery = browserQuery.groupBy(query.groupBy);
+  if (query.orderBy !== undefined) browserQuery = browserQuery.orderBy(query.orderBy);
+  if (query.limit !== undefined) {
+    const limit = query.limit;
+    if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 0) {
+      throw new Error("Direct browser API query adapter requires a non-negative integer limit.");
+    }
+    browserQuery = browserQuery.limit(limit);
+  }
+  if (query.offset !== undefined) {
+    const offset = query.offset;
+    if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) {
+      throw new Error("Direct browser API query adapter requires a non-negative integer offset.");
+    }
+    browserQuery = browserQuery.offset(offset);
+  }
+
+  return browserQuery;
+}
+
+async function runBrowserQuery<T>(
+  connection: BrowserApiConnection,
+  body: object
+): Promise<T> {
+  const api = await getBrowserApiRuntime(connection);
+  const runner = api.aqlQuery ?? api.runQuery;
+  if (!runner) throw unsupportedTransportOperation("browser-api", "ActualQL queries");
+  return (await runner(createBrowserQuery(api, body))) as T;
+}
+
+function toBudgetAmount(amount: number): number {
+  if (!Number.isFinite(amount)) {
+    throw new Error("Budget amount must be a finite number.");
+  }
+  return Math.round(amount);
+}
+
+function normalizeBudgetMonth(raw: unknown): TransportBudgetMonth {
+  if (!isRecord(raw)) throw new Error("Budget month response was not an object.");
+  return raw as TransportBudgetMonth;
+}
+
+function findBudgetedAmount(
+  month: TransportBudgetMonth,
+  categoryId: string
+): number {
+  for (const group of month.categoryGroups) {
+    for (const category of group.categories) {
+      if (category.id === categoryId) return category.budgeted ?? 0;
+    }
+  }
+  throw new Error("Category " + categoryId + " was not found in month " + month.month + ".");
+}
+
+async function runBrowserBudgetBatch<T>(
+  connection: BrowserApiConnection,
+  operation: () => Promise<T>
+): Promise<T> {
+  const api = await getBrowserApiRuntime(connection);
+  let result: T | undefined;
+  await api.batchBudgetUpdates(async () => {
+    result = await operation();
+  });
+  return result as T;
 }
 
 function buildActualQuery(
@@ -283,6 +408,8 @@ export function createBrowserApiTransport(
   return {
     mode: connection.mode,
     sync: () => syncBrowserApiRuntime(connection),
+    batchBudgetUpdates: (operation) => runBrowserBudgetBatch(connection, operation),
+    runQuery: (body) => runBrowserQuery(connection, body),
     getServerVersion: async () => {
       const api = await getBrowserApiRuntime(connection);
       if (typeof api.getServerVersion !== "function") return null;
@@ -458,6 +585,44 @@ export function createBrowserApiTransport(
     deleteSchedule: async (id) => {
       const api = await getBrowserApiRuntime(connection);
       await api.deleteSchedule(id);
+    },
+
+    getBudgetMonths: async () => {
+      const api = await getBrowserApiRuntime(connection);
+      return api.getBudgetMonths();
+    },
+    getBudgetMonth: async (month) => {
+      const api = await getBrowserApiRuntime(connection);
+      return normalizeBudgetMonth(await api.getBudgetMonth(month));
+    },
+    setBudgetAmount: async (month, categoryId, amount) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.setBudgetAmount(month, categoryId, toBudgetAmount(amount));
+    },
+    setBudgetCarryover: async (month, categoryId, flag) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.setBudgetCarryover(month, categoryId, flag);
+    },
+    transferBudget: async (month, input) => {
+      const api = await getBrowserApiRuntime(connection);
+      const monthData = normalizeBudgetMonth(await api.getBudgetMonth(month));
+      const fromBudgeted = findBudgetedAmount(monthData, input.fromCategoryId);
+      const toBudgeted = findBudgetedAmount(monthData, input.toCategoryId);
+      const amount = toBudgetAmount(input.amount);
+
+      // Actual's browser API does not expose the server's category-transfer
+      // endpoint. Inside a budget batch, setting both final budget values is
+      // the same persisted budget state for the Direct transport.
+      await api.setBudgetAmount(month, input.fromCategoryId, fromBudgeted - amount);
+      await api.setBudgetAmount(month, input.toCategoryId, toBudgeted + amount);
+    },
+    holdBudgetForNextMonth: async (month, amount) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.holdBudgetForNextMonth(month, toBudgetAmount(amount));
+    },
+    resetBudgetHold: async (month) => {
+      const api = await getBrowserApiRuntime(connection);
+      await api.resetBudgetHold(month);
     },
 
     getNotesIndex: async () => {

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -387,14 +387,23 @@ function findBudgetedAmount(
   throw new Error("Category " + categoryId + " was not found in month " + month.month + ".");
 }
 
+let browserBudgetBatchDepth = 0;
+
 async function runBrowserBudgetBatch<T>(
   connection: BrowserApiConnection,
   operation: () => Promise<T>
 ): Promise<T> {
+  if (browserBudgetBatchDepth > 0) return operation();
+
   const api = await getBrowserApiRuntime(connection);
   let result: T | undefined;
   await api.batchBudgetUpdates(async () => {
-    result = await operation();
+    browserBudgetBatchDepth++;
+    try {
+      result = await operation();
+    } finally {
+      browserBudgetBatchDepth--;
+    }
   });
   return result as T;
 }
@@ -549,9 +558,14 @@ async function getBrowserAllNotes(
   const api = await getBrowserApiRuntime(connection);
   const query = buildActualQuery(api, "notes", "*");
   const runner = api.aqlQuery?.bind(api) ?? api.runQuery?.bind(api);
-  const rows = runner
-    ? responseRows<NoteRow>(await runner(query).catch(() => []))
-    : [];
+  let rows: NoteRow[] = [];
+  if (runner) {
+    try {
+      rows = responseRows<NoteRow>(await runner(query));
+    } catch (err) {
+      throw cleanBrowserQueryError(err);
+    }
+  }
 
   const map = new Map<string, string>();
   for (const row of rows) {
@@ -762,17 +776,19 @@ export function createBrowserApiTransport(
       await api.setBudgetCarryover(month, categoryId, flag);
     },
     transferBudget: async (month, input) => {
-      const api = await getBrowserApiRuntime(connection);
-      const monthData = normalizeBudgetMonth(await api.getBudgetMonth(month));
-      const fromBudgeted = findBudgetedAmount(monthData, input.fromCategoryId);
-      const toBudgeted = findBudgetedAmount(monthData, input.toCategoryId);
-      const amount = toBudgetAmount(input.amount);
+      await runBrowserBudgetBatch(connection, async () => {
+        const api = await getBrowserApiRuntime(connection);
+        const monthData = normalizeBudgetMonth(await api.getBudgetMonth(month));
+        const fromBudgeted = findBudgetedAmount(monthData, input.fromCategoryId);
+        const toBudgeted = findBudgetedAmount(monthData, input.toCategoryId);
+        const amount = toBudgetAmount(input.amount);
 
-      // Actual's browser API does not expose the server's category-transfer
-      // endpoint. Inside a budget batch, setting both final budget values is
-      // the same persisted budget state for the Direct transport.
-      await api.setBudgetAmount(month, input.fromCategoryId, fromBudgeted - amount);
-      await api.setBudgetAmount(month, input.toCategoryId, toBudgeted + amount);
+        // Actual's browser API does not expose the server's category-transfer
+        // endpoint. Setting both final budget values inside one batch keeps
+        // the transfer atomic for the Direct transport.
+        await api.setBudgetAmount(month, input.fromCategoryId, fromBudgeted - amount);
+        await api.setBudgetAmount(month, input.toCategoryId, toBudgeted + amount);
+      });
     },
     holdBudgetForNextMonth: async (month, amount) => {
       const api = await getBrowserApiRuntime(connection);

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -1,0 +1,13 @@
+import type { BrowserApiConnection } from "@/store/connection";
+import type { ActualBenchTransport } from "./transport";
+import { unsupportedTransportOperation } from "./transport";
+
+export function createBrowserApiTransport(
+  connection: BrowserApiConnection
+): ActualBenchTransport {
+  return {
+    mode: connection.mode,
+    getAccounts: () =>
+      Promise.reject(unsupportedTransportOperation(connection.mode, "getAccounts")),
+  };
+}

--- a/src/lib/actual/httpApiTransport.ts
+++ b/src/lib/actual/httpApiTransport.ts
@@ -1,4 +1,11 @@
-import { getAccounts } from "../api/accounts";
+import { getAccounts, getAccountBalances } from "../api/accounts";
+import { getCategoryGroups } from "../api/categoryGroups";
+import { getServerVersion } from "../api/client";
+import { getAllNotes, getNotesIndex, getAccountNote, getCategoryLikeNote } from "../api/notes";
+import { getPayees } from "../api/payees";
+import { getRules } from "../api/rules";
+import { getSchedules } from "../api/schedules";
+import { getTags } from "../api/tags";
 import type { HttpApiConnection } from "@/store/connection";
 import type { ActualBenchTransport } from "./transport";
 
@@ -7,6 +14,27 @@ export function createHttpApiTransport(
 ): ActualBenchTransport {
   return {
     mode: "http-api",
+    getServerVersion: async () => {
+      try {
+        return await getServerVersion(
+          connection.baseUrl,
+          connection.apiKey,
+          connection.budgetSyncId
+        );
+      } catch {
+        return null;
+      }
+    },
     getAccounts: () => getAccounts(connection),
+    getAccountBalances: () => getAccountBalances(connection),
+    getPayees: () => getPayees(connection),
+    getCategoryGroups: () => getCategoryGroups(connection),
+    getTags: () => getTags(connection),
+    getRules: () => getRules(connection),
+    getSchedules: () => getSchedules(connection),
+    getNotesIndex: () => getNotesIndex(connection),
+    getAccountNote: (accountId) => getAccountNote(connection, accountId),
+    getAllNotes: () => getAllNotes(connection),
+    getCategoryLikeNote: (id) => getCategoryLikeNote(connection, id),
   };
 }

--- a/src/lib/actual/httpApiTransport.ts
+++ b/src/lib/actual/httpApiTransport.ts
@@ -1,12 +1,61 @@
-import { getAccounts, getAccountBalances } from "../api/accounts";
-import { getCategoryGroups } from "../api/categoryGroups";
+import {
+  createAccount,
+  deleteAccount,
+  getAccounts,
+  getAccountBalances,
+  updateAccount,
+} from "../api/accounts";
+import {
+  createCategory,
+  deleteCategory,
+  updateCategory,
+} from "../api/categories";
+import {
+  createCategoryGroup,
+  deleteCategoryGroup,
+  getCategoryGroups,
+  updateCategoryGroup,
+} from "../api/categoryGroups";
 import { getServerVersion } from "../api/client";
-import { getAllNotes, getNotesIndex, getAccountNote, getCategoryLikeNote } from "../api/notes";
-import { getPayees } from "../api/payees";
-import { getRules } from "../api/rules";
-import { getSchedules } from "../api/schedules";
-import { getTags } from "../api/tags";
+import {
+  deleteAccountNote,
+  deleteBudgetMonthNote,
+  deleteCategoryNote,
+  getAllNotes,
+  getNotesIndex,
+  getAccountNote,
+  getCategoryLikeNote,
+  setAccountNote,
+  setBudgetMonthNote,
+  setCategoryNote,
+} from "../api/notes";
+import {
+  createPayee,
+  deletePayee,
+  getPayees,
+  mergePayees,
+  updatePayee,
+} from "../api/payees";
+import {
+  createRule,
+  deleteRule,
+  getRules,
+  updateRule,
+} from "../api/rules";
+import {
+  createSchedule,
+  deleteSchedule,
+  getSchedules,
+  updateSchedule,
+} from "../api/schedules";
+import {
+  createTag,
+  deleteTag,
+  getTags,
+  updateTag,
+} from "../api/tags";
 import type { HttpApiConnection } from "@/store/connection";
+import { prepareRuleForTransport, prepareRulePatchForTransport } from "./ruleMutation";
 import type { ActualBenchTransport } from "./transport";
 
 export function createHttpApiTransport(
@@ -14,6 +63,7 @@ export function createHttpApiTransport(
 ): ActualBenchTransport {
   return {
     mode: "http-api",
+    sync: () => Promise.resolve(),
     getServerVersion: async () => {
       try {
         return await getServerVersion(
@@ -27,14 +77,49 @@ export function createHttpApiTransport(
     },
     getAccounts: () => getAccounts(connection),
     getAccountBalances: () => getAccountBalances(connection),
+    createAccount: (input) => createAccount(connection, input),
+    updateAccount: (id, patch) => updateAccount(connection, id, patch),
+    deleteAccount: (id) => deleteAccount(connection, id),
+
     getPayees: () => getPayees(connection),
+    createPayee: (input) => createPayee(connection, input),
+    updatePayee: (id, patch) => updatePayee(connection, id, patch),
+    deletePayee: (id) => deletePayee(connection, id),
+    mergePayees: (targetId, mergeIds) => mergePayees(connection, targetId, mergeIds),
+
     getCategoryGroups: () => getCategoryGroups(connection),
+    createCategoryGroup: (input) => createCategoryGroup(connection, input),
+    updateCategoryGroup: (id, patch) => updateCategoryGroup(connection, id, patch),
+    deleteCategoryGroup: (id) => deleteCategoryGroup(connection, id),
+    createCategory: (input) => createCategory(connection, input),
+    updateCategory: (id, patch) => updateCategory(connection, id, patch),
+    deleteCategory: (id) => deleteCategory(connection, id),
+
     getTags: () => getTags(connection),
+    createTag: (input) => createTag(connection, input),
+    updateTag: (id, patch) => updateTag(connection, id, patch),
+    deleteTag: (id) => deleteTag(connection, id),
+
     getRules: () => getRules(connection),
+    createRule: (input) => createRule(connection, prepareRuleForTransport(input)),
+    updateRule: (id, patch) =>
+      updateRule(connection, id, prepareRulePatchForTransport(patch)),
+    deleteRule: (id) => deleteRule(connection, id),
+
     getSchedules: () => getSchedules(connection),
+    createSchedule: (input) => createSchedule(connection, input),
+    updateSchedule: (id, input) => updateSchedule(connection, id, input),
+    deleteSchedule: (id) => deleteSchedule(connection, id),
+
     getNotesIndex: () => getNotesIndex(connection),
     getAccountNote: (accountId) => getAccountNote(connection, accountId),
     getAllNotes: () => getAllNotes(connection),
     getCategoryLikeNote: (id) => getCategoryLikeNote(connection, id),
+    setAccountNote: (accountId, note) => setAccountNote(connection, accountId, note),
+    deleteAccountNote: (accountId) => deleteAccountNote(connection, accountId),
+    setCategoryNote: (id, note) => setCategoryNote(connection, id, note),
+    deleteCategoryNote: (id) => deleteCategoryNote(connection, id),
+    setBudgetMonthNote: (month, note) => setBudgetMonthNote(connection, month, note),
+    deleteBudgetMonthNote: (month) => deleteBudgetMonthNote(connection, month),
   };
 }

--- a/src/lib/actual/httpApiTransport.ts
+++ b/src/lib/actual/httpApiTransport.ts
@@ -16,7 +16,7 @@ import {
   getCategoryGroups,
   updateCategoryGroup,
 } from "../api/categoryGroups";
-import { getServerVersion } from "../api/client";
+import { apiRequest, getServerVersion } from "../api/client";
 import {
   deleteAccountNote,
   deleteBudgetMonthNote,
@@ -56,7 +56,7 @@ import {
 } from "../api/tags";
 import type { HttpApiConnection } from "@/store/connection";
 import { prepareRuleForTransport, prepareRulePatchForTransport } from "./ruleMutation";
-import type { ActualBenchTransport } from "./transport";
+import type { ActualBenchTransport, TransportBudgetMonth } from "./transport";
 
 export function createHttpApiTransport(
   connection: HttpApiConnection
@@ -64,6 +64,12 @@ export function createHttpApiTransport(
   return {
     mode: "http-api",
     sync: () => Promise.resolve(),
+    batchBudgetUpdates: (operation) => operation(),
+    runQuery: (body) =>
+      apiRequest(connection, "/run-query", {
+        method: "POST",
+        body,
+      }),
     getServerVersion: async () => {
       try {
         return await getServerVersion(
@@ -110,6 +116,48 @@ export function createHttpApiTransport(
     createSchedule: (input) => createSchedule(connection, input),
     updateSchedule: (id, input) => updateSchedule(connection, id, input),
     deleteSchedule: (id) => deleteSchedule(connection, id),
+
+    getBudgetMonths: async () => {
+      const response = await apiRequest<{ data: string[] }>(connection, "/months");
+      return response.data;
+    },
+    getBudgetMonth: async (month) => {
+      const response = await apiRequest<{ data: TransportBudgetMonth }>(
+        connection,
+        "/months/" + month
+      );
+      return response.data;
+    },
+    setBudgetAmount: (month, categoryId, amount) =>
+      apiRequest(connection, "/months/" + month + "/categories/" + categoryId, {
+        method: "PATCH",
+        body: { category: { budgeted: amount } },
+      }),
+    setBudgetCarryover: (month, categoryId, flag) =>
+      apiRequest(connection, "/months/" + month + "/categories/" + categoryId, {
+        method: "PATCH",
+        body: { category: { carryover: flag } },
+      }),
+    transferBudget: (month, input) =>
+      apiRequest(connection, "/months/" + month + "/categorytransfers", {
+        method: "POST",
+        body: {
+          categorytransfer: {
+            fromCategoryId: input.fromCategoryId,
+            toCategoryId: input.toCategoryId,
+            amount: input.amount,
+          },
+        },
+      }),
+    holdBudgetForNextMonth: (month, amount) =>
+      apiRequest(connection, "/months/" + month + "/nextmonthbudgethold", {
+        method: "POST",
+        body: { amount },
+      }),
+    resetBudgetHold: (month) =>
+      apiRequest(connection, "/months/" + month + "/nextmonthbudgethold", {
+        method: "DELETE",
+      }),
 
     getNotesIndex: () => getNotesIndex(connection),
     getAccountNote: (accountId) => getAccountNote(connection, accountId),

--- a/src/lib/actual/httpApiTransport.ts
+++ b/src/lib/actual/httpApiTransport.ts
@@ -1,0 +1,12 @@
+import { getAccounts } from "../api/accounts";
+import type { HttpApiConnection } from "@/store/connection";
+import type { ActualBenchTransport } from "./transport";
+
+export function createHttpApiTransport(
+  connection: HttpApiConnection
+): ActualBenchTransport {
+  return {
+    mode: "http-api",
+    getAccounts: () => getAccounts(connection),
+  };
+}

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -287,7 +287,10 @@ describe("Actual transport factory", () => {
     expect(setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-1", 124);
   });
 
-  it("Direct category transfers bridge to final budget amounts", async () => {
+  it("Direct category transfers bridge to final budget amounts in one batch", async () => {
+    const batchBudgetUpdates = jest.fn(async (fn: () => Promise<void>) => {
+      await fn();
+    });
     const setBudgetAmount = jest.fn().mockResolvedValue(undefined);
     const getBudgetMonth = jest.fn().mockResolvedValue({
       month: "2026-01",
@@ -308,6 +311,7 @@ describe("Actual transport factory", () => {
       ],
     });
     mockGetBrowserApiRuntime.mockResolvedValue({
+      batchBudgetUpdates,
       getBudgetMonth,
       setBudgetAmount,
     } as never);
@@ -318,6 +322,7 @@ describe("Actual transport factory", () => {
       amount: 125,
     });
 
+    expect(batchBudgetUpdates).toHaveBeenCalledTimes(1);
     expect(setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-from", 875);
     expect(setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-to", 375);
   });

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -1,8 +1,8 @@
 import { getAccounts } from "../api/accounts";
-import { getBrowserApiRuntime } from "./browser/runtime";
+import { getBrowserApiRuntime, syncBrowserApiRuntime } from "./browser/runtime";
 import { getTransport } from "./index";
 import type { BrowserApiConnection, HttpApiConnection } from "@/store/connection";
-import type { Account } from "@/types/entities";
+import type { Account, Rule } from "@/types/entities";
 
 jest.mock("../api/accounts", () => ({
   ...jest.requireActual("../api/accounts"),
@@ -11,11 +11,15 @@ jest.mock("../api/accounts", () => ({
 
 jest.mock("./browser/runtime", () => ({
   getBrowserApiRuntime: jest.fn(),
+  syncBrowserApiRuntime: jest.fn(),
 }));
 
 const mockGetAccounts = getAccounts as jest.MockedFunction<typeof getAccounts>;
 const mockGetBrowserApiRuntime = getBrowserApiRuntime as jest.MockedFunction<
   typeof getBrowserApiRuntime
+>;
+const mockSyncBrowserApiRuntime = syncBrowserApiRuntime as jest.MockedFunction<
+  typeof syncBrowserApiRuntime
 >;
 
 const httpConnection: HttpApiConnection = {
@@ -40,6 +44,7 @@ describe("Actual transport factory", () => {
   beforeEach(() => {
     mockGetAccounts.mockReset();
     mockGetBrowserApiRuntime.mockReset();
+    mockSyncBrowserApiRuntime.mockReset();
   });
 
   it("dispatches Classic connections to the HTTP API transport", () => {
@@ -76,6 +81,77 @@ describe("Actual transport factory", () => {
     ]);
     expect(mockGetAccounts).not.toHaveBeenCalled();
     expect(mockGetBrowserApiRuntime).toHaveBeenCalledWith(browserConnection);
+  });
+
+  it("Direct account creates use the browser runtime and convert the initial balance", async () => {
+    const createAccount = jest.fn().mockResolvedValue("account-1");
+    const closeAccount = jest.fn().mockResolvedValue(undefined);
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      createAccount,
+      closeAccount,
+    } as never);
+
+    await expect(
+      getTransport(browserConnection).createAccount({
+        name: "New Checking",
+        offBudget: true,
+        closed: true,
+        initialBalance: 12.34,
+      })
+    ).resolves.toEqual({
+      id: "account-1",
+      name: "New Checking",
+      offBudget: true,
+      closed: true,
+      initialBalance: 12.34,
+    });
+
+    expect(createAccount).toHaveBeenCalledWith(
+      { name: "New Checking", offbudget: true, closed: false },
+      1234
+    );
+    expect(closeAccount).toHaveBeenCalledWith("account-1");
+  });
+
+  it("Direct rule creates convert default stage and amount values for the browser API", async () => {
+    const createRule = jest.fn().mockResolvedValue({
+      id: "rule-1",
+      stage: null,
+      conditionsOp: "and",
+      conditions: [{ field: "amount", op: "is", value: 1234 }],
+      actions: [],
+    });
+    mockGetBrowserApiRuntime.mockResolvedValue({ createRule } as never);
+
+    const rule: Omit<Rule, "id"> = {
+      stage: "default",
+      conditionsOp: "and",
+      conditions: [{ field: "amount", op: "is", value: 12.34 }],
+      actions: [],
+    };
+
+    await expect(getTransport(browserConnection).createRule(rule)).resolves.toEqual({
+      id: "rule-1",
+      stage: "default",
+      conditionsOp: "and",
+      conditions: [{ field: "amount", op: "is", value: 12.34 }],
+      actions: [],
+    });
+
+    expect(createRule).toHaveBeenCalledWith({
+      stage: null,
+      conditionsOp: "and",
+      conditions: [{ field: "amount", op: "is", value: 1234 }],
+      actions: [],
+    });
+  });
+
+  it("Direct transport sync delegates to the browser runtime sync queue", async () => {
+    mockSyncBrowserApiRuntime.mockResolvedValueOnce(undefined);
+
+    await getTransport(browserConnection).sync();
+
+    expect(mockSyncBrowserApiRuntime).toHaveBeenCalledWith(browserConnection);
   });
 
   it("Direct account balances are converted from cents without using fetch", async () => {

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -47,7 +47,7 @@ describe("Actual transport factory", () => {
     mockSyncBrowserApiRuntime.mockReset();
   });
 
-  it("dispatches Classic connections to the HTTP API transport", () => {
+  it("dispatches HTTP API connections to the HTTP API transport", () => {
     expect(getTransport(httpConnection).mode).toBe("http-api");
   });
 
@@ -55,7 +55,7 @@ describe("Actual transport factory", () => {
     expect(getTransport(browserConnection).mode).toBe("browser-api");
   });
 
-  it("Classic account reads delegate to the existing accounts API helper", async () => {
+  it("HTTP API account reads delegate to the existing accounts API helper", async () => {
     const accounts: Account[] = [
       { id: "account-1", name: "Checking", offBudget: false, closed: false },
     ];

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -1,8 +1,13 @@
 import { getAccounts } from "../api/accounts";
-import { getBrowserApiRuntime, syncBrowserApiRuntime } from "./browser/runtime";
-import { getTransport } from "./index";
+import {
+  ensureBrowserApiBudgetOpen,
+  getBrowserApiRuntime,
+  syncBrowserApiRuntime,
+} from "./browser/runtime";
+import { ensureTransportReady, getTransport, settleTransportWrites } from "./index";
 import type { BrowserApiConnection, HttpApiConnection } from "@/store/connection";
 import type { Account, Rule } from "@/types/entities";
+import type { ActualBenchTransport } from "./transport";
 
 jest.mock("../api/accounts", () => ({
   ...jest.requireActual("../api/accounts"),
@@ -10,11 +15,14 @@ jest.mock("../api/accounts", () => ({
 }));
 
 jest.mock("./browser/runtime", () => ({
+  ensureBrowserApiBudgetOpen: jest.fn(),
   getBrowserApiRuntime: jest.fn(),
   syncBrowserApiRuntime: jest.fn(),
 }));
 
 const mockGetAccounts = getAccounts as jest.MockedFunction<typeof getAccounts>;
+const mockEnsureBrowserApiBudgetOpen =
+  ensureBrowserApiBudgetOpen as jest.MockedFunction<typeof ensureBrowserApiBudgetOpen>;
 const mockGetBrowserApiRuntime = getBrowserApiRuntime as jest.MockedFunction<
   typeof getBrowserApiRuntime
 >;
@@ -62,6 +70,7 @@ function createMockQueryBuilder() {
 describe("Actual transport factory", () => {
   beforeEach(() => {
     mockGetAccounts.mockReset();
+    mockEnsureBrowserApiBudgetOpen.mockReset();
     mockGetBrowserApiRuntime.mockReset();
     mockSyncBrowserApiRuntime.mockReset();
   });
@@ -72,6 +81,63 @@ describe("Actual transport factory", () => {
 
   it("dispatches Direct connections to the browser API transport", () => {
     expect(getTransport(browserConnection).mode).toBe("browser-api");
+  });
+
+  it("ensures Direct readiness by opening the browser budget", async () => {
+    mockEnsureBrowserApiBudgetOpen.mockResolvedValueOnce(undefined);
+
+    await expect(ensureTransportReady(browserConnection)).resolves.toBeUndefined();
+
+    expect(mockEnsureBrowserApiBudgetOpen).toHaveBeenCalledWith(browserConnection);
+  });
+
+  it("does not open a browser budget for HTTP API readiness", async () => {
+    await expect(ensureTransportReady(httpConnection)).resolves.toBeUndefined();
+
+    expect(mockEnsureBrowserApiBudgetOpen).not.toHaveBeenCalled();
+  });
+
+  it("settles HTTP transport writes in parallel", async () => {
+    const transport = { mode: "http-api" } as ActualBenchTransport;
+    let active = 0;
+    let maxActive = 0;
+
+    const results = await settleTransportWrites(transport, [1, 2], async (value) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, value === 1 ? 15 : 0));
+      active -= 1;
+      return value * 2;
+    });
+
+    expect(maxActive).toBe(2);
+    expect(results).toEqual([
+      { status: "fulfilled", value: 2 },
+      { status: "fulfilled", value: 4 },
+    ]);
+  });
+
+  it("settles Direct transport writes sequentially without short-circuiting failures", async () => {
+    const transport = { mode: "browser-api" } as ActualBenchTransport;
+    const starts: number[] = [];
+    const activeAtStart: number[] = [];
+    let active = 0;
+
+    const results = await settleTransportWrites(transport, [1, 2, 3], async (value) => {
+      starts.push(value);
+      activeAtStart.push(active);
+      active += 1;
+      await Promise.resolve();
+      active -= 1;
+      if (value === 2) throw new Error("boom");
+      return value * 2;
+    });
+
+    expect(starts).toEqual([1, 2, 3]);
+    expect(activeAtStart).toEqual([0, 0, 0]);
+    expect(results[0]).toEqual({ status: "fulfilled", value: 2 });
+    expect(results[1].status).toBe("rejected");
+    expect(results[2]).toEqual({ status: "fulfilled", value: 6 });
   });
 
   it("HTTP API account reads delegate to the existing accounts API helper", async () => {

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -154,6 +154,154 @@ describe("Actual transport factory", () => {
     expect(mockSyncBrowserApiRuntime).toHaveBeenCalledWith(browserConnection);
   });
 
+  it("Direct budget reads delegate to the browser budget API", async () => {
+    const getBudgetMonths = jest.fn().mockResolvedValue(["2026-01", "2026-02"]);
+    const month = {
+      month: "2026-01",
+      incomeAvailable: 0,
+      lastMonthOverspent: 0,
+      forNextMonth: 0,
+      totalBudgeted: 0,
+      toBudget: 0,
+      fromLastMonth: 0,
+      totalIncome: 0,
+      totalSpent: 0,
+      totalBalance: 0,
+      categoryGroups: [],
+    };
+    const getBudgetMonth = jest.fn().mockResolvedValue(month);
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      getBudgetMonths,
+      getBudgetMonth,
+    } as never);
+
+    const transport = getTransport(browserConnection);
+
+    await expect(transport.getBudgetMonths()).resolves.toEqual(["2026-01", "2026-02"]);
+    await expect(transport.getBudgetMonth("2026-01")).resolves.toBe(month);
+    expect(getBudgetMonths).toHaveBeenCalledTimes(1);
+    expect(getBudgetMonth).toHaveBeenCalledWith("2026-01");
+  });
+
+  it("Direct budget writes run inside the browser budget batch and round minor-unit amounts", async () => {
+    const batchBudgetUpdates = jest.fn(async (fn: () => Promise<void>) => {
+      await fn();
+    });
+    const setBudgetAmount = jest.fn().mockResolvedValue(undefined);
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      batchBudgetUpdates,
+      setBudgetAmount,
+    } as never);
+
+    const transport = getTransport(browserConnection);
+    await transport.batchBudgetUpdates(async () => {
+      await transport.setBudgetAmount("2026-01", "cat-1", 123.6);
+    });
+
+    expect(batchBudgetUpdates).toHaveBeenCalledTimes(1);
+    expect(setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-1", 124);
+  });
+
+  it("Direct category transfers bridge to final budget amounts", async () => {
+    const setBudgetAmount = jest.fn().mockResolvedValue(undefined);
+    const getBudgetMonth = jest.fn().mockResolvedValue({
+      month: "2026-01",
+      categoryGroups: [
+        {
+          id: "group-1",
+          name: "Expenses",
+          is_income: false,
+          hidden: false,
+          budgeted: 0,
+          spent: 0,
+          balance: 0,
+          categories: [
+            { id: "cat-from", name: "From", group_id: "group-1", is_income: false, budgeted: 1000 },
+            { id: "cat-to", name: "To", group_id: "group-1", is_income: false, budgeted: 250 },
+          ],
+        },
+      ],
+    });
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      getBudgetMonth,
+      setBudgetAmount,
+    } as never);
+
+    await getTransport(browserConnection).transferBudget("2026-01", {
+      fromCategoryId: "cat-from",
+      toCategoryId: "cat-to",
+      amount: 125,
+    });
+
+    expect(setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-from", 875);
+    expect(setBudgetAmount).toHaveBeenCalledWith("2026-01", "cat-to", 375);
+  });
+
+  it("Direct runQuery adapts supported wrapped ActualQL JSON into browser q() calls", async () => {
+    const builder = {
+      options: jest.fn(),
+      filter: jest.fn(),
+      select: jest.fn(),
+      calculate: jest.fn(),
+      groupBy: jest.fn(),
+      orderBy: jest.fn(),
+      limit: jest.fn(),
+      offset: jest.fn(),
+    };
+    for (const method of Object.values(builder)) method.mockReturnValue(builder);
+    const q = jest.fn().mockReturnValue(builder);
+    const aqlQuery = jest.fn().mockResolvedValue({ data: [] });
+    mockGetBrowserApiRuntime.mockResolvedValue({ q, aqlQuery } as never);
+
+    const body = {
+      ActualQLquery: {
+        table: "transactions",
+        options: { splits: "inline" },
+        filter: { account: "account-1" },
+        select: ["id", "date"],
+        groupBy: ["account"],
+        orderBy: [{ date: "desc" }],
+        limit: 10,
+      },
+    };
+
+    await expect(getTransport(browserConnection).runQuery(body)).resolves.toEqual({ data: [] });
+
+    expect(q).toHaveBeenCalledWith("transactions");
+    expect(builder.options).toHaveBeenCalledWith({ splits: "inline" });
+    expect(builder.filter).toHaveBeenCalledWith({ account: "account-1" });
+    expect(builder.select).toHaveBeenCalledWith(["id", "date"]);
+    expect(builder.groupBy).toHaveBeenCalledWith(["account"]);
+    expect(builder.orderBy).toHaveBeenCalledWith([{ date: "desc" }]);
+    expect(builder.limit).toHaveBeenCalledWith(10);
+    expect(aqlQuery).toHaveBeenCalledWith(builder);
+  });
+
+  it("Direct runQuery rejects unsupported wrapped ActualQL fields explicitly", async () => {
+    const builder = {
+      options: jest.fn().mockReturnThis(),
+      filter: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      calculate: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+    };
+    const aqlQuery = jest.fn();
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      q: jest.fn().mockReturnValue(builder),
+      aqlQuery,
+    } as never);
+
+    await expect(
+      getTransport(browserConnection).runQuery({
+        ActualQLquery: { table: "transactions", join: ["accounts"] },
+      })
+    ).rejects.toThrow("Direct browser API query adapter does not support ActualQL field: join");
+    expect(aqlQuery).not.toHaveBeenCalled();
+  });
+
   it("Direct account balances are converted from cents without using fetch", async () => {
     const originalFetch = global.fetch;
     const fetchMock = jest.fn();

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -1,0 +1,60 @@
+import { getAccounts } from "../api/accounts";
+import { getTransport } from "./index";
+import type { BrowserApiConnection, HttpApiConnection } from "@/store/connection";
+import type { Account } from "@/types/entities";
+
+jest.mock("../api/accounts", () => ({
+  getAccounts: jest.fn(),
+}));
+
+const mockGetAccounts = getAccounts as jest.MockedFunction<typeof getAccounts>;
+
+const httpConnection: HttpApiConnection = {
+  id: "conn-1",
+  label: "Family Fund",
+  mode: "http-api",
+  baseUrl: "https://api.example.com",
+  apiKey: "api-key",
+  budgetSyncId: "budget-1",
+};
+
+const browserConnection: BrowserApiConnection = {
+  id: "conn-2",
+  label: "Family Fund",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "server-password",
+  budgetSyncId: "budget-1",
+};
+
+describe("Actual transport factory", () => {
+  beforeEach(() => {
+    mockGetAccounts.mockReset();
+  });
+
+  it("dispatches Classic connections to the HTTP API transport", () => {
+    expect(getTransport(httpConnection).mode).toBe("http-api");
+  });
+
+  it("dispatches Direct connections to the browser API transport", () => {
+    expect(getTransport(browserConnection).mode).toBe("browser-api");
+  });
+
+  it("Classic account reads delegate to the existing accounts API helper", async () => {
+    const accounts: Account[] = [
+      { id: "account-1", name: "Checking", offBudget: false, closed: false },
+    ];
+    mockGetAccounts.mockResolvedValueOnce(accounts);
+
+    await expect(getTransport(httpConnection).getAccounts()).resolves.toEqual(accounts);
+    expect(mockGetAccounts).toHaveBeenCalledTimes(1);
+    expect(mockGetAccounts).toHaveBeenCalledWith(httpConnection);
+  });
+
+  it("Direct account reads fail clearly until implemented", async () => {
+    await expect(getTransport(browserConnection).getAccounts()).rejects.toThrow(
+      "Direct browser API transport does not support getAccounts yet."
+    );
+    expect(mockGetAccounts).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -1,13 +1,22 @@
 import { getAccounts } from "../api/accounts";
+import { getBrowserApiRuntime } from "./browser/runtime";
 import { getTransport } from "./index";
 import type { BrowserApiConnection, HttpApiConnection } from "@/store/connection";
 import type { Account } from "@/types/entities";
 
 jest.mock("../api/accounts", () => ({
+  ...jest.requireActual("../api/accounts"),
   getAccounts: jest.fn(),
 }));
 
+jest.mock("./browser/runtime", () => ({
+  getBrowserApiRuntime: jest.fn(),
+}));
+
 const mockGetAccounts = getAccounts as jest.MockedFunction<typeof getAccounts>;
+const mockGetBrowserApiRuntime = getBrowserApiRuntime as jest.MockedFunction<
+  typeof getBrowserApiRuntime
+>;
 
 const httpConnection: HttpApiConnection = {
   id: "conn-1",
@@ -30,6 +39,7 @@ const browserConnection: BrowserApiConnection = {
 describe("Actual transport factory", () => {
   beforeEach(() => {
     mockGetAccounts.mockReset();
+    mockGetBrowserApiRuntime.mockReset();
   });
 
   it("dispatches Classic connections to the HTTP API transport", () => {
@@ -51,10 +61,56 @@ describe("Actual transport factory", () => {
     expect(mockGetAccounts).toHaveBeenCalledWith(httpConnection);
   });
 
-  it("Direct account reads fail clearly until implemented", async () => {
-    await expect(getTransport(browserConnection).getAccounts()).rejects.toThrow(
-      "Direct browser API transport does not support getAccounts yet."
-    );
+  it("Direct account reads use the browser runtime and normalize account shape", async () => {
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      getAccounts: jest.fn().mockResolvedValue([
+        { id: "account-1", name: "Checking", offbudget: true, closed: false },
+        { id: "account-2", name: "Savings", offbudget: false, closed: true },
+        { id: null, name: "Broken" },
+      ]),
+    } as never);
+
+    await expect(getTransport(browserConnection).getAccounts()).resolves.toEqual([
+      { id: "account-1", name: "Checking", offBudget: true, closed: false },
+      { id: "account-2", name: "Savings", offBudget: false, closed: true },
+    ]);
     expect(mockGetAccounts).not.toHaveBeenCalled();
+    expect(mockGetBrowserApiRuntime).toHaveBeenCalledWith(browserConnection);
+  });
+
+  it("Direct account balances are converted from cents without using fetch", async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn();
+    Object.defineProperty(global, "fetch", {
+      configurable: true,
+      writable: true,
+      value: fetchMock,
+    });
+
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      getAccounts: jest.fn().mockResolvedValue([
+        { id: "account-1", name: "Checking", offbudget: false, closed: false },
+        { id: "account-2", name: "Savings", offbudget: false, closed: false },
+      ]),
+      getAccountBalance: jest
+        .fn()
+        .mockResolvedValueOnce(12345)
+        .mockResolvedValueOnce(-250),
+    } as never);
+
+    try {
+      const balances = await getTransport(browserConnection).getAccountBalances();
+      expect([...balances.entries()]).toEqual([
+        ["account-1", 123.45],
+        ["account-2", -2.5],
+      ]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(global, "fetch", {
+        configurable: true,
+        writable: true,
+        value: originalFetch,
+      });
+    }
   });
 });

--- a/src/lib/actual/index.test.ts
+++ b/src/lib/actual/index.test.ts
@@ -40,6 +40,25 @@ const browserConnection: BrowserApiConnection = {
   budgetSyncId: "budget-1",
 };
 
+function createMockQueryBuilder() {
+  const builder = {
+    options: jest.fn(),
+    filter: jest.fn(),
+    select: jest.fn(),
+    calculate: jest.fn(),
+    groupBy: jest.fn(),
+    orderBy: jest.fn(),
+    limit: jest.fn(),
+    offset: jest.fn(),
+    unfilter: jest.fn(),
+    raw: jest.fn(),
+    withDead: jest.fn(),
+    withoutValidatedRefs: jest.fn(),
+  };
+  for (const method of Object.values(builder)) method.mockReturnValue(builder);
+  return builder;
+}
+
 describe("Actual transport factory", () => {
   beforeEach(() => {
     mockGetAccounts.mockReset();
@@ -238,17 +257,7 @@ describe("Actual transport factory", () => {
   });
 
   it("Direct runQuery adapts supported wrapped ActualQL JSON into browser q() calls", async () => {
-    const builder = {
-      options: jest.fn(),
-      filter: jest.fn(),
-      select: jest.fn(),
-      calculate: jest.fn(),
-      groupBy: jest.fn(),
-      orderBy: jest.fn(),
-      limit: jest.fn(),
-      offset: jest.fn(),
-    };
-    for (const method of Object.values(builder)) method.mockReturnValue(builder);
+    const builder = createMockQueryBuilder();
     const q = jest.fn().mockReturnValue(builder);
     const aqlQuery = jest.fn().mockResolvedValue({ data: [] });
     mockGetBrowserApiRuntime.mockResolvedValue({ q, aqlQuery } as never);
@@ -271,23 +280,67 @@ describe("Actual transport factory", () => {
     expect(builder.options).toHaveBeenCalledWith({ splits: "inline" });
     expect(builder.filter).toHaveBeenCalledWith({ account: "account-1" });
     expect(builder.select).toHaveBeenCalledWith(["id", "date"]);
-    expect(builder.groupBy).toHaveBeenCalledWith(["account"]);
-    expect(builder.orderBy).toHaveBeenCalledWith([{ date: "desc" }]);
+    expect(builder.groupBy).toHaveBeenCalledWith("account");
+    expect(builder.orderBy).toHaveBeenCalledWith({ date: "desc" });
     expect(builder.limit).toHaveBeenCalledWith(10);
+    expect(builder.offset).not.toHaveBeenCalled();
     expect(aqlQuery).toHaveBeenCalledWith(builder);
   });
 
-  it("Direct runQuery rejects unsupported wrapped ActualQL fields explicitly", async () => {
-    const builder = {
-      options: jest.fn().mockReturnThis(),
-      filter: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      calculate: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      orderBy: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      offset: jest.fn().mockReturnThis(),
-    };
+  it("Direct runQuery adapts bare query JSON arrays, flags, and unfilter", async () => {
+    const builder = createMockQueryBuilder();
+    const q = jest.fn().mockReturnValue(builder);
+    const aqlQuery = jest.fn().mockResolvedValue({ data: [] });
+    mockGetBrowserApiRuntime.mockResolvedValue({ q, aqlQuery } as never);
+
+    await expect(
+      getTransport(browserConnection).runQuery({
+        table: "transactions",
+        filter: [{ account: "account-1" }, { date: { $gte: "2026-01-01" } }],
+        groupBy: ["account", "account.name"],
+        orderBy: [{ date: "desc" }, "account.name"],
+        select: ["account", "account.name", { total: { $sum: "$amount" } }],
+        offset: 5,
+        unfilter: "date",
+        raw: true,
+        withDead: true,
+        withoutValidatedRefs: true,
+      })
+    ).resolves.toEqual({ data: [] });
+
+    expect(q).toHaveBeenCalledWith("transactions");
+    expect(builder.filter).toHaveBeenNthCalledWith(1, { account: "account-1" });
+    expect(builder.filter).toHaveBeenNthCalledWith(2, { date: { $gte: "2026-01-01" } });
+    expect(builder.groupBy).toHaveBeenNthCalledWith(1, "account");
+    expect(builder.groupBy).toHaveBeenNthCalledWith(2, "account.name");
+    expect(builder.orderBy).toHaveBeenNthCalledWith(1, { date: "desc" });
+    expect(builder.orderBy).toHaveBeenNthCalledWith(2, "account.name");
+    expect(builder.offset).toHaveBeenCalledWith(5);
+    expect(builder.limit).not.toHaveBeenCalled();
+    expect(builder.unfilter).toHaveBeenCalledWith(["date"]);
+    expect(builder.raw).toHaveBeenCalledTimes(1);
+    expect(builder.withDead).toHaveBeenCalledTimes(1);
+    expect(builder.withoutValidatedRefs).toHaveBeenCalledTimes(1);
+    expect(aqlQuery).toHaveBeenCalledWith(builder);
+  });
+
+  it("Direct runQuery falls back to deprecated browser runQuery when aqlQuery is unavailable", async () => {
+    const builder = createMockQueryBuilder();
+    const runQuery = jest.fn().mockResolvedValue({ data: 3 });
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      q: jest.fn().mockReturnValue(builder),
+      runQuery,
+    } as never);
+
+    await expect(
+      getTransport(browserConnection).runQuery({ ActualQLquery: { table: "payees" } })
+    ).resolves.toEqual({ data: 3 });
+
+    expect(runQuery).toHaveBeenCalledWith(builder);
+  });
+
+  it("Direct runQuery rejects unsupported ActualQL fields before execution", async () => {
+    const builder = createMockQueryBuilder();
     const aqlQuery = jest.fn();
     mockGetBrowserApiRuntime.mockResolvedValue({
       q: jest.fn().mockReturnValue(builder),
@@ -299,6 +352,27 @@ describe("Actual transport factory", () => {
         ActualQLquery: { table: "transactions", join: ["accounts"] },
       })
     ).rejects.toThrow("Direct browser API query adapter does not support ActualQL field: join");
+    expect(aqlQuery).not.toHaveBeenCalled();
+  });
+
+  it("Direct runQuery validates limit and offset before execution", async () => {
+    const builder = createMockQueryBuilder();
+    const aqlQuery = jest.fn();
+    mockGetBrowserApiRuntime.mockResolvedValue({
+      q: jest.fn().mockReturnValue(builder),
+      aqlQuery,
+    } as never);
+
+    await expect(
+      getTransport(browserConnection).runQuery({
+        ActualQLquery: { table: "transactions", limit: Number.MAX_SAFE_INTEGER + 1 },
+      })
+    ).rejects.toThrow("ActualQLquery.limit to be a non-negative safe integer");
+    await expect(
+      getTransport(browserConnection).runQuery({
+        ActualQLquery: { table: "transactions", offset: -1 },
+      })
+    ).rejects.toThrow("ActualQLquery.offset to be a non-negative safe integer");
     expect(aqlQuery).not.toHaveBeenCalled();
   });
 

--- a/src/lib/actual/index.ts
+++ b/src/lib/actual/index.ts
@@ -2,6 +2,7 @@ import {
   isHttpApiConnection,
   type ConnectionInstance,
 } from "@/store/connection";
+import { ensureBrowserApiBudgetOpen } from "./browser/runtime";
 import { createBrowserApiTransport } from "./browserApiTransport";
 import { createHttpApiTransport } from "./httpApiTransport";
 import type { ActualBenchTransport } from "./transport";
@@ -14,5 +15,12 @@ export function getTransport(
     : createBrowserApiTransport(connection);
 }
 
-export { syncTransportAfterChanges } from "./transport";
+export async function ensureTransportReady(
+  connection: ConnectionInstance
+): Promise<void> {
+  if (isHttpApiConnection(connection)) return;
+  await ensureBrowserApiBudgetOpen(connection);
+}
+
+export { settleTransportWrites, syncTransportAfterChanges } from "./transport";
 export type { ActualBenchTransport } from "./transport";

--- a/src/lib/actual/index.ts
+++ b/src/lib/actual/index.ts
@@ -14,4 +14,5 @@ export function getTransport(
     : createBrowserApiTransport(connection);
 }
 
+export { syncTransportAfterChanges } from "./transport";
 export type { ActualBenchTransport } from "./transport";

--- a/src/lib/actual/index.ts
+++ b/src/lib/actual/index.ts
@@ -1,0 +1,17 @@
+import {
+  isHttpApiConnection,
+  type ConnectionInstance,
+} from "@/store/connection";
+import { createBrowserApiTransport } from "./browserApiTransport";
+import { createHttpApiTransport } from "./httpApiTransport";
+import type { ActualBenchTransport } from "./transport";
+
+export function getTransport(
+  connection: ConnectionInstance
+): ActualBenchTransport {
+  return isHttpApiConnection(connection)
+    ? createHttpApiTransport(connection)
+    : createBrowserApiTransport(connection);
+}
+
+export type { ActualBenchTransport } from "./transport";

--- a/src/lib/actual/ruleMutation.ts
+++ b/src/lib/actual/ruleMutation.ts
@@ -1,0 +1,78 @@
+import { CONDITION_FIELDS, ACTION_FIELDS } from "@/features/rules/utils/ruleFields";
+import type { AmountRange, ConditionOrAction, Rule } from "@/types/entities";
+
+/** Fields whose values are entity IDs that may need client-to-server substitution. */
+const ENTITY_REF_FIELDS = new Set([
+  "payee",
+  "account",
+  "category",
+  "category_group",
+  "categoryGroup",
+]);
+
+export function applyRuleEntityIdMap(
+  parts: ConditionOrAction[],
+  idMap: Record<string, string>
+): ConditionOrAction[] {
+  if (Object.keys(idMap).length === 0) return parts;
+  return parts.map((part) => {
+    if (!part.field || !ENTITY_REF_FIELDS.has(part.field)) return part;
+    const value = part.value;
+    if (typeof value === "string" && idMap[value]) {
+      return { ...part, value: idMap[value] };
+    }
+    if (Array.isArray(value)) {
+      return {
+        ...part,
+        value: value.map((item) =>
+          typeof item === "string" && idMap[item] ? idMap[item] : item
+        ),
+      };
+    }
+    return part;
+  });
+}
+
+function amountToInternal(value: ConditionOrAction["value"]): ConditionOrAction["value"] {
+  if (typeof value === "number") return Math.round(value * 100);
+  if (typeof value === "object" && value !== null && "num1" in value) {
+    const range = value as AmountRange;
+    return {
+      num1: Math.round(range.num1 * 100),
+      num2: Math.round(range.num2 * 100),
+    };
+  }
+  return value;
+}
+
+function prepareRuleParts(parts: ConditionOrAction[]): ConditionOrAction[] {
+  return parts.map((part) => {
+    const definition = CONDITION_FIELDS[part.field ?? ""] ?? ACTION_FIELDS[part.field ?? ""];
+    if (definition?.type !== "number") return part;
+
+    let value: ConditionOrAction["value"] = part.value;
+    if (typeof value === "string" && value !== "") value = Number(value);
+
+    return { ...part, value: amountToInternal(value) };
+  });
+}
+
+export function prepareRuleForTransport(rule: Omit<Rule, "id">): Omit<Rule, "id">;
+export function prepareRuleForTransport(rule: Rule): Rule;
+export function prepareRuleForTransport(rule: Rule | Omit<Rule, "id">): Rule | Omit<Rule, "id"> {
+  return {
+    ...rule,
+    conditions: prepareRuleParts(rule.conditions),
+    actions: prepareRuleParts(rule.actions),
+  };
+}
+
+export function prepareRulePatchForTransport(
+  patch: Partial<Omit<Rule, "id">>
+): Partial<Omit<Rule, "id">> {
+  return {
+    ...patch,
+    ...(patch.conditions ? { conditions: prepareRuleParts(patch.conditions) } : {}),
+    ...(patch.actions ? { actions: prepareRuleParts(patch.actions) } : {}),
+  };
+}

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -16,17 +16,20 @@ export type ScheduleWriteInput = Omit<
   "id" | "ruleId" | "nextDate" | "completed"
 >;
 
+/** Integer minor currency units, matching Actual's cents-style amount fields. */
+export type MinorUnitAmount = number;
+
 export type TransportBudgetMonthCategory = {
   id: string;
   name: string;
   is_income: boolean;
   hidden?: boolean;
   group_id: string;
-  budgeted?: number | null;
-  spent?: number | null;
-  balance?: number | null;
+  budgeted?: MinorUnitAmount | null;
+  spent?: MinorUnitAmount | null;
+  balance?: MinorUnitAmount | null;
   carryover?: boolean;
-  received?: number | null;
+  received?: MinorUnitAmount | null;
 };
 
 export type TransportBudgetMonthCategoryGroup =
@@ -35,9 +38,9 @@ export type TransportBudgetMonthCategoryGroup =
       name: string;
       is_income: false;
       hidden: boolean;
-      budgeted: number | null;
-      spent: number | null;
-      balance: number | null;
+      budgeted: MinorUnitAmount | null;
+      spent: MinorUnitAmount | null;
+      balance: MinorUnitAmount | null;
       categories: TransportBudgetMonthCategory[];
     }
   | {
@@ -45,30 +48,31 @@ export type TransportBudgetMonthCategoryGroup =
       name: string;
       is_income: true;
       hidden: boolean;
-      received: number | null;
-      budgeted?: number | null;
-      balance?: number | null;
+      received: MinorUnitAmount | null;
+      budgeted?: MinorUnitAmount | null;
+      balance?: MinorUnitAmount | null;
       categories: TransportBudgetMonthCategory[];
     };
 
 export type TransportBudgetMonth = {
   month: string;
-  incomeAvailable: number;
-  lastMonthOverspent: number;
-  forNextMonth: number;
-  totalBudgeted: number;
-  toBudget: number;
-  fromLastMonth: number;
-  totalIncome: number;
-  totalSpent: number;
-  totalBalance: number;
+  incomeAvailable: MinorUnitAmount;
+  lastMonthOverspent: MinorUnitAmount;
+  forNextMonth: MinorUnitAmount;
+  totalBudgeted: MinorUnitAmount;
+  toBudget: MinorUnitAmount;
+  fromLastMonth: MinorUnitAmount;
+  totalIncome: MinorUnitAmount;
+  totalSpent: MinorUnitAmount;
+  totalBalance: MinorUnitAmount;
   categoryGroups: TransportBudgetMonthCategoryGroup[];
 };
 
 export type BudgetTransferInput = {
   fromCategoryId: string;
   toCategoryId: string;
-  amount: number;
+  /** Amount to move, in integer minor units. */
+  amount: MinorUnitAmount;
 };
 
 export interface ActualBenchTransport {
@@ -80,7 +84,9 @@ export interface ActualBenchTransport {
   getServerVersion(): Promise<string | null>;
 
   getAccounts(): Promise<Account[]>;
+  /** Account balances are returned in decimal currency units for entity pages. */
   getAccountBalances(): Promise<Map<string, number>>;
+  /** Account initialBalance follows Account.initialBalance: decimal currency units. */
   createAccount(input: Omit<Account, "id">): Promise<Account>;
   updateAccount(id: string, patch: Partial<Omit<Account, "id" | "initialBalance">>): Promise<void>;
   deleteAccount(id: string): Promise<void>;
@@ -115,11 +121,12 @@ export interface ActualBenchTransport {
   deleteSchedule(id: string): Promise<void>;
 
   getBudgetMonths(): Promise<string[]>;
+  /** Budget month amount fields are integer minor units. */
   getBudgetMonth(month: string): Promise<TransportBudgetMonth>;
-  setBudgetAmount(month: string, categoryId: string, amount: number): Promise<void>;
+  setBudgetAmount(month: string, categoryId: string, amount: MinorUnitAmount): Promise<void>;
   setBudgetCarryover(month: string, categoryId: string, flag: boolean): Promise<void>;
   transferBudget(month: string, input: BudgetTransferInput): Promise<void>;
-  holdBudgetForNextMonth(month: string, amount: number): Promise<void>;
+  holdBudgetForNextMonth(month: string, amount: MinorUnitAmount): Promise<void>;
   resetBudgetHold(month: string): Promise<void>;
 
   getNotesIndex(): Promise<NotesIndex>;

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -141,6 +141,26 @@ export async function syncTransportAfterChanges(
   if (changed && transport.mode === "browser-api") await transport.sync();
 }
 
+export async function settleTransportWrites<TInput, TResult>(
+  transport: ActualBenchTransport,
+  inputs: TInput[],
+  write: (input: TInput) => Promise<TResult>
+): Promise<PromiseSettledResult<TResult>[]> {
+  if (transport.mode !== "browser-api") {
+    return Promise.allSettled(inputs.map(write));
+  }
+
+  const results: PromiseSettledResult<TResult>[] = [];
+  for (const input of inputs) {
+    try {
+      results.push({ status: "fulfilled", value: await write(input) });
+    } catch (reason) {
+      results.push({ status: "rejected", reason });
+    }
+  }
+  return results;
+}
+
 export function unsupportedTransportOperation(
   mode: ConnectionMode,
   operation: string

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -1,0 +1,18 @@
+import type { ConnectionMode } from "@/store/connection";
+import type { Account } from "@/types/entities";
+
+export interface ActualBenchTransport {
+  readonly mode: ConnectionMode;
+  getAccounts(): Promise<Account[]>;
+}
+
+export function unsupportedTransportOperation(
+  mode: ConnectionMode,
+  operation: string
+): Error {
+  return new Error(
+    mode === "browser-api"
+      ? "Direct browser API transport does not support " + operation + " yet."
+      : "Transport operation " + operation + " is not supported."
+  );
+}

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -1,9 +1,22 @@
+import type { CategoryGroupsResponse } from "../api/categoryGroups";
+import type { NotesIndex } from "../api/notes";
 import type { ConnectionMode } from "@/store/connection";
-import type { Account } from "@/types/entities";
+import type { Account, Payee, Rule, Schedule, Tag } from "@/types/entities";
 
 export interface ActualBenchTransport {
   readonly mode: ConnectionMode;
+  getServerVersion(): Promise<string | null>;
   getAccounts(): Promise<Account[]>;
+  getAccountBalances(): Promise<Map<string, number>>;
+  getPayees(): Promise<Payee[]>;
+  getCategoryGroups(): Promise<CategoryGroupsResponse>;
+  getTags(): Promise<Tag[]>;
+  getRules(): Promise<Rule[]>;
+  getSchedules(): Promise<Schedule[]>;
+  getNotesIndex(): Promise<NotesIndex>;
+  getAccountNote(accountId: string): Promise<string>;
+  getAllNotes(): Promise<Map<string, string>>;
+  getCategoryLikeNote(id: string): Promise<string>;
 }
 
 export function unsupportedTransportOperation(

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -16,9 +16,66 @@ export type ScheduleWriteInput = Omit<
   "id" | "ruleId" | "nextDate" | "completed"
 >;
 
+export type TransportBudgetMonthCategory = {
+  id: string;
+  name: string;
+  is_income: boolean;
+  hidden?: boolean;
+  group_id: string;
+  budgeted?: number | null;
+  spent?: number | null;
+  balance?: number | null;
+  carryover?: boolean;
+  received?: number | null;
+};
+
+export type TransportBudgetMonthCategoryGroup =
+  | {
+      id: string;
+      name: string;
+      is_income: false;
+      hidden: boolean;
+      budgeted: number | null;
+      spent: number | null;
+      balance: number | null;
+      categories: TransportBudgetMonthCategory[];
+    }
+  | {
+      id: string;
+      name: string;
+      is_income: true;
+      hidden: boolean;
+      received: number | null;
+      budgeted?: number | null;
+      balance?: number | null;
+      categories: TransportBudgetMonthCategory[];
+    };
+
+export type TransportBudgetMonth = {
+  month: string;
+  incomeAvailable: number;
+  lastMonthOverspent: number;
+  forNextMonth: number;
+  totalBudgeted: number;
+  toBudget: number;
+  fromLastMonth: number;
+  totalIncome: number;
+  totalSpent: number;
+  totalBalance: number;
+  categoryGroups: TransportBudgetMonthCategoryGroup[];
+};
+
+export type BudgetTransferInput = {
+  fromCategoryId: string;
+  toCategoryId: string;
+  amount: number;
+};
+
 export interface ActualBenchTransport {
   readonly mode: ConnectionMode;
   sync(): Promise<void>;
+  batchBudgetUpdates<T>(operation: () => Promise<T>): Promise<T>;
+  runQuery<T>(body: object): Promise<T>;
 
   getServerVersion(): Promise<string | null>;
 
@@ -56,6 +113,14 @@ export interface ActualBenchTransport {
   createSchedule(input: ScheduleWriteInput): Promise<Schedule>;
   updateSchedule(id: string, input: ScheduleWriteInput): Promise<void>;
   deleteSchedule(id: string): Promise<void>;
+
+  getBudgetMonths(): Promise<string[]>;
+  getBudgetMonth(month: string): Promise<TransportBudgetMonth>;
+  setBudgetAmount(month: string, categoryId: string, amount: number): Promise<void>;
+  setBudgetCarryover(month: string, categoryId: string, flag: boolean): Promise<void>;
+  transferBudget(month: string, input: BudgetTransferInput): Promise<void>;
+  holdBudgetForNextMonth(month: string, amount: number): Promise<void>;
+  resetBudgetHold(month: string): Promise<void>;
 
   getNotesIndex(): Promise<NotesIndex>;
   getAccountNote(accountId: string): Promise<string>;

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -1,22 +1,79 @@
 import type { CategoryGroupsResponse } from "../api/categoryGroups";
 import type { NotesIndex } from "../api/notes";
 import type { ConnectionMode } from "@/store/connection";
-import type { Account, Payee, Rule, Schedule, Tag } from "@/types/entities";
+import type {
+  Account,
+  Category,
+  CategoryGroup,
+  Payee,
+  Rule,
+  Schedule,
+  Tag,
+} from "@/types/entities";
+
+export type ScheduleWriteInput = Omit<
+  Schedule,
+  "id" | "ruleId" | "nextDate" | "completed"
+>;
 
 export interface ActualBenchTransport {
   readonly mode: ConnectionMode;
+  sync(): Promise<void>;
+
   getServerVersion(): Promise<string | null>;
+
   getAccounts(): Promise<Account[]>;
   getAccountBalances(): Promise<Map<string, number>>;
+  createAccount(input: Omit<Account, "id">): Promise<Account>;
+  updateAccount(id: string, patch: Partial<Omit<Account, "id" | "initialBalance">>): Promise<void>;
+  deleteAccount(id: string): Promise<void>;
+
   getPayees(): Promise<Payee[]>;
+  createPayee(input: Pick<Payee, "name">): Promise<Payee>;
+  updatePayee(id: string, patch: Partial<Pick<Payee, "name">>): Promise<void>;
+  deletePayee(id: string): Promise<void>;
+  mergePayees(targetId: string, mergeIds: string[]): Promise<void>;
+
   getCategoryGroups(): Promise<CategoryGroupsResponse>;
+  createCategoryGroup(input: Pick<CategoryGroup, "name" | "isIncome" | "hidden">): Promise<string>;
+  updateCategoryGroup(id: string, patch: Partial<Pick<CategoryGroup, "name" | "hidden">>): Promise<void>;
+  deleteCategoryGroup(id: string): Promise<void>;
+  createCategory(input: Pick<Category, "name" | "groupId" | "isIncome" | "hidden">): Promise<string>;
+  updateCategory(id: string, patch: Partial<Pick<Category, "name" | "hidden">>): Promise<void>;
+  deleteCategory(id: string): Promise<void>;
+
   getTags(): Promise<Tag[]>;
+  createTag(input: Pick<Tag, "name"> & Partial<Pick<Tag, "color" | "description">>): Promise<Tag>;
+  updateTag(id: string, patch: Partial<Pick<Tag, "name" | "color" | "description">>): Promise<void>;
+  deleteTag(id: string): Promise<void>;
+
   getRules(): Promise<Rule[]>;
+  createRule(input: Omit<Rule, "id">): Promise<Rule>;
+  updateRule(id: string, patch: Partial<Omit<Rule, "id">>): Promise<void>;
+  deleteRule(id: string): Promise<void>;
+
   getSchedules(): Promise<Schedule[]>;
+  createSchedule(input: ScheduleWriteInput): Promise<Schedule>;
+  updateSchedule(id: string, input: ScheduleWriteInput): Promise<void>;
+  deleteSchedule(id: string): Promise<void>;
+
   getNotesIndex(): Promise<NotesIndex>;
   getAccountNote(accountId: string): Promise<string>;
   getAllNotes(): Promise<Map<string, string>>;
   getCategoryLikeNote(id: string): Promise<string>;
+  setAccountNote(accountId: string, note: string): Promise<void>;
+  deleteAccountNote(accountId: string): Promise<void>;
+  setCategoryNote(id: string, note: string): Promise<void>;
+  deleteCategoryNote(id: string): Promise<void>;
+  setBudgetMonthNote(month: string, note: string): Promise<void>;
+  deleteBudgetMonthNote(month: string): Promise<void>;
+}
+
+export async function syncTransportAfterChanges(
+  transport: ActualBenchTransport,
+  changed: boolean
+): Promise<void> {
+  if (changed && transport.mode === "browser-api") await transport.sync();
 }
 
 export function unsupportedTransportOperation(

--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -17,7 +17,7 @@ import type { Account } from "@/types/entities";
 
 // ─── Normalization ────────────────────────────────────────────────────────────
 
-function normalizeAccount(raw: ApiAccount): Account {
+export function normalizeAccount(raw: ApiAccount): Account {
   return {
     id: raw.id,
     name: raw.name,

--- a/src/lib/api/apiDownload.test.ts
+++ b/src/lib/api/apiDownload.test.ts
@@ -8,6 +8,7 @@ import type { ApiError } from "@/types/errors";
 const connection: ConnectionInstance = {
   id: "c",
   label: "test",
+  mode: "http-api",
   baseUrl: "http://example.test",
   apiKey: "key",
   budgetSyncId: "b1",

--- a/src/lib/api/apiDownload.test.ts
+++ b/src/lib/api/apiDownload.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { apiDownload } from "./client";
+import { apiDownload, apiRequest } from "./client";
 import type { ConnectionInstance } from "@/store/connection";
 import type { ApiError } from "@/types/errors";
 
@@ -11,6 +11,15 @@ const connection: ConnectionInstance = {
   mode: "http-api",
   baseUrl: "http://example.test",
   apiKey: "key",
+  budgetSyncId: "b1",
+};
+
+const browserConnection: ConnectionInstance = {
+  id: "direct-c",
+  label: "Direct test",
+  mode: "browser-api",
+  baseUrl: "http://actual.example.test",
+  serverPassword: "password",
   budgetSyncId: "b1",
 };
 
@@ -177,5 +186,23 @@ describe("apiDownload", () => {
         body: JSON.stringify({ connection, path: "/export", method: "GET" }),
       })
     );
+  });
+
+  it("rejects Direct browser-api connections before fetching", async () => {
+    await expect(apiDownload(browserConnection, "/export")).rejects.toMatchObject<Partial<ApiError>>({
+      kind: "api",
+      status: 400,
+      message: expect.stringContaining("Direct Actual Server transport"),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects apiRequest calls with Direct browser-api connections before fetching", async () => {
+    await expect(apiRequest(browserConnection, "/accounts")).rejects.toMatchObject<Partial<ApiError>>({
+      kind: "api",
+      status: 400,
+      message: expect.stringContaining("Direct Actual Server transport"),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -6,8 +6,20 @@
  * forwards to: {baseUrl}/v1/budgets/{budgetSyncId}/{resource}
  */
 
-import type { ConnectionInstance } from "@/store/connection";
+import { isHttpApiConnection, type ConnectionInstance, type HttpApiConnection } from "@/store/connection";
 import type { ApiError } from "@/types/errors";
+
+// ─── Connection mode guard ─────────────────────────────────────────────────────
+
+function requireHttpApiConnection(connection: ConnectionInstance): HttpApiConnection {
+  if (isHttpApiConnection(connection)) return connection;
+  const error: ApiError = {
+    kind: "api",
+    status: 400,
+    message: "Direct Actual Server transport is not active for app pages yet.",
+  };
+  throw error;
+}
 
 // ─── Request helpers ──────────────────────────────────────────────────────────
 
@@ -27,6 +39,7 @@ export async function apiRequest<T>(
   options: RequestOptions = {}
 ): Promise<T> {
   const { method = "GET", body } = options;
+  const httpConnection = requireHttpApiConnection(connection);
 
   let response: Response;
 
@@ -34,7 +47,7 @@ export async function apiRequest<T>(
     response = await fetch("/api/proxy", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ connection, path, method, body }),
+      body: JSON.stringify({ connection: httpConnection, path, method, body }),
     });
   } catch (err) {
     // Network-level failure (e.g. server not running)
@@ -121,13 +134,14 @@ export async function apiDownload(
   connection: ConnectionInstance,
   path: string
 ): Promise<DownloadResult> {
+  const httpConnection = requireHttpApiConnection(connection);
   let response: Response;
 
   try {
     response = await fetch("/api/proxy/download", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ connection, path, method: "GET" }),
+      body: JSON.stringify({ connection: httpConnection, path, method: "GET" }),
     });
   } catch (err) {
     const error: ApiError = {

--- a/src/lib/api/notes.test.ts
+++ b/src/lib/api/notes.test.ts
@@ -33,6 +33,7 @@ const mockRunQuery = runQuery as jest.MockedFunction<typeof runQuery>;
 const connection: ConnectionInstance = {
   id: "conn-1",
   label: "Test",
+  mode: "http-api",
   baseUrl: "http://localhost:5006",
   apiKey: "test-key",
   budgetSyncId: "budget-1",

--- a/src/lib/api/notes.ts
+++ b/src/lib/api/notes.ts
@@ -20,7 +20,7 @@ type NotePayload =
   | null
   | undefined;
 
-function extractNote(payload: NotePayload): string {
+export function extractNote(payload: NotePayload): string {
   if (typeof payload === "string") return payload;
   if (!payload || typeof payload !== "object") return "";
 

--- a/src/lib/api/payees.ts
+++ b/src/lib/api/payees.ts
@@ -14,7 +14,7 @@ import type { Payee } from "@/types/entities";
 
 // ─── Normalization ────────────────────────────────────────────────────────────
 
-function normalizePayee(raw: ApiPayee): Payee {
+export function normalizePayee(raw: ApiPayee): Payee {
   return {
     id: raw.id!,
     name: raw.name,

--- a/src/lib/api/query.test.ts
+++ b/src/lib/api/query.test.ts
@@ -13,6 +13,7 @@ const mockApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
 const connection: ConnectionInstance = {
   id: "conn-1",
   label: "Test",
+  mode: "http-api",
   baseUrl: "http://localhost:5006",
   apiKey: "test-key",
   budgetSyncId: "budget-1",

--- a/src/lib/api/query.test.ts
+++ b/src/lib/api/query.test.ts
@@ -1,10 +1,20 @@
-import { getTransactionCountsForIds } from "./query";
+import { getTransactionCountsForIds, runQuery } from "./query";
 import type { ConnectionInstance } from "@/store/connection";
 
 // ─── Mock apiRequest ──────────────────────────────────────────────────────────
 
 jest.mock("./client", () => ({
   apiRequest: jest.fn(),
+}));
+
+const mockTransportRunQuery = jest.fn();
+const mockGetTransport = jest.fn((connection: unknown) => {
+  void connection;
+  return { runQuery: mockTransportRunQuery };
+});
+
+jest.mock("../actual", () => ({
+  getTransport: (connection: unknown) => mockGetTransport(connection),
 }));
 
 import { apiRequest } from "./client";
@@ -19,11 +29,33 @@ const connection: ConnectionInstance = {
   budgetSyncId: "budget-1",
 };
 
+const directConnection: ConnectionInstance = {
+  id: "conn-2",
+  label: "Direct",
+  mode: "browser-api",
+  baseUrl: "https://actual.example.com",
+  serverPassword: "password",
+  budgetSyncId: "budget-1",
+};
+
 // ─── getTransactionCountsForIds ───────────────────────────────────────────────
 
 describe("getTransactionCountsForIds", () => {
   beforeEach(() => {
     mockApiRequest.mockReset();
+    mockTransportRunQuery.mockReset();
+    mockGetTransport.mockClear();
+  });
+
+  it("routes Direct runQuery calls through the active transport", async () => {
+    const body = { ActualQLquery: { table: "transactions", calculate: { $count: "$id" } } };
+    mockTransportRunQuery.mockResolvedValueOnce({ data: 9 });
+
+    await expect(runQuery(directConnection, body)).resolves.toEqual({ data: 9 });
+
+    expect(mockGetTransport).toHaveBeenCalledWith(directConnection);
+    expect(mockTransportRunQuery).toHaveBeenCalledWith(body);
+    expect(mockApiRequest).not.toHaveBeenCalled();
   });
 
   it("returns empty Map immediately when ids is empty — no network call", async () => {

--- a/src/lib/api/query.ts
+++ b/src/lib/api/query.ts
@@ -1,14 +1,16 @@
 /**
  * Shared ActualQL query helper.
  *
- * Scope: intentionally narrow — RD-016 impact warnings only.
- * RD-007 (ActualQL console) will expand this file when it ships.
- *
- * All calls route through the proxy queue via apiRequest.
+ * Scope: intentionally narrow for internal app queries. The Query Console still
+ * gates itself to Classic mode; Direct mode support here adapts the known query
+ * shapes used by Budget Management, preferences, overview, and impact warnings.
  */
 
 import { apiRequest } from "./client";
-import type { ConnectionInstance } from "@/store/connection";
+import {
+  isHttpApiConnection,
+  type ConnectionInstance,
+} from "@/store/connection";
 
 // ─── Generic runner ───────────────────────────────────────────────────────────
 
@@ -16,10 +18,15 @@ export async function runQuery<T>(
   connection: ConnectionInstance,
   body: object
 ): Promise<T> {
-  return apiRequest<T>(connection, "/run-query", {
-    method: "POST",
-    body,
-  });
+  if (isHttpApiConnection(connection)) {
+    return apiRequest<T>(connection, "/run-query", {
+      method: "POST",
+      body,
+    });
+  }
+
+  const { getTransport } = await import("../actual");
+  return getTransport(connection).runQuery<T>(body);
 }
 
 // ─── Transaction counts ───────────────────────────────────────────────────────
@@ -38,10 +45,10 @@ type TransactionCountRow = Record<string, string | number> & {
  * Fetches transaction counts for a specific set of entity IDs via a single
  * $oneof-filtered ActualQL query. Returns Map<entityId, count>.
  *
- * Entities absent from the response have zero transactions — callers use
+ * Entities absent from the response have zero transactions; callers use
  * `map.get(id) ?? 0`.
  *
- * Guard: ids.length === 0 → returns empty Map immediately, no network call.
+ * Guard: ids.length === 0 returns empty Map immediately, no network call.
  */
 export async function getTransactionCountsForIds(
   connection: ConnectionInstance,
@@ -54,10 +61,10 @@ export async function getTransactionCountsForIds(
     ActualQLquery: {
       table: "transactions",
       filter: { [groupField]: { $oneof: ids } },
-      groupBy: [groupField, `${groupField}.name`],
+      groupBy: [groupField, groupField + ".name"],
       select: [
         groupField,
-        `${groupField}.name`,
+        groupField + ".name",
         { transactionCount: { $count: "$id" } },
       ],
     },

--- a/src/lib/api/query.ts
+++ b/src/lib/api/query.ts
@@ -2,7 +2,7 @@
  * Shared ActualQL query helper.
  *
  * Scope: intentionally narrow for internal app queries. The Query Console still
- * gates itself to Classic mode; Direct mode support here adapts the known query
+ * gates itself to HTTP API Server mode; Direct mode support here adapts the known query
  * shapes used by Budget Management, preferences, overview, and impact warnings.
  */
 

--- a/src/lib/api/rules.ts
+++ b/src/lib/api/rules.ts
@@ -46,7 +46,7 @@ function stageToApi(stage: RuleStage | null | undefined): string | null {
 
 // ─── Normalization ────────────────────────────────────────────────────────────
 
-function normalizeRule(raw: ApiRule): Rule {
+export function normalizeRule(raw: ApiRule): Rule {
   return {
     id: raw.id!,
     stage: stageFromApi(raw.stage),

--- a/src/lib/api/schedules.ts
+++ b/src/lib/api/schedules.ts
@@ -16,7 +16,7 @@ import type { Schedule } from "@/types/entities";
 
 // ─── Normalization ────────────────────────────────────────────────────────────
 
-function normalizeSchedule(raw: ApiSchedule): Schedule {
+export function normalizeSchedule(raw: ApiSchedule): Schedule {
   return {
     id: raw.id!,
     name: raw.name ?? undefined,

--- a/src/lib/api/tags.ts
+++ b/src/lib/api/tags.ts
@@ -13,7 +13,7 @@ import type { Tag } from "@/types/entities";
 
 // ─── Normalization ────────────────────────────────────────────────────────────
 
-function normalizeTag(raw: ApiTag): Tag {
+export function normalizeTag(raw: ApiTag): Tag {
   return {
     id: raw.id,
     name: raw.tag,

--- a/src/lib/directMode.test.ts
+++ b/src/lib/directMode.test.ts
@@ -1,0 +1,29 @@
+import {
+  DIRECT_MODE_HEADERS,
+  isDirectBrowserApiDisabled,
+  isDirectBrowserApiEnabled,
+} from "./directMode";
+
+describe("direct mode config", () => {
+  it("treats 0, false, and off as disabled values", () => {
+    expect(isDirectBrowserApiDisabled("0")).toBe(true);
+    expect(isDirectBrowserApiDisabled(" false ")).toBe(true);
+    expect(isDirectBrowserApiDisabled("OFF")).toBe(true);
+    expect(isDirectBrowserApiDisabled("1")).toBe(false);
+    expect(isDirectBrowserApiDisabled(undefined)).toBe(false);
+  });
+
+  it("enables Direct mode by default and honors either disable env", () => {
+    expect(isDirectBrowserApiEnabled({})).toBe(true);
+    expect(isDirectBrowserApiEnabled({ DIRECT_BROWSER_API: "0" })).toBe(false);
+    expect(isDirectBrowserApiEnabled({ NEXT_PUBLIC_DIRECT_BROWSER_API: "off" })).toBe(false);
+  });
+
+  it("defines the isolation headers required by the browser API", () => {
+    expect(DIRECT_MODE_HEADERS).toEqual({
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Resource-Policy": "same-origin",
+    });
+  });
+});

--- a/src/lib/directMode.ts
+++ b/src/lib/directMode.ts
@@ -1,0 +1,27 @@
+export const DIRECT_MODE_HEADERS = {
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "require-corp",
+  "Cross-Origin-Resource-Policy": "same-origin",
+} as const;
+
+export function isDirectBrowserApiDisabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "off";
+}
+
+type DirectModeEnv = {
+  DIRECT_BROWSER_API?: string;
+  NEXT_PUBLIC_DIRECT_BROWSER_API?: string;
+};
+
+export function isDirectBrowserApiEnabled(
+  env: DirectModeEnv = {
+    DIRECT_BROWSER_API: process.env.DIRECT_BROWSER_API,
+    NEXT_PUBLIC_DIRECT_BROWSER_API: process.env.NEXT_PUBLIC_DIRECT_BROWSER_API,
+  }
+): boolean {
+  return (
+    !isDirectBrowserApiDisabled(env.DIRECT_BROWSER_API) &&
+    !isDirectBrowserApiDisabled(env.NEXT_PUBLIC_DIRECT_BROWSER_API)
+  );
+}

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -1,0 +1,15 @@
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function getPersistedState<TState extends object>(value: unknown): Partial<TState> {
+  if (typeof value !== "object" || value === null) return {};
+  if (
+    "state" in value &&
+    typeof value.state === "object" &&
+    value.state !== null
+  ) {
+    return value.state as Partial<TState>;
+  }
+  return value as Partial<TState>;
+}

--- a/src/lib/savedServerCleanup.ts
+++ b/src/lib/savedServerCleanup.ts
@@ -1,0 +1,38 @@
+import type { ConnectionInstance } from "@/store/connection";
+import type { SavedServer } from "@/store/savedServers";
+
+export function findUnusedSavedServerId(
+  instance: ConnectionInstance,
+  instances: ConnectionInstance[],
+  savedServers: SavedServer[]
+): string | null {
+  const stillUsed = instances.some(
+    (other) =>
+      other.id !== instance.id &&
+      other.mode === instance.mode &&
+      other.baseUrl === instance.baseUrl
+  );
+
+  if (stillUsed) return null;
+
+  return (
+    savedServers.find(
+      (server) => server.mode === instance.mode && server.baseUrl === instance.baseUrl
+    )?.id ?? null
+  );
+}
+
+export function removeSavedServerIfUnused({
+  instance,
+  instances,
+  savedServers,
+  removeServer,
+}: {
+  instance: ConnectionInstance;
+  instances: ConnectionInstance[];
+  savedServers: SavedServer[];
+  removeServer: (id: string) => void;
+}): void {
+  const savedServerId = findUnusedSavedServerId(instance, instances, savedServers);
+  if (savedServerId) removeServer(savedServerId);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { DIRECT_MODE_HEADERS, isDirectBrowserApiEnabled } from "@/lib/directMode";
+
+function applyDirectModeHeaders(response: NextResponse): void {
+  for (const [key, value] of Object.entries(DIRECT_MODE_HEADERS)) {
+    response.headers.set(key, value);
+  }
+}
+
+export function proxy() {
+  const response = NextResponse.next();
+
+  if (isDirectBrowserApiEnabled()) {
+    applyDirectModeHeaders(response);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/((?!api/).*)"],
+};

--- a/src/store/connection.test.ts
+++ b/src/store/connection.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./connection";
 
 describe("connection store migration", () => {
-  it("migrates legacy connections without a mode to Classic http-api", () => {
+  it("migrates legacy connections without a mode to HTTP API mode", () => {
     const migrated = migrateConnectionState({
       instances: [
         {
@@ -26,7 +26,7 @@ describe("connection store migration", () => {
     expect(migrated.instances).toHaveLength(1);
     const [instance] = migrated.instances;
     expect(isHttpApiConnection(instance)).toBe(true);
-    if (!isHttpApiConnection(instance)) throw new Error("Expected Classic connection");
+    if (!isHttpApiConnection(instance)) throw new Error("Expected HTTP API connection");
     expect(instance.mode).toBe("http-api");
     expect(instance.apiKey).toBe("api-key");
     expect(instance.encryptionPassword).toBe("budget-password");
@@ -34,7 +34,7 @@ describe("connection store migration", () => {
     expect(instance.serverVersion).toBe("25.4.0");
   });
 
-  it("preserves Direct connections but does not restore them as active", () => {
+  it("preserves Direct connections and restores them as active within the session", () => {
     const migrated = migrateConnectionState({
       state: {
         instances: [
@@ -52,7 +52,7 @@ describe("connection store migration", () => {
       },
     });
 
-    expect(migrated.activeInstanceId).toBeNull();
+    expect(migrated.activeInstanceId).toBe("direct-1");
     expect(migrated.instances).toHaveLength(1);
     const [instance] = migrated.instances;
     expect(isBrowserApiConnection(instance)).toBe(true);

--- a/src/store/connection.test.ts
+++ b/src/store/connection.test.ts
@@ -1,11 +1,11 @@
 import {
-  isBrowserApiConnection,
-  isHttpApiConnection,
   migrateConnectionState,
+  toPersistedConnectionState,
+  type ConnectionInstance,
 } from "./connection";
 
-describe("connection store migration", () => {
-  it("migrates legacy connections without a mode to HTTP API mode", () => {
+describe("connection store persistence", () => {
+  it("drops legacy HTTP API connections so stored credentials are not rehydrated", () => {
     const migrated = migrateConnectionState({
       instances: [
         {
@@ -22,19 +22,10 @@ describe("connection store migration", () => {
       activeInstanceId: "conn-1",
     });
 
-    expect(migrated.activeInstanceId).toBe("conn-1");
-    expect(migrated.instances).toHaveLength(1);
-    const [instance] = migrated.instances;
-    expect(isHttpApiConnection(instance)).toBe(true);
-    if (!isHttpApiConnection(instance)) throw new Error("Expected HTTP API connection");
-    expect(instance.mode).toBe("http-api");
-    expect(instance.apiKey).toBe("api-key");
-    expect(instance.encryptionPassword).toBe("budget-password");
-    expect(instance.apiVersion).toBe("1.2.3");
-    expect(instance.serverVersion).toBe("25.4.0");
+    expect(migrated).toEqual({ instances: [], activeInstanceId: null });
   });
 
-  it("preserves Direct connections and restores them as active within the session", () => {
+  it("drops legacy Direct connections so stored passwords are not rehydrated", () => {
     const migrated = migrateConnectionState({
       state: {
         instances: [
@@ -52,13 +43,24 @@ describe("connection store migration", () => {
       },
     });
 
-    expect(migrated.activeInstanceId).toBe("direct-1");
-    expect(migrated.instances).toHaveLength(1);
-    const [instance] = migrated.instances;
-    expect(isBrowserApiConnection(instance)).toBe(true);
-    if (!isBrowserApiConnection(instance)) throw new Error("Expected Direct connection");
-    expect(instance.mode).toBe("browser-api");
-    expect(instance.serverPassword).toBe("server-password");
-    expect(instance.encryptionPassword).toBe("budget-password");
+    expect(migrated).toEqual({ instances: [], activeInstanceId: null });
+  });
+
+  it("persists no active connection secrets from in-memory state", () => {
+    const instance: ConnectionInstance = {
+      id: "conn-1",
+      mode: "http-api",
+      label: "Family Fund",
+      baseUrl: "https://api.example.com",
+      apiKey: "api-key",
+      budgetSyncId: "budget-1",
+      encryptionPassword: "budget-password",
+      apiVersion: "1.2.3",
+      serverVersion: "25.4.0",
+    };
+
+    expect(
+      toPersistedConnectionState({ instances: [instance], activeInstanceId: instance.id })
+    ).toEqual({ instances: [], activeInstanceId: null });
   });
 });

--- a/src/store/connection.test.ts
+++ b/src/store/connection.test.ts
@@ -1,0 +1,64 @@
+import {
+  isBrowserApiConnection,
+  isHttpApiConnection,
+  migrateConnectionState,
+} from "./connection";
+
+describe("connection store migration", () => {
+  it("migrates legacy connections without a mode to Classic http-api", () => {
+    const migrated = migrateConnectionState({
+      instances: [
+        {
+          id: "conn-1",
+          label: "Family Fund",
+          baseUrl: "https://api.example.com",
+          apiKey: "api-key",
+          budgetSyncId: "budget-1",
+          encryptionPassword: "budget-password",
+          apiVersion: "1.2.3",
+          serverVersion: "25.4.0",
+        },
+      ],
+      activeInstanceId: "conn-1",
+    });
+
+    expect(migrated.activeInstanceId).toBe("conn-1");
+    expect(migrated.instances).toHaveLength(1);
+    const [instance] = migrated.instances;
+    expect(isHttpApiConnection(instance)).toBe(true);
+    if (!isHttpApiConnection(instance)) throw new Error("Expected Classic connection");
+    expect(instance.mode).toBe("http-api");
+    expect(instance.apiKey).toBe("api-key");
+    expect(instance.encryptionPassword).toBe("budget-password");
+    expect(instance.apiVersion).toBe("1.2.3");
+    expect(instance.serverVersion).toBe("25.4.0");
+  });
+
+  it("preserves Direct connections but does not restore them as active", () => {
+    const migrated = migrateConnectionState({
+      state: {
+        instances: [
+          {
+            id: "direct-1",
+            mode: "browser-api",
+            label: "Family Fund",
+            baseUrl: "https://actual.example.com",
+            serverPassword: "server-password",
+            budgetSyncId: "budget-1",
+            encryptionPassword: "budget-password",
+          },
+        ],
+        activeInstanceId: "direct-1",
+      },
+    });
+
+    expect(migrated.activeInstanceId).toBeNull();
+    expect(migrated.instances).toHaveLength(1);
+    const [instance] = migrated.instances;
+    expect(isBrowserApiConnection(instance)).toBe(true);
+    if (!isBrowserApiConnection(instance)) throw new Error("Expected Direct connection");
+    expect(instance.mode).toBe("browser-api");
+    expect(instance.serverPassword).toBe("server-password");
+    expect(instance.encryptionPassword).toBe("budget-password");
+  });
+});

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -3,19 +3,35 @@ import { persist, createJSONStorage } from "zustand/middleware";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type ConnectionInstance = {
+export type ConnectionMode = "http-api" | "browser-api";
+
+type ConnectionBase = {
   id: string;
   label: string;
+  mode: ConnectionMode;
   baseUrl: string;
-  apiKey: string;
   budgetSyncId: string;
   /** Optional: required by the jhonderson actual-http-api when the budget is encrypted */
   encryptionPassword?: string;
+};
+
+export type HttpApiConnection = ConnectionBase & {
+  mode: "http-api";
+  apiKey: string;
   /** actual-http-api wrapper version — fetched once on connect, stored in session */
   apiVersion?: string;
   /** Actual Budget server version — fetched once on connect, stored in session */
   serverVersion?: string;
 };
+
+export type BrowserApiConnection = ConnectionBase & {
+  mode: "browser-api";
+  serverPassword: string;
+  /** Actual Budget server version — fetched once available, stored in session */
+  serverVersion?: string;
+};
+
+export type ConnectionInstance = HttpApiConnection | BrowserApiConnection;
 
 type ConnectionState = {
   instances: ConnectionInstance[];
@@ -26,9 +42,119 @@ type ConnectionActions = {
   addInstance: (instance: ConnectionInstance) => void;
   removeInstance: (id: string) => void;
   setActiveInstance: (id: string | null) => void;
-  updateInstance: (id: string, patch: Partial<Omit<ConnectionInstance, "id">>) => void;
+  updateInstance: (id: string, patch: Partial<ConnectionInstance>) => void;
   clearAll: () => void;
 };
+
+type PersistedConnectionRecord = {
+  id?: unknown;
+  label?: unknown;
+  mode?: unknown;
+  baseUrl?: unknown;
+  apiKey?: unknown;
+  serverPassword?: unknown;
+  budgetSyncId?: unknown;
+  encryptionPassword?: unknown;
+  apiVersion?: unknown;
+  serverVersion?: unknown;
+};
+
+type PersistedConnectionState = {
+  instances?: unknown;
+  activeInstanceId?: unknown;
+};
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function getPersistedState(value: unknown): PersistedConnectionState {
+  if (typeof value !== "object" || value === null) return {};
+  if (
+    "state" in value &&
+    typeof value.state === "object" &&
+    value.state !== null
+  ) {
+    return value.state as PersistedConnectionState;
+  }
+  return value as PersistedConnectionState;
+}
+
+export function isHttpApiConnection(
+  connection: ConnectionInstance | null | undefined
+): connection is HttpApiConnection {
+  return connection?.mode === "http-api";
+}
+
+export function isBrowserApiConnection(
+  connection: ConnectionInstance | null | undefined
+): connection is BrowserApiConnection {
+  return connection?.mode === "browser-api";
+}
+
+export function normalizeConnectionInstance(
+  record: unknown
+): ConnectionInstance | null {
+  if (typeof record !== "object" || record === null) return null;
+  const persisted = record as PersistedConnectionRecord;
+  const id = asString(persisted.id);
+  const label = asString(persisted.label);
+  const baseUrl = asString(persisted.baseUrl);
+  const budgetSyncId = asString(persisted.budgetSyncId);
+
+  if (!id || !label || !baseUrl || !budgetSyncId) return null;
+
+  const common = {
+    id,
+    label,
+    baseUrl,
+    budgetSyncId,
+    ...(asString(persisted.encryptionPassword)
+      ? { encryptionPassword: asString(persisted.encryptionPassword) }
+      : {}),
+    ...(asString(persisted.serverVersion)
+      ? { serverVersion: asString(persisted.serverVersion) }
+      : {}),
+  };
+
+  if (persisted.mode === "browser-api") {
+    return {
+      ...common,
+      mode: "browser-api",
+      serverPassword: asString(persisted.serverPassword) ?? "",
+    };
+  }
+
+  return {
+    ...common,
+    mode: "http-api",
+    apiKey: asString(persisted.apiKey) ?? "",
+    ...(asString(persisted.apiVersion)
+      ? { apiVersion: asString(persisted.apiVersion) }
+      : {}),
+  };
+}
+
+export function migrateConnectionState(value: unknown): ConnectionState {
+  const persisted = getPersistedState(value);
+  const instances = Array.isArray(persisted.instances)
+    ? persisted.instances
+        .map(normalizeConnectionInstance)
+        .filter((instance): instance is ConnectionInstance => instance !== null)
+    : [];
+  const activeInstanceId = asString(persisted.activeInstanceId);
+
+  return {
+    instances,
+    activeInstanceId:
+      activeInstanceId &&
+      instances.some(
+        (instance) => instance.id === activeInstanceId && isHttpApiConnection(instance)
+      )
+        ? activeInstanceId
+        : null,
+  };
+}
 
 // ─── Store ────────────────────────────────────────────────────────────────────
 
@@ -49,7 +175,8 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
       addInstance: (instance) =>
         set((state) => ({
           instances: [...state.instances, instance],
-          activeInstanceId: state.activeInstanceId ?? instance.id,
+          activeInstanceId:
+            state.activeInstanceId ?? (isHttpApiConnection(instance) ? instance.id : null),
         })),
 
       removeInstance: (id) =>
@@ -57,17 +184,26 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
           const remaining = state.instances.filter((i) => i.id !== id);
           const nextActive =
             state.activeInstanceId === id
-              ? (remaining[0]?.id ?? null)
+              ? (remaining.find(isHttpApiConnection)?.id ?? null)
               : state.activeInstanceId;
           return { instances: remaining, activeInstanceId: nextActive };
         }),
 
-      setActiveInstance: (id) => set({ activeInstanceId: id }),
+      setActiveInstance: (id) =>
+        set((state) => ({
+          activeInstanceId:
+            id === null ||
+            state.instances.some(
+              (instance) => instance.id === id && isHttpApiConnection(instance)
+            )
+              ? id
+              : state.activeInstanceId,
+        })),
 
       updateInstance: (id, patch) =>
         set((state) => ({
           instances: state.instances.map((i) =>
-            i.id === id ? { ...i, ...patch } : i
+            i.id === id ? ({ ...i, ...patch } as ConnectionInstance) : i
           ),
         })),
 
@@ -75,6 +211,8 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
     }),
     {
       name: "actual-admin-connection",
+      version: 2,
+      migrate: (persistedState) => migrateConnectionState(persistedState),
       // Guard for SSR — sessionStorage is only available in the browser.
       // Returning null here causes Zustand to skip persistence on the server
       // without throwing, preventing hydration mismatches.

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -147,10 +147,7 @@ export function migrateConnectionState(value: unknown): ConnectionState {
   return {
     instances,
     activeInstanceId:
-      activeInstanceId &&
-      instances.some(
-        (instance) => instance.id === activeInstanceId && isHttpApiConnection(instance)
-      )
+      activeInstanceId && instances.some((instance) => instance.id === activeInstanceId)
         ? activeInstanceId
         : null,
   };
@@ -175,8 +172,7 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
       addInstance: (instance) =>
         set((state) => ({
           instances: [...state.instances, instance],
-          activeInstanceId:
-            state.activeInstanceId ?? (isHttpApiConnection(instance) ? instance.id : null),
+          activeInstanceId: state.activeInstanceId ?? instance.id,
         })),
 
       removeInstance: (id) =>
@@ -184,7 +180,7 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
           const remaining = state.instances.filter((i) => i.id !== id);
           const nextActive =
             state.activeInstanceId === id
-              ? (remaining.find(isHttpApiConnection)?.id ?? null)
+              ? (remaining[0]?.id ?? null)
               : state.activeInstanceId;
           return { instances: remaining, activeInstanceId: nextActive };
         }),
@@ -192,10 +188,7 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
       setActiveInstance: (id) =>
         set((state) => ({
           activeInstanceId:
-            id === null ||
-            state.instances.some(
-              (instance) => instance.id === id && isHttpApiConnection(instance)
-            )
+            id === null || state.instances.some((instance) => instance.id === id)
               ? id
               : state.activeInstanceId,
         })),

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -11,23 +11,23 @@ type ConnectionBase = {
   mode: ConnectionMode;
   baseUrl: string;
   budgetSyncId: string;
-  /** Optional: required by the jhonderson actual-http-api when the budget is encrypted */
+  /** Optional budget encryption password, kept in memory only. */
   encryptionPassword?: string;
 };
 
 export type HttpApiConnection = ConnectionBase & {
   mode: "http-api";
   apiKey: string;
-  /** actual-http-api wrapper version — fetched once on connect, stored in session */
+  /** actual-http-api wrapper version, held in memory for the active connection. */
   apiVersion?: string;
-  /** Actual Budget server version — fetched once on connect, stored in session */
+  /** Actual Budget server version, held in memory for the active connection. */
   serverVersion?: string;
 };
 
 export type BrowserApiConnection = ConnectionBase & {
   mode: "browser-api";
   serverPassword: string;
-  /** Actual Budget server version — fetched once available, stored in session */
+  /** Actual Budget server version, held in memory for the active connection. */
   serverVersion?: string;
 };
 
@@ -46,40 +46,6 @@ type ConnectionActions = {
   clearAll: () => void;
 };
 
-type PersistedConnectionRecord = {
-  id?: unknown;
-  label?: unknown;
-  mode?: unknown;
-  baseUrl?: unknown;
-  apiKey?: unknown;
-  serverPassword?: unknown;
-  budgetSyncId?: unknown;
-  encryptionPassword?: unknown;
-  apiVersion?: unknown;
-  serverVersion?: unknown;
-};
-
-type PersistedConnectionState = {
-  instances?: unknown;
-  activeInstanceId?: unknown;
-};
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-function getPersistedState(value: unknown): PersistedConnectionState {
-  if (typeof value !== "object" || value === null) return {};
-  if (
-    "state" in value &&
-    typeof value.state === "object" &&
-    value.state !== null
-  ) {
-    return value.state as PersistedConnectionState;
-  }
-  return value as PersistedConnectionState;
-}
-
 export function isHttpApiConnection(
   connection: ConnectionInstance | null | undefined
 ): connection is HttpApiConnection {
@@ -92,79 +58,35 @@ export function isBrowserApiConnection(
   return connection?.mode === "browser-api";
 }
 
-export function normalizeConnectionInstance(
-  record: unknown
-): ConnectionInstance | null {
-  if (typeof record !== "object" || record === null) return null;
-  const persisted = record as PersistedConnectionRecord;
-  const id = asString(persisted.id);
-  const label = asString(persisted.label);
-  const baseUrl = asString(persisted.baseUrl);
-  const budgetSyncId = asString(persisted.budgetSyncId);
-
-  if (!id || !label || !baseUrl || !budgetSyncId) return null;
-
-  const common = {
-    id,
-    label,
-    baseUrl,
-    budgetSyncId,
-    ...(asString(persisted.encryptionPassword)
-      ? { encryptionPassword: asString(persisted.encryptionPassword) }
-      : {}),
-    ...(asString(persisted.serverVersion)
-      ? { serverVersion: asString(persisted.serverVersion) }
-      : {}),
-  };
-
-  if (persisted.mode === "browser-api") {
-    return {
-      ...common,
-      mode: "browser-api",
-      serverPassword: asString(persisted.serverPassword) ?? "",
-    };
-  }
-
-  return {
-    ...common,
-    mode: "http-api",
-    apiKey: asString(persisted.apiKey) ?? "",
-    ...(asString(persisted.apiVersion)
-      ? { apiVersion: asString(persisted.apiVersion) }
-      : {}),
-  };
+/**
+ * Active connections require credentials for every transport call. Persisted
+ * storage is now secret-free, so legacy persisted connections are intentionally
+ * dropped and users reconnect through saved server presets.
+ */
+export function normalizeConnectionInstance(_record: unknown): ConnectionInstance | null {
+  void _record;
+  return null;
 }
 
-export function migrateConnectionState(value: unknown): ConnectionState {
-  const persisted = getPersistedState(value);
-  const instances = Array.isArray(persisted.instances)
-    ? persisted.instances
-        .map(normalizeConnectionInstance)
-        .filter((instance): instance is ConnectionInstance => instance !== null)
-    : [];
-  const activeInstanceId = asString(persisted.activeInstanceId);
+export function migrateConnectionState(_value: unknown): ConnectionState {
+  void _value;
+  return { instances: [], activeInstanceId: null };
+}
 
-  return {
-    instances,
-    activeInstanceId:
-      activeInstanceId && instances.some((instance) => instance.id === activeInstanceId)
-        ? activeInstanceId
-        : null,
-  };
+export function toPersistedConnectionState(_state: ConnectionState): ConnectionState {
+  void _state;
+  return { instances: [], activeInstanceId: null };
 }
 
 // ─── Store ────────────────────────────────────────────────────────────────────
 
 /**
- * Connection state is persisted to sessionStorage so it survives:
- *  - Next.js App Router client-side navigation
- *  - Turbopack HMR module re-initialization in dev mode
- *
- * sessionStorage (not localStorage) is intentional: credentials are cleared
- * when the browser tab is closed.
+ * Active connection state lives in memory only so API keys, server passwords,
+ * and budget encryption passwords are never written to browser storage. The
+ * persist middleware remains in place to migrate old sessionStorage records out.
  */
 export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
-  persist(
+  persist<ConnectionState & ConnectionActions, [], [], ConnectionState>(
     (set) => ({
       instances: [],
       activeInstanceId: null,
@@ -204,8 +126,9 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
     }),
     {
       name: "actual-admin-connection",
-      version: 2,
+      version: 3,
       migrate: (persistedState) => migrateConnectionState(persistedState),
+      partialize: toPersistedConnectionState,
       // Guard for SSR — sessionStorage is only available in the browser.
       // Returning null here causes Zustand to skip persistence on the server
       // without throwing, preventing hydration mismatches.

--- a/src/store/savedServers.test.ts
+++ b/src/store/savedServers.test.ts
@@ -2,10 +2,12 @@ import {
   isBrowserApiSavedServer,
   isHttpApiSavedServer,
   migrateSavedServersState,
+  toPersistedSavedServersState,
+  type SavedServer,
 } from "./savedServers";
 
 describe("saved servers migration", () => {
-  it("migrates legacy saved servers without a mode to HTTP API mode", () => {
+  it("migrates legacy saved servers without restoring API keys", () => {
     const migrated = migrateSavedServersState({
       servers: [
         {
@@ -21,11 +23,16 @@ describe("saved servers migration", () => {
     const [server] = migrated.servers;
     expect(isHttpApiSavedServer(server)).toBe(true);
     if (!isHttpApiSavedServer(server)) throw new Error("Expected HTTP API saved server");
-    expect(server.mode).toBe("http-api");
-    expect(server.apiKey).toBe("api-key");
+    expect(server).toEqual({
+      id: "server-1",
+      mode: "http-api",
+      label: "api.example.com",
+      baseUrl: "https://api.example.com",
+    });
+    expect(server).not.toHaveProperty("apiKey");
   });
 
-  it("preserves Direct saved server credentials from persisted state wrappers", () => {
+  it("migrates Direct saved servers without restoring server passwords", () => {
     const migrated = migrateSavedServersState({
       state: {
         servers: [
@@ -44,7 +51,48 @@ describe("saved servers migration", () => {
     const [server] = migrated.servers;
     expect(isBrowserApiSavedServer(server)).toBe(true);
     if (!isBrowserApiSavedServer(server)) throw new Error("Expected Direct saved server");
-    expect(server.mode).toBe("browser-api");
-    expect(server.serverPassword).toBe("server-password");
+    expect(server).toEqual({
+      id: "server-2",
+      mode: "browser-api",
+      label: "actual.example.com",
+      baseUrl: "https://actual.example.com",
+    });
+    expect(server).not.toHaveProperty("serverPassword");
+  });
+
+  it("persists only non-secret saved server metadata", () => {
+    const savedServers = [
+      {
+        id: "server-1",
+        mode: "http-api",
+        label: "api.example.com",
+        baseUrl: "https://api.example.com",
+        apiKey: "api-key",
+      },
+      {
+        id: "server-2",
+        mode: "browser-api",
+        label: "actual.example.com",
+        baseUrl: "https://actual.example.com",
+        serverPassword: "server-password",
+      },
+    ] as unknown as SavedServer[];
+
+    expect(toPersistedSavedServersState({ servers: savedServers })).toEqual({
+      servers: [
+        {
+          id: "server-1",
+          mode: "http-api",
+          label: "api.example.com",
+          baseUrl: "https://api.example.com",
+        },
+        {
+          id: "server-2",
+          mode: "browser-api",
+          label: "actual.example.com",
+          baseUrl: "https://actual.example.com",
+        },
+      ],
+    });
   });
 });

--- a/src/store/savedServers.test.ts
+++ b/src/store/savedServers.test.ts
@@ -1,0 +1,50 @@
+import {
+  isBrowserApiSavedServer,
+  isHttpApiSavedServer,
+  migrateSavedServersState,
+} from "./savedServers";
+
+describe("saved servers migration", () => {
+  it("migrates legacy saved servers without a mode to Classic http-api", () => {
+    const migrated = migrateSavedServersState({
+      servers: [
+        {
+          id: "server-1",
+          label: "api.example.com",
+          baseUrl: "https://api.example.com",
+          apiKey: "api-key",
+        },
+      ],
+    });
+
+    expect(migrated.servers).toHaveLength(1);
+    const [server] = migrated.servers;
+    expect(isHttpApiSavedServer(server)).toBe(true);
+    if (!isHttpApiSavedServer(server)) throw new Error("Expected Classic saved server");
+    expect(server.mode).toBe("http-api");
+    expect(server.apiKey).toBe("api-key");
+  });
+
+  it("preserves Direct saved server credentials from persisted state wrappers", () => {
+    const migrated = migrateSavedServersState({
+      state: {
+        servers: [
+          {
+            id: "server-2",
+            mode: "browser-api",
+            label: "actual.example.com",
+            baseUrl: "https://actual.example.com",
+            serverPassword: "server-password",
+          },
+        ],
+      },
+    });
+
+    expect(migrated.servers).toHaveLength(1);
+    const [server] = migrated.servers;
+    expect(isBrowserApiSavedServer(server)).toBe(true);
+    if (!isBrowserApiSavedServer(server)) throw new Error("Expected Direct saved server");
+    expect(server.mode).toBe("browser-api");
+    expect(server.serverPassword).toBe("server-password");
+  });
+});

--- a/src/store/savedServers.test.ts
+++ b/src/store/savedServers.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./savedServers";
 
 describe("saved servers migration", () => {
-  it("migrates legacy saved servers without a mode to Classic http-api", () => {
+  it("migrates legacy saved servers without a mode to HTTP API mode", () => {
     const migrated = migrateSavedServersState({
       servers: [
         {
@@ -20,7 +20,7 @@ describe("saved servers migration", () => {
     expect(migrated.servers).toHaveLength(1);
     const [server] = migrated.servers;
     expect(isHttpApiSavedServer(server)).toBe(true);
-    if (!isHttpApiSavedServer(server)) throw new Error("Expected Classic saved server");
+    if (!isHttpApiSavedServer(server)) throw new Error("Expected HTTP API saved server");
     expect(server.mode).toBe("http-api");
     expect(server.apiKey).toBe("api-key");
   });

--- a/src/store/savedServers.ts
+++ b/src/store/savedServers.ts
@@ -1,32 +1,127 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { generateId } from "@/lib/uuid";
+import type { ConnectionMode } from "@/store/connection";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type SavedServer = {
+type SavedServerBase = {
   id: string;
+  mode: ConnectionMode;
   /** Derived from the URL host at save time (e.g. "budgetapi.example.com") */
   label: string;
   baseUrl: string;
+};
+
+export type SavedHttpApiServer = SavedServerBase & {
+  mode: "http-api";
   apiKey: string;
 };
+
+export type SavedBrowserApiServer = SavedServerBase & {
+  mode: "browser-api";
+  serverPassword: string;
+};
+
+export type SavedServer = SavedHttpApiServer | SavedBrowserApiServer;
 
 type SavedServersState = {
   servers: SavedServer[];
 };
 
+type SavedServerInput = Omit<SavedHttpApiServer, "id"> | Omit<SavedBrowserApiServer, "id">;
+
 type SavedServersActions = {
   /**
-   * Adds a server. Idempotent by baseUrl — if a server with the same baseUrl
-   * already exists it is not added again.
+   * Adds a server. Idempotent by mode + baseUrl so Classic and Direct presets
+   * for the same host can coexist without overwriting each other.
    */
-  addServer: (params: Omit<SavedServer, "id">) => void;
-  /** Removes the saved server entry matching the given baseUrl. No-op if not found. */
-  removeServer: (baseUrl: string) => void;
+  addServer: (params: SavedServerInput) => void;
+  /** Removes the saved server entry matching the given id. No-op if not found. */
+  removeServer: (id: string) => void;
   /** Removes all saved servers. Called alongside clearAll() on the connection store. */
   clearServers: () => void;
 };
+
+type PersistedSavedServerRecord = {
+  id?: unknown;
+  mode?: unknown;
+  label?: unknown;
+  baseUrl?: unknown;
+  apiKey?: unknown;
+  serverPassword?: unknown;
+};
+
+type PersistedSavedServersState = {
+  servers?: unknown;
+};
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function getPersistedState(value: unknown): PersistedSavedServersState {
+  if (typeof value !== "object" || value === null) return {};
+  if (
+    "state" in value &&
+    typeof value.state === "object" &&
+    value.state !== null
+  ) {
+    return value.state as PersistedSavedServersState;
+  }
+  return value as PersistedSavedServersState;
+}
+
+export function isHttpApiSavedServer(
+  server: SavedServer | null | undefined
+): server is SavedHttpApiServer {
+  return server?.mode === "http-api";
+}
+
+export function isBrowserApiSavedServer(
+  server: SavedServer | null | undefined
+): server is SavedBrowserApiServer {
+  return server?.mode === "browser-api";
+}
+
+export function normalizeSavedServer(record: unknown): SavedServer | null {
+  if (typeof record !== "object" || record === null) return null;
+  const persisted = record as PersistedSavedServerRecord;
+  const id = asString(persisted.id);
+  const label = asString(persisted.label);
+  const baseUrl = asString(persisted.baseUrl);
+
+  if (!id || !label || !baseUrl) return null;
+
+  if (persisted.mode === "browser-api") {
+    return {
+      id,
+      mode: "browser-api",
+      label,
+      baseUrl,
+      serverPassword: asString(persisted.serverPassword) ?? "",
+    };
+  }
+
+  return {
+    id,
+    mode: "http-api",
+    label,
+    baseUrl,
+    apiKey: asString(persisted.apiKey) ?? "",
+  };
+}
+
+export function migrateSavedServersState(value: unknown): SavedServersState {
+  const persisted = getPersistedState(value);
+  return {
+    servers: Array.isArray(persisted.servers)
+      ? persisted.servers
+          .map(normalizeSavedServer)
+          .filter((server): server is SavedServer => server !== null)
+      : [],
+  };
+}
 
 // ─── Store ────────────────────────────────────────────────────────────────────
 
@@ -41,26 +136,30 @@ export const useSavedServersStore = create<SavedServersState & SavedServersActio
 
       addServer: (params) =>
         set((state) => {
-          const existing = state.servers.find((s) => s.baseUrl === params.baseUrl);
+          const existing = state.servers.find(
+            (server) => server.mode === params.mode && server.baseUrl === params.baseUrl
+          );
           if (existing) {
             return {
-              servers: state.servers.map((s) =>
-                s.baseUrl === params.baseUrl ? { ...s, ...params } : s
+              servers: state.servers.map((server) =>
+                server.id === existing.id ? ({ ...server, ...params } as SavedServer) : server
               ),
             };
           }
-          return { servers: [...state.servers, { ...params, id: generateId() }] };
+          return { servers: [...state.servers, { ...params, id: generateId() } as SavedServer] };
         }),
 
-      removeServer: (baseUrl) =>
+      removeServer: (id) =>
         set((state) => ({
-          servers: state.servers.filter((s) => s.baseUrl !== baseUrl),
+          servers: state.servers.filter((server) => server.id !== id),
         })),
 
       clearServers: () => set({ servers: [] }),
     }),
     {
       name: "actual-admin-saved-servers",
+      version: 2,
+      migrate: (persistedState) => migrateSavedServersState(persistedState),
       storage: createJSONStorage(() =>
         typeof window !== "undefined" ? sessionStorage : (null as unknown as Storage)
       ),

--- a/src/store/savedServers.ts
+++ b/src/store/savedServers.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
+import { asString, getPersistedState } from "@/lib/persist";
 import { generateId } from "@/lib/uuid";
 import type { ConnectionMode } from "@/store/connection";
 
@@ -15,12 +16,10 @@ type SavedServerBase = {
 
 export type SavedHttpApiServer = SavedServerBase & {
   mode: "http-api";
-  apiKey: string;
 };
 
 export type SavedBrowserApiServer = SavedServerBase & {
   mode: "browser-api";
-  serverPassword: string;
 };
 
 export type SavedServer = SavedHttpApiServer | SavedBrowserApiServer;
@@ -29,7 +28,7 @@ type SavedServersState = {
   servers: SavedServer[];
 };
 
-type SavedServerInput = Omit<SavedHttpApiServer, "id"> | Omit<SavedBrowserApiServer, "id">;
+type SavedServerInput = Omit<SavedServer, "id">;
 
 type SavedServersActions = {
   /**
@@ -55,22 +54,6 @@ type PersistedSavedServerRecord = {
 type PersistedSavedServersState = {
   servers?: unknown;
 };
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-function getPersistedState(value: unknown): PersistedSavedServersState {
-  if (typeof value !== "object" || value === null) return {};
-  if (
-    "state" in value &&
-    typeof value.state === "object" &&
-    value.state !== null
-  ) {
-    return value.state as PersistedSavedServersState;
-  }
-  return value as PersistedSavedServersState;
-}
 
 export function isHttpApiSavedServer(
   server: SavedServer | null | undefined
@@ -99,7 +82,6 @@ export function normalizeSavedServer(record: unknown): SavedServer | null {
       mode: "browser-api",
       label,
       baseUrl,
-      serverPassword: asString(persisted.serverPassword) ?? "",
     };
   }
 
@@ -108,12 +90,11 @@ export function normalizeSavedServer(record: unknown): SavedServer | null {
     mode: "http-api",
     label,
     baseUrl,
-    apiKey: asString(persisted.apiKey) ?? "",
   };
 }
 
 export function migrateSavedServersState(value: unknown): SavedServersState {
-  const persisted = getPersistedState(value);
+  const persisted = getPersistedState<PersistedSavedServersState>(value);
   return {
     servers: Array.isArray(persisted.servers)
       ? persisted.servers
@@ -123,14 +104,25 @@ export function migrateSavedServersState(value: unknown): SavedServersState {
   };
 }
 
+export function toPersistedSavedServersState(state: SavedServersState): SavedServersState {
+  return {
+    servers: state.servers.map(({ id, mode, label, baseUrl }) => ({
+      id,
+      mode,
+      label,
+      baseUrl,
+    })),
+  };
+}
+
 // ─── Store ────────────────────────────────────────────────────────────────────
 
 /**
- * Saved servers are persisted to sessionStorage so credentials are cleared
- * when the browser tab is closed — consistent with connection.ts behaviour.
+ * Saved server presets persist non-secret server metadata only. API keys,
+ * server passwords, and budget encryption passwords stay in memory only.
  */
 export const useSavedServersStore = create<SavedServersState & SavedServersActions>()(
-  persist(
+  persist<SavedServersState & SavedServersActions, [], [], SavedServersState>(
     (set) => ({
       servers: [],
 
@@ -158,8 +150,9 @@ export const useSavedServersStore = create<SavedServersState & SavedServersActio
     }),
     {
       name: "actual-admin-saved-servers",
-      version: 2,
+      version: 3,
       migrate: (persistedState) => migrateSavedServersState(persistedState),
+      partialize: toPersistedSavedServersState,
       storage: createJSONStorage(() =>
         typeof window !== "undefined" ? sessionStorage : (null as unknown as Storage)
       ),

--- a/src/store/savedServers.ts
+++ b/src/store/savedServers.ts
@@ -33,7 +33,7 @@ type SavedServerInput = Omit<SavedHttpApiServer, "id"> | Omit<SavedBrowserApiSer
 
 type SavedServersActions = {
   /**
-   * Adds a server. Idempotent by mode + baseUrl so Classic and Direct presets
+   * Adds a server. Idempotent by mode + baseUrl so HTTP API and Direct presets
    * for the same host can coexist without overwriting each other.
    */
   addServer: (params: SavedServerInput) => void;


### PR DESCRIPTION
## Summary

Covers RD-051 and the PR-017 milestone specs for Direct Browser API Transport.

This PR adds Direct Actual Server mode through the browser build of `@actual-app/api` while keeping the existing HTTP API Server compatibility path intact. It introduces mode-aware connection storage, the transport abstraction under `src/lib/actual`, browser API runtime support, Direct read/write support for core entities, budget-management support, Direct ActualQL query execution, and release-readiness hardening around isolation headers, runtime availability, connection readiness, write serialization, and asset caching.

## Milestones

- PR-017a: Direct Browser API Lab Spike
- PR-017b: Connection Modes Foundation
- PR-017c: Transport Abstraction Foundation
- PR-017d: Direct Read-Only Transport
- PR-017e: Direct Entity Mutations
- PR-017f: Direct Budget Management + Query Subset
- PR-017g: Direct Mode Hardening + Release Docs
- PR-017h: Direct ActualQL Query Console
- PR-017i: Direct Mode Review Hardening

## User and Developer Impact

Direct mode is now the target browser architecture for Actual Bench deployments that can satisfy the browser API requirements. HTTP API Server mode remains supported through the existing Next.js proxy path. User-facing docs now describe Direct mode setup, hosting constraints, and fallback behavior.

Feature code routes through transport/business helpers instead of duplicating proxy behavior, and Direct-mode mutations preserve the staged-save model before writing to Actual Server.

Closes #140

## Validation

- Branch pushed cleanly to `origin/feat/pr-017-direct-browser-api-transport`
- Local worktree is clean before PR creation
- GitHub Actions will run lint, type-check, tests, and build on this PR

Manual Direct-mode validation items are tracked in the PR-017g/PR-017h/PR-017i specs for connection, reload, query, budget-management, cache, and isolation behavior.