### PR TITLE
feat(sync): safe-only automation, background mode & apply/preview perf

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -55,9 +55,9 @@
 
 A compact diagnostics page for Actual Bench's own server-side metadata database. It shows the configured SQLite path, writable state, schema version, migration status, and persistence reminder for the `/data` volume. The database stores app workflow metadata only and does not store Actual credentials.
 
-## Budget File Sync (MVP)
+## Budget File Sync
 
-A workspace for copying transactions from an account in one budget file to an account in another, as saved one-way flows. This first MVP is deliberately conservative: **Direct mode only, cross-budget only, create-only, preview-first.**
+A workspace for copying transactions from an account in one budget file to an account in another, as saved one-way flows. It is deliberately conservative: **Direct mode only, cross-budget only, create-only, preview-first** — with an opt-in safe-only automation layer on top.
 
 - Saved sync flows list with a compact editor: source/target Direct connection + account, filters, and transforms
 - Transforms: amount direction (reverse sign by default, same-sign optional), payee match-by-name (create missing by default, or leave empty), category match-by-name (missing categories are left empty — never auto-created), and a clean visible notes marker (`[Synced from <budget> / <account>]`, on by default)
@@ -68,9 +68,23 @@ A workspace for copying transactions from an account in one budget file to an ac
 - Idempotent reruns: app-owned mappings are the source of truth (with the target marker as a secondary recovery aid), so re-previewing after apply shows already-synced items instead of creating duplicates
 - Marker-match repair: if a target already carries a flow's marker but the mapping was lost, the row can be selected to repair the mapping without creating a duplicate
 - Reverse-flow helper: one click mirrors a flow (source/target swapped, created disabled for review) so two one-way flows form a two-way sync
-- Run history per flow with counts and item-level detail
+- Run history per flow with counts and item-level detail, including how many items were auto-applied vs. left in the review queue vs. failed
 - Because Actual rules run on transaction create, the applied target transaction may differ from the preview (payee/category/notes/cleared); this is surfaced as a warning, not an error
-- Not in this MVP: HTTP API Server mode, same-budget sync, target updates/deletes, category auto-create, background/scheduled sync, and multi-currency conversion
+
+### Safe-only automation (opt-in)
+
+The same engine can run without hand-picking every change — but only for provably safe work. Each flow has a **review policy**:
+
+- **Manual** (default): preview and apply yourself, exactly as above — no behavior change
+- **Auto-apply safe items on preview**: a run auto-applies only safe items (new creates and marker-match repairs); everything uncertain is left for you
+- **Auto-sync on a schedule**: a client-side timer re-runs a safe-only sync at a chosen interval (minimum 15 minutes) **while Actual Bench is open and the connection is unlocked** — this is not an unattended background daemon (that is a future item; nothing runs when the app is closed)
+- **Run safe sync now**: a one-click safe-only run for any automated flow
+- **Review queue**: duplicates, source-changed, source-missing, and blocked items are never auto-applied — they collect in a review queue for you to handle
+- **Exact-duplicate auto-map** (opt-in, off by default): a transaction that already exists on the target with the same date, amount, payee and category is linked to it (mapping only, no new transaction); fuzzy duplicates always stay in the review queue
+- **Retry failed items**: re-attempt just the failed items of a run (marker-based idempotency prevents duplicates on retry)
+- **Flow health**: after repeated failed/partial automated runs a flow auto-pauses (and is badged) so it stops firing until you re-enable it; auto-run outcomes that fail or leave items to review raise an in-app notice
+
+- Not in scope: HTTP API Server mode, same-budget sync, automatic target updates/deletes, category auto-create, fuzzy duplicate auto-mapping, unattended server-side scheduled sync, and multi-currency conversion
 
 ## Data Browser
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ A read-only local diagnostics workspace for the exported budget snapshots.
 
 ### Budget File Sync
 
-Copy transactions from an account in one budget file to an account in another, as saved one-way flows. The MVP is **Direct mode only, cross-budget, create-only, and preview-first**.
+Copy transactions from an account in one budget file to an account in another, as saved one-way flows. It is **Direct mode only, cross-budget, create-only, and preview-first**, with opt-in safe-only automation.
 
 - Compact flow editor: source/target Direct connection + account, filters, and transforms (reverse-sign by default, payee/category match-by-name, clean notes marker)
 - Required dry-run preview classifies each item (new, already synced, duplicate, changed since sync, marker match, blocked) with source and transformed target amounts side by side — no writes to Actual
 - Apply creates only the selected safe new transactions with a durable `imported_id` marker and records app-owned mappings, so reruns skip already-synced items instead of creating duplicates
 - Eligible split lines are exploded into separate target transactions; a reverse-flow helper mirrors a flow for two-way sync
-- Target-budget rules may post-process created transactions; this is surfaced as a warning. Not in the MVP: HTTP mode, same-budget sync, updates/deletes, category auto-create, background sync, and FX conversion
+- Opt-in automation per flow: auto-apply safe items, or auto-sync on a schedule **while the app is open** (client-side, minimum 15 min — not an unattended daemon). Uncertain items collect in a review queue; exact duplicates can be auto-mapped (opt-in); failed items can be retried; and a flow auto-pauses after repeated failures
+- Target-budget rules may post-process created transactions; this is surfaced as a warning. Not in scope: HTTP mode, same-budget sync, updates/deletes, category auto-create, fuzzy duplicate auto-map, unattended server-side sync, and FX conversion
 
 ### ActualQL Queries
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Copy transactions from an account in one budget file to an account in another, a
 - Required dry-run preview classifies each item (new, already synced, duplicate, changed since sync, marker match, blocked) with source and transformed target amounts side by side — no writes to Actual
 - Apply creates only the selected safe new transactions with a durable `imported_id` marker and records app-owned mappings, so reruns skip already-synced items instead of creating duplicates
 - Eligible split lines are exploded into separate target transactions; a reverse-flow helper mirrors a flow for two-way sync
-- Opt-in automation per flow: auto-apply safe items, or auto-sync on a schedule **while the app is open** (client-side, minimum 15 min — not an unattended daemon). Uncertain items collect in a review queue; exact duplicates can be auto-mapped (opt-in); failed items can be retried; and a flow auto-pauses after repeated failures
+- Opt-in automation per flow: auto-apply safe items, or auto-sync on a schedule **while the app is open and the connection is unlocked** (client-side, minimum 15 min — not an unattended daemon). Uncertain items collect in a review queue; exact duplicates can be auto-mapped (opt-in); failed items can be retried; and a flow auto-pauses after repeated failures
 - Target-budget rules may post-process created transactions; this is surfaced as a warning. Not in scope: HTTP mode, same-budget sync, updates/deletes, category auto-create, fuzzy duplicate auto-map, unattended server-side sync, and FX conversion
 
 ### ActualQL Queries

--- a/src/app/api/sync-flow-run-items/route.test.ts
+++ b/src/app/api/sync-flow-run-items/route.test.ts
@@ -64,4 +64,11 @@ describe("/api/sync-flow-run-items batch PATCH", () => {
     const body = (await response.json()) as { updated: number };
     expect(body.updated).toBe(0);
   });
+
+  it("rejects a malformed item with a 400 before touching the database", async () => {
+    const bad = await PATCH(request({ items: [{ itemId: "x" }] }));
+    expect(bad.status).toBe(400);
+    const nullEntry = await PATCH(request({ items: [null] }));
+    expect(nullEntry.status).toBe(400);
+  });
 });

--- a/src/app/api/sync-flow-run-items/route.test.ts
+++ b/src/app/api/sync-flow-run-items/route.test.ts
@@ -1,0 +1,67 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import { createSyncFlow } from "@/lib/app-db/syncFlowRepository";
+import { createSyncFlowRun, createSyncFlowRunItem, listSyncFlowRunItems } from "@/lib/app-db/syncRunRepository";
+import { PATCH } from "./route";
+
+const envelope = { version: 1, data: {} };
+
+function request(body: unknown): Request {
+  return { json: async () => body } as Request;
+}
+
+describe("/api/sync-flow-run-items batch PATCH", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "actual-bench-run-items-route-"));
+    process.env.ACTUAL_BENCH_DB_PATH = join(root, "metadata.sqlite");
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    delete process.env.ACTUAL_BENCH_DB_PATH;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("updates several run item statuses in one transaction", async () => {
+    const db = getAppDb();
+    const flowId = createSyncFlow(db, {
+      name: "Card sync",
+      legs: [{ sourceRef: envelope, targetRef: envelope, filter: envelope, transform: envelope }],
+    }).id;
+    const run = createSyncFlowRun(db, { flowId, status: "applying" });
+    const a = createSyncFlowRunItem(db, { runId: run.id, status: "planned", sourceItemRef: envelope, applyState: "pending" });
+    const b = createSyncFlowRunItem(db, { runId: run.id, status: "planned", sourceItemRef: envelope, applyState: "pending" });
+
+    const response = await PATCH(request({
+      items: [
+        { itemId: a.id, patch: { status: "applied", applyState: "applied" } },
+        { itemId: b.id, patch: { status: "failed", applyState: "failed" } },
+      ],
+    }));
+    const body = (await response.json()) as { updated: number };
+    expect(body.updated).toBe(2);
+
+    const items = listSyncFlowRunItems(db, { runId: run.id });
+    expect(items.find((i) => i.id === a.id)?.applyState).toBe("applied");
+    expect(items.find((i) => i.id === b.id)?.applyState).toBe("failed");
+  });
+
+  it("returns 0 updated for an empty batch", async () => {
+    const response = await PATCH(request({ items: [] }));
+    const body = (await response.json()) as { updated: number };
+    expect(body.updated).toBe(0);
+  });
+});

--- a/src/app/api/sync-flow-run-items/route.ts
+++ b/src/app/api/sync-flow-run-items/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  updateSyncFlowRunItem,
+  type UpdateSyncFlowRunItemPatch,
+} from "@/lib/app-db/syncRunRepository";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type BatchItemUpdate = { itemId: string; patch: UpdateSyncFlowRunItemPatch };
+
+/**
+ * Batch-update run item statuses in ONE transaction (RD-054 / PR-020 perf).
+ *
+ * Apply persists a status per item; doing that as a PATCH-per-item is hundreds
+ * of round-trips on a large run. Buffering them and flushing here collapses that
+ * to a single request + a single commit.
+ */
+export async function PATCH(request: Request) {
+  try {
+    const body = (await readJsonBody(request)) as { items?: BatchItemUpdate[] };
+    const items = Array.isArray(body.items) ? body.items : [];
+    const db = getAppDb();
+    const applyAll = db.transaction(() => {
+      let updated = 0;
+      for (const { itemId, patch } of items) {
+        if (updateSyncFlowRunItem(db, itemId, patch)) updated += 1;
+      }
+      return updated;
+    });
+    return NextResponse.json({ updated: applyAll() });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/sync-flow-run-items/route.ts
+++ b/src/app/api/sync-flow-run-items/route.ts
@@ -22,6 +22,16 @@ export async function PATCH(request: Request) {
   try {
     const body = (await readJsonBody(request)) as { items?: BatchItemUpdate[] };
     const items = Array.isArray(body.items) ? body.items : [];
+    // Validate up front so a malformed entry fails fast with a clear 400 rather
+    // than a TypeError that rolls back the whole transaction with a vague error.
+    for (const item of items) {
+      if (!item || typeof item.itemId !== "string" || typeof item.patch !== "object" || item.patch === null) {
+        return NextResponse.json(
+          { error: "Each item must have a string itemId and a patch object" },
+          { status: 400 }
+        );
+      }
+    }
     const db = getAppDb();
     const applyAll = db.transaction(() => {
       let updated = 0;

--- a/src/app/api/sync-flow-runs/route.ts
+++ b/src/app/api/sync-flow-runs/route.ts
@@ -3,8 +3,17 @@ import { getAppDb } from "@/lib/app-db/connection";
 import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
 import { createSyncFlowRun, listSyncFlowRuns } from "@/lib/app-db/syncRunRepository";
 import { persistDraftPreviewRun } from "@/lib/sync/persistPlan";
-import type { JsonObject } from "@/lib/app-db/types";
+import type { JsonObject, SyncRunTrigger } from "@/lib/app-db/types";
 import type { SyncPlanResult } from "@/lib/sync/plannedChanges";
+
+/** Triggers a client orchestrator is allowed to stamp on a persisted run. */
+const ALLOWED_TRIGGERS: readonly SyncRunTrigger[] = ["manual_preview", "interval_safe_only"];
+
+function normalizeTrigger(value: unknown): SyncRunTrigger {
+  return typeof value === "string" && (ALLOWED_TRIGGERS as readonly string[]).includes(value)
+    ? (value as SyncRunTrigger)
+    : "manual_preview";
+}
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -28,7 +37,7 @@ export function GET(request: NextRequest) {
 }
 
 type PreviewRunBody =
-  | { kind: "draft"; plan: SyncPlanResult; summary?: JsonObject; sourceSnapshotSummary?: JsonObject }
+  | { kind: "draft"; plan: SyncPlanResult; summary?: JsonObject; sourceSnapshotSummary?: JsonObject; trigger?: SyncRunTrigger }
   | { kind: "failed"; flowId: string | null; summary?: JsonObject; error?: JsonObject };
 
 /**
@@ -56,6 +65,7 @@ export async function POST(request: Request) {
     const { run } = persistDraftPreviewRun(db, body.plan, {
       summary: body.summary,
       sourceSnapshotSummary: body.sourceSnapshotSummary,
+      trigger: normalizeTrigger(body.trigger),
     });
     return NextResponse.json({ runId: run.id }, { status: 201 });
   } catch (error) {

--- a/src/app/api/sync-mappings/route.test.ts
+++ b/src/app/api/sync-mappings/route.test.ts
@@ -1,0 +1,81 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import { createSyncFlow } from "@/lib/app-db/syncFlowRepository";
+import { getAllSyncMappingsForFlow } from "@/lib/app-db/syncMappingRepository";
+import { POST } from "./route";
+import type { SyncMapping, SyncMappingInput } from "@/lib/app-db/types";
+
+const envelope = { version: 1, data: {} };
+
+function request(body: unknown): Request {
+  return { json: async () => body } as Request;
+}
+
+function mappingInput(flowId: string, sourceItemKey: string): SyncMappingInput {
+  return {
+    flowId,
+    sourceConnectionFingerprint: "source-fp",
+    sourceBudgetId: "budget-a",
+    sourceAccountId: "account-a",
+    sourceEntityType: "transaction",
+    sourceTransactionId: sourceItemKey.split(":")[1] ?? "t",
+    sourceSplitId: null,
+    sourceItemKey,
+    sourceFingerprint: "source-hash",
+    targetConnectionFingerprint: "target-fp",
+    targetBudgetId: "budget-b",
+    targetAccountId: "account-b",
+    targetEntityType: "transaction",
+    targetTransactionId: "tt-" + sourceItemKey,
+    targetItemKey: "txn:tt-" + sourceItemKey,
+    targetFingerprint: null,
+    targetMarker: "absync:budget-a:budget-b:account-b:" + sourceItemKey,
+    createdRunId: null,
+  };
+}
+
+describe("/api/sync-mappings POST", () => {
+  let root: string;
+  let flowId: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "actual-bench-mappings-route-"));
+    process.env.ACTUAL_BENCH_DB_PATH = join(root, "metadata.sqlite");
+    flowId = createSyncFlow(getAppDb(), {
+      name: "Card sync",
+      legs: [{ sourceRef: envelope, targetRef: envelope, filter: envelope, transform: envelope }],
+    }).id;
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    delete process.env.ACTUAL_BENCH_DB_PATH;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("bulk-creates an array of mappings in one request", async () => {
+    const response = await POST(request([mappingInput(flowId, "txn:a"), mappingInput(flowId, "txn:b"), mappingInput(flowId, "txn:c")]));
+    const body = (await response.json()) as { mappings: SyncMapping[] };
+    expect(response.status).toBe(201);
+    expect(body.mappings).toHaveLength(3);
+    expect(getAllSyncMappingsForFlow(getAppDb(), flowId)).toHaveLength(3);
+  });
+
+  it("still accepts a single mapping object", async () => {
+    const response = await POST(request(mappingInput(flowId, "txn:solo")));
+    const body = (await response.json()) as { mapping: SyncMapping };
+    expect(body.mapping.sourceItemKey).toBe("txn:solo");
+    expect(getAllSyncMappingsForFlow(getAppDb(), flowId)).toHaveLength(1);
+  });
+});

--- a/src/app/api/sync-mappings/route.ts
+++ b/src/app/api/sync-mappings/route.ts
@@ -34,8 +34,15 @@ export function GET(request: NextRequest) {
 
 export async function POST(request: Request) {
   try {
-    const body = (await readJsonBody(request)) as SyncMappingInput;
-    const mapping = createSyncMapping(getAppDb(), body);
+    const body = (await readJsonBody(request)) as SyncMappingInput | SyncMappingInput[];
+    const db = getAppDb();
+    // A batch (array) is written in ONE transaction — one commit for the whole
+    // apply run instead of an HTTP round-trip + commit per mapping.
+    if (Array.isArray(body)) {
+      const createAll = db.transaction(() => body.map((input) => createSyncMapping(db, input)));
+      return NextResponse.json({ mappings: createAll() }, { status: 201 });
+    }
+    const mapping = createSyncMapping(db, body);
     return NextResponse.json({ mapping }, { status: 201 });
   } catch (error) {
     return appDbErrorResponse(error);

--- a/src/features/sync/components/FlowEditDialog.tsx
+++ b/src/features/sync/components/FlowEditDialog.tsx
@@ -100,6 +100,15 @@ export function FlowEditDialog({
   const set = (patch: Partial<SyncFlowFormState>) => onChange({ ...form, ...patch });
   const setFilter = (patch: Partial<SyncFlowFormState["filter"]>) => onChange({ ...form, filter: { ...form.filter, ...patch } });
   const setTransform = (patch: Partial<SyncFlowFormState["transform"]>) => onChange({ ...form, transform: { ...form.transform, ...patch } });
+  const setAutomation = (patch: Partial<SyncFlowFormState["automation"]>) => onChange({ ...form, automation: { ...form.automation, ...patch } });
+
+  const automationHelp: Record<SyncFlowFormState["automation"]["reviewPolicy"], string> = {
+    manual_preview_required: "Preview only. You review and apply every change yourself.",
+    auto_apply_safe_only:
+      "When you run a preview, safe new transactions and mapping repairs are applied automatically. Duplicates, changed, and other uncertain items still wait in the review queue.",
+    auto_sync_on_interval:
+      "Re-runs safe sync on a schedule while Actual Bench is open and this connection is unlocked. Applies only safe items; uncertain items go to the review queue. It does not run in the background when the app is closed.",
+  };
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -130,6 +139,55 @@ export function FlowEditDialog({
             </div>
             {sameBudget && <p className="text-xs text-destructive">Source and target must be different budgets (cross-budget only).</p>}
             <p className="text-xs text-muted-foreground">Source budget · account → target budget · account.</p>
+          </section>
+
+          {/* Automation policy (RD-054 / PR-020) */}
+          <section className="flex flex-col gap-2 border-t border-border py-4">
+            <h4 className="text-sm font-semibold">Automation</h4>
+            <label className="flex max-w-md flex-col gap-1 text-xs text-muted-foreground">
+              Review policy
+              <select
+                aria-label="Review policy"
+                className={selectClass}
+                value={form.automation.reviewPolicy}
+                onChange={(e) => setAutomation({ reviewPolicy: e.target.value as SyncFlowFormState["automation"]["reviewPolicy"] })}
+              >
+                <option value="manual_preview_required">Manual — preview &amp; apply yourself (default)</option>
+                <option value="auto_apply_safe_only">Auto-apply safe items on preview</option>
+                <option value="auto_sync_on_interval">Auto-sync on a schedule (while app is open)</option>
+              </select>
+            </label>
+            <p className="text-xs text-muted-foreground">{automationHelp[form.automation.reviewPolicy]}</p>
+            {form.automation.reviewPolicy === "auto_sync_on_interval" && (
+              <label className="flex max-w-md flex-col gap-1 text-xs text-muted-foreground">
+                Run every (minutes)
+                <Input
+                  type="number"
+                  min={15}
+                  step={5}
+                  aria-label="Auto-sync interval in minutes"
+                  value={form.automation.intervalMinutes}
+                  onChange={(e) => setAutomation({ intervalMinutes: e.target.value })}
+                />
+                <span className="text-[11px]">Minimum 15 minutes. Each run re-opens and syncs the whole budget.</span>
+              </label>
+            )}
+            {form.automation.reviewPolicy !== "manual_preview_required" && (
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  aria-label="Auto-map exact duplicates"
+                  checked={form.automation.exactDuplicateAutoMap}
+                  onChange={(e) => setAutomation({ exactDuplicateAutoMap: e.target.checked })}
+                />
+                Auto-map exact duplicates to the existing transaction
+              </label>
+            )}
+            {form.automation.reviewPolicy !== "manual_preview_required" && (
+              <p className="text-xs text-muted-foreground">
+                When on, a transaction that already exists on the target with the same date, amount, payee and category is linked to it (no new transaction). Uncertain (fuzzy) duplicates still go to the review queue.
+              </p>
+            )}
           </section>
 
           {/* Transform + Filters, side by side at wide widths */}

--- a/src/features/sync/components/FlowEditDialog.tsx
+++ b/src/features/sync/components/FlowEditDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { clampSyncInterval } from "@/lib/sync/flowConfig";
 import { useFlowAccounts } from "../hooks/useSyncData";
 import { isSameBudget, missingRouteFields, type SyncEndpointForm, type SyncFlowFormState } from "../lib/flowForm";
 import type { BrowserApiConnection } from "@/store/connection";
@@ -168,6 +169,8 @@ export function FlowEditDialog({
                   aria-label="Auto-sync interval in minutes"
                   value={form.automation.intervalMinutes}
                   onChange={(e) => setAutomation({ intervalMinutes: e.target.value })}
+                  // Clamp on blur so the shown value matches what save persists.
+                  onBlur={(e) => setAutomation({ intervalMinutes: String(clampSyncInterval(e.target.value)) })}
                 />
                 <span className="text-[11px]">Minimum 15 minutes. Each run re-opens and syncs the whole budget.</span>
               </label>

--- a/src/features/sync/components/FlowHeader.tsx
+++ b/src/features/sync/components/FlowHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeftRight, ArrowRight, History, Pencil, Play } from "lucide-react";
+import { ArrowLeftRight, ArrowRight, History, Loader2, Pencil, Play, Zap } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -14,8 +14,13 @@ type FlowHeaderProps = {
   canPreview: boolean;
   /** Shown as a tooltip on the disabled Run preview button. */
   previewDisabledReason: string | null;
+  /** Show the "Run safe sync now" action (flow opted into automation). */
+  showRunSafeSync: boolean;
+  canRunSafeSync: boolean;
+  runningSafeSync: boolean;
   onToggleEnabled: () => void;
   onRunPreview: () => void;
+  onRunSafeSyncNow: () => void;
   onEdit: () => void;
   onCreateReverse: () => void;
   onShowHistory: () => void;
@@ -44,8 +49,19 @@ function Endpoint({ endpoint, connection }: { endpoint: SyncEndpointForm; connec
   );
 }
 
+function automationChip(form: SyncFlowFormState): string {
+  switch (form.automation.reviewPolicy) {
+    case "auto_apply_safe_only":
+      return "Auto-apply safe";
+    case "auto_sync_on_interval":
+      return `Auto-sync ${form.automation.intervalMinutes}m`;
+    default:
+      return "Manual";
+  }
+}
+
 function summaryChips(form: SyncFlowFormState): string[] {
-  const chips = ["Transactions", "Manual"]; // flow type + trigger (RD-054/055 forward-looking)
+  const chips = ["Transactions", automationChip(form)]; // flow type + automation policy
   chips.push(form.transform.amountDirection === "reverse" ? "Reverse sign" : "Same sign");
   chips.push(form.transform.missingPayee === "create" ? "Create missing payees" : "Leave payee empty");
   if (form.transform.notesMarkerEnabled) chips.push("Notes marker on");
@@ -61,8 +77,12 @@ export function FlowHeader({
   previewing,
   canPreview,
   previewDisabledReason,
+  showRunSafeSync,
+  canRunSafeSync,
+  runningSafeSync,
   onToggleEnabled,
   onRunPreview,
+  onRunSafeSyncNow,
   onEdit,
   onCreateReverse,
   onShowHistory,
@@ -88,6 +108,19 @@ export function FlowHeader({
           >
             <Play className="h-3.5 w-3.5" /> {previewing ? "Previewing…" : "Sync Preview"}
           </Button>
+          {showRunSafeSync && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="text-xs"
+              onClick={onRunSafeSyncNow}
+              disabled={!canRunSafeSync || runningSafeSync}
+              title="Preview and apply only safe changes now; uncertain items go to the review queue"
+            >
+              {runningSafeSync ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />}
+              {runningSafeSync ? "Syncing…" : "Run safe sync now"}
+            </Button>
+          )}
           <Button size="sm" variant="outline" className="text-xs" onClick={onEdit}>
             <Pencil className="h-3.5 w-3.5" /> Edit Flow
           </Button>
@@ -115,6 +148,11 @@ export function FlowHeader({
           <span className={cn("absolute top-0.5 h-[13px] w-[13px] rounded-full bg-white transition-all", form.enabled ? "left-[15px]" : "left-0.5")} />
         </button>
         <span className="mr-1 text-xs text-muted-foreground">{form.enabled ? "Enabled" : "Disabled"}</span>
+        {!form.enabled && form.automation.autoPausedAt && (
+          <Badge variant="status-warning" className="text-[11px] font-normal" title="Auto-sync paused after repeated failures. Re-enable to resume.">
+            Auto-paused
+          </Badge>
+        )}
         {summaryChips(form).map((chip, i) => (
           <Badge key={i} variant="secondary" className="text-[11px] font-normal">
             {chip}

--- a/src/features/sync/components/FlowList.tsx
+++ b/src/features/sync/components/FlowList.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { connectionFingerprint } from "@/lib/sync/connectionRef";
 import { decodeFlowPlanConfig } from "@/lib/sync/flowConfig";
-import { latestRunLabel } from "../lib/runsView";
+import { latestRunLabel, runNeedsAttention, runQueuedCount } from "../lib/runsView";
 import type { BrowserApiConnection } from "@/store/connection";
 import type { SyncFlow, SyncFlowRun } from "@/lib/app-db/types";
 
@@ -74,6 +74,15 @@ export function FlowList({ flows, selectedFlowId, latestRuns, connections, onSel
               const connected =
                 connectionAvailable(config.sourceConnectionFingerprint, connections) &&
                 connectionAvailable(config.targetConnectionFingerprint, connections);
+              const latestRun = latestRuns.get(flow.id);
+              const autoPaused = !flow.enabled && !!config.autoPausedAt;
+              const attentionBadge = autoPaused
+                ? "Auto-paused"
+                : latestRun && runNeedsAttention(latestRun)
+                  ? latestRun.status === "failed" || latestRun.status === "partial"
+                    ? "Failed"
+                    : `${runQueuedCount(latestRun)} to review`
+                  : null;
               return (
                 <button
                   key={flow.id}
@@ -92,9 +101,16 @@ export function FlowList({ flows, selectedFlowId, latestRuns, connections, onSel
                     />
                     <span className="sr-only">{flow.enabled ? "Enabled" : "Disabled"}</span>
                   </div>
-                  <div className="mt-0.5 text-[11.5px] text-muted-foreground">
+                  <div className="mt-0.5 flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
                     {connected ? (
-                      latestRunLabel(latestRuns.get(flow.id))
+                      <>
+                        <span className="truncate">{latestRunLabel(latestRun)}</span>
+                        {attentionBadge && (
+                          <span className="shrink-0 rounded-full border border-amber-400/40 bg-amber-50 px-1.5 py-px text-[10px] font-medium text-amber-700 dark:bg-amber-950/30 dark:text-amber-400">
+                            {attentionBadge}
+                          </span>
+                        )}
+                      </>
                     ) : (
                       <span className="text-amber-600 dark:text-amber-400">Needs connection</span>
                     )}

--- a/src/features/sync/components/PreviewPanel.tsx
+++ b/src/features/sync/components/PreviewPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { CheckCircle2, Info, XCircle } from "lucide-react";
+import { CheckCircle2, Info, ListChecks, Loader2, XCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -11,6 +11,7 @@ import {
   groupLabel,
   matchesPreviewFilter,
   PREVIEW_FILTERS,
+  reviewQueueCount,
   splitPositions,
   tileCounts,
   type PreviewFilter,
@@ -76,10 +77,17 @@ export function PreviewPanel(props: PreviewPanelProps) {
   const visible = rows.filter((r) => matchesPreviewFilter(r, filter));
   const selectedCount = rows.filter((r) => selectedIds.has(r.id)).length;
   const splits = splitPositions(rows);
+  const reviewCount = reviewQueueCount(rows);
 
   return (
     <div className="flex flex-col gap-3.5">
-      {props.applyResult && <ApplyResultBanner result={props.applyResult} />}
+      {props.applying && (
+        <div className="flex items-center gap-2 rounded-md border border-blue-400/40 bg-blue-50/70 px-3.5 py-2.5 text-sm dark:bg-blue-950/20">
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-600 dark:text-blue-400" />
+          <span>Syncing selected changes to the target budget… this can take a while on large budgets.</span>
+        </div>
+      )}
+      {!props.applying && props.applyResult && <ApplyResultBanner result={props.applyResult} />}
 
       {/* Four grouped tiles — click to filter the table */}
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -92,6 +100,26 @@ export function PreviewPanel(props: PreviewPanelProps) {
         {summary.sourceItemsScanned} items scanned · {summary.generatedTransactionsExcluded} sync-generated excluded · {summary.sourceItemsFilteredOut} filtered out
         <PreviewFreshness previewedAt={props.previewedAt} readOnly={props.readOnly} />
       </p>
+
+      {reviewCount > 0 && (
+        <button
+          type="button"
+          aria-pressed={filter === "review_queue"}
+          onClick={() => setFilter(filter === "review_queue" ? "all" : "review_queue")}
+          className={cn(
+            "flex items-start gap-2 rounded-md border border-amber-400/40 bg-amber-50/60 px-3 py-2 text-left text-sm transition-colors hover:bg-amber-100/60 dark:bg-amber-950/20 dark:hover:bg-amber-950/40",
+            filter === "review_queue" && "ring-2 ring-ring"
+          )}
+        >
+          <ListChecks className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <span>
+            <strong className="font-semibold">Review queue · {reviewCount}</strong>
+            <span className="block text-xs text-muted-foreground">
+              Automated sync can&apos;t apply these safely (duplicates, source changed or missing, blocked). Review and handle them yourself.
+            </span>
+          </span>
+        </button>
+      )}
 
       <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
         <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -135,12 +163,19 @@ export function PreviewPanel(props: PreviewPanelProps) {
           ) : (
             <>
               {selectedCount > 0 && (
-                <Button size="sm" variant="ghost" onClick={props.onClearSelection}>Clear</Button>
+                <Button size="sm" variant="ghost" onClick={props.onClearSelection} disabled={props.applying}>Clear</Button>
               )}
-              <Button size="sm" variant="outline" onClick={props.onSelectAllSafeNew}>Select all safe new</Button>
+              <Button size="sm" variant="outline" onClick={props.onSelectAllSafeNew} disabled={props.applying}>Select all safe new</Button>
               <Button size="sm" onClick={props.onApply} disabled={selectedCount === 0 || props.applying}>
-                {props.applying ? "Syncing…" : "Sync selected"}
-                {selectedCount > 0 && <span className="tabular-nums"> · {selectedCount}</span>}
+                {props.applying ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing…
+                  </>
+                ) : (
+                  <>
+                    Sync selected{selectedCount > 0 && <span className="tabular-nums"> · {selectedCount}</span>}
+                  </>
+                )}
               </Button>
             </>
           )}

--- a/src/features/sync/components/RunHistory.tsx
+++ b/src/features/sync/components/RunHistory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import { relativeTime, toRunRow, type RunTone } from "../lib/runsView";
 import type { SyncFlowRun } from "@/lib/app-db/types";
 
@@ -26,7 +27,8 @@ export function RunHistory({ runs, onSelectRun }: RunHistoryProps) {
             <tr>
               <th className="px-3 py-2">Status</th><th className="px-3 py-2">Trigger</th>
               <th className="px-3 py-2 text-right">Planned</th><th className="px-3 py-2 text-right">Created</th>
-              <th className="px-3 py-2 text-right">Re-linked</th><th className="px-3 py-2 text-right">Failed</th>
+              <th className="px-3 py-2 text-right">Re-linked</th><th className="px-3 py-2 text-right">Queued</th>
+              <th className="px-3 py-2 text-right">Failed</th>
               <th className="px-3 py-2">When</th>
             </tr>
           </thead>
@@ -52,7 +54,8 @@ export function RunHistory({ runs, onSelectRun }: RunHistoryProps) {
                   <td className="px-3 py-2 text-right tabular-nums">{r.planned ?? "-"}</td>
                   <td className="px-3 py-2 text-right tabular-nums">{r.created ?? "-"}</td>
                   <td className="px-3 py-2 text-right tabular-nums">{r.relinked ?? "-"}</td>
-                  <td className="px-3 py-2 text-right tabular-nums">{r.failed ?? "-"}</td>
+                  <td className={cn("px-3 py-2 text-right tabular-nums", r.queued && "font-medium text-amber-600 dark:text-amber-400")}>{r.queued ?? "-"}</td>
+                  <td className={cn("px-3 py-2 text-right tabular-nums", r.failed ? "font-medium text-destructive" : "")}>{r.failed ?? "-"}</td>
                   <td className="px-3 py-2 text-muted-foreground" title={new Date(r.when).toLocaleString()}>{relativeTime(r.when)}</td>
                 </tr>
               );

--- a/src/features/sync/components/SyncView.test.tsx
+++ b/src/features/sync/components/SyncView.test.tsx
@@ -10,6 +10,8 @@ import type { SyncFlow, SyncFlowRunItem } from "@/lib/app-db/types";
 jest.mock("../hooks/useSyncFlows");
 jest.mock("../hooks/useSyncData");
 jest.mock("../hooks/useSyncOrchestration");
+// The interval scheduler starts real timers; stub it out for component tests.
+jest.mock("../hooks/useSyncScheduler", () => ({ useSyncScheduler: jest.fn() }));
 
 const conn1: BrowserApiConnection = { id: "c1", label: "Home", mode: "browser-api", baseUrl: "https://s.example.com", serverPassword: "pw", budgetSyncId: "b-src" };
 const conn2: BrowserApiConnection = { id: "c2", label: "Family", mode: "browser-api", baseUrl: "https://t.example.com", serverPassword: "pw", budgetSyncId: "b-tgt" };
@@ -75,6 +77,7 @@ function setup(connections: BrowserApiConnection[]) {
   });
   (orchestrationHook.usePreviewMutation as jest.Mock).mockReturnValue({ mutate: previewMutate, isPending: false });
   (orchestrationHook.useApplyMutation as jest.Mock).mockReturnValue({ mutate: applyMutate, isPending: false });
+  (orchestrationHook.useSafeSyncMutation as jest.Mock).mockReturnValue({ mutate: jest.fn(), isPending: false });
 }
 
 beforeEach(() => jest.clearAllMocks());

--- a/src/features/sync/components/SyncView.tsx
+++ b/src/features/sync/components/SyncView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, Loader2, Play, XCircle } from "lucide-react";
+import { ArrowLeft, Bell, Loader2, Play, XCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DirectOnlyNotice } from "./DirectOnlyNotice";
@@ -12,7 +12,8 @@ import { PreviewPanel } from "./PreviewPanel";
 import { RunHistory } from "./RunHistory";
 import { useSyncFlows, useSyncFlowMutations } from "../hooks/useSyncFlows";
 import { useDirectConnections, useFlowRuns, useLatestRunByFlow, useSyncRun } from "../hooks/useSyncData";
-import { useApplyMutation, usePreviewMutation } from "../hooks/useSyncOrchestration";
+import { useApplyMutation, usePreviewMutation, useSafeSyncMutation } from "../hooks/useSyncOrchestration";
+import { useSyncScheduler } from "../hooks/useSyncScheduler";
 import {
   buildFlowPayload,
   emptyFlowForm,
@@ -27,6 +28,7 @@ import { relativeTime, toRunRow } from "../lib/runsView";
 import type { SyncFlowRun } from "@/lib/app-db/types";
 import type { DryRunError, DryRunSummary } from "@/lib/sync/previewOrchestrator";
 import type { ApplyRunResult } from "@/lib/sync/applyOrchestrator";
+import type { SafeSyncResult } from "@/lib/sync/safeSyncOrchestrator";
 
 function deriveSummary(run: SyncFlowRun | undefined): DryRunSummary | null {
   const data = run?.summary?.data;
@@ -41,6 +43,7 @@ function deriveSummary(run: SyncFlowRun | undefined): DryRunSummary | null {
     createCandidates: n("createCandidates"),
     alreadySynced: n("alreadySynced"),
     duplicatesSkipped: n("duplicatesSkipped"),
+    exactDuplicatesAutoMapped: n("exactDuplicatesAutoMapped"),
     sourceChangedWarnings: n("sourceChangedWarnings"),
     targetMarkerMatches: n("targetMarkerMatches"),
     blocked: n("blocked"),
@@ -55,6 +58,17 @@ export function SyncView() {
   const flowMutations = useSyncFlowMutations();
   const previewMutation = usePreviewMutation();
   const applyMutation = useApplyMutation();
+  const safeSyncMutation = useSafeSyncMutation();
+
+  // Client-side interval auto-sync (RD-054): only acts on flows whose policy is
+  // `auto_sync_on_interval`, and only while their connections are unlocked here.
+  useSyncScheduler({
+    flows: flowsQuery.data ?? [],
+    connections,
+    latestRuns: latestRunsQuery.data ?? new Map(),
+    onRunComplete: (flowId, result) => handleAutoRunComplete(flowId, result),
+    onFlowPaused: (flowId) => pauseFlowForHealth(flowId),
+  });
 
   const [selectedFlowId, setSelectedFlowId] = useState<string | null>(null);
   const [form, setForm] = useState<SyncFlowFormState>(() => emptyFlowForm());
@@ -67,6 +81,7 @@ export function SyncView() {
   const [previewError, setPreviewError] = useState<DryRunError | null>(null);
   const [applyResult, setApplyResult] = useState<ApplyRunResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [autoNotice, setAutoNotice] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   // In history view we show the run the user picked; otherwise the live preview.
@@ -160,7 +175,13 @@ export function SyncView() {
 
   function handleToggleEnabled() {
     if (!selectedFlowId) return;
-    const next = { ...form, enabled: !form.enabled };
+    const enabling = !form.enabled;
+    // Re-enabling clears any health auto-pause so the scheduler can resume.
+    const next = {
+      ...form,
+      enabled: enabling,
+      automation: { ...form.automation, autoPausedAt: enabling ? null : form.automation.autoPausedAt },
+    };
     setForm(next);
     flowMutations.update.mutate(
       { flowId: selectedFlowId, payload: buildFlowPayload(next, connections) },
@@ -202,6 +223,81 @@ export function SyncView() {
           else setPreviewError(result.error);
         },
         onError: (err) => setActionError(err instanceof Error ? err.message : "Preview could not be run."),
+      }
+    );
+  }
+
+  function flowName(flowId: string): string {
+    return (flowsQuery.data ?? []).find((f) => f.id === flowId)?.name ?? "a flow";
+  }
+
+  // Notify on automated (scheduler) run outcomes: failures/partials, or items
+  // left in the review queue. Successful, empty-queue runs stay quiet.
+  function handleAutoRunComplete(flowId: string, result: SafeSyncResult) {
+    latestRunsQuery.refetch();
+    flowsQuery.refetch();
+    const name = flowName(flowId);
+    if (result.status === "failed" || result.status === "partial") {
+      setAutoNotice(`Auto-sync for “${name}” ${result.status === "partial" ? "partially applied — some items failed" : "failed"}.`);
+    } else if (result.status === "preview_failed") {
+      setAutoNotice(`Auto-sync preview for “${name}” failed: ${result.error.message}`);
+    } else if (result.status === "applied" || result.status === "no_safe_items") {
+      const s = result.preview;
+      const queued = s.duplicatesSkipped + s.sourceChangedWarnings + s.blocked;
+      if (queued > 0) setAutoNotice(`Auto-sync for “${name}” left ${queued} item${queued === 1 ? "" : "s"} to review.`);
+    }
+  }
+
+  // Flow health: persist an auto-pause (disable + timestamp) after repeated
+  // automated failures, so the scheduler stops until the user re-enables it.
+  function pauseFlowForHealth(flowId: string) {
+    const flow = (flowsQuery.data ?? []).find((f) => f.id === flowId);
+    if (!flow) return;
+    const paused = flowToFormState(flow, connections);
+    paused.enabled = false;
+    paused.automation = { ...paused.automation, autoPausedAt: new Date().toISOString() };
+    flowMutations.update.mutate(
+      { flowId, payload: buildFlowPayload(paused, connections) },
+      { onSuccess: () => { flowsQuery.refetch(); latestRunsQuery.refetch(); } }
+    );
+    setAutoNotice(`Auto-sync paused for “${flow.name}” after repeated failures. Re-enable it when you're ready.`);
+  }
+
+  function handleRunSafeSyncNow() {
+    if (!selectedFlowId || !sourceConn || !targetConn) return;
+    setActionError(null);
+    safeSyncMutation.mutate(
+      { flowId: selectedFlowId, sourceConnection: sourceConn, targetConnection: targetConn, allowDisabled: true },
+      {
+        onSuccess: (result) => {
+          runsQuery.refetch();
+          flowsQuery.refetch();
+          latestRunsQuery.refetch();
+          if (result.status === "skipped_manual_policy") {
+            setActionError("This flow is set to manual review, so safe sync did not run. Switch its policy to auto to enable it.");
+            return;
+          }
+          if (result.status === "preview_failed") {
+            setActionError(`Safe sync preview failed: ${result.error.message}`);
+            return;
+          }
+          // Show the resulting (already-applied) run read-only, including its review queue.
+          setView("history");
+          setHistoryRunId(result.runId);
+        },
+        onError: (err) => setActionError(err instanceof Error ? err.message : "Safe sync could not be run."),
+      }
+    );
+  }
+
+  function handleRetryFailed() {
+    if (!historyRunId || !targetConn) return;
+    setActionError(null);
+    applyMutation.mutate(
+      { runId: historyRunId, targetConnection: targetConn, selection: { selection: "retry_failed" } },
+      {
+        onSuccess: () => { runQuery.refetch(); runsQuery.refetch(); latestRunsQuery.refetch(); flowsQuery.refetch(); },
+        onError: (err) => setActionError(err instanceof Error ? err.message : "Retry could not be completed."),
       }
     );
   }
@@ -256,8 +352,12 @@ export function SyncView() {
               previewing={previewMutation.isPending}
               canPreview={canPreview}
               previewDisabledReason={blockReason}
+              showRunSafeSync={form.automation.reviewPolicy !== "manual_preview_required"}
+              canRunSafeSync={!!sourceConn && !!targetConn && routeReady && !dirty}
+              runningSafeSync={safeSyncMutation.isPending}
               onToggleEnabled={handleToggleEnabled}
               onRunPreview={handlePreview}
+              onRunSafeSyncNow={handleRunSafeSyncNow}
               onEdit={() => setEditorOpen(true)}
               onCreateReverse={handleCreateReverse}
               onShowHistory={() => { setView("history"); setHistoryRunId(null); }}
@@ -268,6 +368,15 @@ export function SyncView() {
                 <div className="mb-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3.5 py-2.5 text-sm">
                   <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
                   <span>{actionError}</span>
+                </div>
+              )}
+              {autoNotice && (
+                <div className="mb-4 flex items-start gap-2 rounded-md border border-amber-400/40 bg-amber-50/70 px-3.5 py-2.5 text-sm dark:bg-amber-950/20">
+                  <Bell className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <span className="flex-1">{autoNotice}</span>
+                  <button type="button" className="text-xs text-muted-foreground hover:text-foreground" onClick={() => setAutoNotice(null)}>
+                    Dismiss
+                  </button>
                 </div>
               )}
               {view === "history" ? (
@@ -290,6 +399,12 @@ export function SyncView() {
                       <div className="flex items-center gap-2">
                         <Badge variant="secondary" className="text-[10px]">{toRunRow(runQuery.data.run).statusLabel}</Badge>
                         <span className="text-xs text-muted-foreground" title={new Date(toRunRow(runQuery.data.run).when).toLocaleString()}>{relativeTime(toRunRow(runQuery.data.run).when)}</span>
+                        {(runQuery.data.run.status === "partial" || runQuery.data.run.status === "failed") && !!targetConn && (
+                          <Button size="sm" variant="outline" className="ml-auto text-xs" onClick={handleRetryFailed} disabled={applyMutation.isPending}>
+                            {applyMutation.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                            {applyMutation.isPending ? "Retrying…" : "Retry failed"}
+                          </Button>
+                        )}
                       </div>
                       <PreviewPanel
                         summary={summary}

--- a/src/features/sync/hooks/useSyncOrchestration.ts
+++ b/src/features/sync/hooks/useSyncOrchestration.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
-import { runClientApply, runClientPreview } from "../lib/clientOrchestration";
+import { runClientApply, runClientPreview, runClientSafeSync } from "../lib/clientOrchestration";
 import type { ConnectionInstance } from "@/store/connection";
 import type { ApplySelection } from "@/lib/sync/applyOrchestrator";
 
@@ -26,4 +26,16 @@ export type ApplyArgs = {
 /** Runs the Slice 4 apply via the client orchestrator (browser transport). */
 export function useApplyMutation() {
   return useMutation({ mutationFn: (args: ApplyArgs) => runClientApply(args) });
+}
+
+export type SafeSyncArgs = {
+  flowId: string;
+  sourceConnection: ConnectionInstance;
+  targetConnection: ConnectionInstance;
+  allowDisabled?: boolean;
+};
+
+/** "Run safe sync now" (RD-054 / PR-020): policy-gated preview + safe-only apply. */
+export function useSafeSyncMutation() {
+  return useMutation({ mutationFn: (args: SafeSyncArgs) => runClientSafeSync(args) });
 }

--- a/src/features/sync/hooks/useSyncScheduler.ts
+++ b/src/features/sync/hooks/useSyncScheduler.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { decodeFlowPlanConfig } from "@/lib/sync/flowConfig";
+import { runClientSafeSync } from "../lib/clientOrchestration";
+import { flowToFormState } from "../lib/flowForm";
+import {
+  classifySafeSyncOutcome,
+  nextConsecutiveFailures,
+  shouldPauseForHealth,
+} from "../lib/flowHealth";
+import { selectFlowsToAutoRun, type SchedulableFlow } from "../lib/scheduler";
+import type { BrowserApiConnection } from "@/store/connection";
+import type { SyncFlow, SyncFlowRun } from "@/lib/app-db/types";
+import type { SafeSyncResult } from "@/lib/sync/safeSyncOrchestrator";
+
+/**
+ * Client-side interval auto-sync (RD-054 / PR-020 Slice 4). Runs a safe-only sync
+ * for `auto_sync_on_interval` flows **while this tab is open and their
+ * connections are unlocked**. All the actual gating lives in the pure
+ * `selectFlowsToAutoRun`; this hook is just the timer + non-overlap bookkeeping.
+ *
+ * Not a background daemon — nothing runs when the app is closed (that is RD-058).
+ */
+
+const TICK_MS = 60_000;
+const INITIAL_DELAY_MS = 3_000;
+
+function runTimeMs(run: SyncFlowRun | undefined): number | null {
+  if (!run) return null;
+  const ms = new Date(run.finishedAt ?? run.startedAt).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function useSyncScheduler(params: {
+  flows: SyncFlow[];
+  connections: BrowserApiConnection[];
+  latestRuns: Map<string, SyncFlowRun>;
+  /** Master switch (default on); the per-flow opt-in is the review policy. */
+  enabled?: boolean;
+  onRunComplete?: (flowId: string, result: SafeSyncResult) => void;
+  /** Persist a health pause after repeated automated failures (RD-054). */
+  onFlowPaused?: (flowId: string) => void;
+}) {
+  const { enabled = true } = params;
+  const inFlightRef = useRef<Set<string>>(new Set());
+  const lastRunRef = useRef<Map<string, number>>(new Map());
+  const failuresRef = useRef<Map<string, number>>(new Map());
+  // Flows paused this session — a local guard so a slow enabled=false persist
+  // can't let one more auto run slip through before the DB reflects the pause.
+  const pausedRef = useRef<Set<string>>(new Set());
+
+  // Latest inputs, read inside the timer without resetting it each render.
+  const stateRef = useRef(params);
+  useEffect(() => {
+    stateRef.current = params;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function tick() {
+      const { flows, connections, latestRuns, onRunComplete, onFlowPaused } = stateRef.current;
+      const resolved = new Map<string, { source: BrowserApiConnection; target: BrowserApiConnection }>();
+
+      const schedulable: SchedulableFlow[] = flows.map((flow) => {
+        const config = decodeFlowPlanConfig(flow);
+        // A re-enabled flow clears its local pause guard and failure streak.
+        if (flow.enabled && !config.autoPausedAt) {
+          pausedRef.current.delete(flow.id);
+          failuresRef.current.delete(flow.id);
+        }
+        const form = flowToFormState(flow, connections);
+        const source = connections.find((c) => c.id === form.source.connectionId);
+        const target = connections.find((c) => c.id === form.target.connectionId);
+        let connectionsReady = false;
+        if (source && target) {
+          connectionsReady = true;
+          resolved.set(flow.id, { source, target });
+        }
+        return {
+          flowId: flow.id,
+          reviewPolicy: config.reviewPolicy,
+          // A flow paused for health is treated as disabled until re-enabled.
+          enabled: flow.enabled && !pausedRef.current.has(flow.id),
+          intervalMinutes: config.intervalMinutes,
+          connectionsReady,
+          lastRunAtMs: lastRunRef.current.get(flow.id) ?? runTimeMs(latestRuns.get(flow.id)),
+        };
+      });
+
+      const due = selectFlowsToAutoRun({ flows: schedulable, inFlight: inFlightRef.current, nowMs: Date.now() });
+      for (const flowId of due) {
+        const conns = resolved.get(flowId);
+        if (!conns) continue;
+        // Mark started immediately so the next tick can't double-fire, and so a
+        // fast-failing run still waits a full interval before retrying.
+        inFlightRef.current.add(flowId);
+        lastRunRef.current.set(flowId, Date.now());
+        runClientSafeSync({ flowId, sourceConnection: conns.source, targetConnection: conns.target })
+          .then((result) => {
+            recordHealth(flowId, result.status, onFlowPaused);
+            onRunComplete?.(flowId, result);
+          })
+          .catch(() => {
+            // A thrown run counts as a failure for health purposes.
+            recordHealth(flowId, "failed", onFlowPaused);
+          })
+          .finally(() => {
+            inFlightRef.current.delete(flowId);
+          });
+      }
+    }
+
+    // Update the failure streak for a completed auto run; pause the flow once it
+    // crosses the threshold, then reset the streak so a re-enable starts clean.
+    function recordHealth(
+      flowId: string,
+      status: SafeSyncResult["status"],
+      onFlowPaused?: (flowId: string) => void
+    ) {
+      const outcome = classifySafeSyncOutcome(status);
+      const count = nextConsecutiveFailures(failuresRef.current.get(flowId) ?? 0, outcome);
+      if (shouldPauseForHealth(count)) {
+        failuresRef.current.set(flowId, 0);
+        pausedRef.current.add(flowId);
+        onFlowPaused?.(flowId);
+      } else {
+        failuresRef.current.set(flowId, count);
+      }
+    }
+
+    const interval = setInterval(tick, TICK_MS);
+    const initial = setTimeout(tick, INITIAL_DELAY_MS);
+    return () => {
+      clearInterval(interval);
+      clearTimeout(initial);
+    };
+  }, [enabled]);
+}

--- a/src/features/sync/lib/clientOrchestration.ts
+++ b/src/features/sync/lib/clientOrchestration.ts
@@ -11,9 +11,11 @@ import {
   type ApplyStore,
   type ApplySelection,
   type ApplyTransportProvider,
+  type RunItemStatusPatch,
 } from "@/lib/sync/applyOrchestrator";
+import { runSafeSync, type SafeSyncResult } from "@/lib/sync/safeSyncOrchestrator";
 import type { ConnectionInstance } from "@/store/connection";
-import type { SyncMapping } from "@/lib/app-db/types";
+import type { SyncMapping, SyncMappingInput } from "@/lib/app-db/types";
 import * as api from "./syncApi";
 
 /**
@@ -37,7 +39,7 @@ function previewStore(): PreviewStore {
     loadFlow: async (flowId) => (await api.getFlow(flowId)).flow,
     loadMappings: async (flowId) => (await api.listMappings(flowId)).mappings,
     persistPlan: async (plan, meta) =>
-      api.persistDraftRun({ plan, summary: meta.summary, sourceSnapshotSummary: meta.sourceSnapshotSummary }),
+      api.persistDraftRun({ plan, summary: meta.summary, sourceSnapshotSummary: meta.sourceSnapshotSummary, trigger: meta.trigger }),
     persistFailedRun: async (flowId, error, meta) => {
       const { runId } = await api.persistFailedRun({
         flowId,
@@ -60,6 +62,25 @@ function applyStore(): ApplyStore {
     return mappingCache;
   }
 
+  // Per-item mapping creates and status updates are buffered and flushed in one
+  // request each (one insert-transaction + one update-transaction) instead of an
+  // HTTP round-trip per item — the dominant apply cost on large runs. The
+  // durable target `imported_id` marker is the real idempotency guarantee, so a
+  // deferred flush cannot cause duplicates even if the tab closes mid-run.
+  const pendingMappings: SyncMappingInput[] = [];
+  const pendingItemPatches: { itemId: string; patch: RunItemStatusPatch }[] = [];
+
+  async function flush(): Promise<void> {
+    if (pendingMappings.length > 0) {
+      await api.createMappings(pendingMappings);
+      pendingMappings.length = 0;
+    }
+    if (pendingItemPatches.length > 0) {
+      await api.updateRunItems(pendingItemPatches);
+      pendingItemPatches.length = 0;
+    }
+  }
+
   return {
     loadRun: async (runId) => (await api.getRun(runId)).run,
     loadRunItems: async (runId) => (await api.getRun(runId)).items,
@@ -67,17 +88,22 @@ function applyStore(): ApplyStore {
     getMappingBySource: async (flowId, sourceItemKey) =>
       (await ensureMappingCache(flowId)).get(sourceItemKey) ?? null,
     createMapping: async (input) => {
-      const { mapping } = await api.createMapping(input);
-      // Keep the cache coherent for the rest of this apply run.
-      if (mappingCache) mappingCache.set(mapping.sourceItemKey, mapping);
+      pendingMappings.push(input);
+      // Keep the in-memory cache coherent immediately (the DB write is deferred).
+      if (mappingCache) mappingCache.set(input.sourceItemKey, input as unknown as SyncMapping);
     },
     updateRunStatus: async (runId, patch) => {
+      // A terminal status marks the end of the run: flush buffered item writes
+      // first so the finalized run reflects them, then update the run itself.
+      if (patch.status !== "applying") await flush();
       await api.updateRun(runId, { status: patch.status, finishedAt: patch.finishedAt, counts: patch.counts });
     },
     updateRunItemStatus: async (itemId, patch) => {
-      await api.updateRunItem(itemId, patch);
+      pendingItemPatches.push({ itemId, patch });
     },
     persistApplyFailure: async (runId, error) => {
+      // Persist whatever succeeded before the failure, then record the error.
+      await flush();
       await api.updateRun(runId, {
         status: "failed",
         finishedAt: new Date().toISOString(),
@@ -111,5 +137,26 @@ export function runClientApply(input: {
   return applySyncRun(
     { runId: input.runId, targetConnection: input.targetConnection, selection: input.selection },
     { transport: browserTransportProvider, store: applyStore() }
+  );
+}
+
+/**
+ * Run a safe-only automated sync (RD-054 / PR-020) end to end via the browser
+ * transport: policy-gated preview → apply of safe classes only. Used by both the
+ * "Run safe sync now" action and the client interval scheduler.
+ */
+export function runClientSafeSync(input: {
+  flowId: string;
+  sourceConnection: ConnectionInstance;
+  targetConnection: ConnectionInstance;
+  allowDisabled?: boolean;
+}): Promise<SafeSyncResult> {
+  return runSafeSync(
+    {
+      flowId: input.flowId,
+      context: { sourceConnection: input.sourceConnection, targetConnection: input.targetConnection },
+      allowDisabled: input.allowDisabled,
+    },
+    { transport: browserTransportProvider, previewStore: previewStore(), applyStore: applyStore() }
   );
 }

--- a/src/features/sync/lib/flowForm.test.ts
+++ b/src/features/sync/lib/flowForm.test.ts
@@ -40,6 +40,11 @@ describe("form defaults", () => {
     expect(form.transform.missingPayee).toBe("create");
     expect(form.transform.notesMarkerEnabled).toBe(true);
   });
+
+  it("defaults automation to manual preview (RD-053 behavior preserved)", () => {
+    expect(emptyFlowForm().automation.reviewPolicy).toBe("manual_preview_required");
+    expect(emptyFlowForm().automation.intervalMinutes).toBe("60");
+  });
 });
 
 describe("validation", () => {
@@ -78,6 +83,27 @@ describe("buildFlowPayload", () => {
     expect(JSON.stringify(payload)).not.toContain("serverPassword");
     expect(JSON.stringify(payload)).not.toContain("pw");
   });
+
+  it("encodes the automation review policy into the leg options envelope", () => {
+    const form = filledForm();
+    form.automation.reviewPolicy = "auto_sync_on_interval";
+    const payload = buildFlowPayload(form, instances) as JsonObject & { legs: JsonObject[] };
+    const leg = payload.legs[0] as Record<string, { version: number; data: JsonObject }>;
+    expect(leg.options.data).toMatchObject({ reviewPolicy: "auto_sync_on_interval" });
+  });
+
+  it("clamps the interval to its floor on save", () => {
+    const form = filledForm();
+    form.automation.intervalMinutes = "5"; // below the 15-minute floor
+    const payload = buildFlowPayload(form, instances) as JsonObject & { legs: JsonObject[] };
+    const leg = payload.legs[0] as Record<string, { version: number; data: JsonObject }>;
+    expect(leg.options.data.intervalMinutes).toBe(15);
+
+    form.automation.intervalMinutes = "";
+    const blank = buildFlowPayload(form, instances) as JsonObject & { legs: JsonObject[] };
+    const blankLeg = blank.legs[0] as Record<string, { version: number; data: JsonObject }>;
+    expect(blankLeg.options.data.intervalMinutes).toBe(60); // default when unparseable
+  });
 });
 
 describe("flowToFormState", () => {
@@ -106,6 +132,29 @@ describe("flowToFormState", () => {
     expect(form.target.accountName).toBe("Joint");
     expect(form.transform.amountDirection).toBe("reverse");
     expect(form.filter.payeeInclude).toBe("coffee bar, market");
+    // Automation policy survives the round-trip via the options envelope.
+    expect(form.automation.reviewPolicy).toBe("manual_preview_required");
+  });
+
+  it("round-trips a non-default policy and falls back to manual for an unknown value", () => {
+    const auto = filledForm();
+    auto.automation.reviewPolicy = "auto_apply_safe_only";
+    const payload = buildFlowPayload(auto, instances) as JsonObject & { legs: JsonObject[] };
+    const legIn = payload.legs[0] as Record<string, { version: number; data: JsonObject }>;
+    const baseFlow = (options: JsonObject): SyncFlow => ({
+      id: "flow-1", name: "Card sync", enabled: true, flowType: "transaction_sync", description: null,
+      createdAt: "", updatedAt: "",
+      legs: [{
+        id: "leg-1", flowId: "flow-1", position: 0,
+        sourceRef: legIn.sourceRef, targetRef: legIn.targetRef,
+        filter: legIn.filter, transform: legIn.transform, options: { version: 1, data: options },
+        createdAt: "", updatedAt: "",
+      }],
+    });
+
+    expect(flowToFormState(baseFlow({ reviewPolicy: "auto_apply_safe_only" }), instances).automation.reviewPolicy).toBe("auto_apply_safe_only");
+    // Garbage policy value decodes to the safe manual default.
+    expect(flowToFormState(baseFlow({ reviewPolicy: "nonsense" }), instances).automation.reviewPolicy).toBe("manual_preview_required");
   });
 
   it("persists through the real repository and round-trips (regression: envelope shape)", () => {

--- a/src/features/sync/lib/flowForm.ts
+++ b/src/features/sync/lib/flowForm.ts
@@ -1,8 +1,8 @@
 import { connectionFingerprint } from "@/lib/sync/connectionRef";
-import { decodeFlowPlanConfig } from "@/lib/sync/flowConfig";
+import { clampSyncInterval, decodeFlowPlanConfig, DEFAULT_SYNC_INTERVAL_MINUTES } from "@/lib/sync/flowConfig";
 import { decodeSourceFilter } from "@/lib/sync/sourceFilter";
 import type { ConnectionInstance } from "@/store/connection";
-import type { JsonObject, SyncFlow } from "@/lib/app-db/types";
+import type { JsonObject, SyncFlow, SyncReviewPolicy } from "@/lib/app-db/types";
 import type {
   SyncAmountDirection,
   SyncMissingPayeePolicy,
@@ -53,6 +53,17 @@ export type SyncTransformForm = {
   copySourceNotes: boolean;
 };
 
+/** Automation policy for the flow (RD-054 / PR-020). */
+export type SyncAutomationForm = {
+  reviewPolicy: SyncReviewPolicy;
+  /** Interval for `auto_sync_on_interval`; free text in the form, clamped on save. */
+  intervalMinutes: string;
+  /** Set when flow health paused the flow; cleared on re-enable. */
+  autoPausedAt: string | null;
+  /** Auto-map exact duplicates to their existing target instead of queuing them. */
+  exactDuplicateAutoMap: boolean;
+};
+
 export type SyncFlowFormState = {
   name: string;
   enabled: boolean;
@@ -60,6 +71,7 @@ export type SyncFlowFormState = {
   target: SyncEndpointForm;
   filter: SyncFilterForm;
   transform: SyncTransformForm;
+  automation: SyncAutomationForm;
 };
 
 export const EMPTY_ENDPOINT: SyncEndpointForm = {
@@ -95,6 +107,13 @@ export function emptyFlowForm(): SyncFlowFormState {
       missingPayee: "create",
       notesMarkerEnabled: true,
       copySourceNotes: true,
+    },
+    automation: {
+      // Existing/new flows stay manual — RD-053 behavior — until opted in.
+      reviewPolicy: "manual_preview_required",
+      intervalMinutes: String(DEFAULT_SYNC_INTERVAL_MINUTES),
+      autoPausedAt: null,
+      exactDuplicateAutoMap: false,
     },
   };
 }
@@ -181,6 +200,15 @@ export function buildFlowPayload(
     copySourceNotes: form.transform.copySourceNotes,
   };
 
+  // Automation/policy metadata lives in the leg `options` envelope (non-secret).
+  // The interval is clamped to its floor on save so a stored value is always valid.
+  const options: JsonObject = {
+    reviewPolicy: form.automation.reviewPolicy,
+    intervalMinutes: clampSyncInterval(form.automation.intervalMinutes),
+    autoPausedAt: form.automation.autoPausedAt,
+    exactDuplicateAutoMap: form.automation.exactDuplicateAutoMap,
+  };
+
   // Each leg ref/filter/transform must be a versioned JSON envelope, matching
   // what the flow repository normalizes and what the Slice 3 decoders read.
   const envelope = (data: JsonObject) => ({ version: 1, data });
@@ -195,7 +223,7 @@ export function buildFlowPayload(
         targetRef: envelope(targetRef),
         filter: envelope(filter),
         transform: envelope(transform),
-        options: envelope({}),
+        options: envelope(options),
       },
     ],
   };
@@ -239,6 +267,12 @@ export function flowToFormState(
     missingPayee: config.missingPayee,
     notesMarkerEnabled: config.notesMarkerEnabled,
     copySourceNotes: config.copySourceNotes,
+  };
+  form.automation = {
+    reviewPolicy: config.reviewPolicy,
+    intervalMinutes: String(config.intervalMinutes),
+    autoPausedAt: config.autoPausedAt,
+    exactDuplicateAutoMap: config.exactDuplicateAutoMap,
   };
   form.filter = {
     startDate: filter.startDate ?? "",

--- a/src/features/sync/lib/flowHealth.test.ts
+++ b/src/features/sync/lib/flowHealth.test.ts
@@ -1,0 +1,61 @@
+import {
+  classifySafeSyncOutcome,
+  DEFAULT_HEALTH_PAUSE_THRESHOLD,
+  nextConsecutiveFailures,
+  shouldPauseForHealth,
+} from "./flowHealth";
+
+describe("classifySafeSyncOutcome", () => {
+  it("treats clean applies and no-op runs as success", () => {
+    expect(classifySafeSyncOutcome("applied")).toBe("success");
+    expect(classifySafeSyncOutcome("no_safe_items")).toBe("success");
+  });
+
+  it("treats failed, partial, and preview failures as failure", () => {
+    expect(classifySafeSyncOutcome("failed")).toBe("failure");
+    expect(classifySafeSyncOutcome("partial")).toBe("failure");
+    expect(classifySafeSyncOutcome("preview_failed")).toBe("failure");
+  });
+
+  it("ignores a manual-policy skip (not an auto run)", () => {
+    expect(classifySafeSyncOutcome("skipped_manual_policy")).toBe("ignored");
+  });
+});
+
+describe("consecutive-failure streak", () => {
+  it("increments on failure, resets on success, holds on ignored", () => {
+    expect(nextConsecutiveFailures(0, "failure")).toBe(1);
+    expect(nextConsecutiveFailures(2, "failure")).toBe(3);
+    expect(nextConsecutiveFailures(2, "success")).toBe(0);
+    expect(nextConsecutiveFailures(2, "ignored")).toBe(2);
+  });
+
+  it("pauses only once the streak reaches the threshold (default 3)", () => {
+    expect(DEFAULT_HEALTH_PAUSE_THRESHOLD).toBe(3);
+    expect(shouldPauseForHealth(2)).toBe(false);
+    expect(shouldPauseForHealth(3)).toBe(true);
+    expect(shouldPauseForHealth(4)).toBe(true);
+  });
+
+  it("simulates three consecutive failures pausing the flow, and a success clearing it", () => {
+    let streak = 0;
+    for (const status of ["failed", "partial", "failed"] as const) {
+      streak = nextConsecutiveFailures(streak, classifySafeSyncOutcome(status));
+    }
+    expect(shouldPauseForHealth(streak)).toBe(true);
+
+    // A later successful run resets the streak below the threshold again.
+    streak = nextConsecutiveFailures(streak, classifySafeSyncOutcome("applied"));
+    expect(streak).toBe(0);
+    expect(shouldPauseForHealth(streak)).toBe(false);
+  });
+
+  it("does not pause when failures are interrupted by a success", () => {
+    let streak = 0;
+    for (const status of ["failed", "failed", "applied", "failed"] as const) {
+      streak = nextConsecutiveFailures(streak, classifySafeSyncOutcome(status));
+    }
+    expect(streak).toBe(1);
+    expect(shouldPauseForHealth(streak)).toBe(false);
+  });
+});

--- a/src/features/sync/lib/flowHealth.ts
+++ b/src/features/sync/lib/flowHealth.ts
@@ -1,0 +1,51 @@
+import type { SafeSyncResult } from "@/lib/sync/safeSyncOrchestrator";
+
+/**
+ * Flow health for automated safe-sync (RD-054 / PR-020 Slice 5).
+ *
+ * Repeated failing/partial automated runs pause a flow so it stops auto-firing
+ * until the user re-enables it. All the counting is pure and here so the pause
+ * rule is unit-testable; the scheduler hook only keeps the running count and
+ * calls back to persist the pause.
+ */
+
+export const DEFAULT_HEALTH_PAUSE_THRESHOLD = 3;
+
+export type AutoRunHealthOutcome = "success" | "failure" | "ignored";
+
+/**
+ * Map a safe-sync result to a health outcome:
+ * - a clean apply or a nothing-to-do run is success (resets the streak);
+ * - a failed/partial apply or a failed preview is a failure (extends the streak);
+ * - a manual-policy skip never happened as an auto run, so it is ignored.
+ */
+export function classifySafeSyncOutcome(status: SafeSyncResult["status"]): AutoRunHealthOutcome {
+  switch (status) {
+    case "applied":
+    case "no_safe_items":
+      return "success";
+    case "partial":
+    case "failed":
+    case "preview_failed":
+      return "failure";
+    case "skipped_manual_policy":
+      return "ignored";
+    default:
+      return "ignored";
+  }
+}
+
+/** Next consecutive-failure count after observing an outcome. */
+export function nextConsecutiveFailures(prev: number, outcome: AutoRunHealthOutcome): number {
+  if (outcome === "failure") return prev + 1;
+  if (outcome === "success") return 0;
+  return prev; // ignored: leave the streak unchanged
+}
+
+/** True once the failure streak reaches the pause threshold. */
+export function shouldPauseForHealth(
+  consecutiveFailures: number,
+  threshold: number = DEFAULT_HEALTH_PAUSE_THRESHOLD
+): boolean {
+  return consecutiveFailures >= threshold;
+}

--- a/src/features/sync/lib/previewRows.test.ts
+++ b/src/features/sync/lib/previewRows.test.ts
@@ -1,4 +1,15 @@
-import { classificationGroup, filterCount, formatAmount, selectableRowIds, splitPositions, toPreviewRow } from "./previewRows";
+import {
+  classificationGroup,
+  filterCount,
+  formatAmount,
+  isReviewRequired,
+  matchesPreviewFilter,
+  reviewQueueCount,
+  reviewQueueRows,
+  selectableRowIds,
+  splitPositions,
+  toPreviewRow,
+} from "./previewRows";
 import type { SyncFlowRunItem } from "@/lib/app-db/types";
 
 function item(overrides: Partial<SyncFlowRunItem> = {}): SyncFlowRunItem {
@@ -52,6 +63,72 @@ describe("classificationGroup", () => {
     expect(classificationGroup("source_changed_since_sync")).toBe("source_changed");
     expect(classificationGroup("target_marker_match")).toBe("marker_match");
     expect(classificationGroup("blocked")).toBe("blocked");
+  });
+});
+
+describe("review queue (RD-054)", () => {
+  it("classifies only uncertain, non-safe, non-resolved items as review-required", () => {
+    expect(isReviewRequired("exact_duplicate")).toBe(true);
+    expect(isReviewRequired("strong_duplicate")).toBe(true);
+    expect(isReviewRequired("weak_duplicate")).toBe(true);
+    expect(isReviewRequired("source_changed_since_sync")).toBe(true);
+    expect(isReviewRequired("source_missing")).toBe(true);
+    expect(isReviewRequired("blocked")).toBe(true);
+    expect(isReviewRequired("warning")).toBe(true);
+    // Safe (auto-applied) and resolved classes are NOT review-required.
+    expect(isReviewRequired("new")).toBe(false);
+    expect(isReviewRequired("target_marker_match")).toBe(false);
+    expect(isReviewRequired("already_synced")).toBe(false);
+    expect(isReviewRequired(null)).toBe(false);
+  });
+
+  it("queues review-required pending rows and never the auto-applied safe set", () => {
+    const rows = [
+      toPreviewRow(item({ id: "new-1", classification: "new" })),
+      toPreviewRow(item({ id: "mm-1", classification: "target_marker_match" })),
+      toPreviewRow(item({ id: "dup-1", classification: "strong_duplicate", plannedAction: "skip", applyState: "pending" })),
+      toPreviewRow(item({ id: "chg-1", classification: "source_changed_since_sync", applyState: null })),
+      toPreviewRow(item({ id: "blk-1", classification: "blocked", plannedAction: "blocked" })),
+      toPreviewRow(item({ id: "done-1", classification: "already_synced", plannedAction: "skip" })),
+    ];
+    const queued = reviewQueueRows(rows).map((r) => r.id).sort();
+    expect(queued).toEqual(["blk-1", "chg-1", "dup-1"]);
+    expect(reviewQueueCount(rows)).toBe(3);
+    // The safe set (new + marker-match) is exactly what automation applies — never queued.
+    expect(queued).not.toContain("new-1");
+    expect(queued).not.toContain("mm-1");
+  });
+
+  it("drops items once they have been applied or skipped by a human", () => {
+    const applied = toPreviewRow(item({ id: "dup-applied", classification: "exact_duplicate", applyState: "applied" }));
+    const skipped = toPreviewRow(item({ id: "dup-skipped", classification: "weak_duplicate", applyState: "skipped" }));
+    const pending = toPreviewRow(item({ id: "dup-pending", classification: "weak_duplicate", applyState: "pending" }));
+    expect(reviewQueueRows([applied, skipped, pending]).map((r) => r.id)).toEqual(["dup-pending"]);
+  });
+
+  it("treats an auto-mapped exact duplicate as safe: selectable, not queued", () => {
+    const autoMap = toPreviewRow(item({
+      classification: "exact_duplicate",
+      plannedAction: "skip",
+      warnings: { version: 1, data: { flags: ["exact_duplicate_auto_map"] } },
+    }));
+    expect(autoMap.selectable).toBe(true);
+    expect(autoMap.reviewRequired).toBe(false);
+    expect(reviewQueueRows([autoMap])).toHaveLength(0);
+
+    // Without the flag, the same exact duplicate stays review-required.
+    const review = toPreviewRow(item({ classification: "exact_duplicate", plannedAction: "skip", warnings: { version: 1, data: { flags: ["duplicate_review"] } } }));
+    expect(review.reviewRequired).toBe(true);
+    expect(review.selectable).toBe(false);
+  });
+
+  it("matches the review_queue filter for pending review-required rows only", () => {
+    const dup = toPreviewRow(item({ classification: "strong_duplicate", applyState: "pending" }));
+    const dupApplied = toPreviewRow(item({ classification: "strong_duplicate", applyState: "applied" }));
+    const fresh = toPreviewRow(item({ classification: "new" }));
+    expect(matchesPreviewFilter(dup, "review_queue")).toBe(true);
+    expect(matchesPreviewFilter(dupApplied, "review_queue")).toBe(false);
+    expect(matchesPreviewFilter(fresh, "review_queue")).toBe(false);
   });
 });
 

--- a/src/features/sync/lib/previewRows.ts
+++ b/src/features/sync/lib/previewRows.ts
@@ -1,4 +1,4 @@
-import type { SyncFlowRunItem, SyncItemClassification } from "@/lib/app-db/types";
+import type { SyncApplyState, SyncFlowRunItem, SyncItemClassification } from "@/lib/app-db/types";
 
 /**
  * Read persisted run items into display rows for the preview table
@@ -22,6 +22,14 @@ export type PreviewRow = {
   selectable: boolean;
   /** Included in "select all safe new" (new create candidates only). */
   isSafeNew: boolean;
+  /**
+   * Item an automated safe-only run could not apply and left for a human
+   * (RD-054 review queue): an uncertain class that is neither safe (new /
+   * marker-match) nor already resolved (already-synced).
+   */
+  reviewRequired: boolean;
+  /** Persisted apply lifecycle state (null on a never-applied draft preview). */
+  applyState: SyncApplyState | null;
   sourceItemKey: string;
   isSplit: boolean;
   flags: string[];
@@ -40,6 +48,25 @@ function str(value: unknown): string | null {
 
 function numOrNull(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Classes a safe-only automated run cannot apply and routes to the review queue
+ * (RD-054). Deliberately excludes `new` and `target_marker_match` (both safe →
+ * auto-applied) and `already_synced` (already resolved, no action needed).
+ */
+const REVIEW_REQUIRED_CLASSIFICATIONS: readonly SyncItemClassification[] = [
+  "exact_duplicate",
+  "strong_duplicate",
+  "weak_duplicate",
+  "source_changed_since_sync",
+  "source_missing",
+  "blocked",
+  "warning",
+];
+
+export function isReviewRequired(classification: SyncItemClassification | null): boolean {
+  return classification != null && REVIEW_REQUIRED_CLASSIFICATIONS.includes(classification);
 }
 
 export function classificationGroup(classification: SyncItemClassification | null): PreviewGroup {
@@ -72,13 +99,18 @@ export function toPreviewRow(item: SyncFlowRunItem): PreviewRow {
     : [];
 
   const isSafeNew = item.classification === "new" && item.plannedAction === "create";
+  // An exact duplicate the flow opted to auto-map is safe (mapping-only, no write).
+  const isExactDupAutoMap =
+    item.classification === "exact_duplicate" && flags.includes("exact_duplicate_auto_map");
   return {
     id: item.id,
     classification: item.classification,
     group: classificationGroup(item.classification),
-    // Marker-match rows are selectable for mapping repair (no target write).
-    selectable: isSafeNew || item.classification === "target_marker_match",
+    // Selectable: safe creates, marker-match repairs, or auto-mappable exact dups.
+    selectable: isSafeNew || item.classification === "target_marker_match" || isExactDupAutoMap,
     isSafeNew,
+    reviewRequired: isReviewRequired(item.classification) && !isExactDupAutoMap,
+    applyState: item.applyState,
     sourceItemKey: item.sourceItemKey ?? "",
     isSplit: item.sourceEntityType === "split_line",
     flags,
@@ -105,6 +137,24 @@ export function selectableRowIds(rows: PreviewRow[]): string[] {
   return rows.filter((r) => r.isSafeNew).map((r) => r.id);
 }
 
+/** Row is a live review-queue member: review-required and still pending. */
+export function isInReviewQueue(row: PreviewRow): boolean {
+  return row.reviewRequired && (row.applyState == null || row.applyState === "pending");
+}
+
+/**
+ * The RD-054 review queue: review-required items an automated run did not apply
+ * and that still await a human decision. Applied/skipped items have been
+ * resolved and drop out; a never-applied draft preview keeps its pending rows.
+ */
+export function reviewQueueRows(rows: PreviewRow[]): PreviewRow[] {
+  return rows.filter(isInReviewQueue);
+}
+
+export function reviewQueueCount(rows: PreviewRow[]): number {
+  return reviewQueueRows(rows).length;
+}
+
 const GROUP_LABELS: Record<PreviewGroup, string> = {
   new: "New",
   already_synced: "Already synced",
@@ -121,7 +171,7 @@ export function groupLabel(group: PreviewGroup): string {
 
 // --- Preview table filtering (detailed statuses) ---------------------------
 
-export type PreviewFilter = "all" | "needs_review" | PreviewGroup;
+export type PreviewFilter = "all" | "needs_review" | "review_queue" | PreviewGroup;
 
 /** The three groups the "Needs review" tile/filter covers. */
 const NEEDS_REVIEW_GROUPS: PreviewGroup[] = ["duplicate", "source_changed", "marker_match"];
@@ -140,6 +190,7 @@ export const PREVIEW_FILTERS: { key: PreviewFilter; label: string }[] = [
 export function matchesPreviewFilter(row: PreviewRow, filter: PreviewFilter): boolean {
   if (filter === "all") return true;
   if (filter === "needs_review") return NEEDS_REVIEW_GROUPS.includes(row.group);
+  if (filter === "review_queue") return isInReviewQueue(row);
   return row.group === filter;
 }
 

--- a/src/features/sync/lib/runsView.test.ts
+++ b/src/features/sync/lib/runsView.test.ts
@@ -1,4 +1,11 @@
-import { latestRunLabel, toRunRow } from "./runsView";
+import {
+  isAutoRun,
+  latestRunLabel,
+  runAutoAppliedCount,
+  runNeedsAttention,
+  runQueuedCount,
+  toRunRow,
+} from "./runsView";
 import type { SyncFlowRun } from "@/lib/app-db/types";
 
 function run(overrides: Partial<SyncFlowRun> = {}): SyncFlowRun {
@@ -23,7 +30,41 @@ describe("toRunRow", () => {
   });
 
   it("marks a background run as automated", () => {
-    expect(toRunRow(run({ createdByTrigger: "background_future" })).trigger).toBe("Automated");
+    const r = toRunRow(run({ createdByTrigger: "interval_safe_only" }));
+    expect(r.trigger).toBe("Auto-sync");
+    expect(r.isAuto).toBe(true);
+  });
+
+  it("exposes the review-queue count from the preview summary", () => {
+    const r = toRunRow(run({
+      status: "applied",
+      counts: { version: 1, data: { applied: 5, repaired: 0, failed: 0 } },
+      summary: { version: 1, data: { totalItems: 12, duplicatesSkipped: 2, sourceChangedWarnings: 1, blocked: 1 } },
+    }));
+    expect(r.queued).toBe(4);
+  });
+});
+
+describe("run summary helpers (RD-054)", () => {
+  it("isAutoRun distinguishes automated runs", () => {
+    expect(isAutoRun(run({ createdByTrigger: "interval_safe_only" }))).toBe(true);
+    expect(isAutoRun(run({ createdByTrigger: "manual_preview" }))).toBe(false);
+  });
+
+  it("runQueuedCount sums the review-required summary fields", () => {
+    expect(runQueuedCount(run({ summary: { version: 1, data: { duplicatesSkipped: 3, sourceChangedWarnings: 2, blocked: 1 } } }))).toBe(6);
+    expect(runQueuedCount(run({ summary: null as unknown as SyncFlowRun["summary"] }))).toBe(0);
+  });
+
+  it("runAutoAppliedCount adds creates and repairs", () => {
+    expect(runAutoAppliedCount(run({ counts: { version: 1, data: { applied: 4, repaired: 3 } } }))).toBe(7);
+  });
+
+  it("runNeedsAttention flags failed/partial runs or queued items", () => {
+    expect(runNeedsAttention(run({ status: "failed" }))).toBe(true);
+    expect(runNeedsAttention(run({ status: "partial" }))).toBe(true);
+    expect(runNeedsAttention(run({ status: "applied", summary: { version: 1, data: { blocked: 2 } } }))).toBe(true);
+    expect(runNeedsAttention(run({ status: "applied", summary: { version: 1, data: { totalItems: 3 } } }))).toBe(false);
   });
 });
 

--- a/src/features/sync/lib/runsView.ts
+++ b/src/features/sync/lib/runsView.ts
@@ -13,15 +13,52 @@ export type RunRowView = {
   statusLabel: string;
   tone: RunTone;
   trigger: string;
+  /** True for an automated safe-only run (interval / "Run safe sync now"). */
+  isAuto: boolean;
   planned: number | null;
   created: number | null;
   relinked: number | null;
   failed: number | null;
+  /** Review-required items this run did not apply (the review queue). */
+  queued: number | null;
   when: string;
 };
 
 function num(value: unknown): number | null {
   return typeof value === "number" ? value : null;
+}
+
+function n0(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/** True for an automated safe-only run. */
+export function isAutoRun(run: SyncFlowRun): boolean {
+  return run.createdByTrigger === "interval_safe_only";
+}
+
+/**
+ * Count of review-required items a run left for the human (the review queue),
+ * derived from the persisted preview summary: duplicates + source-changed +
+ * blocked. Zero on runs without a stored summary.
+ */
+export function runQueuedCount(run: SyncFlowRun): number {
+  const s = run.summary?.data ?? {};
+  return n0(s.duplicatesSkipped) + n0(s.sourceChangedWarnings) + n0(s.blocked);
+}
+
+/** Auto-applied count for an applied run: creates plus mapping repairs. */
+export function runAutoAppliedCount(run: SyncFlowRun): number {
+  const c = run.counts?.data ?? {};
+  return n0(c.applied) + n0(c.repaired);
+}
+
+/**
+ * A run needs the user's attention when it failed/partially applied, or left
+ * items in the review queue. Used for the flow-list notification badge.
+ */
+export function runNeedsAttention(run: SyncFlowRun): boolean {
+  return run.status === "failed" || run.status === "partial" || runQueuedCount(run) > 0;
 }
 
 function statusView(status: string): { label: string; tone: RunTone } {
@@ -44,7 +81,7 @@ function statusView(status: string): { label: string; tone: RunTone } {
 }
 
 function triggerLabel(trigger: string): string {
-  return trigger === "background_future" ? "Automated" : "Manual";
+  return trigger === "interval_safe_only" ? "Auto-sync" : "Manual";
 }
 
 export function toRunRow(run: SyncFlowRun): RunRowView {
@@ -52,15 +89,18 @@ export function toRunRow(run: SyncFlowRun): RunRowView {
   const counts = run.counts?.data ?? {};
   const summary = run.summary?.data ?? {};
   const applied = run.status !== "draft_preview";
+  const queued = runQueuedCount(run);
   return {
     id: run.id,
     statusLabel: status.label,
     tone: status.tone,
     trigger: triggerLabel(run.createdByTrigger),
+    isAuto: isAutoRun(run),
     planned: num(summary.totalItems) ?? num(counts.new),
     created: applied ? num(counts.applied) ?? 0 : null,
     relinked: applied ? num(counts.repaired) ?? 0 : null,
     failed: applied ? num(counts.failed) ?? 0 : null,
+    queued: queued > 0 ? queued : null,
     when: run.finishedAt ?? run.startedAt,
   };
 }

--- a/src/features/sync/lib/scheduler.test.ts
+++ b/src/features/sync/lib/scheduler.test.ts
@@ -1,0 +1,71 @@
+import { isFlowDue, selectFlowsToAutoRun, type SchedulableFlow } from "./scheduler";
+
+const NOW = 1_000_000_000_000;
+
+function flow(overrides: Partial<SchedulableFlow> = {}): SchedulableFlow {
+  return {
+    flowId: "f1",
+    reviewPolicy: "auto_sync_on_interval",
+    enabled: true,
+    intervalMinutes: 60,
+    connectionsReady: true,
+    lastRunAtMs: null,
+    ...overrides,
+  };
+}
+
+const noneInFlight = new Set<string>();
+
+describe("isFlowDue", () => {
+  it("runs an opted-in flow that has never run", () => {
+    expect(isFlowDue(flow(), noneInFlight, NOW)).toBe(true);
+  });
+
+  it("never runs manual or auto-apply-on-preview policies on the interval", () => {
+    expect(isFlowDue(flow({ reviewPolicy: "manual_preview_required" }), noneInFlight, NOW)).toBe(false);
+    expect(isFlowDue(flow({ reviewPolicy: "auto_apply_safe_only" }), noneInFlight, NOW)).toBe(false);
+  });
+
+  it("never runs a disabled/paused flow", () => {
+    expect(isFlowDue(flow({ enabled: false }), noneInFlight, NOW)).toBe(false);
+  });
+
+  it("skips a flow whose connections are locked/absent", () => {
+    expect(isFlowDue(flow({ connectionsReady: false }), noneInFlight, NOW)).toBe(false);
+  });
+
+  it("never double-runs an in-flight flow", () => {
+    expect(isFlowDue(flow({ flowId: "busy" }), new Set(["busy"]), NOW)).toBe(false);
+  });
+
+  it("honors the interval: not due before it elapses, due after", () => {
+    const justRan = flow({ lastRunAtMs: NOW - 59 * 60_000 }); // 59 min ago, interval 60
+    const overdue = flow({ lastRunAtMs: NOW - 61 * 60_000 }); // 61 min ago
+    expect(isFlowDue(justRan, noneInFlight, NOW)).toBe(false);
+    expect(isFlowDue(overdue, noneInFlight, NOW)).toBe(true);
+  });
+});
+
+describe("selectFlowsToAutoRun", () => {
+  it("returns only the due, opted-in, ready, not-in-flight flows", () => {
+    const flows: SchedulableFlow[] = [
+      flow({ flowId: "due-never" }),
+      flow({ flowId: "due-overdue", lastRunAtMs: NOW - 120 * 60_000 }),
+      flow({ flowId: "manual", reviewPolicy: "manual_preview_required" }),
+      flow({ flowId: "disabled", enabled: false }),
+      flow({ flowId: "locked", connectionsReady: false }),
+      flow({ flowId: "busy" }),
+      flow({ flowId: "recent", lastRunAtMs: NOW - 5 * 60_000 }),
+    ];
+    const due = selectFlowsToAutoRun({ flows, inFlight: new Set(["busy"]), nowMs: NOW });
+    expect(due.sort()).toEqual(["due-never", "due-overdue"]);
+  });
+
+  it("returns nothing when no flow has opted into interval auto-sync", () => {
+    const flows = [
+      flow({ flowId: "a", reviewPolicy: "manual_preview_required" }),
+      flow({ flowId: "b", reviewPolicy: "auto_apply_safe_only" }),
+    ];
+    expect(selectFlowsToAutoRun({ flows, inFlight: noneInFlight, nowMs: NOW })).toEqual([]);
+  });
+});

--- a/src/features/sync/lib/scheduler.ts
+++ b/src/features/sync/lib/scheduler.ts
@@ -1,0 +1,52 @@
+import type { SyncReviewPolicy } from "@/lib/app-db/types";
+
+/**
+ * Pure scheduling decision for client-side interval auto-sync
+ * (RD-054 / PR-020 Slice 4).
+ *
+ * This is intentionally a plain function, not a hook: all the rules that matter
+ * — policy gate, enabled gate, connection availability, the interval floor, and
+ * non-overlap — are decided here so they can be unit-tested without React or a
+ * live timer. `useSyncScheduler` is only a thin timer wrapper around this.
+ *
+ * There is no server here: the engine and credentials live in the browser, so a
+ * flow is only schedulable while its connections are unlocked in this tab
+ * (`connectionsReady`). Unattended server-side scheduling is RD-058.
+ */
+
+export type SchedulableFlow = {
+  flowId: string;
+  reviewPolicy: SyncReviewPolicy;
+  /** Disabled/paused flows are never auto-triggered. */
+  enabled: boolean;
+  intervalMinutes: number;
+  /** Both source and target connections are resolved/unlocked in this tab. */
+  connectionsReady: boolean;
+  /** Start time (ms) of this flow's most recent auto run, or null if never. */
+  lastRunAtMs: number | null;
+};
+
+export type AutoRunSelectionInput = {
+  flows: SchedulableFlow[];
+  /** Flows whose auto run is currently in progress — never started twice. */
+  inFlight: ReadonlySet<string>;
+  nowMs: number;
+};
+
+/** True when a flow is due for an automated safe-only run right now. */
+export function isFlowDue(flow: SchedulableFlow, inFlight: ReadonlySet<string>, nowMs: number): boolean {
+  if (flow.reviewPolicy !== "auto_sync_on_interval") return false;
+  if (!flow.enabled) return false;
+  if (!flow.connectionsReady) return false;
+  if (inFlight.has(flow.flowId)) return false;
+  if (flow.lastRunAtMs == null) return true;
+  const intervalMs = Math.max(1, flow.intervalMinutes) * 60_000;
+  return nowMs - flow.lastRunAtMs >= intervalMs;
+}
+
+/** Flow ids that should start an automated safe-only run on this tick. */
+export function selectFlowsToAutoRun(input: AutoRunSelectionInput): string[] {
+  return input.flows
+    .filter((flow) => isFlowDue(flow, input.inFlight, input.nowMs))
+    .map((flow) => flow.flowId);
+}

--- a/src/features/sync/lib/syncApi.ts
+++ b/src/features/sync/lib/syncApi.ts
@@ -5,6 +5,7 @@ import type {
   SyncFlowRunItem,
   SyncMapping,
   SyncMappingInput,
+  SyncRunTrigger,
 } from "@/lib/app-db/types";
 import type { SyncPlanResult } from "@/lib/sync/plannedChanges";
 import type {
@@ -80,6 +81,11 @@ export function createMapping(input: SyncMappingInput): Promise<{ mapping: SyncM
   return jsonFetch("/api/sync-mappings", { method: "POST", body: JSON.stringify(input) });
 }
 
+/** Bulk-create mappings in one request/transaction (apply-run flush). */
+export function createMappings(inputs: SyncMappingInput[]): Promise<{ mappings: SyncMapping[] }> {
+  return jsonFetch("/api/sync-mappings", { method: "POST", body: JSON.stringify(inputs) });
+}
+
 // --- Runs -------------------------------------------------------------------
 
 export function listRuns(flowId: string, limit = 20): Promise<{ runs: SyncFlowRun[] }> {
@@ -94,6 +100,7 @@ export function persistDraftRun(body: {
   plan: SyncPlanResult;
   summary?: JsonObject;
   sourceSnapshotSummary?: JsonObject;
+  trigger?: SyncRunTrigger;
 }): Promise<{ runId: string }> {
   return jsonFetch("/api/sync-flow-runs", {
     method: "POST",
@@ -118,4 +125,11 @@ export function updateRun(runId: string, patch: UpdateSyncFlowRunPatch): Promise
 
 export function updateRunItem(itemId: string, patch: UpdateSyncFlowRunItemPatch): Promise<{ item: SyncFlowRunItem }> {
   return jsonFetch(`/api/sync-flow-run-items/${itemId}`, { method: "PATCH", body: JSON.stringify(patch) });
+}
+
+/** Bulk-update run item statuses in one request/transaction (apply-run flush). */
+export function updateRunItems(
+  items: { itemId: string; patch: UpdateSyncFlowRunItemPatch }[]
+): Promise<{ updated: number }> {
+  return jsonFetch("/api/sync-flow-run-items", { method: "PATCH", body: JSON.stringify({ items }) });
 }

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -48,10 +48,12 @@ import {
   type ListTransactionsForSyncInput,
   type ResolvedSyncPayee,
   type ScheduleWriteInput,
+  type SyncAppliedSnapshot,
   type SyncCreatedTransaction,
   type SyncSourceSplitLine,
   type SyncSourceTransaction,
   type SyncTargetLookup,
+  type SyncTargetLookupTransaction,
   type SyncTargetTransactionInput,
   type TransportBudgetMonth,
 } from "./transport";
@@ -700,40 +702,38 @@ async function createOrResolveBrowserPayee(
   return { id, name, created: true };
 }
 
-async function resolveCreatedTransactionId(
-  api: ActualBrowserApi,
-  accountId: string,
-  date: string,
-  importedId: string
-): Promise<string | null> {
-  // addTransactions returns only "ok"; recover the id via the durable marker.
-  const rows = await api.getTransactions(accountId, date, date);
-  for (const row of rows) {
-    if (isRecord(row) && asString(row.imported_id) === importedId) {
-      return asString(row.id) ?? null;
-    }
-  }
-  return null;
-}
-
 async function createBrowserTransactionsForSync(
   connection: BrowserApiConnection,
   inputs: SyncTargetTransactionInput[]
 ): Promise<CreateTransactionsForSyncResult> {
   const api = await getBrowserApiRuntime(connection);
-  const created: SyncCreatedTransaction[] = [];
+  if (inputs.length === 0) return { created: [] };
 
-  // Writes to the same target budget are serialized to keep the single runtime
-  // consistent and to make per-item apply-state deterministic.
-  for (let requestIndex = 0; requestIndex < inputs.length; requestIndex++) {
-    const input = inputs[requestIndex];
+  // 1. Resolve/create every payee ONCE for the whole batch (load payees once,
+  //    create missing ones on demand), instead of a lookup per transaction.
+  const payeeIdByName = new Map<string, string>();
+  for (const raw of await api.getPayees()) {
+    const payee = normalizeDirectPayee(raw);
+    if (payee) payeeIdByName.set(normalizeName(payee.name), payee.id);
+  }
+  async function resolvePayeeId(input: SyncTargetTransactionInput): Promise<string | null> {
+    if (input.payeeId) return input.payeeId;
+    if (!input.payeeName) return null;
+    const key = normalizeName(input.payeeName);
+    const existing = payeeIdByName.get(key);
+    if (existing) return existing;
+    const id = await api.createPayee({ name: input.payeeName });
+    payeeIdByName.set(key, id);
+    return id;
+  }
 
-    let payeeId = input.payeeId ?? null;
-    if (!payeeId && input.payeeName) {
-      payeeId = (await createOrResolveBrowserPayee(connection, input.payeeName)).id;
-    }
-
-    const importedId = input.importedId ?? null;
+  // 2. Build payloads with resolved payees, grouped by target account (Budget
+  //    File Sync uses a single account, but grouping keeps this general).
+  type Entry = { index: number; input: SyncTargetTransactionInput; payload: ApiImportTransaction; payeeId: string | null };
+  const byAccount = new Map<string, { entries: Entry[]; minDate: string; maxDate: string }>();
+  for (let index = 0; index < inputs.length; index++) {
+    const input = inputs[index];
+    const payeeId = await resolvePayeeId(input);
     const payload: ApiImportTransaction = {
       date: input.date,
       amount: input.amount,
@@ -743,24 +743,62 @@ async function createBrowserTransactionsForSync(
       // Actual defaults missing `cleared` to true; be explicit for synced rows.
       cleared: input.cleared ?? false,
     };
-    if (importedId) payload.imported_id = importedId;
+    if (input.importedId) payload.imported_id = input.importedId;
 
-    // addTransactions performs a plain insert (no dedupe/reconcile), so the
-    // created row matches the planned payload. See the Slice 1 spike notes for
-    // why this is preferred over importTransactions for the MVP.
-    await api.addTransactions(input.accountId, [payload], {
+    const group = byAccount.get(input.accountId);
+    if (group) {
+      group.entries.push({ index, input, payload, payeeId });
+      if (input.date < group.minDate) group.minDate = input.date;
+      if (input.date > group.maxDate) group.maxDate = input.date;
+    } else {
+      byAccount.set(input.accountId, { entries: [{ index, input, payload, payeeId }], minDate: input.date, maxDate: input.date });
+    }
+  }
+
+  // 3. One addTransactions per account (a plain insert — no dedupe/reconcile, so
+  //    created rows match the planned payloads; see the Slice 1 spike notes for
+  //    why this is preferred over importTransactions), then ONE range read per
+  //    account to recover ids + persisted fields by marker.
+  const created: SyncCreatedTransaction[] = new Array(inputs.length);
+  for (const [accountId, group] of byAccount) {
+    await api.addTransactions(accountId, group.entries.map((e) => e.payload), {
       learnCategories: false,
       runTransfers: false,
     });
 
-    const transactionId = importedId
-      ? await resolveCreatedTransactionId(api, input.accountId, input.date, importedId)
-      : null;
+    const rowByMarker = new Map<string, ApiTransaction>();
+    const rows = await api.getTransactions(accountId, group.minDate, group.maxDate);
+    for (const row of rows) {
+      if (!isRecord(row)) continue;
+      const marker = asString(row.imported_id);
+      if (marker && !rowByMarker.has(marker)) rowByMarker.set(marker, row as ApiTransaction);
+    }
 
-    created.push({ requestIndex, transactionId, importedId });
+    for (const entry of group.entries) {
+      const marker = entry.input.importedId ?? null;
+      const row = marker ? rowByMarker.get(marker) : undefined;
+      created[entry.index] = {
+        requestIndex: entry.index,
+        transactionId: row ? asString(row.id) ?? null : null,
+        importedId: marker,
+        resolvedPayeeId: entry.payeeId,
+        applied: row ? appliedFromRow(row, entry.input.date) : null,
+      };
+    }
   }
 
   return { created };
+}
+
+function appliedFromRow(row: ApiTransaction, fallbackDate: string): SyncAppliedSnapshot {
+  return {
+    amount: typeof row.amount === "number" ? row.amount : 0,
+    date: asString(row.date) ?? fallbackDate,
+    cleared: row.cleared === true,
+    categoryId: asString(row.category) ?? null,
+    payeeId: asString(row.payee) ?? null,
+    notes: asString(row.notes) ?? null,
+  };
 }
 
 async function getBrowserTargetLookupForSync(
@@ -771,23 +809,35 @@ async function getBrowserTargetLookupForSync(
   const payees = (await api.getPayees())
     .map(normalizeDirectPayee)
     .filter((payee): payee is Payee => payee !== null);
+  const payeeNameById = new Map(payees.map((p) => [p.id, p.name]));
 
+  // Single range read serves BOTH the marker index and the dedupe transaction
+  // list, so the caller does not need a second listTransactionsForSync (which
+  // would reload payees + categories again).
   const importedIdIndex = new Map<string, string>();
+  const transactions: SyncTargetLookupTransaction[] = [];
   const rows = await api.getTransactions(
     input.accountId,
     input.startDate ?? "",
     input.endDate ?? ""
   );
   for (const row of rows) {
-    if (!isRecord(row)) continue;
-    const importedId = asString(row.imported_id);
+    if (!isRecord(row) || row.is_child === true) continue;
     const id = asString(row.id);
-    if (importedId && id && !importedIdIndex.has(importedId)) {
-      importedIdIndex.set(importedId, id);
-    }
+    if (!id) continue;
+    const importedId = asString(row.imported_id);
+    if (importedId && !importedIdIndex.has(importedId)) importedIdIndex.set(importedId, id);
+    const payeeId = asString(row.payee);
+    transactions.push({
+      id,
+      date: asString(row.date) ?? "",
+      amount: typeof row.amount === "number" ? row.amount : 0,
+      payeeName: payeeId ? payeeNameById.get(payeeId) ?? null : null,
+      categoryId: asString(row.category) ?? null,
+    });
   }
 
-  return { payees, importedIdIndex };
+  return { payees, importedIdIndex, transactions };
 }
 
 export function createBrowserApiTransport(

--- a/src/lib/actual/syncTransactions.test.ts
+++ b/src/lib/actual/syncTransactions.test.ts
@@ -217,8 +217,16 @@ describe("createTransactionsForSync (Direct)", () => {
 
     // The id-recovery lookup is a same-day query filtered by the marker.
     expect(getTransactions).toHaveBeenCalledWith("acct-tgt", "2026-07-01", "2026-07-01");
+    // The id and the persisted fields are recovered from the same read (no
+    // second fetch), so callers can diff planned vs actual cheaply.
     expect(result.created).toEqual([
-      { requestIndex: 0, transactionId: "created-1", importedId: "sync-marker-1" },
+      {
+        requestIndex: 0,
+        transactionId: "created-1",
+        importedId: "sync-marker-1",
+        resolvedPayeeId: "tp1",
+        applied: { amount: 1250, date: "2026-07-01", cleared: false, categoryId: null, payeeId: null, notes: null },
+      },
     ]);
   });
 
@@ -243,7 +251,7 @@ describe("createTransactionsForSync (Direct)", () => {
       { accountId: "acct-tgt", date: "2026-07-03", amount: 500 },
     ]);
     expect(result.created).toEqual([
-      { requestIndex: 0, transactionId: null, importedId: null },
+      { requestIndex: 0, transactionId: null, importedId: null, resolvedPayeeId: null, applied: null },
     ]);
   });
 });

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -148,6 +148,20 @@ export type SyncTargetTransactionInput = {
   importedId?: string | null;
 };
 
+/**
+ * The persisted fields of a just-created target transaction, captured while the
+ * id is recovered so callers can diff planned-vs-actual (e.g. target rules that
+ * ran on create) without a second read.
+ */
+export type SyncAppliedSnapshot = {
+  amount: number;
+  date: string;
+  cleared: boolean;
+  categoryId: string | null;
+  payeeId: string | null;
+  notes: string | null;
+};
+
 export type SyncCreatedTransaction = {
   /** Index into the input array this result corresponds to. */
   requestIndex: number;
@@ -155,6 +169,10 @@ export type SyncCreatedTransaction = {
   transactionId: string | null;
   /** The marker actually written, echoed back for mapping records. */
   importedId: string | null;
+  /** The payee id the transport resolved/created for this row (for diffing). */
+  resolvedPayeeId?: string | null;
+  /** The persisted row's fields, when recovered alongside the id. */
+  applied?: SyncAppliedSnapshot | null;
 };
 
 export type CreateTransactionsForSyncResult = {
@@ -168,11 +186,26 @@ export type ResolvedSyncPayee = {
   created: boolean;
 };
 
+/** Minimal target transaction shape for the planner's duplicate heuristic. */
+export type SyncTargetLookupTransaction = {
+  id: string;
+  date: string;
+  amount: number;
+  payeeName: string | null;
+  categoryId: string | null;
+};
+
 /** Lightweight target lookup used for marker-match dedupe before applying. */
 export type SyncTargetLookup = {
   payees: Payee[];
   /** Map of existing target `imported_id` -> target transaction id. */
   importedIdIndex: Map<string, string>;
+  /**
+   * Target transactions in range for the duplicate heuristic. Returned here so
+   * a single read + payee load covers both the marker index and dedupe, instead
+   * of a second full `listTransactionsForSync` (which reloads payees+categories).
+   */
+  transactions: SyncTargetLookupTransaction[];
 };
 
 export interface ActualBenchTransport {

--- a/src/lib/app-db/connection.ts
+++ b/src/lib/app-db/connection.ts
@@ -76,6 +76,10 @@ export function getAppDb(dbPath = resolveAppDbPath()): SqliteDatabase {
   try {
     db.pragma("foreign_keys = ON");
     db.pragma("journal_mode = WAL");
+    // NORMAL is durable under WAL (only risks the last commit on OS crash, not
+    // corruption) and avoids an fsync per write — a large win for the many small
+    // writes a sync run makes.
+    db.pragma("synchronous = NORMAL");
     runMigrations(db);
     cachedDb = { path: dbPath, db };
     return db;

--- a/src/lib/app-db/types.ts
+++ b/src/lib/app-db/types.ts
@@ -57,7 +57,31 @@ export type SyncRunStatus =
   | "failed"
   | "cancelled";
 
-export type SyncRunTrigger = "manual_preview" | "manual_apply" | "background_future";
+export type SyncRunTrigger =
+  | "manual_preview"
+  | "manual_apply"
+  /**
+   * A safe-only automated run (RD-054 / PR-020): the "Run safe sync now" action
+   * or the client-side interval timer. Stamped on the run so history can
+   * distinguish automated from hand-applied runs. (Client-side only — there is
+   * no unattended server daemon; that is RD-058.)
+   */
+  | "interval_safe_only";
+
+/**
+ * Per-flow automation policy (RD-054 / PR-020). Gates how much of a run is
+ * applied without a human:
+ * - `manual_preview_required`: preview only; the human selects and applies (RD-053 default).
+ * - `auto_apply_safe_only`: a user-initiated run auto-applies only safe classes.
+ * - `auto_sync_on_interval`: a client-side interval re-runs safe sync while the app is
+ *   open and the connection is unlocked (Tier 1; not a server daemon — see PR-020).
+ *
+ * Uncertain items are never auto-applied under any policy; they go to the review queue.
+ */
+export type SyncReviewPolicy =
+  | "manual_preview_required"
+  | "auto_apply_safe_only"
+  | "auto_sync_on_interval";
 
 /**
  * Primary, mutually-exclusive lifecycle/dedupe state persisted for each run

--- a/src/lib/sync/appDbPreviewStore.ts
+++ b/src/lib/sync/appDbPreviewStore.ts
@@ -22,6 +22,7 @@ export function createAppDbPreviewStore(db: SqliteDatabase): PreviewStore {
       const { run } = persistDraftPreviewRun(db, plan, {
         summary: meta.summary,
         sourceSnapshotSummary: meta.sourceSnapshotSummary,
+        trigger: meta.trigger,
       });
       return { runId: run.id };
     },

--- a/src/lib/sync/applyOrchestrator.test.ts
+++ b/src/lib/sync/applyOrchestrator.test.ts
@@ -91,12 +91,17 @@ function makeTargetTransport(opts: TargetOptions = {}) {
       counter += 1;
       const id = "tt" + counter;
       const ruled = opts.ruleMutate ? opts.ruleMutate({ categoryId: inp.categoryId ?? null, payeeId: inp.payeeId ?? null, notes: inp.notes ?? null }) : {};
-      rows.push(targetRow({
+      const row = targetRow({
         id, date: inp.date, amount: inp.amount, payeeId: inp.payeeId ?? null,
         categoryId: inp.categoryId ?? null, notes: inp.notes ?? null, cleared: inp.cleared ?? false,
         importedId: inp.importedId ?? null, ...ruled,
-      }));
-      return { requestIndex: i, transactionId: id, importedId: inp.importedId ?? null };
+      });
+      rows.push(row);
+      // Mirror the Direct transport: the persisted fields come back with the id.
+      return {
+        requestIndex: i, transactionId: id, importedId: inp.importedId ?? null,
+        applied: { amount: row.amount, date: row.date, cleared: row.cleared, categoryId: row.categoryId, payeeId: row.payeeId, notes: row.notes },
+      };
     });
     return { created };
   });
@@ -211,7 +216,7 @@ describe("applySyncRun — validation", () => {
 describe("applySyncRun — create path", () => {
   it("creates a target transaction, resolves the id, and records a mapping immediately", async () => {
     const { store, createdMappings, itemPatches } = makeStore();
-    const { transport, createTransactionsForSync, createPayee } = makeTargetTransport();
+    const { transport, createTransactionsForSync } = makeTargetTransport();
 
     const result = await applySyncRun({ runId: "run-1", targetConnection: targetConn }, { transport: provider(transport), store });
 
@@ -219,10 +224,10 @@ describe("applySyncRun — create path", () => {
     expect(result.counts).toMatchObject({ selected: 1, applied: 1, failed: 0 });
     expect(result.items[0]).toMatchObject({ outcome: "applied", targetTransactionId: "tt1" });
 
-    // create used the marker; payee was resolved from name
-    expect(createPayee).toHaveBeenCalledWith({ name: "Coffee Bar" });
+    // Orchestrator forwards the marker + payee name to the batch create; payee
+    // resolution is the transport's job (covered in the transport tests).
     expect(createTransactionsForSync.mock.calls[0][0][0]).toMatchObject({
-      importedId: MARKER_T1, payeeId: "payee-Coffee Bar", categoryId: "tc1", amount: 1250,
+      importedId: MARKER_T1, payeeName: "Coffee Bar", categoryId: "tc1", amount: 1250,
     });
 
     // mapping recorded with target id + marker
@@ -232,6 +237,24 @@ describe("applySyncRun — create path", () => {
       targetMarker: MARKER_T1, sourceEntityType: "transaction",
     });
     expect(itemPatches.get("item-1")).toMatchObject({ applyState: "applied" });
+  });
+
+  it("creates every selected item in a single batched transport call", async () => {
+    const items = [
+      runItem({ id: "a", sourceItemKey: "txn:t1", payloadData: { importedId: MARKER_T1 } } as unknown as Partial<SyncFlowRunItem>),
+      runItem({ id: "b", sourceItemKey: "txn:t2", sourceTransactionId: "t2", payloadData: { importedId: MARKER_T2 } } as unknown as Partial<SyncFlowRunItem>),
+      runItem({ id: "c", sourceItemKey: "split:t1:s1", payloadData: { importedId: MARKER_SPLIT } } as unknown as Partial<SyncFlowRunItem>),
+    ];
+    const { store, createdMappings } = makeStore({ items });
+    const { transport, createTransactionsForSync } = makeTargetTransport();
+
+    const result = await applySyncRun({ runId: "run-1", targetConnection: targetConn }, { transport: provider(transport), store });
+
+    expect(result.counts).toMatchObject({ selected: 3, applied: 3, failed: 0 });
+    // The whole batch is ONE insert call, not one round-trip per transaction.
+    expect(createTransactionsForSync).toHaveBeenCalledTimes(1);
+    expect(createTransactionsForSync.mock.calls[0][0]).toHaveLength(3);
+    expect(createdMappings).toHaveLength(3);
   });
 
   it("does not create a payee when policy left it empty", async () => {
@@ -352,6 +375,113 @@ describe("applySyncRun — marker-match repair", () => {
     // No new create candidates and marker-match is not auto-selected → nothing to do.
     expect(result).toMatchObject({ status: "failed", error: { code: "no_eligible_items" } });
   });
+
+  it("all_safe auto-selects both new creates and repairable marker matches", async () => {
+    const create = runItem(); // item-1: new create, txn:t1
+    const repair = runItem({
+      id: "mm-2", sourceItemKey: "txn:t2", sourceTransactionId: "t2",
+      classification: "target_marker_match", plannedAction: "skip", plannedTargetPayload: null,
+      targetItemRef: { version: 1, data: { targetTransactionId: "pre-existing" } },
+    });
+    const { store, createdMappings } = makeStore({ items: [create, repair] });
+    const { transport, createTransactionsForSync } = makeTargetTransport({
+      preloaded: [targetRow({ id: "pre-existing", importedId: MARKER_T2 })],
+    });
+
+    const result = await applySyncRun(
+      { runId: "run-1", targetConnection: targetConn, selection: { selection: "all_safe" } },
+      { transport: provider(transport), store }
+    );
+
+    expect(result.status).toBe("applied");
+    expect(result.counts).toMatchObject({ selected: 2, applied: 1, repaired: 1 });
+    // Only the create performs an Actual write; the repair just records a mapping.
+    expect(createTransactionsForSync).toHaveBeenCalledTimes(1);
+    expect(createdMappings.map((m) => m.sourceItemKey).sort()).toEqual(["txn:t1", "txn:t2"]);
+  });
+});
+
+describe("applySyncRun — exact-duplicate auto-map", () => {
+  function autoMapItem(): SyncFlowRunItem {
+    return runItem({
+      id: "dup-1",
+      classification: "exact_duplicate",
+      plannedAction: "skip",
+      warnings: { version: 1, data: { flags: ["exact_duplicate_auto_map"] } },
+      targetItemRef: { version: 1, data: { targetTransactionId: "existing-1" } },
+    });
+  }
+
+  it("maps an exact duplicate to the existing target without creating a transaction", async () => {
+    const { store, createdMappings } = makeStore({ items: [autoMapItem()] });
+    const { transport, createTransactionsForSync } = makeTargetTransport({
+      preloaded: [targetRow({ id: "existing-1", date: "2026-07-10" })],
+    });
+    const result = await applySyncRun(
+      { runId: "run-1", targetConnection: targetConn, selection: { selection: "all_safe" } },
+      { transport: provider(transport), store }
+    );
+    expect(createTransactionsForSync).not.toHaveBeenCalled();
+    expect(result.counts.repaired).toBe(1);
+    expect(result.items[0]).toMatchObject({ outcome: "repaired", targetTransactionId: "existing-1" });
+    expect(createdMappings[0]).toMatchObject({ sourceItemKey: "txn:t1", targetTransactionId: "existing-1", targetMarker: null });
+    expect(result.status).toBe("applied");
+  });
+
+  it("does not map when the exact-duplicate target has disappeared from the budget", async () => {
+    const { store, createdMappings } = makeStore({ items: [autoMapItem()] });
+    const { transport } = makeTargetTransport({ preloaded: [] });
+    const result = await applySyncRun(
+      { runId: "run-1", targetConnection: targetConn, selection: { selection: "all_safe" } },
+      { transport: provider(transport), store }
+    );
+    expect(result.items[0].outcome).toBe("skipped");
+    expect(createdMappings).toHaveLength(0);
+  });
+
+  it("never auto-maps under the default all_safe_new selection", async () => {
+    const { store } = makeStore({ items: [autoMapItem()] });
+    const { transport } = makeTargetTransport({ preloaded: [targetRow({ id: "existing-1", date: "2026-07-10" })] });
+    const result = await applySyncRun({ runId: "run-1", targetConnection: targetConn }, { transport: provider(transport), store });
+    expect(result).toMatchObject({ status: "failed", error: { code: "no_eligible_items" } });
+  });
+});
+
+describe("applySyncRun — retry failed", () => {
+  it("re-attempts only the previously-failed items on a partial run", async () => {
+    const failed = runItem({ id: "f1", sourceItemKey: "txn:t1", applyState: "failed", payloadData: { importedId: MARKER_T1 } } as unknown as Partial<SyncFlowRunItem>);
+    const done = runItem({ id: "ok1", sourceItemKey: "txn:t2", applyState: "applied", payloadData: { importedId: MARKER_T2 } } as unknown as Partial<SyncFlowRunItem>);
+    const { store, createdMappings } = makeStore({ runStatus: "partial", items: [failed, done] });
+    const { transport, createTransactionsForSync } = makeTargetTransport();
+
+    const result = await applySyncRun(
+      { runId: "run-1", targetConnection: targetConn, selection: { selection: "retry_failed" } },
+      { transport: provider(transport), store }
+    );
+
+    expect(result.status).toBe("applied");
+    expect(result.counts).toMatchObject({ selected: 1, applied: 1 });
+    // Only the failed item was re-created; the applied one was left alone.
+    expect(createTransactionsForSync).toHaveBeenCalledTimes(1);
+    expect(createdMappings.map((m) => m.sourceItemKey)).toEqual(["txn:t1"]);
+  });
+
+  it("refuses a normal apply on a non-draft run, but allows retry", async () => {
+    const { store } = makeStore({ runStatus: "failed", items: [runItem({ applyState: "failed" })] });
+    const { transport } = makeTargetTransport();
+    const normal = await applySyncRun({ runId: "run-1", targetConnection: targetConn }, { transport: provider(transport), store });
+    expect(normal).toMatchObject({ status: "failed", error: { code: "run_not_applyable" } });
+  });
+
+  it("reports no eligible items when a failed run has nothing left to retry", async () => {
+    const { store } = makeStore({ runStatus: "failed", items: [runItem({ applyState: "applied" })] });
+    const { transport } = makeTargetTransport();
+    const result = await applySyncRun(
+      { runId: "run-1", targetConnection: targetConn, selection: { selection: "retry_failed" } },
+      { transport: provider(transport), store }
+    );
+    expect(result).toMatchObject({ status: "failed", error: { code: "no_eligible_items" } });
+  });
 });
 
 describe("applySyncRun — partial failure & splits", () => {
@@ -359,15 +489,15 @@ describe("applySyncRun — partial failure & splits", () => {
     const good = runItem({ id: "good", sourceItemKey: "txn:t1", payloadData: { importedId: MARKER_T1 } } as unknown as Partial<SyncFlowRunItem>);
     const bad = runItem({ id: "bad", sourceItemKey: "txn:t2", sourceTransactionId: "t2", payloadData: { importedId: MARKER_T2 } } as unknown as Partial<SyncFlowRunItem>);
     const { store, createdMappings } = makeStore({ items: [good, bad] });
-    // Fail resolution only for the second create by toggling after first success.
+    // The whole batch is created in one call; only MARKER_T2's id fails to resolve.
     const target = makeTargetTransport();
-    let call = 0;
-    (target.transport.createTransactionsForSync as jest.Mock).mockImplementation(async (inputs: Array<{ importedId?: string | null; date: string; amount: number }>) => {
-      call += 1;
-      if (call === 2) return { created: [{ requestIndex: 0, transactionId: null, importedId: inputs[0].importedId ?? null }] };
-      target.rows.push(targetRow({ id: "tt-good", importedId: inputs[0].importedId ?? null }));
-      return { created: [{ requestIndex: 0, transactionId: "tt-good", importedId: inputs[0].importedId ?? null }] };
-    });
+    (target.transport.createTransactionsForSync as jest.Mock).mockImplementation(async (inputs: Array<{ importedId?: string | null; date: string; amount: number }>) =>
+      ({ created: inputs.map((inp, i) => {
+        if (inp.importedId === MARKER_T2) return { requestIndex: i, transactionId: null, importedId: inp.importedId ?? null, applied: null };
+        target.rows.push(targetRow({ id: "tt-good", importedId: inp.importedId ?? null }));
+        return { requestIndex: i, transactionId: "tt-good", importedId: inp.importedId ?? null, applied: null };
+      }) })
+    );
 
     const result = await applySyncRun({ runId: "run-1", targetConnection: targetConn }, { transport: provider(target.transport), store });
     expect(result.status).toBe("partial");

--- a/src/lib/sync/applyOrchestrator.ts
+++ b/src/lib/sync/applyOrchestrator.ts
@@ -2,9 +2,9 @@ import { getBudgetFileSyncCapabilities } from "./capabilities";
 import { connectionFingerprint } from "./connectionRef";
 import { decodeFlowPlanConfig, type SyncFlowPlanConfig } from "./flowConfig";
 import { generateSyncMarker } from "./marker";
-import { transactionFingerprint } from "./sourceItems";
 import type {
   ActualBenchTransport,
+  SyncCreatedTransaction,
   SyncTargetTransactionInput,
 } from "@/lib/actual/transport";
 import type { ConnectionInstance } from "@/store/connection";
@@ -71,7 +71,20 @@ export type RunItemStatusPatch = {
 
 export type ApplySelection =
   | { selectedItemIds: string[] }
-  | { selection: "all_safe_new" };
+  /** Auto-select every new create candidate (RD-053 default). */
+  | { selection: "all_safe_new" }
+  /**
+   * Auto-select every safe item: new create candidates **and** repairable
+   * `target_marker_match` rows. Used by RD-054 safe-only automation so an
+   * auto run also self-heals a lost DB mapping when the marker already exists
+   * on the target (no Actual write for the repair).
+   */
+  | { selection: "all_safe" }
+  /**
+   * Re-attempt every item that previously failed on this run (RD-054 retry).
+   * Permitted on a partial/failed run, not only a fresh draft preview.
+   */
+  | { selection: "retry_failed" };
 
 export type ApplySyncRunInput = {
   runId: string;
@@ -186,15 +199,19 @@ export async function applySyncRun(
     return { status: "failed", runId, error, counts, items };
   }
 
-  // Writes to the same target are serialized (single-runtime, deterministic).
-  for (const item of eligible) {
-    const result = await applyOneItem(item, { config, transport, markerIndex }, deps.store);
+  const ctx: ItemContext = { config, transport, markerIndex };
+
+  // Repair/map items write nothing, so they stay per-item (cheap). Creates are
+  // batched into ONE insert + ONE id-recovery read instead of one round-trip per
+  // transaction — the dominant cost on large runs.
+  for (const eligibleItem of eligible.filter((e) => e.mode !== "create")) {
+    const result = await applyOneItem(eligibleItem, ctx, deps.store);
     items.push(result);
     tally(counts, result.outcome);
-    // A create adds a live marker; guard against intra-run duplicates.
-    if (result.outcome !== "failed" && result.targetTransactionId && item.payload?.importedId) {
-      markerIndex.set(item.payload.importedId, result.targetTransactionId);
-    }
+  }
+  for (const result of await applyCreateBatch(eligible.filter((e) => e.mode === "create"), ctx, deps.store)) {
+    items.push(result);
+    tally(counts, result.outcome);
   }
 
   const status = deriveRunStatus(counts);
@@ -219,7 +236,7 @@ export async function applySyncRun(
 
 // --- Validation / preparation ----------------------------------------------
 
-type ApplyItemMode = "create" | "repair";
+type ApplyItemMode = "create" | "repair" | "map";
 
 type EligibleItem = {
   item: SyncFlowRunItem;
@@ -242,6 +259,20 @@ function isEligibleNew(item: SyncFlowRunItem): boolean {
     item.plannedAction === "create" &&
     item.applyState !== "applied" &&
     item.plannedTargetPayload != null
+  );
+}
+
+function itemHasFlag(item: SyncFlowRunItem, flag: string): boolean {
+  const flags = (item.warnings?.data as { flags?: unknown } | undefined)?.flags;
+  return Array.isArray(flags) && flags.includes(flag);
+}
+
+/** An exact duplicate the flow opted to auto-map to its existing target (no write). */
+function isExactDupAutoMap(item: SyncFlowRunItem): boolean {
+  return (
+    item.classification === "exact_duplicate" &&
+    itemHasFlag(item, "exact_duplicate_auto_map") &&
+    readTargetTxnId(item) != null
   );
 }
 
@@ -281,10 +312,20 @@ async function validateAndPrepare(
   input: ApplySyncRunInput,
   store: ApplyStore
 ): Promise<PreparedApply> {
+  const isRetry =
+    !!input.selection && "selection" in input.selection && input.selection.selection === "retry_failed";
+
   const run = await store.loadRun(input.runId);
   if (!run) throw new ApplyPreflightError("run_not_found", `Run ${input.runId} was not found.`);
-  if (run.status !== "draft_preview") {
-    throw new ApplyPreflightError("run_not_applyable", `Run is ${run.status}; only draft_preview runs can be applied.`);
+  // A retry may run on a partial/failed run; a normal apply only on a fresh draft.
+  const applyableStatuses = isRetry ? ["draft_preview", "partial", "failed"] : ["draft_preview"];
+  if (!applyableStatuses.includes(run.status)) {
+    throw new ApplyPreflightError(
+      "run_not_applyable",
+      isRetry
+        ? `Run is ${run.status}; only partial/failed runs can be retried.`
+        : `Run is ${run.status}; only draft_preview runs can be applied.`
+    );
   }
   if (!run.flowId) throw new ApplyPreflightError("flow_not_found", "Run has no associated flow.");
 
@@ -314,8 +355,9 @@ async function validateAndPrepare(
   const byId = new Map(allItems.map((item) => [item.id, item]));
 
   // Resolve each selected item to a create or repair candidate. Explicit
-  // selection may include target_marker_match rows (repair); "all_safe_new"
-  // only ever includes new create candidates.
+  // selection may include target_marker_match rows (repair). Bulk modes:
+  //   "all_safe_new" (and undefined) → new create candidates only;
+  //   "all_safe"                     → new creates + repairable marker matches.
   const eligible: EligibleItem[] = [];
   if (input.selection && "selectedItemIds" in input.selection) {
     for (const id of input.selection.selectedItemIds) {
@@ -327,12 +369,31 @@ async function validateAndPrepare(
         eligible.push(toCreateCandidate(item));
       } else if (isRepairable(item)) {
         eligible.push({ item, mode: "repair", payload: null, targetTransactionId: readTargetTxnId(item) });
+      } else if (isExactDupAutoMap(item)) {
+        eligible.push({ item, mode: "map", payload: null, targetTransactionId: readTargetTxnId(item) });
       } else {
-        throw new ApplyPreflightError("ineligible_selection", `Selected item ${id} is not an applyable create or repair candidate.`);
+        throw new ApplyPreflightError("ineligible_selection", `Selected item ${id} is not an applyable create, repair, or map candidate.`);
       }
     }
+  } else if (isRetry) {
+    // Re-attempt only items that previously failed, routed to their normal mode.
+    for (const item of allItems) {
+      if (item.applyState !== "failed") continue;
+      if (isEligibleNew(item)) eligible.push(toCreateCandidate(item));
+      else if (isRepairable(item)) eligible.push({ item, mode: "repair", payload: null, targetTransactionId: readTargetTxnId(item) });
+      else if (isExactDupAutoMap(item)) eligible.push({ item, mode: "map", payload: null, targetTransactionId: readTargetTxnId(item) });
+    }
   } else {
-    for (const item of allItems.filter(isEligibleNew)) eligible.push(toCreateCandidate(item));
+    const includeRepairs = input.selection?.selection === "all_safe";
+    for (const item of allItems) {
+      if (isEligibleNew(item)) {
+        eligible.push(toCreateCandidate(item));
+      } else if (includeRepairs && isRepairable(item)) {
+        eligible.push({ item, mode: "repair", payload: null, targetTransactionId: readTargetTxnId(item) });
+      } else if (includeRepairs && isExactDupAutoMap(item)) {
+        eligible.push({ item, mode: "map", payload: null, targetTransactionId: readTargetTxnId(item) });
+      }
+    }
   }
 
   if (eligible.length === 0) {
@@ -375,64 +436,111 @@ type ItemContext = {
   markerIndex: Map<string, string>;
 };
 
+/** Repair/map items perform no Actual write; they are applied one at a time. */
 async function applyOneItem(
   eligible: EligibleItem,
   ctx: ItemContext,
   store: ApplyStore
 ): Promise<ApplyItemResult> {
-  if (eligible.mode === "repair") return repairOneItem(eligible, ctx, store);
+  if (eligible.mode === "map") return mapExactDuplicateItem(eligible, ctx, store);
+  return repairOneItem(eligible, ctx, store);
+}
 
-  const { item } = eligible;
-  const payload = eligible.payload as PlannedTargetPayload;
-  const marker = payload.importedId as string;
-  const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
+/**
+ * Apply create candidates as a batch: resolve which items still need a write
+ * (skipping already-mapped items and repairing marker hits — no writes), then
+ * create the remainder in **one** `createTransactionsForSync` call (one insert +
+ * one id-recovery read in the transport) instead of a round-trip per item.
+ */
+async function applyCreateBatch(
+  createItems: EligibleItem[],
+  ctx: ItemContext,
+  store: ApplyStore
+): Promise<ApplyItemResult[]> {
+  const results: ApplyItemResult[] = [];
+  const toCreate: { item: SyncFlowRunItem; payload: PlannedTargetPayload }[] = [];
 
+  // Phase A — no writes: skip already-mapped items; repair a lost mapping when
+  // the marker is already on the target; queue the rest for the batch insert.
+  for (const eligible of createItems) {
+    const item = eligible.item;
+    const payload = eligible.payload as PlannedTargetPayload;
+    const marker = payload.importedId as string;
+    const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
+    try {
+      const existingMapping = await store.getMappingBySource(ctx.config.flowId, item.sourceItemKey ?? "");
+      if (existingMapping) {
+        await store.updateRunItemStatus(item.id, {
+          status: "skipped",
+          applyState: "skipped",
+          message: "Already mapped; skipped to avoid a duplicate.",
+        });
+        results.push({ ...base, outcome: "skipped", targetTransactionId: existingMapping.targetTransactionId, message: "already mapped" });
+        continue;
+      }
+      const markerHit = ctx.markerIndex.get(marker);
+      if (markerHit) {
+        await recordMapping(store, ctx.config, item, markerHit, marker, null);
+        await store.updateRunItemStatus(item.id, {
+          status: "skipped",
+          applyState: "skipped",
+          message: "Target already has this marker; repaired mapping without creating a duplicate.",
+          warnings: flagEnvelope(["target_marker_match_repair"]),
+          createdTargetTransactionId: markerHit,
+          createdTargetMarker: marker,
+        });
+        results.push({ ...base, outcome: "repaired", targetTransactionId: markerHit, message: "repaired mapping" });
+        continue;
+      }
+      toCreate.push({ item, payload });
+    } catch (err) {
+      await store.updateRunItemStatus(item.id, {
+        status: "failed",
+        applyState: "failed",
+        message: describe(err, "Apply failed for this item."),
+        errors: envelope({ code: "create_failed", message: describe(err, "unknown error") }),
+      });
+      results.push({ ...base, outcome: "failed", targetTransactionId: null, message: describe(err, "apply failed") });
+    }
+  }
+
+  if (toCreate.length === 0) return results;
+
+  // Phase B — one batched insert (+ one id-recovery read inside the transport).
+  let created: SyncCreatedTransaction[];
   try {
-    // 1. Existing DB mapping ⇒ already applied; skip (idempotent rerun).
-    const existingMapping = await store.getMappingBySource(ctx.config.flowId, item.sourceItemKey ?? "");
-    if (existingMapping) {
-      await store.updateRunItemStatus(item.id, {
-        status: "skipped",
-        applyState: "skipped",
-        message: "Already mapped; skipped to avoid a duplicate.",
-      });
-      return { ...base, outcome: "skipped", targetTransactionId: existingMapping.targetTransactionId, message: "already mapped" };
-    }
-
-    // 2. Marker already on target (mapping lost) ⇒ repair, do not duplicate.
-    const markerHit = ctx.markerIndex.get(marker);
-    if (markerHit) {
-      await recordMapping(store, ctx.config, item, markerHit, marker, null);
-      await store.updateRunItemStatus(item.id, {
-        status: "skipped",
-        applyState: "skipped",
-        message: "Target already has this marker; repaired mapping without creating a duplicate.",
-        warnings: flagEnvelope(["target_marker_match_repair"]),
-        createdTargetTransactionId: markerHit,
-        createdTargetMarker: marker,
-      });
-      return { ...base, outcome: "repaired", targetTransactionId: markerHit, message: "repaired mapping" };
-    }
-
-    // 3. Resolve payee per policy, then create.
-    let payeeId = payload.payeeId;
-    if (!payeeId && payload.payeeName) {
-      payeeId = (await ctx.transport.createOrResolvePayee({ name: payload.payeeName })).id;
-    }
-
-    const createInput: SyncTargetTransactionInput = {
+    const inputs: SyncTargetTransactionInput[] = toCreate.map(({ payload }) => ({
       accountId: ctx.config.targetAccountId,
       date: payload.date,
       amount: payload.amount,
-      payeeId: payeeId ?? null,
+      payeeId: payload.payeeId,
+      payeeName: payload.payeeName,
       categoryId: payload.categoryId,
       notes: payload.notes,
       cleared: payload.cleared,
-      importedId: marker,
-    };
+      importedId: payload.importedId,
+    }));
+    ({ created } = await ctx.transport.createTransactionsForSync(inputs));
+  } catch (err) {
+    for (const { item } of toCreate) {
+      await store.updateRunItemStatus(item.id, {
+        status: "failed",
+        applyState: "failed",
+        message: describe(err, "Batch create failed."),
+        errors: envelope({ code: "create_failed", message: describe(err, "unknown error") }),
+      });
+      results.push({ itemId: item.id, sourceItemKey: item.sourceItemKey ?? "", outcome: "failed", targetTransactionId: null, message: describe(err, "apply failed") });
+    }
+    return results;
+  }
 
-    const created = await ctx.transport.createTransactionsForSync([createInput]);
-    const targetId = created.created[0]?.transactionId ?? null;
+  // Phase C — per created row: verify id, diff vs planned, record the mapping.
+  for (let i = 0; i < toCreate.length; i++) {
+    const { item, payload } = toCreate[i];
+    const marker = payload.importedId as string;
+    const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
+    const res = created[i];
+    const targetId = res?.transactionId ?? null;
 
     if (!targetId) {
       await store.updateRunItemStatus(item.id, {
@@ -442,58 +550,48 @@ async function applyOneItem(
         errors: envelope({ code: "unresolved_target_id", marker }),
         createdTargetMarker: marker,
       });
-      return {
-        ...base,
-        outcome: "failed",
-        targetTransactionId: null,
-        message: "target id unresolved; a transaction may exist but was not confirmed",
-      };
+      results.push({ ...base, outcome: "failed", targetTransactionId: null, message: "target id unresolved; a transaction may exist but was not confirmed" });
+      continue;
     }
 
-    // 4. Compare planned vs actual (target rules run on create).
-    const actual = await findCreatedTransaction(ctx.transport, ctx.config.targetAccountId, payload.date, marker);
-    const changedFields = actual ? diffPlannedVsActual(payload, payeeId ?? null, actual) : [];
-    const targetFingerprint = actual ? transactionFingerprint(actual) : null;
+    // Target rules can run on create; the actual row + resolved payee come back
+    // with the id, so the diff needs no extra read.
+    const actual = res?.applied ?? null;
+    const changedFields = actual ? diffPlannedVsActual(payload, res?.resolvedPayeeId ?? payload.payeeId ?? null, actual) : [];
 
-    // 5. Record the mapping immediately (before touching later items).
-    await recordMapping(store, ctx.config, item, targetId, marker, targetFingerprint);
+    try {
+      // Fingerprint is unused downstream, so it is not recomputed here.
+      await recordMapping(store, ctx.config, item, targetId, marker, null);
+    } catch (err) {
+      await store.updateRunItemStatus(item.id, {
+        status: "failed",
+        applyState: "failed",
+        message: describe(err, "Mapping failed after create."),
+        errors: envelope({ code: "map_failed", message: describe(err, "unknown error") }),
+        createdTargetTransactionId: targetId,
+        createdTargetMarker: marker,
+      });
+      results.push({ ...base, outcome: "failed", targetTransactionId: targetId, message: describe(err, "mapping failed") });
+      continue;
+    }
+
+    // New live marker on the target — guard later items against duplicating it.
+    ctx.markerIndex.set(marker, targetId);
 
     const hasWarnings = changedFields.length > 0;
     await store.updateRunItemStatus(item.id, {
       status: "applied",
       applyState: "applied",
-      message: hasWarnings ? "Applied; target rules modified some fields." : "Applied.",
+      message: hasWarnings ? "Synced; target rules modified some fields." : "Synced.",
       warnings: hasWarnings ? flagEnvelope(["target_rules_modified"], { changedFields }) : null,
       createdTargetTransactionId: targetId,
       createdTargetMarker: marker,
       targetItemRef: { version: 1, data: { targetTransactionId: targetId } },
     });
-
-    return {
-      ...base,
-      outcome: hasWarnings ? "applied_with_warnings" : "applied",
-      targetTransactionId: targetId,
-      changedFields: hasWarnings ? changedFields : undefined,
-    };
-  } catch (err) {
-    await store.updateRunItemStatus(item.id, {
-      status: "failed",
-      applyState: "failed",
-      message: describe(err, "Apply failed for this item."),
-      errors: envelope({ code: "create_failed", message: describe(err, "unknown error") }),
-    });
-    return { ...base, outcome: "failed", targetTransactionId: null, message: describe(err, "apply failed") };
+    results.push({ ...base, outcome: hasWarnings ? "applied_with_warnings" : "applied", targetTransactionId: targetId, changedFields: hasWarnings ? changedFields : undefined });
   }
-}
 
-async function findCreatedTransaction(
-  transport: ActualBenchTransport,
-  accountId: string,
-  date: string,
-  marker: string
-) {
-  const rows = await transport.listTransactionsForSync({ accountId, startDate: date, endDate: date });
-  return rows.find((row) => row.importedId === marker) ?? null;
+  return results;
 }
 
 function diffPlannedVsActual(
@@ -602,6 +700,66 @@ async function repairOneItem(
       errors: envelope({ code: "repair_failed", message: describe(err, "unknown error") }),
     });
     return { ...base, outcome: "failed", targetTransactionId: null, message: describe(err, "repair failed") };
+  }
+}
+
+/**
+ * Auto-map an exact-duplicate item to its existing target transaction (RD-054):
+ * record a mapping to the previewed target, with no Actual write. Unlike a
+ * marker repair there is no sync marker on the target (it is a coincidental
+ * match), so existence is re-validated against the live target instead.
+ */
+async function mapExactDuplicateItem(
+  eligible: EligibleItem,
+  ctx: ItemContext,
+  store: ApplyStore
+): Promise<ApplyItemResult> {
+  const { item } = eligible;
+  const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
+  const targetId = eligible.targetTransactionId as string;
+  const date = readPayload(item)?.date ?? null;
+
+  try {
+    const existingMapping = await store.getMappingBySource(ctx.config.flowId, item.sourceItemKey ?? "");
+    if (existingMapping) {
+      await store.updateRunItemStatus(item.id, {
+        status: "skipped",
+        applyState: "skipped",
+        message: "Already mapped; nothing to map.",
+      });
+      return { ...base, outcome: "skipped", targetTransactionId: existingMapping.targetTransactionId, message: "already mapped" };
+    }
+
+    // Re-validate the matched target still exists before linking to it.
+    const stillPresent = date
+      ? (await ctx.transport.listTransactionsForSync({ accountId: ctx.config.targetAccountId, startDate: date, endDate: date })).some((t) => t.id === targetId)
+      : false;
+    if (!stillPresent) {
+      await store.updateRunItemStatus(item.id, {
+        status: "skipped",
+        applyState: "skipped",
+        message: "Exact-duplicate target is no longer present; not mapped.",
+      });
+      return { ...base, outcome: "skipped", targetTransactionId: null, message: "duplicate target gone" };
+    }
+
+    await recordMapping(store, ctx.config, item, targetId, null, null);
+    await store.updateRunItemStatus(item.id, {
+      status: "mapped",
+      applyState: "skipped",
+      message: "Mapped to the existing exact-duplicate transaction.",
+      warnings: flagEnvelope(["exact_duplicate_auto_mapped"]),
+      createdTargetTransactionId: targetId,
+    });
+    return { ...base, outcome: "repaired", targetTransactionId: targetId, message: "mapped to exact duplicate" };
+  } catch (err) {
+    await store.updateRunItemStatus(item.id, {
+      status: "failed",
+      applyState: "failed",
+      message: describe(err, "Mapping failed for this item."),
+      errors: envelope({ code: "map_failed", message: describe(err, "unknown error") }),
+    });
+    return { ...base, outcome: "failed", targetTransactionId: null, message: describe(err, "map failed") };
   }
 }
 

--- a/src/lib/sync/duplicateClassifier.test.ts
+++ b/src/lib/sync/duplicateClassifier.test.ts
@@ -7,47 +7,57 @@ function target(overrides: Partial<SyncTargetTransactionForDedupe> = {}): SyncTa
   return { id: "x1", date: "2026-07-01", amount: 1250, payeeName: "Coffee Bar", categoryId: "tc1", ...overrides };
 }
 
+/** Shorthand: assert only on the confidence, ignoring the matched id. */
+const confidenceOf = (...args: Parameters<typeof classifyDuplicate>) =>
+  classifyDuplicate(...args).confidence;
+
 describe("classifyDuplicate", () => {
   it("returns none when nothing matches date + amount", () => {
-    expect(classifyDuplicate(payload, [target({ amount: 999 })], "Coffee Bar")).toBe("none");
-    expect(classifyDuplicate(payload, [], "Coffee Bar")).toBe("none");
+    expect(confidenceOf(payload, [target({ amount: 999 })], "Coffee Bar")).toBe("none");
+    expect(confidenceOf(payload, [], "Coffee Bar")).toBe("none");
   });
 
   it("weak when only date + amount match", () => {
-    expect(classifyDuplicate(payload, [target({ payeeName: "Other", categoryId: "zzz" })], "Coffee Bar")).toBe("weak");
+    expect(confidenceOf(payload, [target({ payeeName: "Other", categoryId: "zzz" })], "Coffee Bar")).toBe("weak");
   });
 
   it("strong when payee also matches but category differs", () => {
-    expect(classifyDuplicate(payload, [target({ categoryId: "zzz" })], "Coffee Bar")).toBe("strong");
+    expect(confidenceOf(payload, [target({ categoryId: "zzz" })], "Coffee Bar")).toBe("strong");
   });
 
   it("exact when date, amount, payee, and category all match", () => {
-    expect(classifyDuplicate(payload, [target()], "Coffee Bar")).toBe("exact");
+    expect(confidenceOf(payload, [target()], "Coffee Bar")).toBe("exact");
   });
 
   it("normalizes payee names before comparing", () => {
-    expect(classifyDuplicate(payload, [target({ payeeName: "  coffee  bar " })], "Coffee Bar")).toBe("exact");
+    expect(confidenceOf(payload, [target({ payeeName: "  coffee  bar " })], "Coffee Bar")).toBe("exact");
   });
 
   it("returns the strongest confidence across multiple candidates", () => {
     const rows = [target({ payeeName: "Other", categoryId: "zzz" }), target()];
-    expect(classifyDuplicate(payload, rows, "Coffee Bar")).toBe("exact");
+    expect(confidenceOf(payload, rows, "Coffee Bar")).toBe("exact");
   });
 
   it("treats a null planned payee as not-a-payee-match (weak at best)", () => {
     // No usable payee to compare, even against a target that also has none.
-    expect(classifyDuplicate(payload, [target({ payeeName: null })], null)).toBe("weak");
-    expect(classifyDuplicate(payload, [target({ payeeName: "Coffee Bar" })], null)).toBe("weak");
+    expect(confidenceOf(payload, [target({ payeeName: null })], null)).toBe("weak");
+    expect(confidenceOf(payload, [target({ payeeName: "Coffee Bar" })], null)).toBe("weak");
   });
 
   it("does not treat two null categories as a category match", () => {
     // payee matches, but null==null must not count as same category → strong, not exact.
     const noCat = { date: "2026-07-01", amount: 1250, categoryId: null };
-    expect(classifyDuplicate(noCat, [target({ categoryId: null })], "Coffee Bar")).toBe("strong");
+    expect(confidenceOf(noCat, [target({ categoryId: null })], "Coffee Bar")).toBe("strong");
   });
 
   it("handles null payee and null category together (weak on date+amount only)", () => {
     const bare = { date: "2026-07-01", amount: 1250, categoryId: null };
-    expect(classifyDuplicate(bare, [target({ payeeName: null, categoryId: null })], null)).toBe("weak");
+    expect(confidenceOf(bare, [target({ payeeName: null, categoryId: null })], null)).toBe("weak");
+  });
+
+  it("returns the matched target id for the strongest match", () => {
+    const rows = [target({ id: "weak-1", payeeName: "Other", categoryId: "zzz" }), target({ id: "exact-1" })];
+    expect(classifyDuplicate(payload, rows, "Coffee Bar")).toEqual({ confidence: "exact", targetTransactionId: "exact-1" });
+    expect(classifyDuplicate(payload, [], "Coffee Bar")).toEqual({ confidence: "none", targetTransactionId: null });
   });
 });

--- a/src/lib/sync/duplicateClassifier.ts
+++ b/src/lib/sync/duplicateClassifier.ts
@@ -19,15 +19,23 @@ import type {
  * - weak:   payee differs/absent (date + amount only).
  * - none:   no date+amount match at all.
  */
+/** Result of duplicate detection: confidence plus the best-matching target id. */
+export type DuplicateMatch = {
+  confidence: SyncDuplicateConfidence;
+  /** The matched target transaction id for the strongest match, else null. */
+  targetTransactionId: string | null;
+};
+
 export function classifyDuplicate(
   payload: Pick<PlannedTargetPayload, "date" | "amount" | "categoryId">,
   targetTransactions: SyncTargetTransactionForDedupe[],
   /** Effective target payee name (resolved match, create name, or source name). */
   plannedPayeeName: string | null
-): SyncDuplicateConfidence {
+): DuplicateMatch {
   const plannedPayee = normalizeName(plannedPayeeName);
 
   let best: SyncDuplicateConfidence = "none";
+  let bestId: string | null = null;
   for (const txn of targetTransactions) {
     if (txn.date !== payload.date || txn.amount !== payload.amount) continue;
 
@@ -41,11 +49,14 @@ export function classifyDuplicate(
     else if (samePayee) confidence = "strong";
     else confidence = "weak";
 
-    best = strongest(best, confidence);
+    if (RANK[confidence] > RANK[best]) {
+      best = confidence;
+      bestId = txn.id;
+    }
     if (best === "exact") break;
   }
 
-  return best;
+  return { confidence: best, targetTransactionId: bestId };
 }
 
 const RANK: Record<SyncDuplicateConfidence, number> = {
@@ -54,10 +65,3 @@ const RANK: Record<SyncDuplicateConfidence, number> = {
   strong: 2,
   exact: 3,
 };
-
-function strongest(
-  a: SyncDuplicateConfidence,
-  b: SyncDuplicateConfidence
-): SyncDuplicateConfidence {
-  return RANK[b] > RANK[a] ? b : a;
-}

--- a/src/lib/sync/flowConfig.ts
+++ b/src/lib/sync/flowConfig.ts
@@ -1,4 +1,4 @@
-import type { SyncFlow } from "@/lib/app-db/types";
+import type { SyncFlow, SyncReviewPolicy } from "@/lib/app-db/types";
 
 /**
  * Typed planner view of a saved sync flow (RD-053 / PR-019).
@@ -37,7 +37,55 @@ export type SyncFlowPlanConfig = {
   notesMarkerEnabled: boolean;
   /** Copy the source notes before appending the visible marker. */
   copySourceNotes: boolean;
+  /**
+   * Automation policy (RD-054). Carried here so the single flow-decode point also
+   * yields the policy for the safe-only executor; the planner itself ignores it.
+   */
+  reviewPolicy: SyncReviewPolicy;
+  /**
+   * Interval, in minutes, for `auto_sync_on_interval` flows. Clamped to a floor
+   * because each run re-opens/syncs the whole budget. Ignored for other policies.
+   */
+  intervalMinutes: number;
+  /**
+   * ISO timestamp set when automation paused the flow after repeated failures
+   * (RD-054 flow health); cleared when the user re-enables it. Null when healthy.
+   */
+  autoPausedAt: string | null;
+  /**
+   * When true, an exact duplicate on the target is auto-mapped to that existing
+   * transaction (mapping recorded, no write) instead of waiting for review
+   * (RD-054). Fuzzy (strong/weak) duplicates are never auto-mapped.
+   */
+  exactDuplicateAutoMap: boolean;
 };
+
+/** Smallest allowed auto-sync interval — a budget sync per run is expensive. */
+export const MIN_SYNC_INTERVAL_MINUTES = 15;
+/** Default auto-sync interval when a flow opts in without choosing one. */
+export const DEFAULT_SYNC_INTERVAL_MINUTES = 60;
+
+/** Coerce a stored/user interval to a finite value at or above the floor. */
+export function clampSyncInterval(value: unknown): number {
+  // Blank/whitespace strings mean "unset" → default (Number("") is 0, not NaN).
+  if (typeof value === "string" && value.trim() === "") return DEFAULT_SYNC_INTERVAL_MINUTES;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return DEFAULT_SYNC_INTERVAL_MINUTES;
+  return Math.max(MIN_SYNC_INTERVAL_MINUTES, Math.round(n));
+}
+
+/** Recognised review-policy values; anything else decodes to the safe default. */
+const REVIEW_POLICIES: readonly SyncReviewPolicy[] = [
+  "manual_preview_required",
+  "auto_apply_safe_only",
+  "auto_sync_on_interval",
+];
+
+function reviewPolicy(value: unknown): SyncReviewPolicy | undefined {
+  return typeof value === "string" && (REVIEW_POLICIES as readonly string[]).includes(value)
+    ? (value as SyncReviewPolicy)
+    : undefined;
+}
 
 /** Product defaults (RD-053 §2 / PR-019 Product Defaults table). */
 export const SYNC_PLAN_CONFIG_DEFAULTS = {
@@ -45,6 +93,11 @@ export const SYNC_PLAN_CONFIG_DEFAULTS = {
   missingPayee: "create" as SyncMissingPayeePolicy,
   notesMarkerEnabled: true,
   copySourceNotes: true,
+  // RD-053 behavior is unchanged unless the user opts a flow into automation.
+  reviewPolicy: "manual_preview_required" as SyncReviewPolicy,
+  intervalMinutes: DEFAULT_SYNC_INTERVAL_MINUTES,
+  autoPausedAt: null as string | null,
+  exactDuplicateAutoMap: false,
 };
 
 type PartialRoute = Partial<
@@ -69,7 +122,14 @@ export function buildPlanConfig(
     Partial<
       Pick<
         SyncFlowPlanConfig,
-        "amountDirection" | "missingPayee" | "notesMarkerEnabled" | "copySourceNotes"
+        | "amountDirection"
+        | "missingPayee"
+        | "notesMarkerEnabled"
+        | "copySourceNotes"
+        | "reviewPolicy"
+        | "intervalMinutes"
+        | "autoPausedAt"
+        | "exactDuplicateAutoMap"
       >
     >
 ): SyncFlowPlanConfig {
@@ -90,6 +150,14 @@ export function buildPlanConfig(
     notesMarkerEnabled:
       input.notesMarkerEnabled ?? SYNC_PLAN_CONFIG_DEFAULTS.notesMarkerEnabled,
     copySourceNotes: input.copySourceNotes ?? SYNC_PLAN_CONFIG_DEFAULTS.copySourceNotes,
+    reviewPolicy: input.reviewPolicy ?? SYNC_PLAN_CONFIG_DEFAULTS.reviewPolicy,
+    intervalMinutes:
+      input.intervalMinutes != null
+        ? clampSyncInterval(input.intervalMinutes)
+        : SYNC_PLAN_CONFIG_DEFAULTS.intervalMinutes,
+    autoPausedAt: input.autoPausedAt ?? SYNC_PLAN_CONFIG_DEFAULTS.autoPausedAt,
+    exactDuplicateAutoMap:
+      input.exactDuplicateAutoMap ?? SYNC_PLAN_CONFIG_DEFAULTS.exactDuplicateAutoMap,
   };
 }
 
@@ -111,6 +179,7 @@ export function decodeFlowPlanConfig(flow: SyncFlow): SyncFlowPlanConfig {
   const source = (leg?.sourceRef.data ?? {}) as Record<string, unknown>;
   const target = (leg?.targetRef.data ?? {}) as Record<string, unknown>;
   const transform = (leg?.transform.data ?? {}) as Record<string, unknown>;
+  const options = (leg?.options.data ?? {}) as Record<string, unknown>;
 
   const direction = str(transform.amountDirection);
   const missingPayee = str(transform.missingPayee);
@@ -132,5 +201,9 @@ export function decodeFlowPlanConfig(flow: SyncFlow): SyncFlowPlanConfig {
       missingPayee === "create" || missingPayee === "leave_empty" ? missingPayee : undefined,
     notesMarkerEnabled: bool(transform.notesMarkerEnabled),
     copySourceNotes: bool(transform.copySourceNotes),
+    reviewPolicy: reviewPolicy(options.reviewPolicy),
+    intervalMinutes: options.intervalMinutes != null ? clampSyncInterval(options.intervalMinutes) : undefined,
+    autoPausedAt: str(options.autoPausedAt) ?? null,
+    exactDuplicateAutoMap: bool(options.exactDuplicateAutoMap),
   });
 }

--- a/src/lib/sync/persistPlan.test.ts
+++ b/src/lib/sync/persistPlan.test.ts
@@ -95,6 +95,28 @@ describe("persistDraftPreviewRun", () => {
     }
   });
 
+  it("defaults the run trigger to manual_preview and honors an explicit trigger", () => {
+    const { root, db } = tempDb();
+    try {
+      const flowId = createFlow(db);
+      const plan = planSyncFlow({
+        config: buildPlanConfig({ flowId, sourceBudgetId: "budget-src", targetBudgetId: "budget-tgt", targetAccountId: "acct-tgt", sourceBudgetName: "Home", sourceAccountName: "Checking" }),
+        capabilities: getBudgetFileSyncCapabilities({ mode: "browser-api" }),
+        sourceTransactions: [source],
+        target: { payees: [], categories: [], importedIdIndex: new Map(), transactions: [] },
+        existingMappings: [],
+      });
+
+      const manual = persistDraftPreviewRun(db, plan);
+      expect(getSyncFlowRun(db, manual.run.id)?.createdByTrigger).toBe("manual_preview");
+
+      const auto = persistDraftPreviewRun(db, plan, { trigger: "interval_safe_only" });
+      expect(getSyncFlowRun(db, auto.run.id)?.createdByTrigger).toBe("interval_safe_only");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("persists one item per exploded split line", () => {
     const { root, db } = tempDb();
     try {

--- a/src/lib/sync/persistPlan.ts
+++ b/src/lib/sync/persistPlan.ts
@@ -7,6 +7,7 @@ import type {
   SqliteDatabase,
   SyncFlowRun,
   SyncFlowRunItem,
+  SyncRunTrigger,
 } from "@/lib/app-db/types";
 import type { PlannedTargetPayload, SyncPlannedItem, SyncPlanResult } from "./plannedChanges";
 
@@ -29,6 +30,8 @@ export type PersistDraftPreviewOptions = {
   summary?: JsonObject;
   /** Source snapshot summary stored on the run. */
   sourceSnapshotSummary?: JsonObject;
+  /** What created this run; defaults to a manual preview (RD-054). */
+  trigger?: SyncRunTrigger;
 };
 
 function payloadToJsonObject(payload: PlannedTargetPayload): JsonObject {
@@ -69,45 +72,51 @@ export function persistDraftPreviewRun(
   plan: SyncPlanResult,
   options: PersistDraftPreviewOptions = {}
 ): PersistDraftPreviewResult {
-  const run = createSyncFlowRun(db, {
-    flowId: plan.flowId,
-    status: "draft_preview",
-    createdByTrigger: "manual_preview",
-    summary: { version: 1, data: { totalItems: plan.items.length, ...options.summary } },
-    counts: { version: 1, data: { ...plan.counts } },
-    sourceSnapshotSummary: options.sourceSnapshotSummary
-      ? { version: 1, data: options.sourceSnapshotSummary }
-      : null,
+  // Persist the run + all its items in ONE transaction: 1 commit instead of
+  // N+1, which is the difference between one fsync and hundreds for a big run.
+  const persist = db.transaction((): PersistDraftPreviewResult => {
+    const run = createSyncFlowRun(db, {
+      flowId: plan.flowId,
+      status: "draft_preview",
+      createdByTrigger: options.trigger ?? "manual_preview",
+      summary: { version: 1, data: { totalItems: plan.items.length, ...options.summary } },
+      counts: { version: 1, data: { ...plan.counts } },
+      sourceSnapshotSummary: options.sourceSnapshotSummary
+        ? { version: 1, data: options.sourceSnapshotSummary }
+        : null,
+    });
+
+    const items = plan.items.map((item, index) =>
+      createSyncFlowRunItem(db, {
+        runId: run.id,
+        flowId: plan.flowId,
+        sequence: index,
+        status: "planned",
+        message: item.message,
+        sourceItemRef: { version: 1, data: sourceItemRef(item) },
+        targetItemRef: item.targetTransactionId
+          ? { version: 1, data: { targetTransactionId: item.targetTransactionId } }
+          : null,
+        sourceEntityType: item.sourceEntityType,
+        sourceItemKey: item.sourceItemKey,
+        sourceTransactionId: item.sourceTransactionId,
+        sourceSplitId: item.sourceSplitId,
+        sourceFingerprint: item.sourceFingerprint,
+        plannedAction: item.action,
+        plannedTargetPayload: item.plannedTargetPayload
+          ? { version: 1, data: payloadToJsonObject(item.plannedTargetPayload) }
+          : null,
+        classification: item.classification,
+        duplicateConfidence: item.duplicateConfidence,
+        warnings: { version: 1, data: { flags: [...item.flags] } },
+        selectedForApply: item.selectedForApply,
+        applyState: "pending",
+        createdTargetMarker: item.plannedTargetPayload?.importedId ?? null,
+      })
+    );
+
+    return { run, items };
   });
 
-  const items = plan.items.map((item, index) =>
-    createSyncFlowRunItem(db, {
-      runId: run.id,
-      flowId: plan.flowId,
-      sequence: index,
-      status: "planned",
-      message: item.message,
-      sourceItemRef: { version: 1, data: sourceItemRef(item) },
-      targetItemRef: item.targetTransactionId
-        ? { version: 1, data: { targetTransactionId: item.targetTransactionId } }
-        : null,
-      sourceEntityType: item.sourceEntityType,
-      sourceItemKey: item.sourceItemKey,
-      sourceTransactionId: item.sourceTransactionId,
-      sourceSplitId: item.sourceSplitId,
-      sourceFingerprint: item.sourceFingerprint,
-      plannedAction: item.action,
-      plannedTargetPayload: item.plannedTargetPayload
-        ? { version: 1, data: payloadToJsonObject(item.plannedTargetPayload) }
-        : null,
-      classification: item.classification,
-      duplicateConfidence: item.duplicateConfidence,
-      warnings: { version: 1, data: { flags: [...item.flags] } },
-      selectedForApply: item.selectedForApply,
-      applyState: "pending",
-      createdTargetMarker: item.plannedTargetPayload?.importedId ?? null,
-    })
-  );
-
-  return { run, items };
+  return persist();
 }

--- a/src/lib/sync/plannedChanges.ts
+++ b/src/lib/sync/plannedChanges.ts
@@ -29,6 +29,7 @@ export type SyncPlanFlag =
   | "source_changed_since_sync"
   | "target_marker_match_repair"
   | "duplicate_review"
+  | "exact_duplicate_auto_map"
   | "blocked_no_marker"
   | "split_fallback_key";
 

--- a/src/lib/sync/previewOrchestrator.test.ts
+++ b/src/lib/sync/previewOrchestrator.test.ts
@@ -73,7 +73,13 @@ function makeTransport(kind: "source" | "target", fx: TransportFixture): ActualB
     }),
     getTargetLookupForSync: jest.fn(async () => {
       events.push(`lookup:${kind}`);
-      return { payees: fx.targetPayees ?? [], importedIdIndex: fx.importedIdIndex ?? new Map() };
+      return {
+        payees: fx.targetPayees ?? [],
+        importedIdIndex: fx.importedIdIndex ?? new Map(),
+        transactions: (fx.targetTransactions ?? []).map((t) => ({
+          id: t.id, date: t.date, amount: t.amount, payeeName: t.payeeName, categoryId: t.categoryId,
+        })),
+      };
     }),
     getCategoryGroups: jest.fn(async () => categoryGroups),
   } as unknown as ActualBenchTransport;

--- a/src/lib/sync/previewOrchestrator.ts
+++ b/src/lib/sync/previewOrchestrator.ts
@@ -12,7 +12,7 @@ import {
 } from "./sourceFilter";
 import type { ActualBenchTransport } from "@/lib/actual/transport";
 import type { ConnectionInstance } from "@/store/connection";
-import type { JsonObject, SyncFlow, SyncMapping } from "@/lib/app-db/types";
+import type { JsonObject, SyncFlow, SyncMapping, SyncRunTrigger } from "@/lib/app-db/types";
 import type {
   SyncPlannerTargetSnapshot,
   SyncPlanResult,
@@ -44,6 +44,8 @@ export type PreviewTransportProvider = {
 export type PreviewPersistMeta = {
   summary: JsonObject;
   sourceSnapshotSummary: JsonObject;
+  /** What created this run; defaults to a manual preview when unset (RD-054). */
+  trigger?: SyncRunTrigger;
 };
 
 export type PreviewStore = {
@@ -67,6 +69,8 @@ export type LiveDryRunInput = {
   context: LiveDryRunContext;
   /** Allow running a disabled flow (e.g. preview-before-enable). Default false. */
   allowDisabled?: boolean;
+  /** What created this run; stamped on the persisted run (RD-054). */
+  trigger?: SyncRunTrigger;
 };
 
 // --- Result / error shapes --------------------------------------------------
@@ -95,6 +99,8 @@ export type DryRunSummary = {
   createCandidates: number;
   alreadySynced: number;
   duplicatesSkipped: number;
+  /** Exact duplicates the flow will auto-map (safe; excluded from duplicatesSkipped). */
+  exactDuplicatesAutoMapped: number;
   sourceChangedWarnings: number;
   targetMarkerMatches: number;
   blocked: number;
@@ -233,6 +239,7 @@ export async function runLiveDryRunPreview(
           budgetId: config.sourceBudgetId,
           connectionFingerprint: config.sourceConnectionFingerprint,
         },
+        trigger: input.trigger,
       }));
     } catch (err) {
       throw new DryRunPreviewError("persistence_failed", describe(err, "Failed to persist the preview run."));
@@ -343,16 +350,17 @@ async function loadTargetSnapshot(
   config: SyncFlowPlanConfig,
   filter: SyncSourceFilter
 ): Promise<SyncPlannerTargetSnapshot> {
+  // One lookup covers payees, the marker index, and the dedupe transaction list
+  // (single range read); categories still come from the category-group query.
   const range = { accountId: config.targetAccountId, startDate: filter.startDate ?? undefined, endDate: filter.endDate ?? undefined };
   const lookup = await transport.getTargetLookupForSync(range);
   const categoryGroups = await transport.getCategoryGroups();
-  const targetTxns = await transport.listTransactionsForSync(range);
 
   return {
     payees: lookup.payees.map((p) => ({ id: p.id, name: p.name })),
     categories: categoryGroups.categories.map((c) => ({ id: c.id, name: c.name })),
     importedIdIndex: lookup.importedIdIndex,
-    transactions: targetTxns.map((t) => ({
+    transactions: lookup.transactions.map((t) => ({
       id: t.id,
       date: t.date,
       amount: t.amount,
@@ -367,7 +375,11 @@ function buildSummary(
   source: { scanned: number; generatedExcluded: number; expandedCount: number; keptCount: number }
 ): DryRunSummary {
   const c = plan.counts;
-  const dup = (c.exact_duplicate ?? 0) + (c.strong_duplicate ?? 0) + (c.weak_duplicate ?? 0);
+  // Auto-mapped exact duplicates are safe (mapping-only), so they are reported
+  // separately and excluded from the review-queue "duplicatesSkipped" count.
+  const autoMapped = plan.items.filter((i) => i.flags.includes("exact_duplicate_auto_map")).length;
+  const dup =
+    (c.exact_duplicate ?? 0) + (c.strong_duplicate ?? 0) + (c.weak_duplicate ?? 0) - autoMapped;
   return {
     sourceTransactionsScanned: source.scanned,
     generatedTransactionsExcluded: source.generatedExcluded,
@@ -376,7 +388,8 @@ function buildSummary(
     plannedItems: plan.items.length,
     createCandidates: c.new ?? 0,
     alreadySynced: c.already_synced ?? 0,
-    duplicatesSkipped: dup,
+    duplicatesSkipped: Math.max(0, dup),
+    exactDuplicatesAutoMapped: autoMapped,
     sourceChangedWarnings: c.source_changed_since_sync ?? 0,
     targetMarkerMatches: c.target_marker_match ?? 0,
     blocked: c.blocked ?? 0,

--- a/src/lib/sync/safeSyncOrchestrator.test.ts
+++ b/src/lib/sync/safeSyncOrchestrator.test.ts
@@ -1,0 +1,165 @@
+import { runSafeSync, type SafeSyncDeps } from "./safeSyncOrchestrator";
+import type {
+  DryRunSummary,
+  LiveDryRunContext,
+  LiveDryRunResult,
+  PreviewStore,
+} from "./previewOrchestrator";
+import type { ApplyRunResult, ApplyStore } from "./applyOrchestrator";
+import type { BrowserApiConnection } from "@/store/connection";
+import type { JsonEnvelope, SyncFlow, SyncReviewPolicy } from "@/lib/app-db/types";
+
+const sourceConn: BrowserApiConnection = {
+  id: "src", label: "Home", mode: "browser-api", baseUrl: "https://s.example.com", serverPassword: "pw", budgetSyncId: "budget-src",
+};
+const targetConn: BrowserApiConnection = {
+  id: "tgt", label: "Family", mode: "browser-api", baseUrl: "https://t.example.com", serverPassword: "pw", budgetSyncId: "budget-tgt",
+};
+const context: LiveDryRunContext = { sourceConnection: sourceConn, targetConnection: targetConn };
+
+function flowWithPolicy(reviewPolicy: SyncReviewPolicy | null): SyncFlow {
+  const options: JsonEnvelope = { version: 1, data: reviewPolicy ? { reviewPolicy } : {} };
+  return {
+    id: "flow-1", name: "Cross-budget", enabled: true, flowType: "transaction_sync",
+    description: null, createdAt: "", updatedAt: "",
+    legs: [{
+      id: "leg-1", flowId: "flow-1", position: 0,
+      sourceRef: { version: 1, data: { budgetId: "budget-src", accountId: "acct-src" } },
+      targetRef: { version: 1, data: { budgetId: "budget-tgt", accountId: "acct-tgt" } },
+      filter: { version: 1, data: {} }, transform: { version: 1, data: {} }, options,
+      createdAt: "", updatedAt: "",
+    }],
+  };
+}
+
+function summary(overrides: Partial<DryRunSummary> = {}): DryRunSummary {
+  return {
+    sourceTransactionsScanned: 0, generatedTransactionsExcluded: 0, sourceItemsScanned: 0,
+    sourceItemsFilteredOut: 0, plannedItems: 0, createCandidates: 0, alreadySynced: 0,
+    duplicatesSkipped: 0, exactDuplicatesAutoMapped: 0, sourceChangedWarnings: 0, targetMarkerMatches: 0, blocked: 0,
+    ...overrides,
+  };
+}
+
+function previewOk(summaryOverrides: Partial<DryRunSummary> = {}): LiveDryRunResult {
+  return { status: "draft_preview", runId: "run-1", flowId: "flow-1", counts: {}, summary: summary(summaryOverrides), warnings: [], errors: [] };
+}
+
+function applyOk(overrides: Partial<ApplyRunResult> = {}): ApplyRunResult {
+  return {
+    status: "applied", runId: "run-1",
+    counts: { selected: 1, applied: 1, appliedWithWarnings: 0, repaired: 0, skipped: 0, failed: 0 },
+    items: [], ...overrides,
+  };
+}
+
+function makeDeps(
+  flow: SyncFlow | null,
+  stubs: { runPreview?: jest.Mock; runApply?: jest.Mock } = {}
+): SafeSyncDeps {
+  const runPreview = stubs.runPreview ?? jest.fn(async () => previewOk({ createCandidates: 1 }));
+  const runApply = stubs.runApply ?? jest.fn(async () => applyOk());
+  return {
+    transport: {} as SafeSyncDeps["transport"],
+    previewStore: { loadFlow: jest.fn(async () => flow) } as unknown as PreviewStore,
+    applyStore: {} as unknown as ApplyStore,
+    runPreview: runPreview as unknown as SafeSyncDeps["runPreview"],
+    runApply: runApply as unknown as SafeSyncDeps["runApply"],
+  };
+}
+
+describe("runSafeSync — policy gate", () => {
+  it("refuses to auto-apply a manual_preview_required flow (never previews or applies)", async () => {
+    const runPreview = jest.fn();
+    const runApply = jest.fn();
+    const deps = makeDeps(flowWithPolicy("manual_preview_required"), { runPreview, runApply });
+
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+
+    expect(result).toEqual({ status: "skipped_manual_policy", flowId: "flow-1", reviewPolicy: "manual_preview_required" });
+    expect(runPreview).not.toHaveBeenCalled();
+    expect(runApply).not.toHaveBeenCalled();
+  });
+
+  it("treats an unset policy as manual (safe default) and skips", async () => {
+    const runApply = jest.fn();
+    const deps = makeDeps(flowWithPolicy(null), { runApply });
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result.status).toBe("skipped_manual_policy");
+    expect(runApply).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing flow as a preview failure without previewing", async () => {
+    const runPreview = jest.fn();
+    const deps = makeDeps(null, { runPreview });
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result).toMatchObject({ status: "preview_failed", runId: null, error: { code: "flow_not_found" } });
+    expect(runPreview).not.toHaveBeenCalled();
+  });
+
+  it.each(["auto_apply_safe_only", "auto_sync_on_interval"] as const)(
+    "proceeds to preview + safe apply for %s",
+    async (policy) => {
+      const runApply = jest.fn(async () => applyOk());
+      const deps = makeDeps(flowWithPolicy(policy), { runApply });
+      const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+      expect(result.status).toBe("applied");
+      // Apply is always driven with the safe-only bulk selection.
+      expect(runApply).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: "run-1", selection: { selection: "all_safe" } }),
+        expect.anything()
+      );
+    }
+  );
+});
+
+describe("runSafeSync — composition", () => {
+  it("returns preview_failed and never applies when preview fails", async () => {
+    const runPreview = jest.fn(async (): Promise<LiveDryRunResult> => ({
+      status: "failed", runId: "run-1", flowId: "flow-1",
+      error: { code: "target_load_failed", message: "boom" }, warnings: [],
+    }));
+    const runApply = jest.fn();
+    const deps = makeDeps(flowWithPolicy("auto_apply_safe_only"), { runPreview, runApply });
+
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result).toMatchObject({ status: "preview_failed", error: { code: "target_load_failed" } });
+    expect(runApply).not.toHaveBeenCalled();
+  });
+
+  it("no-ops without reopening the target when preview has no safe items", async () => {
+    const runPreview = jest.fn(async () => previewOk({ createCandidates: 0, targetMarkerMatches: 0, duplicatesSkipped: 3 }));
+    const runApply = jest.fn();
+    const deps = makeDeps(flowWithPolicy("auto_apply_safe_only"), { runPreview, runApply });
+
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result.status).toBe("no_safe_items");
+    expect(runApply).not.toHaveBeenCalled();
+  });
+
+  it("applies when a marker match is the only safe item", async () => {
+    const runPreview = jest.fn(async () => previewOk({ createCandidates: 0, targetMarkerMatches: 1 }));
+    const runApply = jest.fn(async () => applyOk({ counts: { selected: 1, applied: 0, appliedWithWarnings: 0, repaired: 1, skipped: 0, failed: 0 } }));
+    const deps = makeDeps(flowWithPolicy("auto_sync_on_interval"), { runPreview, runApply });
+
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result.status).toBe("applied");
+    expect(runApply).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a benign no_eligible_items apply failure to a no-op", async () => {
+    const runApply = jest.fn(async () => applyOk({ status: "failed", error: { code: "no_eligible_items", message: "none" }, counts: { selected: 0, applied: 0, appliedWithWarnings: 0, repaired: 0, skipped: 0, failed: 0 } }));
+    const deps = makeDeps(flowWithPolicy("auto_apply_safe_only"), { runApply });
+
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result.status).toBe("no_safe_items");
+  });
+
+  it("surfaces a partial apply with its detail", async () => {
+    const runApply = jest.fn(async () => applyOk({ status: "partial", counts: { selected: 2, applied: 1, appliedWithWarnings: 0, repaired: 0, skipped: 0, failed: 1 } }));
+    const deps = makeDeps(flowWithPolicy("auto_apply_safe_only"), { runApply });
+
+    const result = await runSafeSync({ flowId: "flow-1", context }, deps);
+    expect(result).toMatchObject({ status: "partial", apply: { status: "partial", counts: { failed: 1 } } });
+  });
+});

--- a/src/lib/sync/safeSyncOrchestrator.ts
+++ b/src/lib/sync/safeSyncOrchestrator.ts
@@ -1,0 +1,158 @@
+import { decodeFlowPlanConfig } from "./flowConfig";
+import {
+  runLiveDryRunPreview,
+  type DryRunError,
+  type DryRunSummary,
+  type LiveDryRunContext,
+  type PreviewStore,
+  type PreviewTransportProvider,
+} from "./previewOrchestrator";
+import {
+  applySyncRun,
+  type ApplyRunResult,
+  type ApplyStore,
+  type ApplyTransportProvider,
+} from "./applyOrchestrator";
+import type { SyncReviewPolicy, SyncRunTrigger } from "@/lib/app-db/types";
+
+/**
+ * Safe-only run executor for Budget File Sync automation (RD-054 / PR-020 Slice 2).
+ *
+ * This is **not a second sync engine**. It composes the two existing RD-053
+ * orchestrators — `runLiveDryRunPreview` (plan, no writes) then `applySyncRun`
+ * with `{ selection: "all_safe" }` (apply only safe classes) — behind a single
+ * headless call, gated by the flow's automation policy.
+ *
+ * Safety guarantees:
+ * - **Policy is a gate, never a bypass.** The `reviewPolicy` check runs here,
+ *   server-side, before any preview or apply. A `manual_preview_required` flow
+ *   can never be auto-applied through this path, whatever the caller passes.
+ * - **Safe classes only.** Apply uses `all_safe`, which resolves to `new`
+ *   create candidates plus repairable `target_marker_match` rows. Every
+ *   uncertain class (duplicates, source-changed, source-missing, blocked,
+ *   warning) is planned and left pending for the review queue.
+ * - **RD-053 preflight intact.** The composed apply still re-checks route,
+ *   capabilities, marker presence, and preview freshness before writing.
+ *
+ * There is no UI here (that is Slice 4) and no review-queue surface (Slice 3);
+ * this slice only makes the safe-only behavior exist and be testable.
+ */
+
+export type SafeSyncInput = {
+  flowId: string;
+  context: LiveDryRunContext;
+  /** Allow running a disabled flow (e.g. an explicit "run now" on a paused flow). */
+  allowDisabled?: boolean;
+  /** Trigger stamped on the run; both "Run now" and the interval use the default. */
+  trigger?: SyncRunTrigger;
+};
+
+export type SafeSyncDeps = {
+  transport: PreviewTransportProvider & ApplyTransportProvider;
+  previewStore: PreviewStore;
+  applyStore: ApplyStore;
+  /** Injectable for tests; default to the real orchestrators. */
+  runPreview?: typeof runLiveDryRunPreview;
+  runApply?: typeof applySyncRun;
+};
+
+export type SafeSyncResult =
+  /** Flow is manual-only (or was not found); nothing was previewed or applied. */
+  | { status: "skipped_manual_policy"; flowId: string; reviewPolicy: SyncReviewPolicy }
+  /** Preview never produced an applyable run. */
+  | { status: "preview_failed"; flowId: string; runId: string | null; error: DryRunError }
+  /** Preview succeeded but there was nothing safe to apply — a benign no-op. */
+  | {
+      status: "no_safe_items";
+      flowId: string;
+      runId: string;
+      reviewPolicy: SyncReviewPolicy;
+      preview: DryRunSummary;
+    }
+  /** Safe apply ran; `apply.status` carries applied / partial / failed detail. */
+  | {
+      status: "applied" | "partial" | "failed";
+      flowId: string;
+      runId: string;
+      reviewPolicy: SyncReviewPolicy;
+      preview: DryRunSummary;
+      apply: ApplyRunResult;
+    };
+
+export async function runSafeSync(
+  input: SafeSyncInput,
+  deps: SafeSyncDeps
+): Promise<SafeSyncResult> {
+  const { flowId } = input;
+  const runPreview = deps.runPreview ?? runLiveDryRunPreview;
+  const runApply = deps.runApply ?? applySyncRun;
+
+  // 1. Policy gate — authoritative and first. A flow that has not opted into
+  //    automation is never auto-applied here, regardless of caller intent. A
+  //    missing flow is reported as a preview failure (the preview would fail the
+  //    same way) rather than silently skipped.
+  const flow = await deps.previewStore.loadFlow(flowId);
+  if (!flow) {
+    return {
+      status: "preview_failed",
+      flowId,
+      runId: null,
+      error: { code: "flow_not_found", message: `Sync flow ${flowId} was not found.` },
+    };
+  }
+  const reviewPolicy = decodeFlowPlanConfig(flow).reviewPolicy;
+  if (reviewPolicy === "manual_preview_required") {
+    return { status: "skipped_manual_policy", flowId, reviewPolicy };
+  }
+
+  // 2. Preview (no Actual writes) — the RD-053 planner, unchanged. The run is
+  //    stamped so history shows it was automated (default: interval_safe_only).
+  const preview = await runPreview(
+    {
+      flowId,
+      context: input.context,
+      allowDisabled: input.allowDisabled,
+      trigger: input.trigger ?? "interval_safe_only",
+    },
+    { transport: deps.transport, store: deps.previewStore }
+  );
+  if (preview.status !== "draft_preview") {
+    return { status: "preview_failed", flowId, runId: preview.runId, error: preview.error };
+  }
+
+  // 3. Nothing safe to apply → benign no-op; don't reopen the target budget.
+  const safeCount =
+    preview.summary.createCandidates +
+    preview.summary.targetMarkerMatches +
+    preview.summary.exactDuplicatesAutoMapped;
+  if (safeCount === 0) {
+    return { status: "no_safe_items", flowId, runId: preview.runId, reviewPolicy, preview: preview.summary };
+  }
+
+  // 4. Apply safe classes only (new creates + target-marker repairs). Apply
+  //    re-validates freshness/route/capabilities per RD-053.
+  const apply = await runApply(
+    {
+      runId: preview.runId,
+      targetConnection: input.context.targetConnection,
+      selection: { selection: "all_safe" },
+    },
+    { transport: deps.transport, store: deps.applyStore }
+  );
+
+  // A "no eligible items" apply after a non-zero preview is still a benign no-op
+  // (e.g. the only safe rows resolved away between preview and apply), not a real
+  // failure — report it as such rather than surfacing an error.
+  if (apply.status === "failed" && apply.error?.code === "no_eligible_items") {
+    return { status: "no_safe_items", flowId, runId: preview.runId, reviewPolicy, preview: preview.summary };
+  }
+
+  return {
+    status: apply.status,
+    flowId,
+    runId: preview.runId,
+    reviewPolicy,
+    preview: preview.summary,
+    apply,
+  };
+}

--- a/src/lib/sync/syncPlanner.test.ts
+++ b/src/lib/sync/syncPlanner.test.ts
@@ -227,6 +227,32 @@ describe("planSyncFlow — duplicates", () => {
     const plan = planSyncFlow(baseInput({ target }));
     expect(plan.items[0].classification).toBe("weak_duplicate");
   });
+
+  it("auto-maps an exact duplicate when the flow opts in (target id + flag, no create)", () => {
+    const target = emptyTarget({
+      payees: [{ id: "tp1", name: "Coffee Bar" }],
+      categories: [{ id: "tc1", name: "Dining" }],
+      transactions: [
+        { id: "existing-1", date: "2026-07-01", amount: 1250, payeeName: "Coffee Bar", categoryId: "tc1" },
+      ],
+    });
+    const autoMapConfig = buildPlanConfig({ ...config, exactDuplicateAutoMap: true });
+    const plan = planSyncFlow(baseInput({ config: autoMapConfig, target }));
+    const item = plan.items[0];
+    expect(item.classification).toBe("exact_duplicate");
+    expect(item.flags).toContain("exact_duplicate_auto_map");
+    expect(item.targetTransactionId).toBe("existing-1");
+    expect(item.action).toBe("skip"); // mapping only; no create
+
+    // A strong (fuzzy) duplicate is never auto-mapped, even with the option on.
+    const strongTarget = emptyTarget({
+      payees: [{ id: "tp1", name: "Coffee Bar" }],
+      transactions: [{ id: "s1", date: "2026-07-01", amount: 1250, payeeName: "Coffee Bar", categoryId: "other" }],
+    });
+    const strong = planSyncFlow(baseInput({ config: autoMapConfig, target: strongTarget })).items[0];
+    expect(strong.classification).toBe("strong_duplicate");
+    expect(strong.flags).not.toContain("exact_duplicate_auto_map");
+  });
 });
 
 describe("planSyncFlow — splits", () => {

--- a/src/lib/sync/syncPlanner.ts
+++ b/src/lib/sync/syncPlanner.ts
@@ -172,8 +172,26 @@ function planSourceItem(
   }
 
   // 3. Duplicate heuristic (skipped by default when uncertain).
-  const confidence = classifyDuplicate(payload, target.transactions, effectivePayeeName);
+  const { confidence, targetTransactionId: dupTargetId } = classifyDuplicate(
+    payload,
+    target.transactions,
+    effectivePayeeName
+  );
   if (confidence !== "none") {
+    // Exact duplicates can be auto-mapped to the existing target when the flow
+    // opts in: record a mapping (no write), instead of routing to review. Fuzzy
+    // (strong/weak) duplicates always stay review-required.
+    if (confidence === "exact" && config.exactDuplicateAutoMap && dupTargetId) {
+      return baseItem(item, {
+        classification: "exact_duplicate",
+        action: "skip",
+        duplicateConfidence: confidence,
+        flags: ["exact_duplicate_auto_map"],
+        plannedTargetPayload: payload,
+        targetTransactionId: dupTargetId,
+        message: "Exact duplicate on the target; will be mapped to the existing transaction.",
+      });
+    }
     return baseItem(item, {
       classification: duplicateClassification(confidence),
       action: "skip",


### PR DESCRIPTION
Adds opt-in, **safe-only automation** on top of the preview-first Budget File Sync engine, reusing the same planner, classifications, markers, and mappings (no second engine). Plus a round of apply/preview performance work.

## Automation
- **Flow review policy:** manual (default — unchanged behavior) / auto-apply safe items on preview / auto-sync on a schedule, with editor controls.
- **Safe-only executor:** policy-gated preview → apply of **safe classes only** (new creates + target-marker repairs). The gate is enforced server-side and cannot be bypassed by the client.
- **Review queue:** duplicates, source-changed/-missing, and blocked items are never auto-applied — they surface for manual handling.
- **Client-side interval auto-sync** + a **"Run safe sync now"** action. Runs only **while the app is open and the connection is unlocked** — not an unattended server daemon.
- **Run summaries** (auto-applied vs queued vs failed), in-app **notifications**, and **flow health**: a flow auto-pauses after repeated failed/partial auto runs and is cleared on re-enable.
- **Exact-duplicate auto-map** (opt-in, off by default) and **retry-failed-items**.

## Performance
- **Apply:** creates all selected transactions in **one batched `addTransactions` + one id-recovery read** (was one round-trip per item); mapping + run-item-status writes are **buffered and flushed in one bulk request each** via new batch endpoints (`POST /api/sync-mappings` array, `PATCH /api/sync-flow-run-items`). ~800 round-trips → ~2 for a 400-item run.
- **Preview:** persist wrapped in a **single transaction** (hundreds of commits → 1); target-phase reads **de-duplicated** (payees/categories/transactions loaded once instead of 2×); `PRAGMA synchronous = NORMAL` under WAL.

## Follow-ups (deliberately out of scope)
- Unattended server-side scheduled sync (needs a credential vault + server runtime).
- Keeping the Direct runtime alive across a same-server budget switch (the largest remaining preview cost) — a core-runtime change affecting all Direct-mode features, so tracked separately.

## Testing
- `jest` — 118 suites, 1154 tests passing. `tsc --noEmit` clean, `eslint` 0 errors.
- New tests cover: the policy gate + safe executor, review-queue derivation, the scheduler decision, flow-health pause/reset, exact-dup auto-map, retry, batched create, and the new bulk endpoints.
