### PR TITLE
Fix Edge Docker build dependencies

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,6 +1,8 @@
 # ── Stage 1: full build ────────────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 WORKDIR /app
+# Native modules such as better-sqlite3 may fall back to node-gyp on Alpine.
+RUN apk add --no-cache python3 make g++
 COPY package*.json ./
 COPY scripts/copy-sqlite-wasm.mjs ./scripts/copy-sqlite-wasm.mjs
 RUN npm ci


### PR DESCRIPTION
## Summary

Adds Python and compiler build dependencies to the production Docker builder stage so Alpine can compile native modules such as `better-sqlite3` when no musl prebuild is available.

## Why

The Edge workflow failed in `docker/Dockerfile.prod` during `npm ci` because `better-sqlite3` fell back to `node-gyp`, and `node-gyp` could not find Python in `node:20-alpine`.

## Validation

- `git diff --check`
- Local Docker validation could not run in this workspace because `docker` is not installed; the Edge workflow will validate the image build after merge.