### PR TITLE
Release v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actual-bench",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@actual-app/api": "26.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-bench",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Web-based admin panel for Actual Budget — manage accounts, payees, categories, and rules via actual-http-api",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump package metadata from 1.2.0 to 1.2.1.
- Keep package-lock root metadata in sync for the release workflow version check.

## Validation
- Confirmed `package.json` and `package-lock.json` both report 1.2.1.
- Confirmed tag `v1.2.1` did not already exist locally before release prep.
- Ran `git diff --check` successfully.

After this PR lands on `main`, tag `v1.2.1` from `main` to trigger `.github/workflows/release.yml`.