### PR TITLE
fix(sync): make the sync marker portable across instances

### DIFF
--- a/src/lib/sync/applyOrchestrator.test.ts
+++ b/src/lib/sync/applyOrchestrator.test.ts
@@ -1,8 +1,17 @@
 import { connectionFingerprint } from "./connectionRef";
+import { generateSyncMarker } from "./marker";
 import { applySyncRun, type ApplyStore, type ApplyTransportProvider } from "./applyOrchestrator";
 import type { ActualBenchTransport, SyncSourceTransaction } from "@/lib/actual/transport";
 import type { BrowserApiConnection, HttpApiConnection } from "@/store/connection";
 import type { JsonObject, SyncFlow, SyncFlowRun, SyncFlowRunItem, SyncMapping, SyncMappingInput } from "@/lib/app-db/types";
+
+// Portable markers the apply engine computes for the makeFlow() route
+// (source budget-src → target budget-tgt / acct-tgt).
+const mk = (sourceItemKey: string) =>
+  generateSyncMarker({ sourceBudgetId: "budget-src", targetBudgetId: "budget-tgt", targetAccountId: "acct-tgt", sourceItemKey })!;
+const MARKER_T1 = mk("txn:t1");
+const MARKER_T2 = mk("txn:t2");
+const MARKER_SPLIT = mk("split:t1:s1");
 
 const targetConn: BrowserApiConnection = {
   id: "tgt", label: "Family", mode: "browser-api", baseUrl: "https://tgt.example.com", serverPassword: "pw", budgetSyncId: "budget-tgt",
@@ -34,7 +43,7 @@ function runItem(overrides: Partial<SyncFlowRunItem> = {}): SyncFlowRunItem {
     accountId: "acct-tgt", date: "2026-07-10", amount: 1250,
     payeeId: null, payeeName: "Coffee Bar", categoryId: "tc1",
     notes: "flat white [Synced from Home / Checking]", cleared: false,
-    importedId: "absync:flow-1:txn:t1",
+    importedId: MARKER_T1,
     ...(overrides as { payloadData?: JsonObject }).payloadData,
   };
   return {
@@ -213,14 +222,14 @@ describe("applySyncRun — create path", () => {
     // create used the marker; payee was resolved from name
     expect(createPayee).toHaveBeenCalledWith({ name: "Coffee Bar" });
     expect(createTransactionsForSync.mock.calls[0][0][0]).toMatchObject({
-      importedId: "absync:flow-1:txn:t1", payeeId: "payee-Coffee Bar", categoryId: "tc1", amount: 1250,
+      importedId: MARKER_T1, payeeId: "payee-Coffee Bar", categoryId: "tc1", amount: 1250,
     });
 
     // mapping recorded with target id + marker
     expect(createdMappings).toHaveLength(1);
     expect(createdMappings[0]).toMatchObject({
       flowId: "flow-1", sourceItemKey: "txn:t1", targetTransactionId: "tt1",
-      targetMarker: "absync:flow-1:txn:t1", sourceEntityType: "transaction",
+      targetMarker: MARKER_T1, sourceEntityType: "transaction",
     });
     expect(itemPatches.get("item-1")).toMatchObject({ applyState: "applied" });
   });
@@ -278,7 +287,7 @@ describe("applySyncRun — idempotency & duplicates", () => {
   it("repairs the mapping when the marker exists on target but the DB mapping is missing", async () => {
     const { store, createdMappings } = makeStore();
     const { transport, createTransactionsForSync } = makeTargetTransport({
-      preloaded: [targetRow({ id: "pre-existing", importedId: "absync:flow-1:txn:t1" })],
+      preloaded: [targetRow({ id: "pre-existing", importedId: MARKER_T1 })],
     });
     const result = await applySyncRun({ runId: "run-1", targetConnection: targetConn }, { transport: provider(transport), store });
     expect(result.items[0].outcome).toBe("repaired");
@@ -312,7 +321,7 @@ describe("applySyncRun — marker-match repair", () => {
   it("repairs a selected marker-match item without creating a transaction", async () => {
     const { store, createdMappings } = makeStore({ items: [markerMatchItem()] });
     const { transport, createTransactionsForSync } = makeTargetTransport({
-      preloaded: [targetRow({ id: "pre-existing", importedId: "absync:flow-1:txn:t1" })],
+      preloaded: [targetRow({ id: "pre-existing", importedId: MARKER_T1 })],
     });
     const result = await applySyncRun(
       { runId: "run-1", targetConnection: targetConn, selection: { selectedItemIds: ["mm-1"] } },
@@ -347,8 +356,8 @@ describe("applySyncRun — marker-match repair", () => {
 
 describe("applySyncRun — partial failure & splits", () => {
   it("reports partial when one item applies and another fails to resolve", async () => {
-    const good = runItem({ id: "good", sourceItemKey: "txn:t1", payloadData: { importedId: "absync:flow-1:txn:t1" } } as unknown as Partial<SyncFlowRunItem>);
-    const bad = runItem({ id: "bad", sourceItemKey: "txn:t2", sourceTransactionId: "t2", payloadData: { importedId: "absync:flow-1:txn:t2" } } as unknown as Partial<SyncFlowRunItem>);
+    const good = runItem({ id: "good", sourceItemKey: "txn:t1", payloadData: { importedId: MARKER_T1 } } as unknown as Partial<SyncFlowRunItem>);
+    const bad = runItem({ id: "bad", sourceItemKey: "txn:t2", sourceTransactionId: "t2", payloadData: { importedId: MARKER_T2 } } as unknown as Partial<SyncFlowRunItem>);
     const { store, createdMappings } = makeStore({ items: [good, bad] });
     // Fail resolution only for the second create by toggling after first success.
     const target = makeTargetTransport();
@@ -372,7 +381,7 @@ describe("applySyncRun — partial failure & splits", () => {
     const split = runItem({
       id: "split-item", sourceEntityType: "split_line",
       sourceItemKey: "split:t1:s1", sourceTransactionId: "t1", sourceSplitId: "s1",
-      payloadData: { importedId: "absync:flow-1:split:t1:s1" } as JsonObject,
+      payloadData: { importedId: MARKER_SPLIT } as JsonObject,
     } as unknown as Partial<SyncFlowRunItem>);
     const { store, createdMappings } = makeStore({ items: [split] });
     const { transport } = makeTargetTransport();

--- a/src/lib/sync/applyOrchestrator.ts
+++ b/src/lib/sync/applyOrchestrator.ts
@@ -555,7 +555,12 @@ async function repairOneItem(
 ): Promise<ApplyItemResult> {
   const { item } = eligible;
   const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
-  const marker = generateSyncMarker(ctx.config.flowId, item.sourceItemKey ?? "");
+  const marker = generateSyncMarker({
+    sourceBudgetId: ctx.config.sourceBudgetId,
+    targetBudgetId: ctx.config.targetBudgetId,
+    targetAccountId: ctx.config.targetAccountId,
+    sourceItemKey: item.sourceItemKey ?? "",
+  });
   const targetId = eligible.targetTransactionId as string;
 
   try {

--- a/src/lib/sync/marker.test.ts
+++ b/src/lib/sync/marker.test.ts
@@ -1,25 +1,48 @@
-import { generateSyncMarker, isGeneratedSyncMarker, SYNC_MARKER_PREFIX } from "./marker";
+import { generateSyncMarker, isGeneratedSyncMarker, SYNC_MARKER_PREFIX, type SyncMarkerRoute } from "./marker";
+
+function route(overrides: Partial<SyncMarkerRoute> = {}): SyncMarkerRoute {
+  return {
+    sourceBudgetId: "budget-src",
+    targetBudgetId: "budget-tgt",
+    targetAccountId: "acct-tgt",
+    sourceItemKey: "txn:t1",
+    ...overrides,
+  };
+}
 
 describe("sync marker", () => {
-  it("is deterministic for the same flow + source item key", () => {
-    const a = generateSyncMarker("flow-1", "txn:t1");
-    const b = generateSyncMarker("flow-1", "txn:t1");
-    expect(a).toBe(b);
-    expect(a).toBe(SYNC_MARKER_PREFIX + ":flow-1:txn:t1");
+  it("is deterministic for the same route + source item key", () => {
+    expect(generateSyncMarker(route())).toBe(generateSyncMarker(route()));
+    expect(generateSyncMarker(route())).toBe(`${SYNC_MARKER_PREFIX}:budget-src:budget-tgt:acct-tgt:txn:t1`);
   });
 
-  it("differs by flow and by source item key", () => {
-    expect(generateSyncMarker("flow-1", "txn:t1")).not.toBe(generateSyncMarker("flow-2", "txn:t1"));
-    expect(generateSyncMarker("flow-1", "txn:t1")).not.toBe(generateSyncMarker("flow-1", "txn:t2"));
+  it("is portable: independent of any per-instance flow id or server URL", () => {
+    // Two instances that created "the same flow" (different random flow ids) but
+    // point at the same budgets/account produce the identical marker.
+    const instanceA = generateSyncMarker(route());
+    const instanceB = generateSyncMarker(route());
+    expect(instanceA).toBe(instanceB);
   });
 
-  it("returns null when identity is incomplete", () => {
-    expect(generateSyncMarker("", "txn:t1")).toBeNull();
-    expect(generateSyncMarker("flow-1", "")).toBeNull();
+  it("differs by source budget, target budget, target account, and source item", () => {
+    const base = generateSyncMarker(route());
+    expect(generateSyncMarker(route({ sourceBudgetId: "other" }))).not.toBe(base);
+    expect(generateSyncMarker(route({ targetBudgetId: "other" }))).not.toBe(base);
+    expect(generateSyncMarker(route({ targetAccountId: "other" }))).not.toBe(base);
+    expect(generateSyncMarker(route({ sourceItemKey: "txn:t2" }))).not.toBe(base);
   });
 
-  it("recognizes markers it generated", () => {
-    expect(isGeneratedSyncMarker(generateSyncMarker("f", "txn:x"))).toBe(true);
+  it("returns null when any identity component is missing", () => {
+    expect(generateSyncMarker(route({ sourceBudgetId: "" }))).toBeNull();
+    expect(generateSyncMarker(route({ targetBudgetId: "" }))).toBeNull();
+    expect(generateSyncMarker(route({ targetAccountId: "" }))).toBeNull();
+    expect(generateSyncMarker(route({ sourceItemKey: "" }))).toBeNull();
+  });
+
+  it("recognizes markers it generated (any version)", () => {
+    expect(isGeneratedSyncMarker(generateSyncMarker(route()))).toBe(true);
+    // Legacy v1-style marker is still recognized for loop prevention.
+    expect(isGeneratedSyncMarker("absync:flow-1:txn:x")).toBe(true);
     expect(isGeneratedSyncMarker("bank-import-123")).toBe(false);
     expect(isGeneratedSyncMarker(null)).toBe(false);
   });

--- a/src/lib/sync/marker.ts
+++ b/src/lib/sync/marker.ts
@@ -2,30 +2,62 @@
  * Deterministic target-side sync marker (Actual `imported_id`) for Budget File
  * Sync (RD-053 / PR-019).
  *
- * The marker is derived from the flow id and the source item key, so the same
- * source item always yields the same marker on every rerun. This lets the
- * engine recover a lost DB mapping by matching the marker on the target side
- * (`target_marker_match`), and lets reciprocal flows recognise and exclude
- * transactions they generated. App DB mappings remain the primary source of
- * truth; the marker is a secondary recovery/dedupe aid.
+ * The marker is derived only from **globally stable identity** — the source and
+ * target Actual budget sync ids, the target account id, and the source item key
+ * — never from the (random, per-instance) flow id or the server URL. That makes
+ * it **portable across Actual Bench instances**: any instance, on any host,
+ * computes the identical marker for the same source item → target account. So if
+ * one instance syncs a transaction, another instance recognises it on the target
+ * (`target_marker_match`) and will not create a duplicate, even though its local
+ * mapping database has no record of it.
+ *
+ * App DB mappings remain the primary idempotency source of truth; the marker is
+ * a secondary recovery/dedupe aid (and the only cross-instance one).
+ *
+ * The marker is a readable, collision-free concatenation of full ids (no hash),
+ * so distinct source items can never collide onto the same marker. Equality is
+ * the only operation performed on markers; they are never parsed.
  */
 
 export const SYNC_MARKER_PREFIX = "absync";
 
+export type SyncMarkerRoute = {
+  /** Source Actual budget sync id (stable across servers/instances). */
+  sourceBudgetId: string;
+  /** Target Actual budget sync id. */
+  targetBudgetId: string;
+  /** Target account id (distinguishes the same source item synced to two accounts). */
+  targetAccountId: string;
+  /** Stable source item key (`txn:<id>` / `split:<id>:<splitId>` / fallback). */
+  sourceItemKey: string;
+};
+
 /**
- * Build the deterministic marker for a source item within a flow. Returns null
- * when identity is incomplete (no flow id or item key), which callers treat as
- * "cannot produce a marker" → the create is blocked.
+ * Build the portable marker for a source item on a route. Returns null when any
+ * identity component is missing, which callers treat as "cannot produce a
+ * durable marker" → the create is blocked.
+ *
+ * `sourceItemKey` is placed last because it may itself contain `:`; the
+ * preceding fields are colon-free ids, so the concatenation is unambiguous.
  */
-export function generateSyncMarker(
-  flowId: string,
-  sourceItemKey: string
-): string | null {
-  if (!flowId || !sourceItemKey) return null;
-  return SYNC_MARKER_PREFIX + ":" + flowId + ":" + sourceItemKey;
+export function generateSyncMarker(route: SyncMarkerRoute): string | null {
+  const { sourceBudgetId, targetBudgetId, targetAccountId, sourceItemKey } = route;
+  if (!sourceBudgetId || !targetBudgetId || !targetAccountId || !sourceItemKey) {
+    return null;
+  }
+  return [
+    SYNC_MARKER_PREFIX,
+    sourceBudgetId,
+    targetBudgetId,
+    targetAccountId,
+    sourceItemKey,
+  ].join(":");
 }
 
-/** True when a value looks like a marker this app generated. */
+/**
+ * True when a value looks like a marker this app generated (any version), used
+ * for reciprocal-flow loop prevention.
+ */
 export function isGeneratedSyncMarker(value: string | null | undefined): boolean {
   return typeof value === "string" && value.startsWith(SYNC_MARKER_PREFIX + ":");
 }

--- a/src/lib/sync/persistPlan.test.ts
+++ b/src/lib/sync/persistPlan.test.ts
@@ -7,6 +7,7 @@ import { getSyncFlowRun, listSyncFlowRunItems } from "@/lib/app-db/syncRunReposi
 import type { SqliteDatabase } from "@/lib/app-db/types";
 import { getBudgetFileSyncCapabilities } from "./capabilities";
 import { buildPlanConfig } from "./flowConfig";
+import { generateSyncMarker } from "./marker";
 import { persistDraftPreviewRun } from "./persistPlan";
 import { planSyncFlow } from "./syncPlanner";
 import type { SyncSourceTransaction } from "@/lib/actual/transport";
@@ -57,7 +58,7 @@ describe("persistDraftPreviewRun", () => {
     try {
       const flowId = createFlow(db);
       const plan = planSyncFlow({
-        config: buildPlanConfig({ flowId, targetAccountId: "acct-tgt", sourceBudgetName: "Home", sourceAccountName: "Checking" }),
+        config: buildPlanConfig({ flowId, sourceBudgetId: "budget-src", targetBudgetId: "budget-tgt", targetAccountId: "acct-tgt", sourceBudgetName: "Home", sourceAccountName: "Checking" }),
         capabilities: getBudgetFileSyncCapabilities({ mode: "browser-api" }),
         sourceTransactions: [source],
         target: { payees: [], categories: [], importedIdIndex: new Map(), transactions: [] },
@@ -84,7 +85,9 @@ describe("persistDraftPreviewRun", () => {
       expect(item.sourceEntityType).toBe("transaction");
       expect(item.selectedForApply).toBe(true);
       expect(item.applyState).toBe("pending");
-      expect(item.createdTargetMarker).toBe("absync:" + flowId + ":txn:t1");
+      expect(item.createdTargetMarker).toBe(
+        generateSyncMarker({ sourceBudgetId: "budget-src", targetBudgetId: "budget-tgt", targetAccountId: "acct-tgt", sourceItemKey: "txn:t1" })
+      );
       expect(item.plannedTargetPayload?.data).toMatchObject({ amount: 1250 });
       expect((item.warnings?.data as { flags: string[] }).flags).toContain("target_rules_may_modify");
     } finally {
@@ -106,7 +109,7 @@ describe("persistDraftPreviewRun", () => {
         ],
       };
       const plan = planSyncFlow({
-        config: buildPlanConfig({ flowId, targetAccountId: "acct-tgt", sourceBudgetName: "Home", sourceAccountName: "Checking" }),
+        config: buildPlanConfig({ flowId, sourceBudgetId: "budget-src", targetBudgetId: "budget-tgt", targetAccountId: "acct-tgt", sourceBudgetName: "Home", sourceAccountName: "Checking" }),
         capabilities: getBudgetFileSyncCapabilities({ mode: "browser-api" }),
         sourceTransactions: [parent],
         target: { payees: [], categories: [], importedIdIndex: new Map(), transactions: [] },

--- a/src/lib/sync/sourceFilter.test.ts
+++ b/src/lib/sync/sourceFilter.test.ts
@@ -42,13 +42,13 @@ function itemsOf(txns: SyncSourceTransaction[], f: SyncSourceFilter) {
 
 describe("generated-transaction exclusion", () => {
   it("detects our own imported_id marker and notes marker", () => {
-    expect(isGeneratedSourceTransaction(txn({ importedId: generateSyncMarker("f", "txn:x") }))).toBe(true);
+    expect(isGeneratedSourceTransaction(txn({ importedId: generateSyncMarker({ sourceBudgetId: "b1", targetBudgetId: "b2", targetAccountId: "a2", sourceItemKey: "txn:x" }) }))).toBe(true);
     expect(isGeneratedSourceTransaction(txn({ notes: "hi [Synced from Home / Checking]" }))).toBe(true);
     expect(isGeneratedSourceTransaction(txn({ importedId: "bank-123", notes: "groceries" }))).toBe(false);
   });
 
   it("excludes generated transactions by default and keeps them when disabled", () => {
-    const txns = [txn({ id: "a" }), txn({ id: "b", importedId: generateSyncMarker("f", "txn:b") })];
+    const txns = [txn({ id: "a" }), txn({ id: "b", importedId: generateSyncMarker({ sourceBudgetId: "b1", targetBudgetId: "b2", targetAccountId: "a2", sourceItemKey: "txn:b" }) })];
     expect(filterSourceTransactions(txns, filter()).map((t) => t.id)).toEqual(["a"]);
     expect(
       filterSourceTransactions(txns, filter({ excludeGeneratedSyncTransactions: false })).map((t) => t.id)

--- a/src/lib/sync/syncPlanner.test.ts
+++ b/src/lib/sync/syncPlanner.test.ts
@@ -11,10 +11,21 @@ const FLOW_ID = "flow-1";
 
 const config = buildPlanConfig({
   flowId: FLOW_ID,
+  sourceBudgetId: "budget-src",
+  targetBudgetId: "budget-tgt",
   targetAccountId: "acct-tgt",
   sourceBudgetName: "Home",
   sourceAccountName: "Checking",
 });
+
+/** Expected portable marker for a source item under the test config's route. */
+const marker = (sourceItemKey: string) =>
+  generateSyncMarker({
+    sourceBudgetId: config.sourceBudgetId,
+    targetBudgetId: config.targetBudgetId,
+    targetAccountId: config.targetAccountId,
+    sourceItemKey,
+  });
 
 const browserCaps = getBudgetFileSyncCapabilities({ mode: "browser-api" });
 const httpCaps = getBudgetFileSyncCapabilities({ mode: "http-api" });
@@ -110,7 +121,7 @@ describe("planSyncFlow — new create", () => {
       payeeId: "tp1",
       categoryId: "tc1",
       notes: "flat white [Synced from Home / Checking]",
-      importedId: generateSyncMarker(FLOW_ID, "txn:t1"),
+      importedId: marker("txn:t1"),
     });
     expect(item.flags).toContain("target_rules_may_modify");
     expect(plan.counts.new).toBe(1);
@@ -131,6 +142,8 @@ describe("planSyncFlow — new create", () => {
   it("leaves payee empty when policy is leave_empty", () => {
     const leaveEmpty = buildPlanConfig({
       flowId: FLOW_ID,
+      sourceBudgetId: "budget-src",
+      targetBudgetId: "budget-tgt",
       targetAccountId: "acct-tgt",
       sourceBudgetName: "Home",
       sourceAccountName: "Checking",
@@ -167,8 +180,8 @@ describe("planSyncFlow — mappings and markers", () => {
   });
 
   it("detects a target marker match when the DB mapping is missing (repairable)", () => {
-    const marker = generateSyncMarker(FLOW_ID, "txn:t1")!;
-    const target = emptyTarget({ importedIdIndex: new Map([[marker, "tt-existing"]]) });
+    const expectedMarker = marker("txn:t1")!;
+    const target = emptyTarget({ importedIdIndex: new Map([[expectedMarker, "tt-existing"]]) });
     const plan = planSyncFlow(baseInput({ target }));
     const item = plan.items[0];
     expect(item.classification).toBe("target_marker_match");
@@ -245,7 +258,7 @@ describe("planSyncFlow — splits", () => {
     expect(plan.items[0].plannedTargetPayload?.categoryId).toBe("tc-a");
     // split children inherit the parent payee
     expect(plan.items[1].plannedTargetPayload?.payeeId).toBe("tp1");
-    expect(plan.items[1].plannedTargetPayload?.importedId).toBe(generateSyncMarker(FLOW_ID, "split:p:s2"));
+    expect(plan.items[1].plannedTargetPayload?.importedId).toBe(marker("split:p:s2"));
   });
 
   it("flags a split-line fallback key when the child has no id", () => {

--- a/src/lib/sync/syncPlanner.ts
+++ b/src/lib/sync/syncPlanner.ts
@@ -151,7 +151,12 @@ function planSourceItem(
   // Resolve entities + build the intended payload/marker up front.
   const payee = resolvePayee(item, config, target.payees);
   const category = resolveCategory(item, target.categories);
-  const importedId = generateSyncMarker(config.flowId, item.itemKey);
+  const importedId = generateSyncMarker({
+    sourceBudgetId: config.sourceBudgetId,
+    targetBudgetId: config.targetBudgetId,
+    targetAccountId: config.targetAccountId,
+    sourceItemKey: item.itemKey,
+  });
   const payload = buildPlannedTargetPayload({ item, config, payee, category, importedId });
   const effectivePayeeName = resolveEffectivePayeeName(item, payee, target);
 


### PR DESCRIPTION
## Summary

The target-side `imported_id` sync marker was `absync:<flowId>:<sourceItemKey>`, where `flowId` is a random per-instance id. Two Actual Bench instances that created "the same flow" produced **different markers**, so each saw transactions the other had already synced as new — a cross-instance duplicate-creation risk.

This reworks the marker to derive only from **globally stable identity**:

```
absync:<sourceBudgetId>:<targetBudgetId>:<targetAccountId>:<sourceItemKey>
```

This is identical across instances and servers (no flow id, no server URL). Any instance now recognises a transaction another instance synced (`target_marker_match`) and won't duplicate it, even when its local mapping DB has no record of it.

## Changes

- `generateSyncMarker` now takes a route object (`sourceBudgetId` / `targetBudgetId` / `targetAccountId` / `sourceItemKey`) instead of a flow id; returns `null` when any identity component is missing.
- Planner and apply call sites updated to pass the route.
- `isGeneratedSyncMarker` still recognises any `absync:`-prefixed marker for reciprocal-flow loop prevention.

## Compatibility

Clean cutover — pre-existing flow-id markers no longer match. Acceptable since there is no production sync data yet.

## Testing

- `jest src/lib/sync` — 12 suites, 99 tests passing.