### PR TITLE
feat(sync): unified engine with payee & category (master-data) sync

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -57,7 +57,17 @@ A compact diagnostics page for Actual Bench's own server-side metadata database.
 
 ## Budget File Sync
 
-A workspace for copying transactions from an account in one budget file to an account in another, as saved one-way flows. It is deliberately conservative: **Direct mode only, cross-budget only, create-only, preview-first** — with an opt-in safe-only automation layer on top.
+A workspace for syncing data between budget files as saved one-way flows. One unified engine covers every data type — **transactions, payees, and categories** — so preview, apply, run history, the review queue, and the whole safe-only automation layer work identically for each. It is deliberately conservative: **Direct mode only, cross-budget only, create-only, preview-first.**
+
+### Master data (payees & categories)
+
+- Choose a flow's **data type** — Transactions, Payees, or Categories — in the flow editor. Payee/category flows sync at the **budget** level (no account).
+- **Payees:** missing payees are created on the target; existing ones are matched by normalized name and mapped without duplicating.
+- **Categories:** matched by name within a group; missing categories are created under the matching target group, or a chosen **default group**; a category whose group can't be placed is **blocked for review** unless you enable **create missing groups**. Income and expense categories stay distinct.
+- **No renames, deletes, or hides** — create-only. Mappings are recorded so reruns skip already-synced entities.
+- Everything else — the review queue, run history, auto-apply/auto-sync/flow-health automation — applies to entity flows exactly as it does to transactions.
+
+### Transactions
 
 - Saved sync flows list with a compact editor: source/target Direct connection + account, filters, and transforms
 - Transforms: amount direction (reverse sign by default, same-sign optional), payee match-by-name (create missing by default, or leave empty), category match-by-name (missing categories are left empty — never auto-created), and a clean visible notes marker (`[Synced from <budget> / <account>]`, on by default)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ A read-only local diagnostics workspace for the exported budget snapshots.
 
 ### Budget File Sync
 
-Copy transactions from an account in one budget file to an account in another, as saved one-way flows. It is **Direct mode only, cross-budget, create-only, and preview-first**, with opt-in safe-only automation.
+Sync data between budget files as saved one-way flows. One unified engine covers **transactions, payees, and categories** — preview, apply, run history, the review queue, and the safe-only automation layer work identically for each. It is **Direct mode only, cross-budget, create-only, and preview-first**.
+
+- **Master data:** pick a flow's data type (Transactions / Payees / Categories). Payee and category flows create missing entities on the target and match existing ones by name (no renames/deletes); categories place under the matching or a chosen default group, and block ambiguous placement for review.
 
 - Compact flow editor: source/target Direct connection + account, filters, and transforms (reverse-sign by default, payee/category match-by-name, clean notes marker)
 - Required dry-run preview classifies each item (new, already synced, duplicate, changed since sync, marker match, blocked) with source and transformed target amounts side by side — no writes to Actual

--- a/src/app/api/sync-mappings/route.ts
+++ b/src/app/api/sync-mappings/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
   try {
     const body = (await readJsonBody(request)) as SyncMappingInput | SyncMappingInput[];
     const db = getAppDb();
-    // A batch (array) is written in ONE transaction — one commit for the whole
+    // A batch (array) is written in ONE transaction - one commit for the whole
     // apply run instead of an HTTP round-trip + commit per mapping.
     if (Array.isArray(body)) {
       const createAll = db.transaction(() => body.map((input) => createSyncMapping(db, input)));

--- a/src/features/sync/components/FlowEditDialog.tsx
+++ b/src/features/sync/components/FlowEditDialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -40,7 +41,7 @@ function InlineEndpoint({
   label: string;
   endpoint: SyncEndpointForm;
   connections: BrowserApiConnection[];
-  /** Entity (payee/category) flows pick a budget only — no account. */
+  /** Entity (payee/category) flows pick a budget only - no account. */
   entityMode?: boolean;
   onChange: (next: SyncEndpointForm) => void;
 }) {
@@ -111,11 +112,9 @@ export function FlowEditDialog({
   const entityMode = isEntityFlow(form.flowType);
 
   const automationHelp: Record<SyncFlowFormState["automation"]["reviewPolicy"], string> = {
-    manual_preview_required: "Preview only. You review and apply every change yourself.",
-    auto_apply_safe_only:
-      "When you run a preview, safe new transactions and mapping repairs are applied automatically. Duplicates, changed, and other uncertain items still wait in the review queue.",
-    auto_sync_on_interval:
-      "Re-runs safe sync on a schedule while Actual Bench is open and this connection is unlocked. Applies only safe items; uncertain items go to the review queue. It does not run in the background when the app is closed.",
+    manual_preview_required: "You review and apply every change.",
+    auto_apply_safe_only: "Safe items apply on preview; uncertain ones wait in the review queue.",
+    auto_sync_on_interval: "Runs on a schedule while the app is open. Safe items only; nothing runs in the background.",
   };
 
   return (
@@ -125,47 +124,52 @@ export function FlowEditDialog({
           <DialogTitle>{isNew ? "New sync flow" : "Edit sync flow"}</DialogTitle>
         </DialogHeader>
 
-        <div className="max-h-[72vh] overflow-y-auto pr-1">
-          {/* Name + data type */}
-          <div className="flex flex-wrap gap-4 pb-4">
-            <div className="flex min-w-[16rem] flex-1 flex-col gap-1">
-              <span className="text-[11px] font-semibold uppercase text-muted-foreground">Sync flow name</span>
-              <Input aria-label="Flow name" value={form.name} onChange={(e) => set({ name: e.target.value })} placeholder="e.g. Joint card → Personal budget" />
-            </div>
-            <div className="flex flex-col gap-1">
-              <span className="text-[11px] font-semibold uppercase text-muted-foreground">Data type</span>
-              <select
-                aria-label="Sync data type"
-                className={selectClass}
-                value={form.flowType}
-                onChange={(e) => set({ flowType: e.target.value as SyncFlowFormState["flowType"] })}
-              >
-                <option value="transaction_sync">Transactions</option>
-                <option value="payee_sync">Payees</option>
-                <option value="category_sync">Categories</option>
-              </select>
+        <div className="flex max-h-[72vh] flex-col gap-4 overflow-y-auto pr-1">
+          {/* What to sync — the choice that reshapes the rest of the form */}
+          <div className="flex flex-col gap-1.5">
+            <span className="text-[11px] font-semibold uppercase text-muted-foreground">What to sync</span>
+            <div className="inline-flex w-fit rounded-md border border-border p-0.5">
+              {([["transaction_sync", "Transactions"], ["payee_sync", "Payees"], ["category_sync", "Categories"]] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={form.flowType === value}
+                  onClick={() => set({ flowType: value })}
+                  className={cn(
+                    "rounded px-3 py-1 text-xs font-medium transition-colors",
+                    form.flowType === value ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
           </div>
 
-          {/* Route (full width) */}
-          <section className="flex flex-col gap-2 border-t border-border py-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-[11px] font-semibold uppercase text-muted-foreground">Name</span>
+            <Input aria-label="Flow name" value={form.name} onChange={(e) => set({ name: e.target.value })} placeholder={entityMode ? "e.g. Shared payees" : "e.g. Joint card → Personal"} />
+          </div>
+
+          {/* Route */}
+          <section className="flex flex-col gap-2 border-t border-border pt-4">
             <div className="flex items-center gap-2">
-              <h4 className="text-sm font-semibold">Route</h4>
-              {!sameBudget && routeMissing.length === 0 && (
-                <span className="rounded-full border border-green-500/30 bg-green-50 px-2 py-0.5 text-[11px] text-green-700 dark:bg-green-950/20 dark:text-green-400">Cross-budget OK</span>
-              )}
+              <h4 className="text-sm font-semibold">From → to</h4>
+              {sameBudget ? (
+                <span className="text-xs text-destructive">Pick two different budgets.</span>
+              ) : routeMissing.length === 0 ? (
+                <span className="text-xs text-muted-foreground">{entityMode ? "budget → budget" : "budget · account → budget · account"}</span>
+              ) : null}
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <div className="min-w-0 flex-1"><InlineEndpoint label="Source" endpoint={form.source} connections={connections} entityMode={entityMode} onChange={(source) => set({ source })} /></div>
               <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
               <div className="min-w-0 flex-1"><InlineEndpoint label="Target" endpoint={form.target} connections={connections} entityMode={entityMode} onChange={(target) => set({ target })} /></div>
             </div>
-            {sameBudget && <p className="text-xs text-destructive">Source and target must be different budgets (cross-budget only).</p>}
-            <p className="text-xs text-muted-foreground">{entityMode ? "Source budget → target budget." : "Source budget · account → target budget · account."}</p>
           </section>
 
           {/* Automation policy (RD-054 / PR-020) */}
-          <section className="flex flex-col gap-2 border-t border-border py-4">
+          <section className="flex flex-col gap-2 border-t border-border pt-4">
             <h4 className="text-sm font-semibold">Automation</h4>
             <label className="flex max-w-md flex-col gap-1 text-xs text-muted-foreground">
               Review policy
@@ -175,7 +179,7 @@ export function FlowEditDialog({
                 value={form.automation.reviewPolicy}
                 onChange={(e) => setAutomation({ reviewPolicy: e.target.value as SyncFlowFormState["automation"]["reviewPolicy"] })}
               >
-                <option value="manual_preview_required">Manual — preview &amp; apply yourself (default)</option>
+                <option value="manual_preview_required">Manual - preview &amp; apply yourself (default)</option>
                 <option value="auto_apply_safe_only">Auto-apply safe items on preview</option>
                 <option value="auto_sync_on_interval">Auto-sync on a schedule (while app is open)</option>
               </select>
@@ -197,54 +201,48 @@ export function FlowEditDialog({
                 <span className="text-[11px]">Minimum 15 minutes. Each run re-opens and syncs the whole budget.</span>
               </label>
             )}
-            {form.automation.reviewPolicy !== "manual_preview_required" && (
-              <label className="flex items-center gap-2 text-sm">
+            {form.automation.reviewPolicy !== "manual_preview_required" && !entityMode && (
+              <label className="flex items-center gap-2 text-sm" title="An exact match on date, amount, payee and category is linked instead of duplicated. Fuzzy matches still go to review.">
                 <input
                   type="checkbox"
                   aria-label="Auto-map exact duplicates"
                   checked={form.automation.exactDuplicateAutoMap}
                   onChange={(e) => setAutomation({ exactDuplicateAutoMap: e.target.checked })}
                 />
-                Auto-map exact duplicates to the existing transaction
+                Link exact duplicates instead of creating them
               </label>
-            )}
-            {form.automation.reviewPolicy !== "manual_preview_required" && (
-              <p className="text-xs text-muted-foreground">
-                When on, a transaction that already exists on the target with the same date, amount, payee and category is linked to it (no new transaction). Uncertain (fuzzy) duplicates still go to the review queue.
-              </p>
             )}
           </section>
 
           {/* Master-data (entity) options */}
           {entityMode && (
-            <section className="flex flex-col gap-3 border-t border-border py-4">
+            <section className="flex flex-col gap-2.5 border-t border-border pt-4">
               <h4 className="text-sm font-semibold">{form.flowType === "payee_sync" ? "Payees" : "Categories"}</h4>
               <p className="text-xs text-muted-foreground">
-                Missing {form.flowType === "payee_sync" ? "payees" : "categories"} are created on the target; existing ones are matched by name. Nothing is renamed, deleted, or hidden.
+                Creates missing {form.flowType === "payee_sync" ? "payees" : "categories"}, matches existing ones by name, and never renames or deletes.
               </p>
               {form.flowType === "category_sync" && (
                 <>
-                  <label className="flex max-w-md flex-col gap-1 text-xs text-muted-foreground">
-                    Default target group (optional)
+                  <label className="flex max-w-xs flex-col gap-1 text-xs text-muted-foreground">
+                    Default group
                     <Input
                       aria-label="Default target group"
                       value={form.entity.defaultGroupName}
                       onChange={(e) => setEntity({ defaultGroupName: e.target.value })}
                       placeholder="e.g. Uncategorized"
                     />
-                    <span className="text-[11px]">Used when a category&apos;s source group has no matching group on the target.</span>
                   </label>
-                  <label className="flex items-center gap-2 text-sm">
+                  <label className="flex items-center gap-2 text-sm" title="Create the source group on the target when it doesn't exist there.">
                     <input
                       type="checkbox"
                       aria-label="Create missing groups"
                       checked={form.entity.createMissingGroup}
                       onChange={(e) => setEntity({ createMissingGroup: e.target.checked })}
                     />
-                    Create missing groups on the target
+                    Create missing groups too
                   </label>
                   <p className="text-xs text-muted-foreground">
-                    Without a default group or this option, a category with no matching target group is blocked for review.
+                    A category with no group match - and no default or group creation - is held for review.
                   </p>
                 </>
               )}
@@ -274,7 +272,7 @@ export function FlowEditDialog({
                 <input type="checkbox" aria-label="Add notes marker" checked={form.transform.notesMarkerEnabled} onChange={(e) => setTransform({ notesMarkerEnabled: e.target.checked })} />
                 Add visible notes marker
               </label>
-              <p className="text-xs text-muted-foreground">Categories match by name; missing categories are left empty. Eligible split lines are copied as separate transactions.</p>
+              <p className="text-xs text-muted-foreground">Categories match by name; splits become separate transactions.</p>
             </section>
 
             <section className="flex flex-col gap-3">

--- a/src/features/sync/components/FlowEditDialog.tsx
+++ b/src/features/sync/components/FlowEditDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { clampSyncInterval } from "@/lib/sync/flowConfig";
 import { useFlowAccounts } from "../hooks/useSyncData";
-import { isSameBudget, missingRouteFields, type SyncEndpointForm, type SyncFlowFormState } from "../lib/flowForm";
+import { isEntityFlow, isSameBudget, missingRouteFields, type SyncEndpointForm, type SyncFlowFormState } from "../lib/flowForm";
 import type { BrowserApiConnection } from "@/store/connection";
 
 type FlowEditDialogProps = {
@@ -34,11 +34,14 @@ function InlineEndpoint({
   label,
   endpoint,
   connections,
+  entityMode,
   onChange,
 }: {
   label: string;
   endpoint: SyncEndpointForm;
   connections: BrowserApiConnection[];
+  /** Entity (payee/category) flows pick a budget only — no account. */
+  entityMode?: boolean;
   onChange: (next: SyncEndpointForm) => void;
 }) {
   const accounts = useFlowAccounts(endpoint.connectionId);
@@ -58,6 +61,7 @@ function InlineEndpoint({
           <option key={c.id} value={c.id}>{c.label}</option>
         ))}
       </select>
+      {entityMode ? null : (
       <select
         aria-label={`${label} account`}
         className={`${selectClass} flex-1`}
@@ -73,6 +77,7 @@ function InlineEndpoint({
           <option key={a.id} value={a.id}>{a.name}</option>
         ))}
       </select>
+      )}
     </div>
   );
 }
@@ -102,6 +107,8 @@ export function FlowEditDialog({
   const setFilter = (patch: Partial<SyncFlowFormState["filter"]>) => onChange({ ...form, filter: { ...form.filter, ...patch } });
   const setTransform = (patch: Partial<SyncFlowFormState["transform"]>) => onChange({ ...form, transform: { ...form.transform, ...patch } });
   const setAutomation = (patch: Partial<SyncFlowFormState["automation"]>) => onChange({ ...form, automation: { ...form.automation, ...patch } });
+  const setEntity = (patch: Partial<SyncFlowFormState["entity"]>) => onChange({ ...form, entity: { ...form.entity, ...patch } });
+  const entityMode = isEntityFlow(form.flowType);
 
   const automationHelp: Record<SyncFlowFormState["automation"]["reviewPolicy"], string> = {
     manual_preview_required: "Preview only. You review and apply every change yourself.",
@@ -119,10 +126,25 @@ export function FlowEditDialog({
         </DialogHeader>
 
         <div className="max-h-[72vh] overflow-y-auto pr-1">
-          {/* Name */}
-          <div className="flex max-w-md flex-col gap-1 pb-4">
-            <span className="text-[11px] font-semibold uppercase text-muted-foreground">Sync flow name</span>
-            <Input aria-label="Flow name" value={form.name} onChange={(e) => set({ name: e.target.value })} placeholder="e.g. Joint card → Personal budget" />
+          {/* Name + data type */}
+          <div className="flex flex-wrap gap-4 pb-4">
+            <div className="flex min-w-[16rem] flex-1 flex-col gap-1">
+              <span className="text-[11px] font-semibold uppercase text-muted-foreground">Sync flow name</span>
+              <Input aria-label="Flow name" value={form.name} onChange={(e) => set({ name: e.target.value })} placeholder="e.g. Joint card → Personal budget" />
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-[11px] font-semibold uppercase text-muted-foreground">Data type</span>
+              <select
+                aria-label="Sync data type"
+                className={selectClass}
+                value={form.flowType}
+                onChange={(e) => set({ flowType: e.target.value as SyncFlowFormState["flowType"] })}
+              >
+                <option value="transaction_sync">Transactions</option>
+                <option value="payee_sync">Payees</option>
+                <option value="category_sync">Categories</option>
+              </select>
+            </div>
           </div>
 
           {/* Route (full width) */}
@@ -134,12 +156,12 @@ export function FlowEditDialog({
               )}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <div className="min-w-0 flex-1"><InlineEndpoint label="Source" endpoint={form.source} connections={connections} onChange={(source) => set({ source })} /></div>
+              <div className="min-w-0 flex-1"><InlineEndpoint label="Source" endpoint={form.source} connections={connections} entityMode={entityMode} onChange={(source) => set({ source })} /></div>
               <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <div className="min-w-0 flex-1"><InlineEndpoint label="Target" endpoint={form.target} connections={connections} onChange={(target) => set({ target })} /></div>
+              <div className="min-w-0 flex-1"><InlineEndpoint label="Target" endpoint={form.target} connections={connections} entityMode={entityMode} onChange={(target) => set({ target })} /></div>
             </div>
             {sameBudget && <p className="text-xs text-destructive">Source and target must be different budgets (cross-budget only).</p>}
-            <p className="text-xs text-muted-foreground">Source budget · account → target budget · account.</p>
+            <p className="text-xs text-muted-foreground">{entityMode ? "Source budget → target budget." : "Source budget · account → target budget · account."}</p>
           </section>
 
           {/* Automation policy (RD-054 / PR-020) */}
@@ -193,7 +215,44 @@ export function FlowEditDialog({
             )}
           </section>
 
-          {/* Transform + Filters, side by side at wide widths */}
+          {/* Master-data (entity) options */}
+          {entityMode && (
+            <section className="flex flex-col gap-3 border-t border-border py-4">
+              <h4 className="text-sm font-semibold">{form.flowType === "payee_sync" ? "Payees" : "Categories"}</h4>
+              <p className="text-xs text-muted-foreground">
+                Missing {form.flowType === "payee_sync" ? "payees" : "categories"} are created on the target; existing ones are matched by name. Nothing is renamed, deleted, or hidden.
+              </p>
+              {form.flowType === "category_sync" && (
+                <>
+                  <label className="flex max-w-md flex-col gap-1 text-xs text-muted-foreground">
+                    Default target group (optional)
+                    <Input
+                      aria-label="Default target group"
+                      value={form.entity.defaultGroupName}
+                      onChange={(e) => setEntity({ defaultGroupName: e.target.value })}
+                      placeholder="e.g. Uncategorized"
+                    />
+                    <span className="text-[11px]">Used when a category&apos;s source group has no matching group on the target.</span>
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      aria-label="Create missing groups"
+                      checked={form.entity.createMissingGroup}
+                      onChange={(e) => setEntity({ createMissingGroup: e.target.checked })}
+                    />
+                    Create missing groups on the target
+                  </label>
+                  <p className="text-xs text-muted-foreground">
+                    Without a default group or this option, a category with no matching target group is blocked for review.
+                  </p>
+                </>
+              )}
+            </section>
+          )}
+
+          {/* Transform + Filters (transactions only), side by side at wide widths */}
+          {!entityMode && (
           <div className="grid gap-6 border-t border-border pt-4 lg:grid-cols-2">
             <section className="flex flex-col gap-3">
               <h4 className="text-sm font-semibold">Transform</h4>
@@ -240,6 +299,7 @@ export function FlowEditDialog({
               <p className="text-xs text-muted-foreground">Sync-generated transactions are always excluded to prevent loops.</p>
             </section>
           </div>
+          )}
         </div>
 
         <DialogFooter className="flex-row items-center gap-2">

--- a/src/features/sync/components/FlowHeader.tsx
+++ b/src/features/sync/components/FlowHeader.tsx
@@ -96,14 +96,16 @@ export function FlowHeader({
   const targetConn = connections.find((c) => c.id === form.target.connectionId);
 
   return (
-    <header className="flex h-28 shrink-0 flex-col justify-center gap-2 border-b border-border px-5">
+    <header className="flex min-h-28 shrink-0 flex-col justify-center gap-2 border-b border-border px-5 py-3">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 flex-wrap items-center gap-3">
           <Endpoint endpoint={form.source} connection={sourceConn} showAccount={form.flowType === "transaction_sync"} />
           <ArrowRight className="h-5 w-5 shrink-0 text-muted-foreground" />
           <Endpoint endpoint={form.target} connection={targetConn} showAccount={form.flowType === "transaction_sync"} />
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        {/* Primary actions keep labels; secondary actions are icon-only so the
+            row never wraps and overflows the header. */}
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
           <Button
             size="sm"
             className="text-xs"
@@ -111,7 +113,7 @@ export function FlowHeader({
             disabled={!canPreview || previewing}
             title={!canPreview && previewDisabledReason ? previewDisabledReason : undefined}
           >
-            <Play className="h-3.5 w-3.5" /> {previewing ? "Previewing…" : "Sync Preview"}
+            <Play className="h-3.5 w-3.5" /> {previewing ? "Previewing…" : "Preview"}
           </Button>
           {showRunSafeSync && (
             <Button
@@ -123,17 +125,18 @@ export function FlowHeader({
               title="Preview and apply only safe changes now; uncertain items go to the review queue"
             >
               {runningSafeSync ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />}
-              {runningSafeSync ? "Syncing…" : "Run safe sync now"}
+              {runningSafeSync ? "Syncing…" : "Run safe sync"}
             </Button>
           )}
-          <Button size="sm" variant="outline" className="text-xs" onClick={onEdit}>
-            <Pencil className="h-3.5 w-3.5" /> Edit Flow
+          <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
+          <Button size="icon" variant="outline" className="h-8 w-8" onClick={onEdit} aria-label="Edit flow" title="Edit flow">
+            <Pencil className="h-3.5 w-3.5" />
           </Button>
-          <Button size="sm" variant="outline" className="text-xs" onClick={onCreateReverse} title="Create a mirror flow with source and target swapped">
-            <ArrowLeftRight className="h-3.5 w-3.5" /> Create Reverse Flow
+          <Button size="icon" variant="outline" className="h-8 w-8" onClick={onCreateReverse} aria-label="Create reverse flow" title="Create a mirror flow with source and target swapped">
+            <ArrowLeftRight className="h-3.5 w-3.5" />
           </Button>
-          <Button size="sm" variant="outline" className="text-xs" onClick={onShowHistory}>
-            <History className="h-3.5 w-3.5" /> History
+          <Button size="icon" variant="outline" className="h-8 w-8" onClick={onShowHistory} aria-label="Run history" title="Run history">
+            <History className="h-3.5 w-3.5" />
           </Button>
         </div>
       </div>

--- a/src/features/sync/components/FlowHeader.tsx
+++ b/src/features/sync/components/FlowHeader.tsx
@@ -35,7 +35,7 @@ function hostOf(connection: BrowserApiConnection | undefined): string {
   }
 }
 
-function Endpoint({ endpoint, connection }: { endpoint: SyncEndpointForm; connection?: BrowserApiConnection }) {
+function Endpoint({ endpoint, connection, showAccount }: { endpoint: SyncEndpointForm; connection?: BrowserApiConnection; showAccount: boolean }) {
   return (
     <div className="flex w-[22rem] shrink-0 flex-col gap-0.5 rounded-md border border-border bg-muted/30 px-3 py-2">
       <span className={cn("truncate font-mono text-[11px]", connection ? "text-muted-foreground" : "text-amber-600 dark:text-amber-400")}>
@@ -43,7 +43,7 @@ function Endpoint({ endpoint, connection }: { endpoint: SyncEndpointForm; connec
       </span>
       <span className="truncate text-[13px] font-semibold">
         {endpoint.budgetName || endpoint.budgetSyncId || "-"}
-        <span className="font-medium text-muted-foreground"> / {endpoint.accountName || "-"}</span>
+        {showAccount && <span className="font-medium text-muted-foreground"> / {endpoint.accountName || "-"}</span>}
       </span>
     </div>
   );
@@ -60,8 +60,13 @@ function automationChip(form: SyncFlowFormState): string {
   }
 }
 
+function typeLabel(form: SyncFlowFormState): string {
+  return form.flowType === "payee_sync" ? "Payees" : form.flowType === "category_sync" ? "Categories" : "Transactions";
+}
+
 function summaryChips(form: SyncFlowFormState): string[] {
-  const chips = ["Transactions", automationChip(form)]; // flow type + automation policy
+  const chips = [typeLabel(form), automationChip(form)]; // data type + automation policy
+  if (form.flowType !== "transaction_sync") return chips;
   chips.push(form.transform.amountDirection === "reverse" ? "Reverse sign" : "Same sign");
   chips.push(form.transform.missingPayee === "create" ? "Create missing payees" : "Leave payee empty");
   if (form.transform.notesMarkerEnabled) chips.push("Notes marker on");
@@ -94,9 +99,9 @@ export function FlowHeader({
     <header className="flex h-28 shrink-0 flex-col justify-center gap-2 border-b border-border px-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 flex-wrap items-center gap-3">
-          <Endpoint endpoint={form.source} connection={sourceConn} />
+          <Endpoint endpoint={form.source} connection={sourceConn} showAccount={form.flowType === "transaction_sync"} />
           <ArrowRight className="h-5 w-5 shrink-0 text-muted-foreground" />
-          <Endpoint endpoint={form.target} connection={targetConn} />
+          <Endpoint endpoint={form.target} connection={targetConn} showAccount={form.flowType === "transaction_sync"} />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Button

--- a/src/features/sync/components/FlowList.tsx
+++ b/src/features/sync/components/FlowList.tsx
@@ -63,9 +63,13 @@ export function FlowList({ flows, selectedFlowId, latestRuns, connections, onSel
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
         {flows.length === 0 ? (
-          <p className="px-2 py-8 text-center text-sm text-muted-foreground">No sync flows yet.</p>
+          <div className="px-3 py-8 text-center">
+            <p className="text-sm font-medium">No sync flows yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">Create one to copy data between two budgets.</p>
+            <Button size="sm" variant="outline" className="mt-3 text-xs" onClick={onCreate}><Plus className="h-3.5 w-3.5" /> New flow</Button>
+          </div>
         ) : filtered.length === 0 ? (
-          <p className="px-2 py-8 text-center text-sm text-muted-foreground">No flows match your search.</p>
+          <p className="px-2 py-8 text-center text-sm text-muted-foreground">No flows match “{search}”.</p>
         ) : (
           <div className="flex flex-col gap-0.5">
             {filtered.map((flow) => {

--- a/src/features/sync/components/FlowList.tsx
+++ b/src/features/sync/components/FlowList.tsx
@@ -95,6 +95,11 @@ export function FlowList({ flows, selectedFlowId, latestRuns, connections, onSel
                 >
                   <div className="flex items-center gap-2">
                     <span className="min-w-0 flex-1 truncate text-sm font-medium">{flow.name}</span>
+                    {flow.flowType !== "transaction_sync" && (
+                      <span className="shrink-0 rounded-full border border-border bg-muted px-1.5 py-px text-[10px] text-muted-foreground">
+                        {flow.flowType === "payee_sync" ? "Payees" : "Categories"}
+                      </span>
+                    )}
                     <span
                       className={cn("h-2 w-2 shrink-0 rounded-full", flow.enabled ? "bg-green-500" : "bg-muted-foreground/40")}
                       aria-hidden

--- a/src/features/sync/components/PreviewPanel.tsx
+++ b/src/features/sync/components/PreviewPanel.tsx
@@ -8,19 +8,21 @@ import { cn } from "@/lib/utils";
 import {
   filterCount,
   formatAmount,
-  groupLabel,
   matchesPreviewFilter,
-  PREVIEW_FILTERS,
+  previewFilters,
+  previewTiles,
   reviewQueueCount,
   splitPositions,
-  tileCounts,
+  statusLabel,
   type PreviewFilter,
   type PreviewRow,
+  type SyncKind,
 } from "../lib/previewRows";
 import type { ApplyRunResult } from "@/lib/sync/applyOrchestrator";
 import type { DryRunError, DryRunSummary } from "@/lib/sync/previewOrchestrator";
 
 type PreviewPanelProps = {
+  kind: SyncKind;
   summary: DryRunSummary | null;
   previewError: DryRunError | null;
   rows: PreviewRow[];
@@ -40,6 +42,18 @@ type PreviewPanelProps = {
 /** A preview reflects a point-in-time source snapshot; warn once it's this old. */
 const STALE_AFTER_MS = 120_000;
 
+/** The unit noun for a data type, used throughout the copy. */
+function noun(kind: SyncKind, plural = false): string {
+  const base = kind === "payee" ? "payee" : kind === "category" ? "category" : "change";
+  if (!plural) return base;
+  return kind === "category" ? "categories" : `${base}s`;
+}
+
+/** What the source scan counts, per data type. */
+function scannedNoun(kind: SyncKind): string {
+  return kind === "payee" ? "payees" : kind === "category" ? "categories" : "transactions";
+}
+
 function formatAge(ms: number): string {
   const mins = Math.round(ms / 60000);
   if (mins < 1) return "just now";
@@ -53,10 +67,8 @@ const TILE_BORDER: Record<string, string> = {
   new: "border-green-500/30", warn: "border-amber-400/30", bad: "border-destructive/40",
 };
 
-const COLUMN_COUNT = 10;
-
 export function PreviewPanel(props: PreviewPanelProps) {
-  const { summary, previewError, rows, selectedIds } = props;
+  const { kind, summary, previewError, rows, selectedIds } = props;
   const [filter, setFilter] = useState<PreviewFilter>("all");
 
   if (previewError) {
@@ -64,7 +76,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
       <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm">
         <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
         <div>
-          <p className="font-medium">Preview failed ({previewError.code})</p>
+          <p className="font-medium">Preview couldn&apos;t run</p>
           <p className="text-muted-foreground">{previewError.message}</p>
         </div>
       </div>
@@ -73,31 +85,33 @@ export function PreviewPanel(props: PreviewPanelProps) {
 
   if (!summary) return null;
 
-  const tiles = tileCounts(rows);
+  const tiles = previewTiles(rows, kind);
+  const filters = previewFilters(kind);
   const visible = rows.filter((r) => matchesPreviewFilter(r, filter));
   const selectedCount = rows.filter((r) => selectedIds.has(r.id)).length;
   const splits = splitPositions(rows);
   const reviewCount = reviewQueueCount(rows);
+  const columnCount = kind === "transaction" ? 10 : kind === "category" ? 5 : 4;
 
   return (
     <div className="flex flex-col gap-3.5">
       {props.applying && (
         <div className="flex items-center gap-2 rounded-md border border-blue-400/40 bg-blue-50/70 px-3.5 py-2.5 text-sm dark:bg-blue-950/20">
           <Loader2 className="h-4 w-4 shrink-0 animate-spin text-blue-600 dark:text-blue-400" />
-          <span>Syncing selected changes to the target budget… this can take a while on large budgets.</span>
+          <span>Syncing selected {noun(kind, true)} to the target budget… this can take a while on large budgets.</span>
         </div>
       )}
-      {!props.applying && props.applyResult && <ApplyResultBanner result={props.applyResult} />}
+      {!props.applying && props.applyResult && <ApplyResultBanner result={props.applyResult} kind={kind} />}
 
-      {/* Four grouped tiles — click to filter the table */}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-        <Tile value={tiles.new} label="New - ready to sync" tone="new" active={filter === "new"} onClick={() => setFilter("new")} />
-        <Tile value={tiles.needsReview} label="Needs review" tone="warn" active={filter === "needs_review"} onClick={() => setFilter("needs_review")} />
-        <Tile value={tiles.alreadySynced} label="Already synced" active={filter === "already_synced"} onClick={() => setFilter("already_synced")} />
-        <Tile value={tiles.blocked} label="Blocked" tone="bad" active={filter === "blocked"} onClick={() => setFilter("blocked")} />
+      {/* Grouped tiles — worded for the data type; click to filter the table */}
+      <div className={cn("grid gap-2", tiles.length === 4 ? "grid-cols-2 sm:grid-cols-4" : "grid-cols-2 sm:grid-cols-4")}>
+        {tiles.map((tile) => (
+          <Tile key={tile.key} value={tile.value} label={tile.label} tone={tile.tone} active={filter === tile.filter} onClick={() => setFilter(filter === tile.filter ? "all" : tile.filter)} />
+        ))}
       </div>
       <p className="text-xs tabular-nums text-muted-foreground">
-        {summary.sourceItemsScanned} items scanned · {summary.generatedTransactionsExcluded} sync-generated excluded · {summary.sourceItemsFilteredOut} filtered out
+        {summary.sourceItemsScanned} {scannedNoun(kind)} scanned
+        {kind === "transaction" && ` · ${summary.generatedTransactionsExcluded} sync-generated excluded · ${summary.sourceItemsFilteredOut} filtered out`}
         <PreviewFreshness previewedAt={props.previewedAt} readOnly={props.readOnly} />
       </p>
 
@@ -115,25 +129,27 @@ export function PreviewPanel(props: PreviewPanelProps) {
           <span>
             <strong className="font-semibold">Review queue · {reviewCount}</strong>
             <span className="block text-xs text-muted-foreground">
-              Automated sync can&apos;t apply these safely (duplicates, source changed or missing, blocked). Review and handle them yourself.
+              Automated sync leaves these for you — decide and apply them by hand.
             </span>
           </span>
         </button>
       )}
 
-      <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
-        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-        Target budget rules can adjust a created transaction&apos;s payee, category or notes.
-        {!props.readOnly && " Items that need review are skipped unless you select them."}
-      </p>
+      {kind === "transaction" && (
+        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          Target-budget rules can adjust a created transaction&apos;s payee, category, or notes.
+          {!props.readOnly && " Items that need review stay unchecked until you pick them."}
+        </p>
+      )}
 
-      {/* Table */}
+      {/* Change plan table */}
       <div className="overflow-hidden rounded-md border border-border">
         <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
-          <strong className="text-[13px]">Planned changes</strong>
+          <strong className="text-[13px]">Change plan</strong>
           <span className="text-xs tabular-nums text-muted-foreground">{visible.length} shown</span>
           <div className="flex flex-wrap gap-1">
-            {PREVIEW_FILTERS.map((f) => {
+            {filters.map((f) => {
               const count = filterCount(rows, f.key);
               const disabled = count === 0 && f.key !== "all";
               return (
@@ -144,7 +160,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
                   disabled={disabled}
                   onClick={() => setFilter(f.key)}
                   className={cn(
-                    "rounded-full border px-2.5 py-0.5 text-xs",
+                    "rounded-full border px-2.5 py-0.5 text-xs transition-colors",
                     filter === f.key
                       ? "border-foreground bg-foreground text-background"
                       : "border-border bg-background text-muted-foreground hover:bg-muted",
@@ -159,22 +175,18 @@ export function PreviewPanel(props: PreviewPanelProps) {
           </div>
           <div className="flex-1" />
           {props.readOnly ? (
-            <span className="text-xs text-muted-foreground">Read-only - viewing a past run</span>
+            <span className="text-xs text-muted-foreground">Read-only — a past run</span>
           ) : (
             <>
               {selectedCount > 0 && (
                 <Button size="sm" variant="ghost" onClick={props.onClearSelection} disabled={props.applying}>Clear</Button>
               )}
-              <Button size="sm" variant="outline" onClick={props.onSelectAllSafeNew} disabled={props.applying}>Select all safe new</Button>
+              <Button size="sm" variant="outline" onClick={props.onSelectAllSafeNew} disabled={props.applying}>Select all new</Button>
               <Button size="sm" onClick={props.onApply} disabled={selectedCount === 0 || props.applying}>
                 {props.applying ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing…
-                  </>
+                  <><Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing…</>
                 ) : (
-                  <>
-                    Sync selected{selectedCount > 0 && <span className="tabular-nums"> · {selectedCount}</span>}
-                  </>
+                  <>Sync selected{selectedCount > 0 && <span className="tabular-nums"> · {selectedCount}</span>}</>
                 )}
               </Button>
             </>
@@ -187,13 +199,28 @@ export function PreviewPanel(props: PreviewPanelProps) {
               <tr className="[&>th]:whitespace-nowrap [&>th]:px-2 [&>th]:py-1.5 [&>th]:font-medium">
                 <th className="w-8" />
                 <th>Status</th>
-                <th>Date</th>
-                <th>Payee</th>
-                <th>Category</th>
-                <th>Notes</th>
-                <th className="text-right">Source</th>
-                <th className="text-right">Target</th>
-                <th>Target payee</th>
+                {kind === "transaction" ? (
+                  <>
+                    <th>Date</th>
+                    <th>Payee</th>
+                    <th>Category</th>
+                    <th>Notes</th>
+                    <th className="text-right">Source</th>
+                    <th className="text-right">Target</th>
+                    <th>Target payee</th>
+                  </>
+                ) : kind === "category" ? (
+                  <>
+                    <th>Category</th>
+                    <th>Group</th>
+                    <th>On target</th>
+                  </>
+                ) : (
+                  <>
+                    <th>Payee</th>
+                    <th>On target</th>
+                  </>
+                )}
                 <th>Details</th>
               </tr>
             </thead>
@@ -201,6 +228,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
               {visible.map((row) => {
                 const pos = splits.get(row.id);
                 const details = row.message ?? row.flags.join(", ");
+                const onTarget = row.classification === "already_synced" || row.classification === "target_name_match" ? "Linked" : row.group === "new" ? "New" : "—";
                 return (
                   <tr
                     key={row.id}
@@ -208,25 +236,40 @@ export function PreviewPanel(props: PreviewPanelProps) {
                     className={cn("border-t border-border/60 [&>td]:whitespace-nowrap [&>td]:px-2 [&>td]:py-1.5", !row.selectable && "text-muted-foreground")}
                   >
                     <td>
-                      <input type="checkbox" aria-label={`Select ${row.sourceItemKey}`} disabled={!row.selectable || props.readOnly} checked={selectedIds.has(row.id)} onChange={() => props.onToggle(row.id)} />
+                      <input type="checkbox" aria-label={`Select ${row.source.payeeName ?? row.sourceItemKey}`} disabled={!row.selectable || props.readOnly} checked={selectedIds.has(row.id)} onChange={() => props.onToggle(row.id)} />
                     </td>
                     <td>
-                      <Badge variant={badgeVariant(row.group)} className="text-[10px]">{groupLabel(row.group)}</Badge>
+                      <Badge variant={badgeVariant(row)} className="text-[10px]">{statusLabel(row)}</Badge>
                       {row.isSplit && <span className="ml-1 text-[10px] text-muted-foreground">split{pos ? ` ${pos.index}/${pos.total}` : ""}</span>}
                     </td>
-                    <td className="tabular-nums">{row.source.date}</td>
-                    <td><span className="block max-w-[10rem] truncate" title={row.source.payeeName ?? undefined}>{row.source.payeeName ?? "-"}</span></td>
-                    <td><span className="block max-w-[9rem] truncate" title={row.source.categoryName ?? undefined}>{row.source.categoryName ?? "-"}</span></td>
-                    <td><span className="block max-w-[12rem] truncate" title={row.source.notes ?? undefined}>{row.source.notes ?? "-"}</span></td>
-                    <td className="text-right tabular-nums">{formatAmount(row.source.amount)}</td>
-                    <td className="text-right tabular-nums">{formatAmount(row.target.amount)}</td>
-                    <td><span className="block max-w-[10rem] truncate" title={row.target.payeeName ?? undefined}>{row.target.payeeName ?? "-"}</span></td>
-                    <td className="text-[11px] text-muted-foreground"><span className="block max-w-[12rem] truncate" title={details || undefined}>{details || "-"}</span></td>
+                    {kind === "transaction" ? (
+                      <>
+                        <td className="tabular-nums">{row.source.date}</td>
+                        <td><Truncate text={row.source.payeeName} width="10rem" /></td>
+                        <td><Truncate text={row.source.categoryName} width="9rem" /></td>
+                        <td><Truncate text={row.source.notes} width="12rem" /></td>
+                        <td className="text-right tabular-nums">{formatAmount(row.source.amount)}</td>
+                        <td className="text-right tabular-nums">{formatAmount(row.target.amount)}</td>
+                        <td><Truncate text={row.target.payeeName} width="10rem" /></td>
+                      </>
+                    ) : kind === "category" ? (
+                      <>
+                        <td><Truncate text={row.source.payeeName} width="12rem" /></td>
+                        <td><Truncate text={row.source.categoryName} width="10rem" /></td>
+                        <td className="text-muted-foreground">{onTarget}</td>
+                      </>
+                    ) : (
+                      <>
+                        <td><Truncate text={row.source.payeeName} width="16rem" /></td>
+                        <td className="text-muted-foreground">{onTarget}</td>
+                      </>
+                    )}
+                    <td className="text-[11px] text-muted-foreground"><Truncate text={details || null} width="12rem" /></td>
                   </tr>
                 );
               })}
               {visible.length === 0 && (
-                <tr><td colSpan={COLUMN_COUNT} className="px-3 py-6 text-center text-sm text-muted-foreground">No items in this group.</td></tr>
+                <tr><td colSpan={columnCount} className="px-3 py-8 text-center text-sm text-muted-foreground">Nothing here — try another filter.</td></tr>
               )}
             </tbody>
           </table>
@@ -234,6 +277,10 @@ export function PreviewPanel(props: PreviewPanelProps) {
       </div>
     </div>
   );
+}
+
+function Truncate({ text, width }: { text: string | null | undefined; width: string }) {
+  return <span className="block truncate" style={{ maxWidth: width }} title={text ?? undefined}>{text ?? "—"}</span>;
 }
 
 function PreviewFreshness({ previewedAt, readOnly }: { previewedAt: string | null; readOnly: boolean }) {
@@ -255,7 +302,7 @@ function PreviewFreshness({ previewedAt, readOnly }: { previewedAt: string | nul
     <span className={cn(stale && "font-medium text-amber-600 dark:text-amber-400")}>
       {" · "}
       {readOnly ? `Run from ${label}` : `Previewed ${label}`}
-      {stale && " — source may have changed, re-run Sync Preview"}
+      {stale && " — source may have changed; preview again"}
     </span>
   );
 }
@@ -278,27 +325,30 @@ function Tile({ value, label, tone, active, onClick }: { value: number; label: s
   );
 }
 
-function badgeVariant(group: PreviewRow["group"]): "status-active" | "status-warning" | "secondary" {
-  if (group === "new") return "status-active";
-  if (group === "duplicate" || group === "source_changed" || group === "marker_match" || group === "blocked") return "status-warning";
+function badgeVariant(row: PreviewRow): "status-active" | "status-warning" | "secondary" {
+  if (row.group === "new") return "status-active";
+  if (row.classification === "target_name_match" || row.group === "marker_match") return "secondary";
+  if (row.group === "duplicate" || row.group === "source_changed" || row.group === "blocked") return "status-warning";
   return "secondary";
 }
 
-function ApplyResultBanner({ result }: { result: ApplyRunResult }) {
+function ApplyResultBanner({ result, kind }: { result: ApplyRunResult; kind: SyncKind }) {
   const tone = result.status === "applied" ? "border-green-500/30 bg-green-50 text-green-700 dark:bg-green-950/20 dark:text-green-400"
     : result.status === "partial" ? "border-amber-400/30 bg-amber-50 text-amber-700 dark:bg-amber-950/20 dark:text-amber-400"
     : "border-destructive/40 bg-destructive/10 text-destructive";
   const Icon = result.status === "failed" ? XCircle : CheckCircle2;
   const unresolved = result.items.filter((i) => i.outcome === "failed").length;
+  const created = kind === "transaction" ? "created" : `${noun(kind, true)} created`;
+  const linked = kind === "transaction" ? "re-linked to an existing transaction" : "linked to an existing one";
   const headline =
     result.status === "applied" ? "Synced." : result.status === "partial" ? "Partially synced." : "Sync failed.";
   return (
     <div className={cn("flex items-start gap-2 rounded-md border px-3.5 py-2.5 text-sm", tone)}>
       <Icon className="mt-0.5 h-4 w-4 shrink-0" />
       <div>
-        <p><strong className="font-semibold">{headline}</strong> {result.counts.applied} created · {result.counts.repaired} re-linked to an existing transaction · {result.counts.failed} failed.</p>
-        {result.counts.appliedWithWarnings > 0 && <p className="text-xs opacity-90">{result.counts.appliedWithWarnings} were adjusted by target-budget rules. Synced items now show as “Already synced” on the next preview.</p>}
-        {unresolved > 0 && <p className="text-xs opacity-90">{unresolved} could not be confirmed - a transaction may have been created but was not linked.</p>}
+        <p><strong className="font-semibold">{headline}</strong> {result.counts.applied} {created} · {result.counts.repaired} {linked} · {result.counts.failed} failed.</p>
+        {result.counts.appliedWithWarnings > 0 && <p className="text-xs opacity-90">{result.counts.appliedWithWarnings} were adjusted by target-budget rules. They show as “Already synced” next time.</p>}
+        {unresolved > 0 && <p className="text-xs opacity-90">{unresolved} couldn&apos;t be confirmed on the target.</p>}
       </div>
     </div>
   );

--- a/src/features/sync/components/PreviewPanel.tsx
+++ b/src/features/sync/components/PreviewPanel.tsx
@@ -103,8 +103,8 @@ export function PreviewPanel(props: PreviewPanelProps) {
       )}
       {!props.applying && props.applyResult && <ApplyResultBanner result={props.applyResult} kind={kind} />}
 
-      {/* Grouped tiles — worded for the data type; click to filter the table */}
-      <div className={cn("grid gap-2", tiles.length === 4 ? "grid-cols-2 sm:grid-cols-4" : "grid-cols-2 sm:grid-cols-4")}>
+      {/* Grouped tiles - worded for the data type; click to filter the table */}
+      <div className={cn("grid grid-cols-2 gap-2", tiles.length === 3 ? "sm:grid-cols-3" : "sm:grid-cols-4")}>
         {tiles.map((tile) => (
           <Tile key={tile.key} value={tile.value} label={tile.label} tone={tile.tone} active={filter === tile.filter} onClick={() => setFilter(filter === tile.filter ? "all" : tile.filter)} />
         ))}
@@ -129,7 +129,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
           <span>
             <strong className="font-semibold">Review queue · {reviewCount}</strong>
             <span className="block text-xs text-muted-foreground">
-              Automated sync leaves these for you — decide and apply them by hand.
+              Automated sync leaves these for you - decide and apply them by hand.
             </span>
           </span>
         </button>
@@ -175,7 +175,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
           </div>
           <div className="flex-1" />
           {props.readOnly ? (
-            <span className="text-xs text-muted-foreground">Read-only — a past run</span>
+            <span className="text-xs text-muted-foreground">Read-only - a past run</span>
           ) : (
             <>
               {selectedCount > 0 && (
@@ -228,7 +228,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
               {visible.map((row) => {
                 const pos = splits.get(row.id);
                 const details = row.message ?? row.flags.join(", ");
-                const onTarget = row.classification === "already_synced" || row.classification === "target_name_match" ? "Linked" : row.group === "new" ? "New" : "—";
+                const onTarget = row.classification === "already_synced" || row.classification === "target_name_match" ? "Linked" : row.group === "new" ? "New" : "-";
                 return (
                   <tr
                     key={row.id}
@@ -269,7 +269,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
                 );
               })}
               {visible.length === 0 && (
-                <tr><td colSpan={columnCount} className="px-3 py-8 text-center text-sm text-muted-foreground">Nothing here — try another filter.</td></tr>
+                <tr><td colSpan={columnCount} className="px-3 py-8 text-center text-sm text-muted-foreground">Nothing here - try another filter.</td></tr>
               )}
             </tbody>
           </table>
@@ -280,7 +280,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
 }
 
 function Truncate({ text, width }: { text: string | null | undefined; width: string }) {
-  return <span className="block truncate" style={{ maxWidth: width }} title={text ?? undefined}>{text ?? "—"}</span>;
+  return <span className="block truncate" style={{ maxWidth: width }} title={text ?? undefined}>{text ?? "-"}</span>;
 }
 
 function PreviewFreshness({ previewedAt, readOnly }: { previewedAt: string | null; readOnly: boolean }) {
@@ -302,7 +302,7 @@ function PreviewFreshness({ previewedAt, readOnly }: { previewedAt: string | nul
     <span className={cn(stale && "font-medium text-amber-600 dark:text-amber-400")}>
       {" · "}
       {readOnly ? `Run from ${label}` : `Previewed ${label}`}
-      {stale && " — source may have changed; preview again"}
+      {stale && " - source may have changed; preview again"}
     </span>
   );
 }

--- a/src/features/sync/components/SyncView.test.tsx
+++ b/src/features/sync/components/SyncView.test.tsx
@@ -107,7 +107,7 @@ describe("SyncView", () => {
     fireEvent.click(previewButtons[0]);
 
     expect(previewMutate).toHaveBeenCalledTimes(1);
-    expect(await screen.findByText("Planned changes")).toBeInTheDocument();
+    expect(await screen.findByText("Change plan")).toBeInTheDocument();
 
     const rows = screen.getAllByTestId("preview-row");
     expect(rows).toHaveLength(2);

--- a/src/features/sync/components/SyncView.test.tsx
+++ b/src/features/sync/components/SyncView.test.tsx
@@ -102,7 +102,7 @@ describe("SyncView", () => {
     render(<SyncView />);
     fireEvent.click(screen.getByText("Card sync"));
 
-    const previewButtons = await screen.findAllByRole("button", { name: /sync preview/i });
+    const previewButtons = await screen.findAllByRole("button", { name: /^preview$/i });
     await waitFor(() => expect(previewButtons[0]).toBeEnabled());
     fireEvent.click(previewButtons[0]);
 
@@ -120,7 +120,7 @@ describe("SyncView", () => {
     setup([conn1, conn2]);
     render(<SyncView />);
     fireEvent.click(screen.getByText("Card sync"));
-    const previewButtons = await screen.findAllByRole("button", { name: /sync preview/i });
+    const previewButtons = await screen.findAllByRole("button", { name: /^preview$/i });
     await waitFor(() => expect(previewButtons[0]).toBeEnabled());
     fireEvent.click(previewButtons[0]);
 

--- a/src/features/sync/components/SyncView.tsx
+++ b/src/features/sync/components/SyncView.tsx
@@ -240,7 +240,7 @@ export function SyncView() {
     flowsQuery.refetch();
     const name = flowName(flowId);
     if (result.status === "failed" || result.status === "partial") {
-      setAutoNotice(`Auto-sync for “${name}” ${result.status === "partial" ? "partially applied — some items failed" : "failed"}.`);
+      setAutoNotice(`Auto-sync for “${name}” ${result.status === "partial" ? "partially applied - some items failed" : "failed"}.`);
     } else if (result.status === "preview_failed") {
       setAutoNotice(`Auto-sync preview for “${name}” failed: ${result.error.message}`);
     } else if (result.status === "applied" || result.status === "no_safe_items") {
@@ -350,7 +350,7 @@ export function SyncView() {
             <div>
               <h3 className="text-base font-semibold">Budget File Sync</h3>
               <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-                Copy transactions, payees, or categories from one budget to another — preview first, apply what you choose. Pick a flow on the left, or create one.
+                Copy transactions, payees, or categories from one budget to another - preview first, apply what you choose. Pick a flow on the left, or create one.
               </p>
             </div>
             <Button size="sm" onClick={handleCreate}><Plus className="h-4 w-4" /> New sync flow</Button>
@@ -466,9 +466,9 @@ export function SyncView() {
                   <Play className="h-6 w-6 text-muted-foreground" />
                   <h3 className="text-base font-semibold">See what will change first</h3>
                   <p className="max-w-md text-sm text-muted-foreground">
-                    <strong>Sync Preview</strong> (top right) builds a change plan — every {kind === "transaction" ? "transaction" : kind} that would be created in{" "}
+                    <strong>Preview</strong> (top right) builds a change plan - every {kind === "transaction" ? "transaction" : kind} that would be created in{" "}
                     <strong>{form.target.budgetName || "the target"}</strong> from{" "}
-                    <strong>{form.source.budgetName || "the source"}</strong> — with nothing written to Actual until you review and sync.
+                    <strong>{form.source.budgetName || "the source"}</strong> - with nothing written to Actual until you review and sync.
                   </p>
                   {blockReason && <p className="text-xs font-medium text-amber-600 dark:text-amber-400">{blockReason}</p>}
                 </div>

--- a/src/features/sync/components/SyncView.tsx
+++ b/src/features/sync/components/SyncView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, Bell, Loader2, Play, XCircle } from "lucide-react";
+import { ArrowLeft, ArrowLeftRight, Bell, Loader2, Play, Plus, XCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DirectOnlyNotice } from "./DirectOnlyNotice";
@@ -22,7 +22,7 @@ import {
   missingRouteFields,
   type SyncFlowFormState,
 } from "../lib/flowForm";
-import { selectableRowIds, toPreviewRow } from "../lib/previewRows";
+import { selectableRowIds, syncKindOf, toPreviewRow } from "../lib/previewRows";
 import { buildReverseFlowForm } from "../lib/reverseFlow";
 import { relativeTime, toRunRow } from "../lib/runsView";
 import type { SyncFlowRun } from "@/lib/app-db/types";
@@ -90,6 +90,8 @@ export function SyncView() {
   const runsQuery = useFlowRuns(selectedFlowId);
 
   const flows = flowsQuery.data ?? [];
+  const selectedFlow = flows.find((f) => f.id === selectedFlowId);
+  const kind = syncKindOf(selectedFlow?.flowType ?? "transaction_sync");
   useEffect(() => {
     if (!selectedFlowId) return;
     const flow = flows.find((f) => f.id === selectedFlowId);
@@ -341,8 +343,17 @@ export function SyncView() {
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {!selectedFlowId ? (
-          <div className="flex min-h-0 flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
-            Budget File Sync - select a sync flow, or create one to get started.
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full border border-border bg-muted/50">
+              <ArrowLeftRight className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div>
+              <h3 className="text-base font-semibold">Budget File Sync</h3>
+              <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                Copy transactions, payees, or categories from one budget to another — preview first, apply what you choose. Pick a flow on the left, or create one.
+              </p>
+            </div>
+            <Button size="sm" onClick={handleCreate}><Plus className="h-4 w-4" /> New sync flow</Button>
           </div>
         ) : (
           <>
@@ -407,6 +418,7 @@ export function SyncView() {
                         )}
                       </div>
                       <PreviewPanel
+                        kind={kind}
                         summary={summary}
                         previewError={null}
                         rows={rows}
@@ -435,6 +447,7 @@ export function SyncView() {
                 </div>
               ) : runId || previewError ? (
                 <PreviewPanel
+                  kind={kind}
                   summary={summary}
                   previewError={previewError}
                   rows={rows}
@@ -449,15 +462,15 @@ export function SyncView() {
                   applyResult={applyResult}
                 />
               ) : (
-                <div className="flex flex-col items-center gap-3 rounded-md border border-border bg-background px-6 py-14 text-center shadow-sm">
+                <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border bg-background px-6 py-16 text-center">
                   <Play className="h-6 w-6 text-muted-foreground" />
-                  <h3 className="text-base font-semibold">Preview this flow</h3>
+                  <h3 className="text-base font-semibold">See what will change first</h3>
                   <p className="max-w-md text-sm text-muted-foreground">
-                    Use <strong>Sync Preview</strong> (top right) to see exactly which transactions would be created in{" "}
-                    <strong>{form.target.budgetName || "the target"} / {form.target.accountName || "account"}</strong> from{" "}
-                    <strong>{form.source.budgetName || "the source"} / {form.source.accountName || "account"}</strong>. Nothing is written to Actual until you review and sync.
+                    <strong>Sync Preview</strong> (top right) builds a change plan — every {kind === "transaction" ? "transaction" : kind} that would be created in{" "}
+                    <strong>{form.target.budgetName || "the target"}</strong> from{" "}
+                    <strong>{form.source.budgetName || "the source"}</strong> — with nothing written to Actual until you review and sync.
                   </p>
-                  {blockReason && <p className="text-xs text-muted-foreground">{blockReason}</p>}
+                  {blockReason && <p className="text-xs font-medium text-amber-600 dark:text-amber-400">{blockReason}</p>}
                 </div>
               )}
             </div>

--- a/src/features/sync/hooks/useSyncScheduler.ts
+++ b/src/features/sync/hooks/useSyncScheduler.ts
@@ -20,7 +20,7 @@ import type { SafeSyncResult } from "@/lib/sync/safeSyncOrchestrator";
  * connections are unlocked**. All the actual gating lives in the pure
  * `selectFlowsToAutoRun`; this hook is just the timer + non-overlap bookkeeping.
  *
- * Not a background daemon — nothing runs when the app is closed (that is RD-058).
+ * Not a background daemon - nothing runs when the app is closed (that is RD-058).
  */
 
 const TICK_MS = 60_000;
@@ -46,7 +46,7 @@ export function useSyncScheduler(params: {
   const inFlightRef = useRef<Set<string>>(new Set());
   const lastRunRef = useRef<Map<string, number>>(new Map());
   const failuresRef = useRef<Map<string, number>>(new Map());
-  // Flows paused this session — a local guard so a slow enabled=false persist
+  // Flows paused this session - a local guard so a slow enabled=false persist
   // can't let one more auto run slip through before the DB reflects the pause.
   const pausedRef = useRef<Set<string>>(new Set());
 

--- a/src/features/sync/lib/clientOrchestration.ts
+++ b/src/features/sync/lib/clientOrchestration.ts
@@ -22,7 +22,7 @@ import * as api from "./syncApi";
  * Client-side wiring for the Budget File Sync orchestrators (RD-053 / PR-019
  * Slice 5). The preview/apply orchestrators run in the browser (they need the
  * Direct transport); their DB ports are satisfied by the server routes via
- * `syncApi`. No planner/apply logic is duplicated here — this only assembles
+ * `syncApi`. No planner/apply logic is duplicated here - this only assembles
  * ports and calls the existing orchestrators.
  */
 
@@ -64,7 +64,7 @@ function applyStore(): ApplyStore {
 
   // Per-item mapping creates and status updates are buffered and flushed in one
   // request each (one insert-transaction + one update-transaction) instead of an
-  // HTTP round-trip per item — the dominant apply cost on large runs. The
+  // HTTP round-trip per item - the dominant apply cost on large runs. The
   // durable target `imported_id` marker is the real idempotency guarantee, so a
   // deferred flush cannot cause duplicates even if the tab closes mid-run.
   const pendingMappings: SyncMappingInput[] = [];

--- a/src/features/sync/lib/flowForm.test.ts
+++ b/src/features/sync/lib/flowForm.test.ts
@@ -96,12 +96,12 @@ describe("validation", () => {
     sameAccount.target = { ...sameAccount.source };
     expect(isSameBudget(sameAccount)).toBe(true);
 
-    // Same budget file, different account — still blocked (cross-budget only).
+    // Same budget file, different account - still blocked (cross-budget only).
     const sameBudget = filledForm();
     sameBudget.target = { ...sameBudget.source, accountId: "acct-other", accountName: "Savings" };
     expect(isSameBudget(sameBudget)).toBe(true);
 
-    // Different budgets — allowed.
+    // Different budgets - allowed.
     expect(isSameBudget(filledForm())).toBe(false);
   });
 });

--- a/src/features/sync/lib/flowForm.test.ts
+++ b/src/features/sync/lib/flowForm.test.ts
@@ -45,6 +45,44 @@ describe("form defaults", () => {
     expect(emptyFlowForm().automation.reviewPolicy).toBe("manual_preview_required");
     expect(emptyFlowForm().automation.intervalMinutes).toBe("60");
   });
+
+  it("defaults to a transaction flow", () => {
+    expect(emptyFlowForm().flowType).toBe("transaction_sync");
+  });
+});
+
+describe("entity (master-data) flows", () => {
+  function entityForm(): SyncFlowFormState {
+    const form = emptyFlowForm();
+    form.name = "Payee sync";
+    form.flowType = "category_sync";
+    form.source = { connectionId: "c-src", budgetSyncId: "budget-src", budgetName: "Home", accountId: "", accountName: "" };
+    form.target = { connectionId: "c-tgt", budgetSyncId: "budget-tgt", budgetName: "Family", accountId: "", accountName: "" };
+    form.entity = { defaultGroupName: "Uncategorized", createMissingGroup: true };
+    return form;
+  }
+
+  it("requires only budgets (not accounts) for an entity flow", () => {
+    expect(missingRouteFields(entityForm())).toEqual([]);
+    const noBudget = entityForm();
+    noBudget.source.connectionId = "";
+    expect(missingRouteFields(noBudget)).toContain("source budget");
+  });
+
+  it("round-trips flow type and entity options through the payload", () => {
+    const payload = buildFlowPayload(entityForm(), instances) as JsonObject & { legs: JsonObject[]; flowType: string };
+    expect(payload.flowType).toBe("category_sync");
+    const leg = payload.legs[0] as Record<string, { version: number; data: JsonObject }>;
+    expect(leg.options.data).toMatchObject({ defaultGroupName: "Uncategorized", createMissingGroup: true });
+
+    const flow: SyncFlow = {
+      id: "flow-1", name: "Payee sync", enabled: true, flowType: "category_sync", description: null, createdAt: "", updatedAt: "",
+      legs: [{ id: "leg-1", flowId: "flow-1", position: 0, sourceRef: leg.sourceRef, targetRef: leg.targetRef, filter: leg.filter, transform: leg.transform, options: leg.options, createdAt: "", updatedAt: "" }],
+    };
+    const form = flowToFormState(flow, instances);
+    expect(form.flowType).toBe("category_sync");
+    expect(form.entity).toEqual({ defaultGroupName: "Uncategorized", createMissingGroup: true });
+  });
 });
 
 describe("validation", () => {

--- a/src/features/sync/lib/flowForm.ts
+++ b/src/features/sync/lib/flowForm.ts
@@ -64,15 +64,33 @@ export type SyncAutomationForm = {
   exactDuplicateAutoMap: boolean;
 };
 
+/** Which data type the flow syncs (RD-055). Determines the engine adapter. */
+export type SyncFlowType = "transaction_sync" | "payee_sync" | "category_sync";
+
+/** Master-data (entity) options; only meaningful for payee/category flows. */
+export type SyncEntityForm = {
+  /** Category-only: create categories under this group when none matches. */
+  defaultGroupName: string;
+  /** Category-only: create a missing target group instead of blocking. */
+  createMissingGroup: boolean;
+};
+
 export type SyncFlowFormState = {
   name: string;
   enabled: boolean;
+  flowType: SyncFlowType;
   source: SyncEndpointForm;
   target: SyncEndpointForm;
   filter: SyncFilterForm;
   transform: SyncTransformForm;
   automation: SyncAutomationForm;
+  entity: SyncEntityForm;
 };
+
+/** True for a master-data (payee/category) flow. */
+export function isEntityFlow(flowType: SyncFlowType): boolean {
+  return flowType === "payee_sync" || flowType === "category_sync";
+}
 
 export const EMPTY_ENDPOINT: SyncEndpointForm = {
   connectionId: "",
@@ -86,6 +104,7 @@ export function emptyFlowForm(): SyncFlowFormState {
   return {
     name: "",
     enabled: true,
+    flowType: "transaction_sync",
     source: { ...EMPTY_ENDPOINT },
     target: { ...EMPTY_ENDPOINT },
     filter: {
@@ -115,6 +134,7 @@ export function emptyFlowForm(): SyncFlowFormState {
       autoPausedAt: null,
       exactDuplicateAutoMap: false,
     },
+    entity: { defaultGroupName: "", createMissingGroup: false },
   };
 }
 
@@ -122,6 +142,12 @@ export function emptyFlowForm(): SyncFlowFormState {
 export function missingRouteFields(form: SyncFlowFormState): string[] {
   const missing: string[] = [];
   if (!form.name.trim()) missing.push("name");
+  // Entity flows sync at the budget level (no account); transactions need an account.
+  if (isEntityFlow(form.flowType)) {
+    if (!form.source.connectionId) missing.push("source budget");
+    if (!form.target.connectionId) missing.push("target budget");
+    return missing;
+  }
   if (!form.source.connectionId || !form.source.accountId) missing.push("source account");
   if (!form.target.connectionId || !form.target.accountId) missing.push("target account");
   return missing;
@@ -207,6 +233,9 @@ export function buildFlowPayload(
     intervalMinutes: clampSyncInterval(form.automation.intervalMinutes),
     autoPausedAt: form.automation.autoPausedAt,
     exactDuplicateAutoMap: form.automation.exactDuplicateAutoMap,
+    // Master-data (entity) options — ignored by transaction flows.
+    defaultGroupName: form.entity.defaultGroupName.trim() || null,
+    createMissingGroup: form.entity.createMissingGroup,
   };
 
   // Each leg ref/filter/transform must be a versioned JSON envelope, matching
@@ -216,7 +245,7 @@ export function buildFlowPayload(
   return {
     name: form.name.trim(),
     enabled: form.enabled,
-    flowType: "transaction_sync",
+    flowType: form.flowType,
     legs: [
       {
         sourceRef: envelope(sourceRef),
@@ -248,6 +277,12 @@ export function flowToFormState(
 
   form.name = flow.name;
   form.enabled = flow.enabled;
+  form.flowType = flow.flowType === "payee_sync" || flow.flowType === "category_sync" ? flow.flowType : "transaction_sync";
+  const options = (flow.legs[0]?.options.data ?? {}) as Record<string, unknown>;
+  form.entity = {
+    defaultGroupName: typeof options.defaultGroupName === "string" ? options.defaultGroupName : "",
+    createMissingGroup: options.createMissingGroup === true,
+  };
   form.source = {
     connectionId: resolveConnectionId(config.sourceConnectionFingerprint, config.sourceBudgetId),
     budgetSyncId: config.sourceBudgetId,

--- a/src/features/sync/lib/flowForm.ts
+++ b/src/features/sync/lib/flowForm.ts
@@ -19,7 +19,7 @@ import type {
  * The persisted flow stores only non-secret references (connection fingerprint,
  * budget sync id, account id, display names). The live connection (with its
  * password) is resolved at preview/apply time from the in-memory connection
- * store by fingerprint — never persisted here.
+ * store by fingerprint - never persisted here.
  */
 
 export type SyncEndpointForm = {
@@ -128,7 +128,7 @@ export function emptyFlowForm(): SyncFlowFormState {
       copySourceNotes: true,
     },
     automation: {
-      // Existing/new flows stay manual — RD-053 behavior — until opted in.
+      // Existing/new flows stay manual - RD-053 behavior - until opted in.
       reviewPolicy: "manual_preview_required",
       intervalMinutes: String(DEFAULT_SYNC_INTERVAL_MINUTES),
       autoPausedAt: null,
@@ -156,7 +156,7 @@ export function missingRouteFields(form: SyncFlowFormState): string[] {
 /**
  * MVP is cross-budget only. Two accounts in the *same* budget file is not
  * supported, so any flow whose source and target resolve to the same budget is
- * blocked — regardless of account.
+ * blocked - regardless of account.
  */
 export function isSameBudget(form: SyncFlowFormState): boolean {
   return !!form.source.budgetSyncId && form.source.budgetSyncId === form.target.budgetSyncId;
@@ -233,7 +233,7 @@ export function buildFlowPayload(
     intervalMinutes: clampSyncInterval(form.automation.intervalMinutes),
     autoPausedAt: form.automation.autoPausedAt,
     exactDuplicateAutoMap: form.automation.exactDuplicateAutoMap,
-    // Master-data (entity) options — ignored by transaction flows.
+    // Master-data (entity) options - ignored by transaction flows.
     defaultGroupName: form.entity.defaultGroupName.trim() || null,
     createMissingGroup: form.entity.createMissingGroup,
   };

--- a/src/features/sync/lib/previewRows.test.ts
+++ b/src/features/sync/lib/previewRows.test.ts
@@ -4,10 +4,14 @@ import {
   formatAmount,
   isReviewRequired,
   matchesPreviewFilter,
+  previewFilters,
+  previewTiles,
   reviewQueueCount,
   reviewQueueRows,
   selectableRowIds,
   splitPositions,
+  statusLabel,
+  syncKindOf,
   toPreviewRow,
 } from "./previewRows";
 import type { SyncFlowRunItem } from "@/lib/app-db/types";
@@ -129,6 +133,37 @@ describe("review queue (RD-054)", () => {
     expect(matchesPreviewFilter(dup, "review_queue")).toBe(true);
     expect(matchesPreviewFilter(dupApplied, "review_queue")).toBe(false);
     expect(matchesPreviewFilter(fresh, "review_queue")).toBe(false);
+  });
+});
+
+describe("kind-aware rendering (RD-055 UI)", () => {
+  it("maps flow types to a data-type kind", () => {
+    expect(syncKindOf("transaction_sync")).toBe("transaction");
+    expect(syncKindOf("payee_sync")).toBe("payee");
+    expect(syncKindOf("category_sync")).toBe("category");
+  });
+
+  it("carries the entity type onto the row", () => {
+    expect(toPreviewRow(item({ sourceEntityType: "payee" })).entityType).toBe("payee");
+    expect(toPreviewRow(item()).entityType).toBe("transaction");
+  });
+
+  it("labels an entity name match as 'Name match', not 'Marker match'", () => {
+    const row = toPreviewRow(item({ sourceEntityType: "payee", classification: "target_name_match" }));
+    expect(statusLabel(row)).toBe("Name match");
+    expect(statusLabel(toPreviewRow(item({ classification: "new" })))).toBe("New");
+  });
+
+  it("words tiles and filters per data type", () => {
+    const rows = [toPreviewRow(item({ sourceEntityType: "payee", classification: "new" }))];
+    const txn = previewTiles(rows, "transaction").map((t) => t.label);
+    expect(txn).toContain("Needs review");
+    const payee = previewTiles(rows, "payee").map((t) => t.label);
+    expect(payee).toContain("New payees");
+    expect(payee).not.toContain("Needs review");
+    // Entity filters drop transaction-only groups.
+    expect(previewFilters("payee").map((f) => f.key)).not.toContain("duplicate");
+    expect(previewFilters("transaction").map((f) => f.key)).toContain("duplicate");
   });
 });
 

--- a/src/features/sync/lib/previewRows.test.ts
+++ b/src/features/sync/lib/previewRows.test.ts
@@ -98,7 +98,7 @@ describe("review queue (RD-054)", () => {
     const queued = reviewQueueRows(rows).map((r) => r.id).sort();
     expect(queued).toEqual(["blk-1", "chg-1", "dup-1"]);
     expect(reviewQueueCount(rows)).toBe(3);
-    // The safe set (new + marker-match) is exactly what automation applies — never queued.
+    // The safe set (new + marker-match) is exactly what automation applies - never queued.
     expect(queued).not.toContain("new-1");
     expect(queued).not.toContain("mm-1");
   });

--- a/src/features/sync/lib/previewRows.ts
+++ b/src/features/sync/lib/previewRows.ts
@@ -82,6 +82,7 @@ export function classificationGroup(classification: SyncItemClassification | nul
     case "source_changed_since_sync":
       return "source_changed";
     case "target_marker_match":
+    case "target_name_match":
       return "marker_match";
     case "blocked":
       return "blocked";
@@ -106,8 +107,12 @@ export function toPreviewRow(item: SyncFlowRunItem): PreviewRow {
     id: item.id,
     classification: item.classification,
     group: classificationGroup(item.classification),
-    // Selectable: safe creates, marker-match repairs, or auto-mappable exact dups.
-    selectable: isSafeNew || item.classification === "target_marker_match" || isExactDupAutoMap,
+    // Selectable: safe creates, marker/name-match repairs, or auto-mappable dups.
+    selectable:
+      isSafeNew ||
+      item.classification === "target_marker_match" ||
+      item.classification === "target_name_match" ||
+      isExactDupAutoMap,
     isSafeNew,
     reviewRequired: isReviewRequired(item.classification) && !isExactDupAutoMap,
     applyState: item.applyState,

--- a/src/features/sync/lib/previewRows.ts
+++ b/src/features/sync/lib/previewRows.ts
@@ -150,7 +150,7 @@ export function toPreviewRow(item: SyncFlowRunItem): PreviewRow {
   };
 }
 
-/** Ids for "select all safe new" — excludes repair (marker-match) rows. */
+/** Ids for "select all safe new" - excludes repair (marker-match) rows. */
 export function selectableRowIds(rows: PreviewRow[]): string[] {
   return rows.filter((r) => r.isSafeNew).map((r) => r.id);
 }
@@ -201,31 +201,35 @@ export function previewTiles(rows: PreviewRow[], kind: SyncKind): PreviewTile[] 
   const matched = rows.filter((r) => r.classification === "target_name_match").length;
   if (kind === "transaction") {
     return [
-      { key: "new", label: "New — ready to sync", value: tiles.new, tone: "new", filter: "new" },
+      { key: "new", label: "New - ready to sync", value: tiles.new, tone: "new", filter: "new" },
       { key: "needs_review", label: "Needs review", value: tiles.needsReview, tone: "warn", filter: "needs_review" },
       { key: "already", label: "Already synced", value: tiles.alreadySynced, filter: "already_synced" },
       { key: "blocked", label: "Blocked", value: tiles.blocked, tone: "bad", filter: "blocked" },
     ];
   }
   const noun = kind === "payee" ? "payees" : "categories";
-  return [
+  const base: PreviewTile[] = [
     { key: "new", label: `New ${noun}`, value: tiles.new, tone: "new", filter: "new" },
     { key: "name_match", label: "Match on target", value: matched, filter: "marker_match" },
     { key: "already", label: "Already synced", value: tiles.alreadySynced, filter: "already_synced" },
-    { key: "blocked", label: "Needs a group", value: tiles.blocked, tone: "bad", filter: "blocked" },
   ];
+  // Only categories can be blocked (on ambiguous group placement); payees can't.
+  if (kind === "category") base.push({ key: "blocked", label: "Needs a group", value: tiles.blocked, tone: "bad", filter: "blocked" });
+  return base;
 }
 
 /** The table filter chips relevant to a data type. */
 export function previewFilters(kind: SyncKind): { key: PreviewFilter; label: string }[] {
   if (kind === "transaction") return PREVIEW_FILTERS;
-  return [
+  const chips: { key: PreviewFilter; label: string }[] = [
     { key: "all", label: "All" },
     { key: "new", label: "New" },
     { key: "marker_match", label: "Name match" },
     { key: "already_synced", label: "Already synced" },
-    { key: "blocked", label: "Blocked" },
   ];
+  // Only categories can be blocked (ambiguous group); payees never are.
+  if (kind === "category") chips.push({ key: "blocked", label: "Blocked" });
+  return chips;
 }
 
 // --- Preview table filtering (detailed statuses) ---------------------------

--- a/src/features/sync/lib/previewRows.ts
+++ b/src/features/sync/lib/previewRows.ts
@@ -14,9 +14,20 @@ export type PreviewGroup =
   | "blocked"
   | "other";
 
+/** The data type a sync flow operates on, for kind-aware rendering. */
+export type SyncKind = "transaction" | "payee" | "category";
+
+export function syncKindOf(flowType: string): SyncKind {
+  if (flowType === "payee_sync") return "payee";
+  if (flowType === "category_sync") return "category";
+  return "transaction";
+}
+
 export type PreviewRow = {
   id: string;
   classification: SyncItemClassification | null;
+  /** Data type of the item, for kind-aware columns/labels. */
+  entityType: "payee" | "category" | "transaction";
   group: PreviewGroup;
   /** Checkbox-enabled: safe-new create candidates or repairable marker matches. */
   selectable: boolean;
@@ -103,9 +114,11 @@ export function toPreviewRow(item: SyncFlowRunItem): PreviewRow {
   // An exact duplicate the flow opted to auto-map is safe (mapping-only, no write).
   const isExactDupAutoMap =
     item.classification === "exact_duplicate" && flags.includes("exact_duplicate_auto_map");
+  const entityType = item.sourceEntityType === "payee" || item.sourceEntityType === "category" ? item.sourceEntityType : "transaction";
   return {
     id: item.id,
     classification: item.classification,
+    entityType,
     group: classificationGroup(item.classification),
     // Selectable: safe creates, marker/name-match repairs, or auto-mappable dups.
     selectable:
@@ -172,6 +185,47 @@ const GROUP_LABELS: Record<PreviewGroup, string> = {
 
 export function groupLabel(group: PreviewGroup): string {
   return GROUP_LABELS[group];
+}
+
+/** Human status for a row, in the noun of its data type (e.g. "Name match"). */
+export function statusLabel(row: PreviewRow): string {
+  if (row.classification === "target_name_match") return "Name match";
+  return GROUP_LABELS[row.group];
+}
+
+export type PreviewTile = { key: string; label: string; value: number; tone?: "new" | "warn" | "bad"; filter: PreviewFilter };
+
+/** The summary tiles for a run, worded for its data type. */
+export function previewTiles(rows: PreviewRow[], kind: SyncKind): PreviewTile[] {
+  const tiles = tileCounts(rows);
+  const matched = rows.filter((r) => r.classification === "target_name_match").length;
+  if (kind === "transaction") {
+    return [
+      { key: "new", label: "New — ready to sync", value: tiles.new, tone: "new", filter: "new" },
+      { key: "needs_review", label: "Needs review", value: tiles.needsReview, tone: "warn", filter: "needs_review" },
+      { key: "already", label: "Already synced", value: tiles.alreadySynced, filter: "already_synced" },
+      { key: "blocked", label: "Blocked", value: tiles.blocked, tone: "bad", filter: "blocked" },
+    ];
+  }
+  const noun = kind === "payee" ? "payees" : "categories";
+  return [
+    { key: "new", label: `New ${noun}`, value: tiles.new, tone: "new", filter: "new" },
+    { key: "name_match", label: "Match on target", value: matched, filter: "marker_match" },
+    { key: "already", label: "Already synced", value: tiles.alreadySynced, filter: "already_synced" },
+    { key: "blocked", label: "Needs a group", value: tiles.blocked, tone: "bad", filter: "blocked" },
+  ];
+}
+
+/** The table filter chips relevant to a data type. */
+export function previewFilters(kind: SyncKind): { key: PreviewFilter; label: string }[] {
+  if (kind === "transaction") return PREVIEW_FILTERS;
+  return [
+    { key: "all", label: "All" },
+    { key: "new", label: "New" },
+    { key: "marker_match", label: "Name match" },
+    { key: "already_synced", label: "Already synced" },
+    { key: "blocked", label: "Blocked" },
+  ];
 }
 
 // --- Preview table filtering (detailed statuses) ---------------------------

--- a/src/features/sync/lib/reverseFlow.ts
+++ b/src/features/sync/lib/reverseFlow.ts
@@ -25,6 +25,9 @@ export function buildReverseFlowForm(
 
   reverse.name = `${form.name} (reverse)`;
   reverse.enabled = false;
+  // Preserve the data type + entity options; only the direction is mirrored.
+  reverse.flowType = form.flowType;
+  reverse.entity = { ...form.entity };
 
   // New source = old target. Backfill the budget display name from the live
   // connection when the loaded form did not carry it (cosmetic; self-heals).

--- a/src/features/sync/lib/runsView.ts
+++ b/src/features/sync/lib/runsView.ts
@@ -2,7 +2,7 @@ import type { SyncFlowRun } from "@/lib/app-db/types";
 
 /**
  * Display helpers for run history (RD-053 / PR-019 Slice 5 UI). Pure and
- * testable. Structured for RD-054's automated runs — `trigger` already
+ * testable. Structured for RD-054's automated runs - `trigger` already
  * distinguishes manual vs background.
  */
 

--- a/src/features/sync/lib/scheduler.ts
+++ b/src/features/sync/lib/scheduler.ts
@@ -5,8 +5,8 @@ import type { SyncReviewPolicy } from "@/lib/app-db/types";
  * (RD-054 / PR-020 Slice 4).
  *
  * This is intentionally a plain function, not a hook: all the rules that matter
- * — policy gate, enabled gate, connection availability, the interval floor, and
- * non-overlap — are decided here so they can be unit-tested without React or a
+ * - policy gate, enabled gate, connection availability, the interval floor, and
+ * non-overlap - are decided here so they can be unit-tested without React or a
  * live timer. `useSyncScheduler` is only a thin timer wrapper around this.
  *
  * There is no server here: the engine and credentials live in the browser, so a
@@ -28,7 +28,7 @@ export type SchedulableFlow = {
 
 export type AutoRunSelectionInput = {
   flows: SchedulableFlow[];
-  /** Flows whose auto run is currently in progress — never started twice. */
+  /** Flows whose auto run is currently in progress - never started twice. */
   inFlight: ReadonlySet<string>;
   nowMs: number;
 };

--- a/src/features/sync/lib/syncApi.ts
+++ b/src/features/sync/lib/syncApi.ts
@@ -17,7 +17,7 @@ import type {
  * Thin client for the Budget File Sync server routes (RD-053 / PR-019 Slice 5).
  *
  * The Direct transport runs in the browser; the app DB runs server-side. These
- * helpers are the only bridge — the preview/apply orchestrators run client-side
+ * helpers are the only bridge - the preview/apply orchestrators run client-side
  * and reach the DB exclusively through here. No sync logic lives in this module.
  */
 

--- a/src/lib/app-db/types.ts
+++ b/src/lib/app-db/types.ts
@@ -93,6 +93,12 @@ export type SyncItemClassification =
   | "new"
   | "already_synced"
   | "target_marker_match"
+  /**
+   * Marker-less analogue of target_marker_match for master-data entities
+   * (RD-055): no DB mapping, but a target entity matches by normalized name, so
+   * apply records a mapping to it instead of creating a duplicate.
+   */
+  | "target_name_match"
   | "source_changed_since_sync"
   | "exact_duplicate"
   | "strong_duplicate"

--- a/src/lib/sync/adapters/categoryAdapter.ts
+++ b/src/lib/sync/adapters/categoryAdapter.ts
@@ -1,0 +1,205 @@
+import { getBudgetFileSyncCapabilities } from "../capabilities";
+import { connectionFingerprint } from "../connectionRef";
+import {
+  buildEntityPlannedItem,
+  decodeEntityFlowConfig,
+  mappingFor,
+  normalizeName,
+  toPlanResult,
+} from "./entitySupport";
+import {
+  registerSyncKindAdapter,
+  SyncKindError,
+  type AdapterApplyContext,
+  type AdapterCreateInput,
+  type AdapterCreateResult,
+  type AdapterSourceResult,
+  type AdapterSummary,
+  type AdapterValidateInput,
+  type SyncKindAdapter,
+} from "../syncKind";
+import type { ActualBenchTransport } from "@/lib/actual/transport";
+import type { JsonObject, SyncCapabilitySet, SyncFlow, SyncMapping } from "@/lib/app-db/types";
+import type { EntityTargetPayload, SyncPlanResult } from "../plannedChanges";
+
+/** Category master-data adapter for the unified sync engine (RD-055). */
+
+type SourceCategory = { id: string; name: string; isIncome: boolean; groupName: string };
+type MaterializedCategories = { categories: SourceCategory[] };
+type TargetCategories = {
+  /** `${normName}|${isIncome}` -> category id, for name matching. */
+  categoryByKey: Map<string, string>;
+  /** `${normGroupName}|${isIncome}` -> group id, for placement. */
+  groupByKey: Map<string, string>;
+};
+
+const key = (name: string, isIncome: boolean) => `${normalizeName(name)}|${isIncome}`;
+
+function assertEntityRoute({ flow, sourceConnection, targetConnection }: AdapterValidateInput): void {
+  const config = decodeEntityFlowConfig(flow);
+  if (!config.sourceBudgetId || !config.targetBudgetId) {
+    throw new SyncKindError("missing_route", "Source and target budgets must both be selected.");
+  }
+  for (const [fp, conn, side] of [
+    [config.sourceConnectionFingerprint, sourceConnection, "source"],
+    [config.targetConnectionFingerprint, targetConnection, "target"],
+  ] as const) {
+    if (fp && connectionFingerprint(conn) !== fp) {
+      throw new SyncKindError("connection_mismatch", `The ${side} connection does not match the one this flow was saved with.`);
+    }
+    if (!getBudgetFileSyncCapabilities({ mode: conn.mode }).supported) {
+      throw new SyncKindError("unsupported_connection", `The ${side} connection does not support Budget File Sync.`);
+    }
+  }
+}
+
+export const categoryAdapter: SyncKindAdapter = {
+  flowType: "category_sync",
+
+  validate: assertEntityRoute,
+
+  async loadSource(transport: ActualBenchTransport): Promise<AdapterSourceResult> {
+    try {
+      const { groups, categories } = await transport.getCategoryGroups();
+      const groupName = new Map(groups.map((g) => [g.id, g.name]));
+      const src: SourceCategory[] = categories.map((c) => ({
+        id: c.id,
+        name: c.name,
+        isIncome: c.isIncome,
+        groupName: groupName.get(c.groupId) ?? "",
+      }));
+      const materialized: MaterializedCategories = { categories: src };
+      return { materialized, stats: { scanned: src.length, generatedExcluded: 0, expandedCount: src.length, keptCount: src.length } };
+    } catch (err) {
+      throw new SyncKindError("source_load_failed", err instanceof Error ? err.message : "Failed to read source categories.");
+    }
+  },
+
+  async loadTarget(transport: ActualBenchTransport): Promise<unknown> {
+    try {
+      const { groups, categories } = await transport.getCategoryGroups();
+      const categoryByKey = new Map<string, string>();
+      for (const c of categories) {
+        const k = key(c.name, c.isIncome);
+        if (c.name.trim() && !categoryByKey.has(k)) categoryByKey.set(k, c.id);
+      }
+      const groupByKey = new Map<string, string>();
+      for (const g of groups) {
+        const k = key(g.name, g.isIncome);
+        if (g.name.trim() && !groupByKey.has(k)) groupByKey.set(k, g.id);
+      }
+      return { categoryByKey, groupByKey } satisfies TargetCategories;
+    } catch (err) {
+      throw new SyncKindError("target_load_failed", err instanceof Error ? err.message : "Failed to read target categories.");
+    }
+  },
+
+  plan({ flow, materialized, target, mappings }): SyncPlanResult {
+    const source = materialized as MaterializedCategories;
+    const { categoryByKey, groupByKey } = target as TargetCategories;
+    const config = decodeEntityFlowConfig(flow);
+
+    const items = source.categories
+      .filter((c) => c.name.trim() !== "")
+      .map((cat) => {
+        const itemKey = `category:${cat.id}`;
+        const incomeKind = cat.isIncome ? "income" : "expense";
+        const common = { entityType: "category" as const, sourceId: cat.id, name: cat.name, groupName: cat.groupName };
+
+        const mapping = mappingFor(mappings as SyncMapping[], itemKey);
+        if (mapping) {
+          return buildEntityPlannedItem({ ...common, classification: "already_synced", action: "skip", targetId: mapping.targetTransactionId, entityPayload: null, selectedForApply: false, message: "Already synced." });
+        }
+        const nameMatch = categoryByKey.get(key(cat.name, cat.isIncome));
+        if (nameMatch) {
+          return buildEntityPlannedItem({ ...common, classification: "target_name_match", action: "skip", targetId: nameMatch, entityPayload: null, selectedForApply: true, message: "A category with this name and kind exists on the target." });
+        }
+
+        // Resolve the target group: matching source group, else configured default.
+        let groupId = groupByKey.get(key(cat.groupName, cat.isIncome)) ?? null;
+        let placedGroupName = cat.groupName;
+        if (!groupId && config.defaultGroupName) {
+          groupId = groupByKey.get(key(config.defaultGroupName, cat.isIncome)) ?? null;
+          if (groupId) placedGroupName = config.defaultGroupName;
+        }
+
+        const payload: EntityTargetPayload = { entity: "category", name: cat.name, incomeKind, groupId, groupName: placedGroupName };
+        if (groupId) {
+          return buildEntityPlannedItem({ ...common, classification: "new", action: "create", targetId: null, entityPayload: payload, selectedForApply: true, message: null });
+        }
+        if (config.createMissingGroup && placedGroupName.trim()) {
+          return buildEntityPlannedItem({ ...common, classification: "new", action: "create", targetId: null, entityPayload: { ...payload, groupId: null }, selectedForApply: true, flags: [], message: `Will create group “${placedGroupName}”.` });
+        }
+        // Ambiguous placement — no matching group and no default → review-required.
+        return buildEntityPlannedItem({ ...common, classification: "blocked", action: "blocked", targetId: null, entityPayload: null, selectedForApply: false, message: "No matching target group; choose a default group or enable group creation." });
+      });
+
+    return toPlanResult(flow.id, items);
+  },
+
+  sourceSummary(flow: SyncFlow): JsonObject {
+    const config = decodeEntityFlowConfig(flow);
+    return { budgetId: config.sourceBudgetId, connectionFingerprint: config.sourceConnectionFingerprint, entity: "category" };
+  },
+
+  buildSummary(plan: SyncPlanResult, stats): AdapterSummary {
+    const c = plan.counts;
+    return {
+      sourceTransactionsScanned: stats.scanned,
+      generatedTransactionsExcluded: 0,
+      sourceItemsScanned: stats.expandedCount,
+      sourceItemsFilteredOut: stats.expandedCount - stats.keptCount,
+      plannedItems: plan.items.length,
+      createCandidates: c.new ?? 0,
+      alreadySynced: c.already_synced ?? 0,
+      duplicatesSkipped: 0,
+      exactDuplicatesAutoMapped: 0,
+      sourceChangedWarnings: 0,
+      targetMarkerMatches: c.target_name_match ?? 0,
+      blocked: c.blocked ?? 0,
+    };
+  },
+
+  async prepareApply(): Promise<AdapterApplyContext> {
+    return { markerIndex: new Map() };
+  },
+
+  assertCanApply(_caps: SyncCapabilitySet, _willCreate: boolean): void {
+    // Direct mode (the only supported mode, enforced in validate) can create
+    // categories and groups; no dedicated capability flag exists.
+  },
+
+  async createBatch(
+    transport: ActualBenchTransport,
+    flow: SyncFlow,
+    inputs: AdapterCreateInput[]
+  ): Promise<AdapterCreateResult[]> {
+    void flow;
+    const results: AdapterCreateResult[] = [];
+    const groupCache = new Map<string, string>(); // key(groupName,isIncome) -> created group id
+    for (const { itemId, payload } of inputs) {
+      try {
+        const name = String(payload.name ?? "");
+        const isIncome = payload.incomeKind === "income";
+        let groupId = (payload.groupId as string | null) ?? null;
+        const groupName = String(payload.groupName ?? "");
+        if (!groupId && groupName) {
+          const gk = key(groupName, isIncome);
+          groupId = groupCache.get(gk) ?? (await transport.createCategoryGroup({ name: groupName, isIncome, hidden: false }));
+          groupCache.set(gk, groupId);
+        }
+        if (!groupId) {
+          results.push({ itemId, targetId: null, changedFields: [] });
+          continue;
+        }
+        const catId = await transport.createCategory({ name, groupId, isIncome, hidden: false });
+        results.push({ itemId, targetId: catId, changedFields: [] });
+      } catch {
+        results.push({ itemId, targetId: null, changedFields: [] });
+      }
+    }
+    return results;
+  },
+};
+
+registerSyncKindAdapter(categoryAdapter);

--- a/src/lib/sync/adapters/categoryAdapter.ts
+++ b/src/lib/sync/adapters/categoryAdapter.ts
@@ -130,7 +130,7 @@ export const categoryAdapter: SyncKindAdapter = {
         if (config.createMissingGroup && placedGroupName.trim()) {
           return buildEntityPlannedItem({ ...common, classification: "new", action: "create", targetId: null, entityPayload: { ...payload, groupId: null }, selectedForApply: true, flags: [], message: `Will create group “${placedGroupName}”.` });
         }
-        // Ambiguous placement — no matching group and no default → review-required.
+        // Ambiguous placement - no matching group and no default → review-required.
         return buildEntityPlannedItem({ ...common, classification: "blocked", action: "blocked", targetId: null, entityPayload: null, selectedForApply: false, message: "No matching target group; choose a default group or enable group creation." });
       });
 

--- a/src/lib/sync/adapters/entityAdapters.test.ts
+++ b/src/lib/sync/adapters/entityAdapters.test.ts
@@ -1,0 +1,96 @@
+import { payeeAdapter } from "./payeeAdapter";
+import { categoryAdapter } from "./categoryAdapter";
+import type { ActualBenchTransport } from "@/lib/actual/transport";
+import type { JsonObject, SyncCapabilitySet, SyncFlow, SyncMapping } from "@/lib/app-db/types";
+
+const envelope = (data: JsonObject) => ({ version: 1, data });
+
+function flow(flowType: SyncFlow["flowType"], options: JsonObject = {}): SyncFlow {
+  return {
+    id: "flow-1", name: "Master data", enabled: true, flowType, description: null, createdAt: "", updatedAt: "",
+    legs: [{
+      id: "leg-1", flowId: "flow-1", position: 0,
+      sourceRef: envelope({ connectionFingerprint: "src-fp", budgetId: "budget-src", budgetName: "Personal" }),
+      targetRef: envelope({ connectionFingerprint: "tgt-fp", budgetId: "budget-tgt", budgetName: "Family" }),
+      filter: envelope({}), transform: envelope({}), options: envelope(options),
+      createdAt: "", updatedAt: "",
+    }],
+  };
+}
+
+const caps = {} as SyncCapabilitySet;
+const mapping = (sourceItemKey: string, targetTransactionId: string): SyncMapping =>
+  ({ sourceItemKey, targetTransactionId } as unknown as SyncMapping);
+
+describe("payeeAdapter.plan", () => {
+  const materialized = { payees: [{ id: "s1", name: "Coffee Bar" }, { id: "s2", name: "New Vendor" }, { id: "s3", name: "Mapped Co" }] };
+  const target = { byName: new Map([["coffee bar", "t-coffee"]]) };
+
+  it("classifies mapped / name-matched / new payees", () => {
+    const plan = payeeAdapter.plan({ flow: flow("payee_sync"), materialized, target, mappings: [mapping("payee:s3", "t-mapped")], targetCapabilities: caps });
+    const byKey = Object.fromEntries(plan.items.map((i) => [i.sourceItemKey, i]));
+    expect(byKey["payee:s3"].classification).toBe("already_synced");
+    expect(byKey["payee:s1"].classification).toBe("target_name_match");
+    expect(byKey["payee:s1"].targetTransactionId).toBe("t-coffee");
+    expect(byKey["payee:s2"].classification).toBe("new");
+    expect(byKey["payee:s2"].entityPayload).toMatchObject({ entity: "payee", name: "New Vendor" });
+  });
+
+  it("createBatch creates each new payee and returns its id", async () => {
+    const createPayee = jest.fn(async ({ name }: { name: string }) => ({ id: "created-" + name, name, created: true }));
+    const transport = { createPayee } as unknown as ActualBenchTransport;
+    const results = await payeeAdapter.createBatch(transport, flow("payee_sync"), [{ itemId: "i1", payload: { entity: "payee", name: "New Vendor" } as JsonObject }]);
+    expect(createPayee).toHaveBeenCalledWith({ name: "New Vendor" });
+    expect(results[0]).toMatchObject({ itemId: "i1", targetId: "created-New Vendor" });
+  });
+});
+
+describe("categoryAdapter.plan", () => {
+  const src = {
+    categories: [
+      { id: "c1", name: "Dining", isIncome: false, groupName: "Food" },       // group matches
+      { id: "c2", name: "Salary", isIncome: true, groupName: "Income" },       // name matches on target
+      { id: "c3", name: "Gadgets", isIncome: false, groupName: "NoSuchGroup" }, // ambiguous
+    ],
+  };
+  const target = {
+    categoryByKey: new Map([["salary|true", "t-salary"]]),
+    groupByKey: new Map([["food|false", "g-food"], ["misc|false", "g-misc"]]),
+  };
+
+  it("places under a matching group, name-matches, and blocks ambiguous placement", () => {
+    const plan = categoryAdapter.plan({ flow: flow("category_sync"), materialized: src, target, mappings: [], targetCapabilities: caps });
+    const byKey = Object.fromEntries(plan.items.map((i) => [i.sourceItemKey, i]));
+    expect(byKey["category:c1"]).toMatchObject({ classification: "new" });
+    expect(byKey["category:c1"].entityPayload).toMatchObject({ entity: "category", groupId: "g-food", incomeKind: "expense" });
+    expect(byKey["category:c2"].classification).toBe("target_name_match");
+    expect(byKey["category:c3"].classification).toBe("blocked");
+  });
+
+  it("uses the default group when the source group has no match", () => {
+    const plan = categoryAdapter.plan({ flow: flow("category_sync", { defaultGroupName: "Misc" }), materialized: src, target, mappings: [], targetCapabilities: caps });
+    const c3 = plan.items.find((i) => i.sourceItemKey === "category:c3");
+    expect(c3?.classification).toBe("new");
+    expect(c3?.entityPayload).toMatchObject({ groupId: "g-misc" });
+  });
+
+  it("plans a group creation when createMissingGroup is enabled", () => {
+    const plan = categoryAdapter.plan({ flow: flow("category_sync", { createMissingGroup: true }), materialized: src, target, mappings: [], targetCapabilities: caps });
+    const c3 = plan.items.find((i) => i.sourceItemKey === "category:c3");
+    expect(c3?.classification).toBe("new");
+    expect(c3?.entityPayload).toMatchObject({ groupId: null, groupName: "NoSuchGroup" });
+  });
+
+  it("createBatch creates a missing group once then the category under it", async () => {
+    const createCategoryGroup = jest.fn(async () => "new-group");
+    const createCategory = jest.fn(async () => "new-cat");
+    const transport = { createCategoryGroup, createCategory } as unknown as ActualBenchTransport;
+    const results = await categoryAdapter.createBatch(transport, flow("category_sync"), [
+      { itemId: "i1", payload: { entity: "category", name: "Gadgets", incomeKind: "expense", groupId: null, groupName: "NoSuchGroup" } as JsonObject },
+      { itemId: "i2", payload: { entity: "category", name: "Widgets", incomeKind: "expense", groupId: null, groupName: "NoSuchGroup" } as JsonObject },
+    ]);
+    expect(createCategoryGroup).toHaveBeenCalledTimes(1); // group reused across both
+    expect(createCategory).toHaveBeenCalledTimes(2);
+    expect(results.map((r) => r.targetId)).toEqual(["new-cat", "new-cat"]);
+  });
+});

--- a/src/lib/sync/adapters/entityAdapters.test.ts
+++ b/src/lib/sync/adapters/entityAdapters.test.ts
@@ -43,6 +43,22 @@ describe("payeeAdapter.plan", () => {
     expect(createPayee).toHaveBeenCalledWith({ name: "New Vendor" });
     expect(results[0]).toMatchObject({ itemId: "i1", targetId: "created-New Vendor" });
   });
+
+  it("createBatch isolates a per-item failure and keeps the successes", async () => {
+    const createPayee = jest.fn(async ({ name }: { name: string }) => {
+      if (name === "Boom") throw new Error("create failed");
+      return { id: "created-" + name, name, created: true };
+    });
+    const transport = { createPayee } as unknown as ActualBenchTransport;
+    const results = await payeeAdapter.createBatch(transport, flow("payee_sync"), [
+      { itemId: "ok", payload: { entity: "payee", name: "Good" } as JsonObject },
+      { itemId: "bad", payload: { entity: "payee", name: "Boom" } as JsonObject },
+    ]);
+    expect(results).toEqual([
+      { itemId: "ok", targetId: "created-Good", changedFields: [] },
+      { itemId: "bad", targetId: null, changedFields: [] },
+    ]);
+  });
 });
 
 describe("categoryAdapter.plan", () => {

--- a/src/lib/sync/adapters/entitySupport.ts
+++ b/src/lib/sync/adapters/entitySupport.ts
@@ -6,7 +6,7 @@ import type { EntityTargetPayload, SyncPlannedItem, SyncPlanResult } from "../pl
  * Shared helpers for master-data (entity) sync adapters (RD-055): entity flow
  * config decode, normalized-name matching, and planned-item construction. Entity
  * flows sync at the **budget** level (no account) and have no `imported_id`
- * marker — matching is by normalized name, idempotency by the app-DB mapping.
+ * marker - matching is by normalized name, idempotency by the app-DB mapping.
  */
 
 export type EntityFlowConfig = {

--- a/src/lib/sync/adapters/entitySupport.ts
+++ b/src/lib/sync/adapters/entitySupport.ts
@@ -1,0 +1,106 @@
+import { normalizeName } from "../normalize";
+import type { SyncEntityType, SyncFlow, SyncItemClassification, SyncMapping } from "@/lib/app-db/types";
+import type { EntityTargetPayload, SyncPlannedItem, SyncPlanResult } from "../plannedChanges";
+
+/**
+ * Shared helpers for master-data (entity) sync adapters (RD-055): entity flow
+ * config decode, normalized-name matching, and planned-item construction. Entity
+ * flows sync at the **budget** level (no account) and have no `imported_id`
+ * marker — matching is by normalized name, idempotency by the app-DB mapping.
+ */
+
+export type EntityFlowConfig = {
+  flowId: string;
+  sourceConnectionFingerprint: string;
+  sourceBudgetId: string;
+  sourceBudgetName: string;
+  targetConnectionFingerprint: string;
+  targetBudgetId: string;
+  targetBudgetName: string;
+  /** Category-only: create categories under this target group when no group matches. */
+  defaultGroupName: string | null;
+  /** Category-only: create a missing target group instead of blocking. */
+  createMissingGroup: boolean;
+};
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function decodeEntityFlowConfig(flow: SyncFlow): EntityFlowConfig {
+  const leg = flow.legs[0];
+  const source = (leg?.sourceRef.data ?? {}) as Record<string, unknown>;
+  const target = (leg?.targetRef.data ?? {}) as Record<string, unknown>;
+  const options = (leg?.options.data ?? {}) as Record<string, unknown>;
+  const defaultGroup = str(options.defaultGroupName).trim();
+  return {
+    flowId: flow.id,
+    sourceConnectionFingerprint: str(source.connectionFingerprint),
+    sourceBudgetId: str(source.budgetId),
+    sourceBudgetName: str(source.budgetName),
+    targetConnectionFingerprint: str(target.connectionFingerprint),
+    targetBudgetId: str(target.budgetId),
+    targetBudgetName: str(target.budgetName),
+    defaultGroupName: defaultGroup ? defaultGroup : null,
+    createMissingGroup: options.createMissingGroup === true,
+  };
+}
+
+/** Planned-item factory for an entity, reusing the shared run-item shape. */
+export function buildEntityPlannedItem(input: {
+  entityType: Extract<SyncEntityType, "payee" | "category">;
+  sourceId: string;
+  name: string;
+  /** Display group name (categories); shown in the "group" column. */
+  groupName?: string | null;
+  classification: SyncItemClassification;
+  action: SyncPlannedItem["action"];
+  targetId: string | null;
+  entityPayload: EntityTargetPayload | null;
+  selectedForApply: boolean;
+  message: string | null;
+  flags?: SyncPlannedItem["flags"];
+}): SyncPlannedItem {
+  return {
+    sourceItemKey: `${input.entityType}:${input.sourceId}`,
+    sourceEntityType: input.entityType,
+    sourceTransactionId: input.sourceId,
+    sourceSplitId: null,
+    sourceFingerprint: normalizeName(input.name),
+    usedFallbackKey: false,
+    source: {
+      date: "",
+      amount: 0,
+      payeeName: input.name,
+      categoryName: input.groupName ?? null,
+      notes: null,
+    },
+    classification: input.classification,
+    duplicateConfidence: "none",
+    action: input.action,
+    flags: input.flags ?? [],
+    selectedForApply: input.selectedForApply,
+    plannedTargetPayload: null,
+    entityPayload: input.entityPayload,
+    targetTransactionId: input.targetId,
+    message: input.message,
+  };
+}
+
+/** Tally a plan's items by classification for the run counts. */
+export function countByClassification(items: SyncPlannedItem[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) counts[item.classification] = (counts[item.classification] ?? 0) + 1;
+  return counts;
+}
+
+/** Existing DB mapping for a source entity key, if any. */
+export function mappingFor(mappings: SyncMapping[], sourceItemKey: string): SyncMapping | undefined {
+  return mappings.find((m) => m.sourceItemKey === sourceItemKey);
+}
+
+export function toPlanResult(flowId: string, items: SyncPlannedItem[]): SyncPlanResult {
+  return { flowId, items, counts: countByClassification(items) };
+}
+
+export { normalizeName };

--- a/src/lib/sync/adapters/index.ts
+++ b/src/lib/sync/adapters/index.ts
@@ -1,0 +1,8 @@
+// Importing this module registers every data-type adapter with the unified sync
+// engine (each adapter calls registerSyncKindAdapter on import). The
+// orchestrators import this for its side effects so dispatch-by-flowType works.
+import "./transactionAdapter";
+// Master-data (entity) adapters (RD-055).
+import "./payeeAdapter";
+import "./categoryAdapter";
+

--- a/src/lib/sync/adapters/payeeAdapter.ts
+++ b/src/lib/sync/adapters/payeeAdapter.ts
@@ -149,12 +149,16 @@ export const payeeAdapter: SyncKindAdapter = {
   ): Promise<AdapterCreateResult[]> {
     void flow;
     const results: AdapterCreateResult[] = [];
-    // Payee creates are sequential (no batch primitive), but there are typically
-    // few of them and each is a single cheap write.
+    // Sequential (no batch primitive) but cheap. Isolate per item so one failure
+    // doesn't abort the batch and lose the successes recorded before it.
     for (const { itemId, payload } of inputs) {
-      const name = String(payload.name ?? "");
-      const created = await transport.createPayee({ name });
-      results.push({ itemId, targetId: created.id, changedFields: [] });
+      try {
+        const name = String(payload.name ?? "");
+        const created = await transport.createPayee({ name });
+        results.push({ itemId, targetId: created.id, changedFields: [] });
+      } catch {
+        results.push({ itemId, targetId: null, changedFields: [] });
+      }
     }
     return results;
   },

--- a/src/lib/sync/adapters/payeeAdapter.ts
+++ b/src/lib/sync/adapters/payeeAdapter.ts
@@ -1,0 +1,163 @@
+import { getBudgetFileSyncCapabilities } from "../capabilities";
+import { connectionFingerprint } from "../connectionRef";
+import {
+  buildEntityPlannedItem,
+  decodeEntityFlowConfig,
+  mappingFor,
+  normalizeName,
+  toPlanResult,
+} from "./entitySupport";
+import {
+  registerSyncKindAdapter,
+  SyncKindError,
+  type AdapterApplyContext,
+  type AdapterCreateInput,
+  type AdapterCreateResult,
+  type AdapterSourceResult,
+  type AdapterSummary,
+  type AdapterValidateInput,
+  type SyncKindAdapter,
+} from "../syncKind";
+import type { ActualBenchTransport } from "@/lib/actual/transport";
+import type { JsonObject, SyncCapabilitySet, SyncFlow, SyncMapping } from "@/lib/app-db/types";
+import type { SyncPlanResult } from "../plannedChanges";
+
+/** Payee master-data adapter for the unified sync engine (RD-055). */
+
+type Payee = { id: string; name: string };
+type MaterializedPayees = { payees: Payee[] };
+type TargetPayees = { byName: Map<string, string> };
+
+function assertEntityRoute({ flow, sourceConnection, targetConnection }: AdapterValidateInput): void {
+  const config = decodeEntityFlowConfig(flow);
+  if (!config.sourceBudgetId || !config.targetBudgetId) {
+    throw new SyncKindError("missing_route", "Source and target budgets must both be selected.");
+  }
+  for (const [fp, conn, side] of [
+    [config.sourceConnectionFingerprint, sourceConnection, "source"],
+    [config.targetConnectionFingerprint, targetConnection, "target"],
+  ] as const) {
+    if (fp && connectionFingerprint(conn) !== fp) {
+      throw new SyncKindError("connection_mismatch", `The ${side} connection does not match the one this flow was saved with.`);
+    }
+    if (!getBudgetFileSyncCapabilities({ mode: conn.mode }).supported) {
+      throw new SyncKindError("unsupported_connection", `The ${side} connection does not support Budget File Sync.`);
+    }
+  }
+}
+
+export const payeeAdapter: SyncKindAdapter = {
+  flowType: "payee_sync",
+
+  validate: assertEntityRoute,
+
+  async loadSource(transport: ActualBenchTransport): Promise<AdapterSourceResult> {
+    let payees: Payee[];
+    try {
+      payees = (await transport.getPayees()).map((p) => ({ id: p.id, name: p.name }));
+    } catch (err) {
+      throw new SyncKindError("source_load_failed", err instanceof Error ? err.message : "Failed to read source payees.");
+    }
+    const materialized: MaterializedPayees = { payees };
+    return { materialized, stats: { scanned: payees.length, generatedExcluded: 0, expandedCount: payees.length, keptCount: payees.length } };
+  },
+
+  async loadTarget(transport: ActualBenchTransport): Promise<unknown> {
+    try {
+      const byName = new Map<string, string>();
+      for (const p of await transport.getPayees()) {
+        const key = normalizeName(p.name);
+        if (key && !byName.has(key)) byName.set(key, p.id);
+      }
+      return { byName } satisfies TargetPayees;
+    } catch (err) {
+      throw new SyncKindError("target_load_failed", err instanceof Error ? err.message : "Failed to read target payees.");
+    }
+  },
+
+  plan({ flow, materialized, target, mappings }): SyncPlanResult {
+    const source = materialized as MaterializedPayees;
+    const { byName } = target as TargetPayees;
+    const items = source.payees
+      .filter((p) => p.name.trim() !== "")
+      .map((payee) => {
+        const key = `payee:${payee.id}`;
+        const mapping = mappingFor(mappings as SyncMapping[], key);
+        if (mapping) {
+          return buildEntityPlannedItem({
+            entityType: "payee", sourceId: payee.id, name: payee.name,
+            classification: "already_synced", action: "skip", targetId: mapping.targetTransactionId,
+            entityPayload: null, selectedForApply: false, message: "Already synced.",
+          });
+        }
+        const match = byName.get(normalizeName(payee.name));
+        if (match) {
+          return buildEntityPlannedItem({
+            entityType: "payee", sourceId: payee.id, name: payee.name,
+            classification: "target_name_match", action: "skip", targetId: match,
+            entityPayload: null, selectedForApply: true,
+            message: "A payee with this name exists on the target; mapping can be recorded.",
+          });
+        }
+        return buildEntityPlannedItem({
+          entityType: "payee", sourceId: payee.id, name: payee.name,
+          classification: "new", action: "create", targetId: null,
+          entityPayload: { entity: "payee", name: payee.name }, selectedForApply: true, message: null,
+        });
+      });
+    return toPlanResult(flow.id, items);
+  },
+
+  sourceSummary(flow: SyncFlow): JsonObject {
+    const config = decodeEntityFlowConfig(flow);
+    return { budgetId: config.sourceBudgetId, connectionFingerprint: config.sourceConnectionFingerprint, entity: "payee" };
+  },
+
+  buildSummary(plan: SyncPlanResult, stats): AdapterSummary {
+    const c = plan.counts;
+    return {
+      sourceTransactionsScanned: stats.scanned,
+      generatedTransactionsExcluded: 0,
+      sourceItemsScanned: stats.expandedCount,
+      sourceItemsFilteredOut: stats.expandedCount - stats.keptCount,
+      plannedItems: plan.items.length,
+      createCandidates: c.new ?? 0,
+      alreadySynced: c.already_synced ?? 0,
+      duplicatesSkipped: 0,
+      exactDuplicatesAutoMapped: 0,
+      sourceChangedWarnings: 0,
+      // Name matches are the entity analogue of marker matches (safe map-only).
+      targetMarkerMatches: c.target_name_match ?? 0,
+      blocked: c.blocked ?? 0,
+    };
+  },
+
+  async prepareApply(): Promise<AdapterApplyContext> {
+    return { markerIndex: new Map() };
+  },
+
+  assertCanApply(caps: SyncCapabilitySet, willCreate: boolean): void {
+    if (willCreate && !caps.createPayee) {
+      throw new SyncKindError("unsupported_connection", "Target cannot create payees in this mode.");
+    }
+  },
+
+  async createBatch(
+    transport: ActualBenchTransport,
+    flow: SyncFlow,
+    inputs: AdapterCreateInput[]
+  ): Promise<AdapterCreateResult[]> {
+    void flow;
+    const results: AdapterCreateResult[] = [];
+    // Payee creates are sequential (no batch primitive), but there are typically
+    // few of them and each is a single cheap write.
+    for (const { itemId, payload } of inputs) {
+      const name = String(payload.name ?? "");
+      const created = await transport.createPayee({ name });
+      results.push({ itemId, targetId: created.id, changedFields: [] });
+    }
+    return results;
+  },
+};
+
+registerSyncKindAdapter(payeeAdapter);

--- a/src/lib/sync/adapters/transactionAdapter.ts
+++ b/src/lib/sync/adapters/transactionAdapter.ts
@@ -1,0 +1,232 @@
+import { getBudgetFileSyncCapabilities } from "../capabilities";
+import { connectionFingerprint } from "../connectionRef";
+import { decodeFlowPlanConfig, type SyncFlowPlanConfig } from "../flowConfig";
+import {
+  DEFAULT_SOURCE_FILTER,
+  decodeSourceFilter,
+  filterSourceItems,
+  filterSourceTransactions,
+  type SyncSourceFilter,
+} from "../sourceFilter";
+import { expandSourceTransactions, type SyncSourceItem } from "../sourceItems";
+import { planExpandedItems } from "../syncPlanner";
+import {
+  registerSyncKindAdapter,
+  SyncKindError,
+  type AdapterApplyContext,
+  type AdapterCreateInput,
+  type AdapterCreateResult,
+  type AdapterSourceResult,
+  type AdapterSummary,
+  type AdapterValidateInput,
+  type SyncKindAdapter,
+} from "../syncKind";
+import type {
+  ActualBenchTransport,
+  SyncTargetTransactionInput,
+} from "@/lib/actual/transport";
+import type { JsonObject, SyncCapabilitySet, SyncFlow, SyncMapping } from "@/lib/app-db/types";
+import type { SyncPlannerTargetSnapshot, SyncPlanResult } from "../plannedChanges";
+
+/**
+ * Transaction data-type adapter for the unified sync engine (RD-053 behavior,
+ * unchanged — this is the behavior-preserving extraction of the original
+ * inline transaction logic behind the `SyncKindAdapter` interface).
+ */
+
+type MaterializedSource = { items: SyncSourceItem[]; filter: SyncSourceFilter; config: SyncFlowPlanConfig };
+
+function decodeFilterOrDefault(flow: SyncFlow): SyncSourceFilter {
+  try {
+    return decodeSourceFilter(flow);
+  } catch {
+    return { ...DEFAULT_SOURCE_FILTER };
+  }
+}
+
+async function loadTargetSnapshot(
+  transport: ActualBenchTransport,
+  config: SyncFlowPlanConfig,
+  filter: SyncSourceFilter
+): Promise<SyncPlannerTargetSnapshot> {
+  const range = { accountId: config.targetAccountId, startDate: filter.startDate ?? undefined, endDate: filter.endDate ?? undefined };
+  const lookup = await transport.getTargetLookupForSync(range);
+  const categoryGroups = await transport.getCategoryGroups();
+
+  return {
+    payees: lookup.payees.map((p) => ({ id: p.id, name: p.name })),
+    categories: categoryGroups.categories.map((c) => ({ id: c.id, name: c.name })),
+    importedIdIndex: lookup.importedIdIndex,
+    transactions: lookup.transactions.map((t) => ({
+      id: t.id,
+      date: t.date,
+      amount: t.amount,
+      payeeName: t.payeeName,
+      categoryId: t.categoryId,
+    })),
+  };
+}
+
+function diffPlannedVsActual(
+  payload: JsonObject,
+  resolvedPayeeId: string | null,
+  actual: { amount: number; date: string; cleared: boolean; categoryId: string | null; payeeId: string | null; notes: string | null }
+): string[] {
+  const changed: string[] = [];
+  if (payload.amount !== actual.amount) changed.push("amount");
+  if (payload.date !== actual.date) changed.push("date");
+  if ((payload.cleared ?? false) !== actual.cleared) changed.push("cleared");
+  if ((payload.categoryId ?? null) !== (actual.categoryId ?? null)) changed.push("category");
+  if ((resolvedPayeeId ?? null) !== (actual.payeeId ?? null)) changed.push("payee");
+  if ((payload.notes ?? null) !== (actual.notes ?? null)) changed.push("notes");
+  return changed;
+}
+
+export const transactionAdapter: SyncKindAdapter = {
+  flowType: "transaction_sync",
+
+  validate({ flow, sourceConnection, targetConnection }: AdapterValidateInput): void {
+    const config = decodeFlowPlanConfig(flow);
+    if (!config.sourceAccountId || !config.targetAccountId) {
+      throw new SyncKindError("missing_route", "Source and target accounts must both be selected before previewing.");
+    }
+    assertConnectionMatches(config.sourceConnectionFingerprint, sourceConnection, "source");
+    assertConnectionMatches(config.targetConnectionFingerprint, targetConnection, "target");
+
+    const sourceCaps = getBudgetFileSyncCapabilities({ mode: sourceConnection.mode });
+    const targetCaps = getBudgetFileSyncCapabilities({ mode: targetConnection.mode });
+    if (!sourceCaps.supported) throw new SyncKindError("unsupported_connection", sourceCaps.reason ?? "Source connection is unsupported.");
+    if (!targetCaps.supported) throw new SyncKindError("unsupported_connection", targetCaps.reason ?? "Target connection is unsupported.");
+    if (!sourceCaps.capabilities.listTransactions || !sourceCaps.capabilities.readSplitLines) {
+      throw new SyncKindError("unsupported_connection", "Source connection cannot list transactions or split lines.");
+    }
+    if (!targetCaps.capabilities.listTransactions) {
+      throw new SyncKindError("unsupported_connection", "Target connection cannot list transactions for lookup.");
+    }
+  },
+
+  async loadSource(transport: ActualBenchTransport, flow: SyncFlow): Promise<AdapterSourceResult> {
+    const config = decodeFlowPlanConfig(flow);
+    const filter = decodeFilterOrDefault(flow);
+    let rawSource;
+    try {
+      rawSource = await transport.listTransactionsForSync({
+        accountId: config.sourceAccountId,
+        startDate: filter.startDate ?? undefined,
+        endDate: filter.endDate ?? undefined,
+      });
+    } catch (err) {
+      throw new SyncKindError("source_load_failed", err instanceof Error ? err.message : "Failed to read source transactions.");
+    }
+    const scanned = rawSource.length;
+    const nonGenerated = filterSourceTransactions(rawSource, filter);
+    const generatedExcluded = scanned - nonGenerated.length;
+    const expanded = expandSourceTransactions(nonGenerated);
+    const expandedCount = expanded.length;
+    const kept = filterSourceItems(expanded, filter);
+    const items = JSON.parse(JSON.stringify(kept)) as SyncSourceItem[];
+    const materialized: MaterializedSource = { items, filter, config };
+    return { materialized, stats: { scanned, generatedExcluded, expandedCount, keptCount: items.length } };
+  },
+
+  async loadTarget(transport: ActualBenchTransport, flow: SyncFlow): Promise<unknown> {
+    const config = decodeFlowPlanConfig(flow);
+    const filter = decodeFilterOrDefault(flow);
+    try {
+      return await loadTargetSnapshot(transport, config, filter);
+    } catch (err) {
+      throw new SyncKindError("target_load_failed", err instanceof Error ? err.message : "Failed to read target lookup data.");
+    }
+  },
+
+  plan({ flow, materialized, target, mappings, targetCapabilities }): SyncPlanResult {
+    const source = materialized as MaterializedSource;
+    void flow;
+    return planExpandedItems({
+      config: source.config,
+      capabilities: { mode: "browser-api", supported: true, reason: null, capabilities: targetCapabilities },
+      sourceItems: source.items,
+      target: target as SyncPlannerTargetSnapshot,
+      existingMappings: mappings as SyncMapping[],
+    });
+  },
+
+  sourceSummary(flow: SyncFlow): JsonObject {
+    const config = decodeFlowPlanConfig(flow);
+    return {
+      accountId: config.sourceAccountId,
+      budgetId: config.sourceBudgetId,
+      connectionFingerprint: config.sourceConnectionFingerprint,
+    };
+  },
+
+  buildSummary(plan: SyncPlanResult, stats): AdapterSummary {
+    const c = plan.counts;
+    const autoMapped = plan.items.filter((i) => i.flags.includes("exact_duplicate_auto_map")).length;
+    const dup = (c.exact_duplicate ?? 0) + (c.strong_duplicate ?? 0) + (c.weak_duplicate ?? 0) - autoMapped;
+    return {
+      sourceTransactionsScanned: stats.scanned,
+      generatedTransactionsExcluded: stats.generatedExcluded,
+      sourceItemsScanned: stats.expandedCount,
+      sourceItemsFilteredOut: stats.expandedCount - stats.keptCount,
+      plannedItems: plan.items.length,
+      createCandidates: c.new ?? 0,
+      alreadySynced: c.already_synced ?? 0,
+      duplicatesSkipped: Math.max(0, dup),
+      exactDuplicatesAutoMapped: autoMapped,
+      sourceChangedWarnings: c.source_changed_since_sync ?? 0,
+      targetMarkerMatches: c.target_marker_match ?? 0,
+      blocked: c.blocked ?? 0,
+    };
+  },
+
+  async prepareApply(transport: ActualBenchTransport, flow: SyncFlow): Promise<AdapterApplyContext> {
+    const config = decodeFlowPlanConfig(flow);
+    const lookup = await transport.getTargetLookupForSync({ accountId: config.targetAccountId });
+    return { markerIndex: lookup.importedIdIndex };
+  },
+
+  assertCanApply(caps: SyncCapabilitySet, willCreate: boolean): void {
+    if (!willCreate) return;
+    if (!caps.createTransaction || !caps.createTransactionWithImportedId) {
+      throw new SyncKindError("unsupported_connection", "Target cannot create transactions with a durable marker.");
+    }
+  },
+
+  async createBatch(
+    transport: ActualBenchTransport,
+    flow: SyncFlow,
+    inputs: AdapterCreateInput[]
+  ): Promise<AdapterCreateResult[]> {
+    const config = decodeFlowPlanConfig(flow);
+    const createInputs: SyncTargetTransactionInput[] = inputs.map(({ payload }) => ({
+      accountId: config.targetAccountId,
+      date: String(payload.date ?? ""),
+      amount: Number(payload.amount ?? 0),
+      payeeId: (payload.payeeId as string | null) ?? null,
+      payeeName: (payload.payeeName as string | null) ?? null,
+      categoryId: (payload.categoryId as string | null) ?? null,
+      notes: (payload.notes as string | null) ?? null,
+      cleared: payload.cleared === true,
+      importedId: (payload.importedId as string | null) ?? null,
+    }));
+    const { created } = await transport.createTransactionsForSync(createInputs);
+    return inputs.map((input, i) => {
+      const res = created[i];
+      const actual = res?.applied ?? null;
+      const changedFields = actual
+        ? diffPlannedVsActual(input.payload, res?.resolvedPayeeId ?? (input.payload.payeeId as string | null) ?? null, actual)
+        : [];
+      return { itemId: input.itemId, targetId: res?.transactionId ?? null, changedFields };
+    });
+  },
+};
+
+function assertConnectionMatches(savedFingerprint: string, connection: AdapterValidateInput["sourceConnection"], side: "source" | "target"): void {
+  if (!savedFingerprint) return;
+  if (connectionFingerprint(connection) !== savedFingerprint) {
+    throw new SyncKindError("connection_mismatch", `The ${side} connection does not match the one this flow was saved with.`);
+  }
+}
+
+registerSyncKindAdapter(transactionAdapter);

--- a/src/lib/sync/adapters/transactionAdapter.ts
+++ b/src/lib/sync/adapters/transactionAdapter.ts
@@ -30,7 +30,7 @@ import type { SyncPlannerTargetSnapshot, SyncPlanResult } from "../plannedChange
 
 /**
  * Transaction data-type adapter for the unified sync engine (RD-053 behavior,
- * unchanged — this is the behavior-preserving extraction of the original
+ * unchanged - this is the behavior-preserving extraction of the original
  * inline transaction logic behind the `SyncKindAdapter` interface).
  */
 

--- a/src/lib/sync/applyOrchestrator.test.ts
+++ b/src/lib/sync/applyOrchestrator.test.ts
@@ -162,7 +162,7 @@ const provider = (transport: ActualBenchTransport): ApplyTransportProvider => ({
 
 // --- Tests ------------------------------------------------------------------
 
-describe("applySyncRun — validation", () => {
+describe("applySyncRun - validation", () => {
   it("fails when the run does not exist", async () => {
     const store = makeStore();
     store.store.loadRun = jest.fn(async () => null);
@@ -213,7 +213,7 @@ describe("applySyncRun — validation", () => {
   });
 });
 
-describe("applySyncRun — create path", () => {
+describe("applySyncRun - create path", () => {
   it("creates a target transaction, resolves the id, and records a mapping immediately", async () => {
     const { store, createdMappings, itemPatches } = makeStore();
     const { transport, createTransactionsForSync } = makeTargetTransport();
@@ -295,7 +295,7 @@ describe("applySyncRun — create path", () => {
   });
 });
 
-describe("applySyncRun — idempotency & duplicates", () => {
+describe("applySyncRun - idempotency & duplicates", () => {
   it("skips an item that already has a DB mapping (no duplicate create)", async () => {
     const seed = { flowId: "flow-1", sourceItemKey: "txn:t1", targetTransactionId: "existing" } as unknown as SyncMapping;
     const { store, createdMappings } = makeStore({ seedMappings: [seed] });
@@ -330,7 +330,7 @@ describe("applySyncRun — idempotency & duplicates", () => {
   });
 });
 
-describe("applySyncRun — marker-match repair", () => {
+describe("applySyncRun - marker-match repair", () => {
   function markerMatchItem(): SyncFlowRunItem {
     return runItem({
       id: "mm-1",
@@ -401,7 +401,7 @@ describe("applySyncRun — marker-match repair", () => {
   });
 });
 
-describe("applySyncRun — exact-duplicate auto-map", () => {
+describe("applySyncRun - exact-duplicate auto-map", () => {
   function autoMapItem(): SyncFlowRunItem {
     return runItem({
       id: "dup-1",
@@ -447,7 +447,7 @@ describe("applySyncRun — exact-duplicate auto-map", () => {
   });
 });
 
-describe("applySyncRun — retry failed", () => {
+describe("applySyncRun - retry failed", () => {
   it("re-attempts only the previously-failed items on a partial run", async () => {
     const failed = runItem({ id: "f1", sourceItemKey: "txn:t1", applyState: "failed", payloadData: { importedId: MARKER_T1 } } as unknown as Partial<SyncFlowRunItem>);
     const done = runItem({ id: "ok1", sourceItemKey: "txn:t2", applyState: "applied", payloadData: { importedId: MARKER_T2 } } as unknown as Partial<SyncFlowRunItem>);
@@ -484,7 +484,7 @@ describe("applySyncRun — retry failed", () => {
   });
 });
 
-describe("applySyncRun — partial failure & splits", () => {
+describe("applySyncRun - partial failure & splits", () => {
   it("reports partial when one item applies and another fails to resolve", async () => {
     const good = runItem({ id: "good", sourceItemKey: "txn:t1", payloadData: { importedId: MARKER_T1 } } as unknown as Partial<SyncFlowRunItem>);
     const bad = runItem({ id: "bad", sourceItemKey: "txn:t2", sourceTransactionId: "t2", payloadData: { importedId: MARKER_T2 } } as unknown as Partial<SyncFlowRunItem>);

--- a/src/lib/sync/applyOrchestrator.ts
+++ b/src/lib/sync/applyOrchestrator.ts
@@ -24,7 +24,7 @@ import type { PlannedTargetPayload } from "./plannedChanges";
  * Takes a persisted `draft_preview` run and applies its safe `new` create
  * candidates to the target budget in Direct mode. It re-validates target-side
  * safety before every create, records a mapping immediately after each success,
- * and reports partial failures cleanly. It never opens the source budget — apply
+ * and reports partial failures cleanly. It never opens the source budget - apply
  * works entirely from the persisted preview payload plus live target lookups.
  *
  * Ports keep the browser transport and server SQLite decoupled, mirroring the
@@ -200,7 +200,7 @@ export async function applySyncRun(
 
   // Repair/map items write nothing, so they stay per-item (cheap). Creates are
   // batched into ONE insert + ONE id-recovery read instead of one round-trip per
-  // transaction — the dominant cost on large runs.
+  // transaction - the dominant cost on large runs.
   for (const eligibleItem of eligible.filter((e) => e.mode !== "create")) {
     const result = await applyOneItem(eligibleItem, ctx, deps.store);
     items.push(result);
@@ -343,7 +343,7 @@ async function validateAndPrepare(
   }
   const config = decodeFlowPlanConfig(flow);
 
-  // Direct-only support gate first — an unsupported mode can never apply,
+  // Direct-only support gate first - an unsupported mode can never apply,
   // regardless of route. (Create-capability checks come after eligibility.)
   const caps = getBudgetFileSyncCapabilities({ mode: input.targetConnection.mode });
   if (!caps.supported) {
@@ -407,7 +407,7 @@ async function validateAndPrepare(
   }
 
   // Write-capability gate only matters when we actually create (repair/map write
-  // no Actual entity — they only record a mapping to an existing target).
+  // no Actual entity - they only record a mapping to an existing target).
   const willCreate = eligible.some((e) => e.mode === "create");
   try {
     adapter.assertCanApply(caps.capabilities, willCreate);
@@ -422,7 +422,7 @@ async function validateAndPrepare(
 function toCreateCandidate(item: SyncFlowRunItem): EligibleItem {
   // The persisted create payload (transaction has an imported_id; entity has a
   // name). The planner already blocked transaction items lacking a marker, so no
-  // marker check is needed here — the adapter's createBatch consumes the JSON.
+  // marker check is needed here - the adapter's createBatch consumes the JSON.
   const payloadJson = (item.plannedTargetPayload?.data as JsonObject | undefined) ?? null;
   if (!payloadJson) {
     throw new ApplyPreflightError("ineligible_selection", `Item ${item.id} has no usable planned payload.`);
@@ -452,7 +452,7 @@ async function applyOneItem(
 
 /**
  * Apply create candidates as a batch: resolve which items still need a write
- * (skipping already-mapped items and repairing marker hits — no writes), then
+ * (skipping already-mapped items and repairing marker hits - no writes), then
  * create the remainder in **one** `createTransactionsForSync` call (one insert +
  * one id-recovery read in the transport) instead of a round-trip per item.
  */
@@ -464,7 +464,7 @@ async function applyCreateBatch(
   const results: ApplyItemResult[] = [];
   const toCreate: { item: SyncFlowRunItem; payloadJson: JsonObject; marker: string | null }[] = [];
 
-  // Phase A — no writes: skip already-mapped items; for transactions, repair a
+  // Phase A - no writes: skip already-mapped items; for transactions, repair a
   // lost mapping when the marker is already on the target; queue the rest.
   for (const eligible of createItems) {
     const item = eligible.item;
@@ -511,7 +511,7 @@ async function applyCreateBatch(
 
   if (toCreate.length === 0) return results;
 
-  // Phase B — the adapter creates the batch (transactions: one insert + one
+  // Phase B - the adapter creates the batch (transactions: one insert + one
   // id-recovery read; entities: create payees/categories) and returns per-item ids.
   let created: AdapterCreateResult[];
   try {
@@ -534,7 +534,7 @@ async function applyCreateBatch(
   }
   const resultByItem = new Map(created.map((r) => [r.itemId, r]));
 
-  // Phase C — per created item: verify id, record the mapping, set status.
+  // Phase C - per created item: verify id, record the mapping, set status.
   for (const { item, marker } of toCreate) {
     const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
     const res = resultByItem.get(item.id);
@@ -569,7 +569,7 @@ async function applyCreateBatch(
       continue;
     }
 
-    // New live marker on the target — guard later items against duplicating it.
+    // New live marker on the target - guard later items against duplicating it.
     if (marker) ctx.markerIndex.set(marker, targetId);
 
     const hasWarnings = changedFields.length > 0;
@@ -627,7 +627,7 @@ async function recordMapping(
 /**
  * Repair a lost DB mapping for a `target_marker_match` item: the target already
  * has our deterministic marker, so we map the source item to that existing
- * target transaction — no Actual write, no duplicate.
+ * target transaction - no Actual write, no duplicate.
  */
 async function repairOneItem(
   eligible: EligibleItem,
@@ -638,7 +638,7 @@ async function repairOneItem(
   const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
   const targetId = eligible.targetTransactionId as string;
   // Transactions carry a deterministic marker to re-validate; entity name matches
-  // (target_name_match) do not — the planner already resolved the target id.
+  // (target_name_match) do not - the planner already resolved the target id.
   const isNameMatch = item.classification === "target_name_match";
   const marker = isNameMatch
     ? null

--- a/src/lib/sync/applyOrchestrator.ts
+++ b/src/lib/sync/applyOrchestrator.ts
@@ -1,12 +1,10 @@
 import { getBudgetFileSyncCapabilities } from "./capabilities";
+import "./adapters"; // register all data-type adapters (side-effect)
 import { connectionFingerprint } from "./connectionRef";
 import { decodeFlowPlanConfig, type SyncFlowPlanConfig } from "./flowConfig";
 import { generateSyncMarker } from "./marker";
-import type {
-  ActualBenchTransport,
-  SyncCreatedTransaction,
-  SyncTargetTransactionInput,
-} from "@/lib/actual/transport";
+import { getSyncKindAdapter, SyncKindError, type AdapterCreateResult, type SyncKindAdapter } from "./syncKind";
+import type { ActualBenchTransport } from "@/lib/actual/transport";
 import type { ConnectionInstance } from "@/store/connection";
 import type {
   JsonEnvelope,
@@ -176,7 +174,7 @@ export async function applySyncRun(
     throw err;
   }
 
-  const { config, eligible } = prepared;
+  const { config, adapter, flow, eligible } = prepared;
   const counts: ApplyCounts = { ...EMPTY_COUNTS, selected: eligible.length };
   const items: ApplyItemResult[] = [];
 
@@ -186,9 +184,8 @@ export async function applySyncRun(
   let markerIndex: Map<string, string>;
   try {
     transport = await deps.transport.openTransport(input.targetConnection);
-    // Fresh target marker index for stale-preview revalidation.
-    const lookup = await transport.getTargetLookupForSync({ accountId: config.targetAccountId });
-    markerIndex = lookup.importedIdIndex;
+    // Adapter-specific apply prep (e.g. the target marker index for transactions).
+    ({ markerIndex } = await adapter.prepareApply(transport, flow));
   } catch (err) {
     const error: ApplyError = {
       code: "target_open_failed",
@@ -199,7 +196,7 @@ export async function applySyncRun(
     return { status: "failed", runId, error, counts, items };
   }
 
-  const ctx: ItemContext = { config, transport, markerIndex };
+  const ctx: ItemContext = { config, adapter, flow, transport, markerIndex };
 
   // Repair/map items write nothing, so they stay per-item (cheap). Creates are
   // batched into ONE insert + ONE id-recovery read instead of one round-trip per
@@ -241,15 +238,16 @@ type ApplyItemMode = "create" | "repair" | "map";
 type EligibleItem = {
   item: SyncFlowRunItem;
   mode: ApplyItemMode;
-  /** Present for create items; null for repair. */
-  payload: PlannedTargetPayload | null;
-  /** Existing target transaction id for repair items; null for create. */
+  /** Raw persisted create payload (transaction or entity) for create items. */
+  payloadJson: JsonObject | null;
+  /** Existing target transaction/entity id for repair/map items; null for create. */
   targetTransactionId: string | null;
 };
 
 type PreparedApply = {
   flow: SyncFlow;
   config: SyncFlowPlanConfig;
+  adapter: SyncKindAdapter;
   eligible: EligibleItem[];
 };
 
@@ -276,9 +274,16 @@ function isExactDupAutoMap(item: SyncFlowRunItem): boolean {
   );
 }
 
-/** A target_marker_match item whose target transaction id was resolved at preview. */
+/**
+ * A repairable item whose target id was resolved at preview: a transaction
+ * marker match, or a master-data entity name match (RD-055). Both record a
+ * mapping to the existing target without a write.
+ */
 function isRepairable(item: SyncFlowRunItem): boolean {
-  return item.classification === "target_marker_match" && readTargetTxnId(item) != null;
+  return (
+    (item.classification === "target_marker_match" || item.classification === "target_name_match") &&
+    readTargetTxnId(item) != null
+  );
 }
 
 function readTargetTxnId(item: SyncFlowRunItem): string | null {
@@ -332,13 +337,14 @@ async function validateAndPrepare(
   const flow = await store.loadFlow(run.flowId);
   if (!flow) throw new ApplyPreflightError("flow_not_found", `Flow ${run.flowId} was not found.`);
 
-  const config = decodeFlowPlanConfig(flow);
-  if (!config.targetAccountId) {
-    throw new ApplyPreflightError("route_mismatch", "Flow has no target account.");
+  const adapter = getSyncKindAdapter(flow.flowType);
+  if (!adapter) {
+    throw new ApplyPreflightError("route_mismatch", `Unsupported sync type: ${flow.flowType}.`);
   }
+  const config = decodeFlowPlanConfig(flow);
 
   // Direct-only support gate first — an unsupported mode can never apply,
-  // regardless of route. (Create/payee capability checks come after eligibility.)
+  // regardless of route. (Create-capability checks come after eligibility.)
   const caps = getBudgetFileSyncCapabilities({ mode: input.targetConnection.mode });
   if (!caps.supported) {
     throw new ApplyPreflightError("unsupported_connection", caps.reason ?? "Target connection is unsupported.");
@@ -368,9 +374,9 @@ async function validateAndPrepare(
       if (isEligibleNew(item)) {
         eligible.push(toCreateCandidate(item));
       } else if (isRepairable(item)) {
-        eligible.push({ item, mode: "repair", payload: null, targetTransactionId: readTargetTxnId(item) });
+        eligible.push({ item, mode: "repair", payloadJson: null, targetTransactionId: readTargetTxnId(item) });
       } else if (isExactDupAutoMap(item)) {
-        eligible.push({ item, mode: "map", payload: null, targetTransactionId: readTargetTxnId(item) });
+        eligible.push({ item, mode: "map", payloadJson: null, targetTransactionId: readTargetTxnId(item) });
       } else {
         throw new ApplyPreflightError("ineligible_selection", `Selected item ${id} is not an applyable create, repair, or map candidate.`);
       }
@@ -380,8 +386,8 @@ async function validateAndPrepare(
     for (const item of allItems) {
       if (item.applyState !== "failed") continue;
       if (isEligibleNew(item)) eligible.push(toCreateCandidate(item));
-      else if (isRepairable(item)) eligible.push({ item, mode: "repair", payload: null, targetTransactionId: readTargetTxnId(item) });
-      else if (isExactDupAutoMap(item)) eligible.push({ item, mode: "map", payload: null, targetTransactionId: readTargetTxnId(item) });
+      else if (isRepairable(item)) eligible.push({ item, mode: "repair", payloadJson: null, targetTransactionId: readTargetTxnId(item) });
+      else if (isExactDupAutoMap(item)) eligible.push({ item, mode: "map", payloadJson: null, targetTransactionId: readTargetTxnId(item) });
     }
   } else {
     const includeRepairs = input.selection?.selection === "all_safe";
@@ -389,9 +395,9 @@ async function validateAndPrepare(
       if (isEligibleNew(item)) {
         eligible.push(toCreateCandidate(item));
       } else if (includeRepairs && isRepairable(item)) {
-        eligible.push({ item, mode: "repair", payload: null, targetTransactionId: readTargetTxnId(item) });
+        eligible.push({ item, mode: "repair", payloadJson: null, targetTransactionId: readTargetTxnId(item) });
       } else if (includeRepairs && isExactDupAutoMap(item)) {
-        eligible.push({ item, mode: "map", payload: null, targetTransactionId: readTargetTxnId(item) });
+        eligible.push({ item, mode: "map", payloadJson: null, targetTransactionId: readTargetTxnId(item) });
       }
     }
   }
@@ -400,38 +406,36 @@ async function validateAndPrepare(
     throw new ApplyPreflightError("no_eligible_items", "No eligible create or repair candidates were selected.");
   }
 
-  // Write-capability gate only matters when we actually create (repair writes no
-  // Actual transaction — it only records a mapping to an existing target row).
-  const createItems = eligible.filter((e) => e.mode === "create");
-  if (createItems.length > 0) {
-    if (!caps.capabilities.createTransaction || !caps.capabilities.createTransactionWithImportedId) {
-      throw new ApplyPreflightError("unsupported_connection", "Target cannot create transactions with a durable marker.");
-    }
-    const needsPayeeCreate = createItems.some((e) => e.payload && !e.payload.payeeId && e.payload.payeeName);
-    if (needsPayeeCreate && !caps.capabilities.createPayee) {
-      throw new ApplyPreflightError("unsupported_connection", "Target cannot create the payees this run requires.");
-    }
+  // Write-capability gate only matters when we actually create (repair/map write
+  // no Actual entity — they only record a mapping to an existing target).
+  const willCreate = eligible.some((e) => e.mode === "create");
+  try {
+    adapter.assertCanApply(caps.capabilities, willCreate);
+  } catch (err) {
+    if (err instanceof SyncKindError) throw new ApplyPreflightError("unsupported_connection", err.message);
+    throw err;
   }
 
-  return { flow, config, eligible };
+  return { flow, config, adapter, eligible };
 }
 
 function toCreateCandidate(item: SyncFlowRunItem): EligibleItem {
-  const payload = readPayload(item);
-  if (!payload) {
+  // The persisted create payload (transaction has an imported_id; entity has a
+  // name). The planner already blocked transaction items lacking a marker, so no
+  // marker check is needed here — the adapter's createBatch consumes the JSON.
+  const payloadJson = (item.plannedTargetPayload?.data as JsonObject | undefined) ?? null;
+  if (!payloadJson) {
     throw new ApplyPreflightError("ineligible_selection", `Item ${item.id} has no usable planned payload.`);
   }
-  if (!payload.importedId) {
-    // No deterministic marker ⇒ never create (idempotency guarantee).
-    throw new ApplyPreflightError("ineligible_selection", `Item ${item.id} has no imported_id marker; refusing to create.`);
-  }
-  return { item, mode: "create", payload, targetTransactionId: null };
+  return { item, mode: "create", payloadJson, targetTransactionId: null };
 }
 
 // --- Per-item apply ---------------------------------------------------------
 
 type ItemContext = {
   config: SyncFlowPlanConfig;
+  adapter: SyncKindAdapter;
+  flow: SyncFlow;
   transport: ActualBenchTransport;
   markerIndex: Map<string, string>;
 };
@@ -458,14 +462,15 @@ async function applyCreateBatch(
   store: ApplyStore
 ): Promise<ApplyItemResult[]> {
   const results: ApplyItemResult[] = [];
-  const toCreate: { item: SyncFlowRunItem; payload: PlannedTargetPayload }[] = [];
+  const toCreate: { item: SyncFlowRunItem; payloadJson: JsonObject; marker: string | null }[] = [];
 
-  // Phase A — no writes: skip already-mapped items; repair a lost mapping when
-  // the marker is already on the target; queue the rest for the batch insert.
+  // Phase A — no writes: skip already-mapped items; for transactions, repair a
+  // lost mapping when the marker is already on the target; queue the rest.
   for (const eligible of createItems) {
     const item = eligible.item;
-    const payload = eligible.payload as PlannedTargetPayload;
-    const marker = payload.importedId as string;
+    const payloadJson = eligible.payloadJson ?? {};
+    // Only transaction payloads carry a durable marker; entities are marker-less.
+    const marker = typeof payloadJson.importedId === "string" ? payloadJson.importedId : null;
     const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
     try {
       const existingMapping = await store.getMappingBySource(ctx.config.flowId, item.sourceItemKey ?? "");
@@ -478,8 +483,8 @@ async function applyCreateBatch(
         results.push({ ...base, outcome: "skipped", targetTransactionId: existingMapping.targetTransactionId, message: "already mapped" });
         continue;
       }
-      const markerHit = ctx.markerIndex.get(marker);
-      if (markerHit) {
+      const markerHit = marker ? ctx.markerIndex.get(marker) : undefined;
+      if (marker && markerHit) {
         await recordMapping(store, ctx.config, item, markerHit, marker, null);
         await store.updateRunItemStatus(item.id, {
           status: "skipped",
@@ -492,7 +497,7 @@ async function applyCreateBatch(
         results.push({ ...base, outcome: "repaired", targetTransactionId: markerHit, message: "repaired mapping" });
         continue;
       }
-      toCreate.push({ item, payload });
+      toCreate.push({ item, payloadJson, marker });
     } catch (err) {
       await store.updateRunItemStatus(item.id, {
         status: "failed",
@@ -506,21 +511,15 @@ async function applyCreateBatch(
 
   if (toCreate.length === 0) return results;
 
-  // Phase B — one batched insert (+ one id-recovery read inside the transport).
-  let created: SyncCreatedTransaction[];
+  // Phase B — the adapter creates the batch (transactions: one insert + one
+  // id-recovery read; entities: create payees/categories) and returns per-item ids.
+  let created: AdapterCreateResult[];
   try {
-    const inputs: SyncTargetTransactionInput[] = toCreate.map(({ payload }) => ({
-      accountId: ctx.config.targetAccountId,
-      date: payload.date,
-      amount: payload.amount,
-      payeeId: payload.payeeId,
-      payeeName: payload.payeeName,
-      categoryId: payload.categoryId,
-      notes: payload.notes,
-      cleared: payload.cleared,
-      importedId: payload.importedId,
-    }));
-    ({ created } = await ctx.transport.createTransactionsForSync(inputs));
+    created = await ctx.adapter.createBatch(
+      ctx.transport,
+      ctx.flow,
+      toCreate.map(({ item, payloadJson }) => ({ itemId: item.id, payload: payloadJson }))
+    );
   } catch (err) {
     for (const { item } of toCreate) {
       await store.updateRunItemStatus(item.id, {
@@ -533,32 +532,27 @@ async function applyCreateBatch(
     }
     return results;
   }
+  const resultByItem = new Map(created.map((r) => [r.itemId, r]));
 
-  // Phase C — per created row: verify id, diff vs planned, record the mapping.
-  for (let i = 0; i < toCreate.length; i++) {
-    const { item, payload } = toCreate[i];
-    const marker = payload.importedId as string;
+  // Phase C — per created item: verify id, record the mapping, set status.
+  for (const { item, marker } of toCreate) {
     const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
-    const res = created[i];
-    const targetId = res?.transactionId ?? null;
+    const res = resultByItem.get(item.id);
+    const targetId = res?.targetId ?? null;
 
     if (!targetId) {
       await store.updateRunItemStatus(item.id, {
         status: "failed",
         applyState: "failed",
-        message: "Created transaction could not be resolved by imported_id.",
+        message: "Created item could not be resolved on the target.",
         errors: envelope({ code: "unresolved_target_id", marker }),
         createdTargetMarker: marker,
       });
-      results.push({ ...base, outcome: "failed", targetTransactionId: null, message: "target id unresolved; a transaction may exist but was not confirmed" });
+      results.push({ ...base, outcome: "failed", targetTransactionId: null, message: "target id unresolved; the item may exist but was not confirmed" });
       continue;
     }
 
-    // Target rules can run on create; the actual row + resolved payee come back
-    // with the id, so the diff needs no extra read.
-    const actual = res?.applied ?? null;
-    const changedFields = actual ? diffPlannedVsActual(payload, res?.resolvedPayeeId ?? payload.payeeId ?? null, actual) : [];
-
+    const changedFields = res?.changedFields ?? [];
     try {
       // Fingerprint is unused downstream, so it is not recomputed here.
       await recordMapping(store, ctx.config, item, targetId, marker, null);
@@ -576,7 +570,7 @@ async function applyCreateBatch(
     }
 
     // New live marker on the target — guard later items against duplicating it.
-    ctx.markerIndex.set(marker, targetId);
+    if (marker) ctx.markerIndex.set(marker, targetId);
 
     const hasWarnings = changedFields.length > 0;
     await store.updateRunItemStatus(item.id, {
@@ -594,21 +588,6 @@ async function applyCreateBatch(
   return results;
 }
 
-function diffPlannedVsActual(
-  payload: PlannedTargetPayload,
-  resolvedPayeeId: string | null,
-  actual: { amount: number; date: string; cleared: boolean; categoryId: string | null; payeeId: string | null; notes: string | null }
-): string[] {
-  const changed: string[] = [];
-  if (payload.amount !== actual.amount) changed.push("amount");
-  if (payload.date !== actual.date) changed.push("date");
-  if (payload.cleared !== actual.cleared) changed.push("cleared");
-  if ((payload.categoryId ?? null) !== (actual.categoryId ?? null)) changed.push("category");
-  if ((resolvedPayeeId ?? null) !== (actual.payeeId ?? null)) changed.push("payee");
-  if ((payload.notes ?? null) !== (actual.notes ?? null)) changed.push("notes");
-  return changed;
-}
-
 async function recordMapping(
   store: ApplyStore,
   config: SyncFlowPlanConfig,
@@ -618,6 +597,10 @@ async function recordMapping(
   targetFingerprint: string | null
 ): Promise<void> {
   const entityType: SyncEntityType = item.sourceEntityType ?? "transaction";
+  // Master-data entities map to a same-type target; transactions/splits to a txn.
+  const isEntity = entityType === "payee" || entityType === "category" || entityType === "category_group";
+  const targetEntityType: SyncEntityType = isEntity ? entityType : "transaction";
+  const targetItemKey = isEntity ? `${entityType}:${targetTransactionId}` : "txn:" + targetTransactionId;
   await store.createMapping({
     flowId: config.flowId,
     sourceConnectionFingerprint: config.sourceConnectionFingerprint,
@@ -631,9 +614,9 @@ async function recordMapping(
     targetConnectionFingerprint: config.targetConnectionFingerprint,
     targetBudgetId: config.targetBudgetId,
     targetAccountId: config.targetAccountId || null,
-    targetEntityType: "transaction",
+    targetEntityType,
     targetTransactionId,
-    targetItemKey: "txn:" + targetTransactionId,
+    targetItemKey,
     targetFingerprint,
     targetMarker,
     createdRunId: item.runId,
@@ -653,13 +636,18 @@ async function repairOneItem(
 ): Promise<ApplyItemResult> {
   const { item } = eligible;
   const base = { itemId: item.id, sourceItemKey: item.sourceItemKey ?? "" };
-  const marker = generateSyncMarker({
-    sourceBudgetId: ctx.config.sourceBudgetId,
-    targetBudgetId: ctx.config.targetBudgetId,
-    targetAccountId: ctx.config.targetAccountId,
-    sourceItemKey: item.sourceItemKey ?? "",
-  });
   const targetId = eligible.targetTransactionId as string;
+  // Transactions carry a deterministic marker to re-validate; entity name matches
+  // (target_name_match) do not — the planner already resolved the target id.
+  const isNameMatch = item.classification === "target_name_match";
+  const marker = isNameMatch
+    ? null
+    : generateSyncMarker({
+        sourceBudgetId: ctx.config.sourceBudgetId,
+        targetBudgetId: ctx.config.targetBudgetId,
+        targetAccountId: ctx.config.targetAccountId,
+        sourceItemKey: item.sourceItemKey ?? "",
+      });
 
   try {
     const existingMapping = await store.getMappingBySource(ctx.config.flowId, item.sourceItemKey ?? "");
@@ -672,8 +660,9 @@ async function repairOneItem(
       return { ...base, outcome: "skipped", targetTransactionId: existingMapping.targetTransactionId, message: "already mapped" };
     }
 
-    // Only repair if the marker still maps to the same target we previewed.
-    if (!marker || ctx.markerIndex.get(marker) !== targetId) {
+    // Transactions only: repair just when the marker still maps to the previewed
+    // target. Entity name matches trust the planner-resolved target id.
+    if (!isNameMatch && (!marker || ctx.markerIndex.get(marker) !== targetId)) {
       await store.updateRunItemStatus(item.id, {
         status: "skipped",
         applyState: "skipped",

--- a/src/lib/sync/flowConfig.ts
+++ b/src/lib/sync/flowConfig.ts
@@ -7,7 +7,7 @@ import type { SyncFlow, SyncReviewPolicy } from "@/lib/app-db/types";
  * versioned JSON envelopes (flexible for future domains). The planner needs a
  * concrete, defaulted shape; this module is the single decode point from the
  * loose envelope model into that typed config. Filters are intentionally out of
- * scope here — the planner operates on an already-filtered source snapshot
+ * scope here - the planner operates on an already-filtered source snapshot
  * (source filtering happens during load in Slice 3).
  */
 
@@ -60,7 +60,7 @@ export type SyncFlowPlanConfig = {
   exactDuplicateAutoMap: boolean;
 };
 
-/** Smallest allowed auto-sync interval — a budget sync per run is expensive. */
+/** Smallest allowed auto-sync interval - a budget sync per run is expensive. */
 export const MIN_SYNC_INTERVAL_MINUTES = 15;
 /** Default auto-sync interval when a flow opts in without choosing one. */
 export const DEFAULT_SYNC_INTERVAL_MINUTES = 60;

--- a/src/lib/sync/marker.ts
+++ b/src/lib/sync/marker.ts
@@ -2,9 +2,9 @@
  * Deterministic target-side sync marker (Actual `imported_id`) for Budget File
  * Sync (RD-053 / PR-019).
  *
- * The marker is derived only from **globally stable identity** — the source and
+ * The marker is derived only from **globally stable identity** - the source and
  * target Actual budget sync ids, the target account id, and the source item key
- * — never from the (random, per-instance) flow id or the server URL. That makes
+ * - never from the (random, per-instance) flow id or the server URL. That makes
  * it **portable across Actual Bench instances**: any instance, on any host,
  * computes the identical marker for the same source item → target account. So if
  * one instance syncs a transaction, another instance recognises it on the target

--- a/src/lib/sync/notesMarker.ts
+++ b/src/lib/sync/notesMarker.ts
@@ -3,7 +3,7 @@
  *
  * The marker is a clean, human-readable line appended to target notes so a user
  * can see a transaction came from a sync flow. Technical source IDs are NOT put
- * here — those live in app metadata and the target-side `imported_id` marker.
+ * here - those live in app metadata and the target-side `imported_id` marker.
  */
 
 export type SyncNotesMarkerContext = {

--- a/src/lib/sync/persistPlan.ts
+++ b/src/lib/sync/persistPlan.ts
@@ -9,7 +9,7 @@ import type {
   SyncFlowRunItem,
   SyncRunTrigger,
 } from "@/lib/app-db/types";
-import type { PlannedTargetPayload, SyncPlannedItem, SyncPlanResult } from "./plannedChanges";
+import type { SyncPlannedItem, SyncPlanResult } from "./plannedChanges";
 
 /**
  * Persist a dry-run plan into the PR-018 run/run-item repositories
@@ -34,18 +34,11 @@ export type PersistDraftPreviewOptions = {
   trigger?: SyncRunTrigger;
 };
 
-function payloadToJsonObject(payload: PlannedTargetPayload): JsonObject {
-  return {
-    accountId: payload.accountId,
-    date: payload.date,
-    amount: payload.amount,
-    payeeId: payload.payeeId,
-    payeeName: payload.payeeName,
-    categoryId: payload.categoryId,
-    notes: payload.notes,
-    cleared: payload.cleared,
-    importedId: payload.importedId,
-  };
+/** Serialize whichever create payload the planned item carries (transaction or entity). */
+function payloadToJsonObject(item: SyncPlannedItem): JsonObject | null {
+  const payload = item.plannedTargetPayload ?? item.entityPayload ?? null;
+  // Both transaction and entity payloads are flat, JSON-safe data; store as-is.
+  return payload ? ({ ...payload } as JsonObject) : null;
 }
 
 function sourceItemRef(item: SyncPlannedItem): JsonObject {
@@ -103,9 +96,10 @@ export function persistDraftPreviewRun(
         sourceSplitId: item.sourceSplitId,
         sourceFingerprint: item.sourceFingerprint,
         plannedAction: item.action,
-        plannedTargetPayload: item.plannedTargetPayload
-          ? { version: 1, data: payloadToJsonObject(item.plannedTargetPayload) }
-          : null,
+        plannedTargetPayload: (() => {
+          const data = payloadToJsonObject(item);
+          return data ? { version: 1, data } : null;
+        })(),
         classification: item.classification,
         duplicateConfidence: item.duplicateConfidence,
         warnings: { version: 1, data: { flags: [...item.flags] } },

--- a/src/lib/sync/plannedChanges.ts
+++ b/src/lib/sync/plannedChanges.ts
@@ -48,6 +48,23 @@ export type PlannedTargetPayload = {
   importedId: string | null;
 };
 
+/**
+ * The master-data entity the engine would create on the target (RD-055). A
+ * discriminated alternative to the transaction payload; both are stored as plain
+ * JSON on the run item and read back by the kind-specific apply adapter.
+ */
+export type EntityTargetPayload = {
+  entity: "payee" | "category";
+  name: string;
+  /** Category kind; carried so income/expense stay distinct. */
+  incomeKind?: "income" | "expense";
+  /** Resolved target group id a category will be created under (categories only). */
+  groupId?: string | null;
+  /** Target group display name (categories only). */
+  groupName?: string | null;
+};
+
+
 /** Source-side display snapshot, persisted so the preview can show both sides. */
 export type PlannedSourceSnapshot = {
   date: string;
@@ -70,9 +87,11 @@ export type SyncPlannedItem = {
   action: SyncPlannedAction;
   flags: SyncPlanFlag[];
   selectedForApply: boolean;
-  /** Present for create candidates; null for skip/blocked. */
+  /** Transaction create payload; present for transaction create candidates. */
   plannedTargetPayload: PlannedTargetPayload | null;
-  /** Known target transaction id for already-synced / marker-match items. */
+  /** Master-data entity create payload (RD-055); present for entity candidates. */
+  entityPayload?: EntityTargetPayload | null;
+  /** Known target transaction/entity id for already-synced / matched items. */
   targetTransactionId: string | null;
   message: string | null;
 };

--- a/src/lib/sync/previewOrchestrator.test.ts
+++ b/src/lib/sync/previewOrchestrator.test.ts
@@ -126,7 +126,7 @@ beforeEach(() => {
   events.length = 0;
 });
 
-describe("runLiveDryRunPreview — happy path", () => {
+describe("runLiveDryRunPreview - happy path", () => {
   it("reads source fully before opening the target, then plans and persists", async () => {
     const source = makeTransport("source", { sourceTransactions: [srcTxn()] });
     const target = makeTransport("target", { targetPayees: [{ id: "tp1", name: "Coffee Bar" }], targetCategories: [{ id: "tc1", name: "Dining" }] });
@@ -207,7 +207,7 @@ describe("runLiveDryRunPreview — happy path", () => {
   });
 });
 
-describe("runLiveDryRunPreview — validation", () => {
+describe("runLiveDryRunPreview - validation", () => {
   it("returns flow_not_found with no run when the flow is missing", async () => {
     const { store, persistPlan, persistFailedRun } = makeStore(null);
     const result = await runLiveDryRunPreview(
@@ -250,7 +250,7 @@ describe("runLiveDryRunPreview — validation", () => {
   });
 });
 
-describe("runLiveDryRunPreview — failure handling", () => {
+describe("runLiveDryRunPreview - failure handling", () => {
   it("persists a failed run when source reads throw after validation", async () => {
     const source = makeTransport("source", { failSourceRead: true });
     const { store, persistFailedRun } = makeStore(makeFlow());

--- a/src/lib/sync/previewOrchestrator.ts
+++ b/src/lib/sync/previewOrchestrator.ts
@@ -10,7 +10,7 @@ import type { SyncPlanResult } from "./plannedChanges";
  * Live dry-run orchestration for Budget File Sync (RD-053 / PR-019 Slice 3).
  *
  * Connects the Slice 1 transport primitives with the Slice 2 planner to produce
- * a real, persisted `draft_preview` — with NO Actual writes. Cross-budget access
+ * a real, persisted `draft_preview` - with NO Actual writes. Cross-budget access
  * follows Pattern A: the source snapshot is fully materialized before the target
  * budget is opened, because the browser runtime holds only one budget at a time.
  *

--- a/src/lib/sync/previewOrchestrator.ts
+++ b/src/lib/sync/previewOrchestrator.ts
@@ -159,11 +159,22 @@ export async function runLiveDryRunPreview(
   // Everything past validation can create a run; on failure persist a failed run.
   try {
     // 3. Source phase (Pattern A): the adapter reads + materializes.
-    const sourceTransport = await deps.transport.openTransport(input.context.sourceConnection);
+    let sourceTransport: ActualBenchTransport;
+    try {
+      sourceTransport = await deps.transport.openTransport(input.context.sourceConnection);
+    } catch (err) {
+      throw new SyncKindError("source_load_failed", describe(err, "Failed to open the source budget."));
+    }
     const source = await adapter.loadSource(sourceTransport, flow);
 
     // 4. Target phase: open target (may close source), load its snapshot + mappings.
-    const targetTransport = await deps.transport.openTransport(input.context.targetConnection);
+    // Opening the target must surface as a target failure, not the source fallback.
+    let targetTransport: ActualBenchTransport;
+    try {
+      targetTransport = await deps.transport.openTransport(input.context.targetConnection);
+    } catch (err) {
+      throw new SyncKindError("target_load_failed", describe(err, "Failed to open the target budget."));
+    }
     const target = await adapter.loadTarget(targetTransport, flow);
     let mappings: SyncMapping[];
     try {

--- a/src/lib/sync/previewOrchestrator.ts
+++ b/src/lib/sync/previewOrchestrator.ts
@@ -1,22 +1,10 @@
 import { getBudgetFileSyncCapabilities } from "./capabilities";
-import { connectionFingerprint } from "./connectionRef";
-import { decodeFlowPlanConfig, type SyncFlowPlanConfig } from "./flowConfig";
-import { planExpandedItems } from "./syncPlanner";
-import { expandSourceTransactions, type SyncSourceItem } from "./sourceItems";
-import {
-  DEFAULT_SOURCE_FILTER,
-  decodeSourceFilter,
-  filterSourceItems,
-  filterSourceTransactions,
-  type SyncSourceFilter,
-} from "./sourceFilter";
+import "./adapters"; // register all data-type adapters (side-effect)
+import { getSyncKindAdapter, SyncKindError } from "./syncKind";
 import type { ActualBenchTransport } from "@/lib/actual/transport";
 import type { ConnectionInstance } from "@/store/connection";
 import type { JsonObject, SyncFlow, SyncMapping, SyncRunTrigger } from "@/lib/app-db/types";
-import type {
-  SyncPlannerTargetSnapshot,
-  SyncPlanResult,
-} from "./plannedChanges";
+import type { SyncPlanResult } from "./plannedChanges";
 
 /**
  * Live dry-run orchestration for Budget File Sync (RD-053 / PR-019 Slice 3).
@@ -144,261 +132,76 @@ export async function runLiveDryRunPreview(
   const { flowId } = input;
   const warnings: string[] = [];
 
-  // 1-2. Load flow + validate route/capabilities. Pre-run failures return a
-  // typed error with no persisted run.
+  // 1. Load flow (generic).
   let flow: SyncFlow | null;
   try {
     flow = await deps.store.loadFlow(flowId);
   } catch (err) {
-    return failedResult(flowId, {
-      code: "persistence_failed",
-      message: describe(err, "Failed to load the flow."),
-    }, warnings);
+    return failedResult(flowId, { code: "persistence_failed", message: describe(err, "Failed to load the flow.") }, warnings);
+  }
+  if (!flow) return failedResult(flowId, { code: "flow_not_found", message: `Sync flow ${flowId} was not found.` }, warnings);
+  if (!flow.enabled && !input.allowDisabled) {
+    return failedResult(flowId, { code: "flow_disabled", message: "This sync flow is disabled." }, warnings);
   }
 
-  let validated: ValidatedFlow;
+  // 2. Resolve the data-type adapter and validate the route/capabilities.
+  const adapter = getSyncKindAdapter(flow.flowType);
+  if (!adapter) {
+    return failedResult(flowId, { code: "unsupported_connection", message: `Unsupported sync type: ${flow.flowType}.` }, warnings);
+  }
   try {
-    validated = validateFlow(flow, input, warnings);
+    adapter.validate({ flow, sourceConnection: input.context.sourceConnection, targetConnection: input.context.targetConnection });
   } catch (err) {
-    if (err instanceof DryRunPreviewError) {
-      return failedResult(input.flowId, err.toError(), warnings);
-    }
+    if (err instanceof SyncKindError) return failedResult(flowId, { code: err.code, message: err.message }, warnings);
     throw err;
   }
 
-  const { config, filter } = validated;
-
   // Everything past validation can create a run; on failure persist a failed run.
   try {
-    // 3-5. Source phase (Pattern A): read, filter, expand, materialize.
+    // 3. Source phase (Pattern A): the adapter reads + materializes.
     const sourceTransport = await deps.transport.openTransport(input.context.sourceConnection);
-    let scanned: number;
-    let materialized: SyncSourceItem[];
-    let generatedExcluded: number;
-    let expandedCount: number;
-    try {
-      const rawSource = await sourceTransport.listTransactionsForSync({
-        accountId: config.sourceAccountId,
-        startDate: filter.startDate ?? undefined,
-        endDate: filter.endDate ?? undefined,
-      });
-      scanned = rawSource.length;
+    const source = await adapter.loadSource(sourceTransport, flow);
 
-      const nonGenerated = filterSourceTransactions(rawSource, filter);
-      generatedExcluded = scanned - nonGenerated.length;
-
-      const expanded = expandSourceTransactions(nonGenerated);
-      expandedCount = expanded.length;
-      const kept = filterSourceItems(expanded, filter);
-
-      // Materialize into a plain, serializable snapshot: no live source refs
-      // may survive into the target phase.
-      materialized = JSON.parse(JSON.stringify(kept)) as SyncSourceItem[];
-    } catch (err) {
-      throw new DryRunPreviewError("source_load_failed", describe(err, "Failed to read source transactions."));
-    }
-
-    // 6-8. Target phase: open target (may close source), load lookup + mappings.
-    let target: SyncPlannerTargetSnapshot;
+    // 4. Target phase: open target (may close source), load its snapshot + mappings.
+    const targetTransport = await deps.transport.openTransport(input.context.targetConnection);
+    const target = await adapter.loadTarget(targetTransport, flow);
     let mappings: SyncMapping[];
-    try {
-      const targetTransport = await deps.transport.openTransport(input.context.targetConnection);
-      target = await loadTargetSnapshot(targetTransport, config, filter);
-    } catch (err) {
-      throw new DryRunPreviewError("target_load_failed", describe(err, "Failed to read target lookup data."));
-    }
     try {
       mappings = await deps.store.loadMappings(flowId);
     } catch (err) {
       throw new DryRunPreviewError("persistence_failed", describe(err, "Failed to load existing mappings."));
     }
 
-    // 9. Plan.
-    const plan = planExpandedItems({
-      config,
-      capabilities: getBudgetFileSyncCapabilities({ mode: input.context.targetConnection.mode }),
-      sourceItems: materialized,
-      target,
-      existingMappings: mappings,
-    });
+    // 5. Plan (pure) + summary.
+    const targetCapabilities = getBudgetFileSyncCapabilities({ mode: input.context.targetConnection.mode }).capabilities;
+    const plan = adapter.plan({ flow, materialized: source.materialized, target, mappings, targetCapabilities });
+    const summary = adapter.buildSummary(plan, source.stats);
 
-    const summary = buildSummary(plan, {
-      scanned,
-      generatedExcluded,
-      expandedCount,
-      keptCount: materialized.length,
-    });
-
-    // 10. Persist the draft preview run.
+    // 6. Persist the draft preview run (one transaction).
     let runId: string;
     try {
       ({ runId } = await deps.store.persistPlan(plan, {
-        summary: summaryToJson(summary),
-        sourceSnapshotSummary: {
-          accountId: config.sourceAccountId,
-          budgetId: config.sourceBudgetId,
-          connectionFingerprint: config.sourceConnectionFingerprint,
-        },
+        summary: { ...summary },
+        sourceSnapshotSummary: adapter.sourceSummary(flow),
         trigger: input.trigger,
       }));
     } catch (err) {
       throw new DryRunPreviewError("persistence_failed", describe(err, "Failed to persist the preview run."));
     }
 
-    // 11. Return summary.
-    return {
-      status: "draft_preview",
-      runId,
-      flowId,
-      counts: plan.counts,
-      summary,
-      warnings,
-      errors: [],
-    };
+    return { status: "draft_preview", runId, flowId, counts: plan.counts, summary, warnings, errors: [] };
   } catch (err) {
-    const error =
-      err instanceof DryRunPreviewError
-        ? err.toError()
-        : { code: "source_load_failed" as DryRunErrorCode, message: describe(err, "Dry-run failed.") };
+    const error: DryRunError =
+      err instanceof SyncKindError
+        ? { code: err.code, message: err.message }
+        : err instanceof DryRunPreviewError
+          ? err.toError()
+          : { code: "source_load_failed", message: describe(err, "Dry-run failed.") };
     return persistFailure(deps.store, flowId, error, warnings);
   }
 }
 
 // --- Helpers ----------------------------------------------------------------
-
-type ValidatedFlow = { config: SyncFlowPlanConfig; filter: SyncSourceFilter };
-
-function validateFlow(
-  flow: SyncFlow | null,
-  input: LiveDryRunInput,
-  warnings: string[]
-): ValidatedFlow {
-  if (!flow) {
-    throw new DryRunPreviewError("flow_not_found", `Sync flow ${input.flowId} was not found.`);
-  }
-  if (!flow.enabled && !input.allowDisabled) {
-    throw new DryRunPreviewError("flow_disabled", "This sync flow is disabled.");
-  }
-
-  const config = decodeFlowPlanConfig(flow);
-  if (!config.sourceAccountId || !config.targetAccountId) {
-    throw new DryRunPreviewError(
-      "missing_route",
-      "Source and target accounts must both be selected before previewing."
-    );
-  }
-
-  // Route must still point at the live connections it was saved for.
-  assertConnectionMatches(
-    config.sourceConnectionFingerprint,
-    input.context.sourceConnection,
-    "source",
-    warnings
-  );
-  assertConnectionMatches(
-    config.targetConnectionFingerprint,
-    input.context.targetConnection,
-    "target",
-    warnings
-  );
-
-  // Direct-only capability gate (mode-derived, no runtime needed).
-  const sourceCaps = getBudgetFileSyncCapabilities({ mode: input.context.sourceConnection.mode });
-  const targetCaps = getBudgetFileSyncCapabilities({ mode: input.context.targetConnection.mode });
-  if (!sourceCaps.supported) {
-    throw new DryRunPreviewError("unsupported_connection", sourceCaps.reason ?? "Source connection is unsupported.");
-  }
-  if (!targetCaps.supported) {
-    throw new DryRunPreviewError("unsupported_connection", targetCaps.reason ?? "Target connection is unsupported.");
-  }
-  if (!sourceCaps.capabilities.listTransactions || !sourceCaps.capabilities.readSplitLines) {
-    throw new DryRunPreviewError("unsupported_connection", "Source connection cannot list transactions or split lines.");
-  }
-  if (!targetCaps.capabilities.listTransactions) {
-    throw new DryRunPreviewError("unsupported_connection", "Target connection cannot list transactions for lookup.");
-  }
-
-  return { config, filter: decodeFilterOrDefault(flow) };
-}
-
-function assertConnectionMatches(
-  savedFingerprint: string,
-  connection: ConnectionInstance,
-  side: "source" | "target",
-  warnings: string[]
-): void {
-  if (!savedFingerprint) return; // legacy/unsaved fingerprint: skip strict check.
-  if (connectionFingerprint(connection) !== savedFingerprint) {
-    throw new DryRunPreviewError(
-      "connection_mismatch",
-      `The ${side} connection does not match the one this flow was saved with.`
-    );
-  }
-  void warnings;
-}
-
-function decodeFilterOrDefault(flow: SyncFlow): SyncSourceFilter {
-  try {
-    return decodeSourceFilter(flow);
-  } catch {
-    return { ...DEFAULT_SOURCE_FILTER };
-  }
-}
-
-async function loadTargetSnapshot(
-  transport: ActualBenchTransport,
-  config: SyncFlowPlanConfig,
-  filter: SyncSourceFilter
-): Promise<SyncPlannerTargetSnapshot> {
-  // One lookup covers payees, the marker index, and the dedupe transaction list
-  // (single range read); categories still come from the category-group query.
-  const range = { accountId: config.targetAccountId, startDate: filter.startDate ?? undefined, endDate: filter.endDate ?? undefined };
-  const lookup = await transport.getTargetLookupForSync(range);
-  const categoryGroups = await transport.getCategoryGroups();
-
-  return {
-    payees: lookup.payees.map((p) => ({ id: p.id, name: p.name })),
-    categories: categoryGroups.categories.map((c) => ({ id: c.id, name: c.name })),
-    importedIdIndex: lookup.importedIdIndex,
-    transactions: lookup.transactions.map((t) => ({
-      id: t.id,
-      date: t.date,
-      amount: t.amount,
-      payeeName: t.payeeName,
-      categoryId: t.categoryId,
-    })),
-  };
-}
-
-function buildSummary(
-  plan: SyncPlanResult,
-  source: { scanned: number; generatedExcluded: number; expandedCount: number; keptCount: number }
-): DryRunSummary {
-  const c = plan.counts;
-  // Auto-mapped exact duplicates are safe (mapping-only), so they are reported
-  // separately and excluded from the review-queue "duplicatesSkipped" count.
-  const autoMapped = plan.items.filter((i) => i.flags.includes("exact_duplicate_auto_map")).length;
-  const dup =
-    (c.exact_duplicate ?? 0) + (c.strong_duplicate ?? 0) + (c.weak_duplicate ?? 0) - autoMapped;
-  return {
-    sourceTransactionsScanned: source.scanned,
-    generatedTransactionsExcluded: source.generatedExcluded,
-    sourceItemsScanned: source.expandedCount,
-    sourceItemsFilteredOut: source.expandedCount - source.keptCount,
-    plannedItems: plan.items.length,
-    createCandidates: c.new ?? 0,
-    alreadySynced: c.already_synced ?? 0,
-    duplicatesSkipped: Math.max(0, dup),
-    exactDuplicatesAutoMapped: autoMapped,
-    sourceChangedWarnings: c.source_changed_since_sync ?? 0,
-    targetMarkerMatches: c.target_marker_match ?? 0,
-    blocked: c.blocked ?? 0,
-  };
-}
-
-function summaryToJson(summary: DryRunSummary): JsonObject {
-  return { ...summary };
-}
 
 function describe(err: unknown, fallback: string): string {
   if (err instanceof Error && err.message) return err.message;

--- a/src/lib/sync/safeSyncOrchestrator.test.ts
+++ b/src/lib/sync/safeSyncOrchestrator.test.ts
@@ -68,7 +68,7 @@ function makeDeps(
   };
 }
 
-describe("runSafeSync — policy gate", () => {
+describe("runSafeSync - policy gate", () => {
   it("refuses to auto-apply a manual_preview_required flow (never previews or applies)", async () => {
     const runPreview = jest.fn();
     const runApply = jest.fn();
@@ -113,7 +113,7 @@ describe("runSafeSync — policy gate", () => {
   );
 });
 
-describe("runSafeSync — composition", () => {
+describe("runSafeSync - composition", () => {
   it("returns preview_failed and never applies when preview fails", async () => {
     const runPreview = jest.fn(async (): Promise<LiveDryRunResult> => ({
       status: "failed", runId: "run-1", flowId: "flow-1",

--- a/src/lib/sync/safeSyncOrchestrator.ts
+++ b/src/lib/sync/safeSyncOrchestrator.ts
@@ -19,8 +19,8 @@ import type { SyncReviewPolicy, SyncRunTrigger } from "@/lib/app-db/types";
  * Safe-only run executor for Budget File Sync automation (RD-054 / PR-020 Slice 2).
  *
  * This is **not a second sync engine**. It composes the two existing RD-053
- * orchestrators — `runLiveDryRunPreview` (plan, no writes) then `applySyncRun`
- * with `{ selection: "all_safe" }` (apply only safe classes) — behind a single
+ * orchestrators - `runLiveDryRunPreview` (plan, no writes) then `applySyncRun`
+ * with `{ selection: "all_safe" }` (apply only safe classes) - behind a single
  * headless call, gated by the flow's automation policy.
  *
  * Safety guarantees:
@@ -61,7 +61,7 @@ export type SafeSyncResult =
   | { status: "skipped_manual_policy"; flowId: string; reviewPolicy: SyncReviewPolicy }
   /** Preview never produced an applyable run. */
   | { status: "preview_failed"; flowId: string; runId: string | null; error: DryRunError }
-  /** Preview succeeded but there was nothing safe to apply — a benign no-op. */
+  /** Preview succeeded but there was nothing safe to apply - a benign no-op. */
   | {
       status: "no_safe_items";
       flowId: string;
@@ -87,7 +87,7 @@ export async function runSafeSync(
   const runPreview = deps.runPreview ?? runLiveDryRunPreview;
   const runApply = deps.runApply ?? applySyncRun;
 
-  // 1. Policy gate — authoritative and first. A flow that has not opted into
+  // 1. Policy gate - authoritative and first. A flow that has not opted into
   //    automation is never auto-applied here, regardless of caller intent. A
   //    missing flow is reported as a preview failure (the preview would fail the
   //    same way) rather than silently skipped.
@@ -105,7 +105,7 @@ export async function runSafeSync(
     return { status: "skipped_manual_policy", flowId, reviewPolicy };
   }
 
-  // 2. Preview (no Actual writes) — the RD-053 planner, unchanged. The run is
+  // 2. Preview (no Actual writes) - the RD-053 planner, unchanged. The run is
   //    stamped so history shows it was automated (default: interval_safe_only).
   const preview = await runPreview(
     {
@@ -142,7 +142,7 @@ export async function runSafeSync(
 
   // A "no eligible items" apply after a non-zero preview is still a benign no-op
   // (e.g. the only safe rows resolved away between preview and apply), not a real
-  // failure — report it as such rather than surfacing an error.
+  // failure - report it as such rather than surfacing an error.
   if (apply.status === "failed" && apply.error?.code === "no_eligible_items") {
     return { status: "no_safe_items", flowId, runId: preview.runId, reviewPolicy, preview: preview.summary };
   }

--- a/src/lib/sync/sourceFilter.ts
+++ b/src/lib/sync/sourceFilter.ts
@@ -12,7 +12,7 @@ import type { SyncSourceItem } from "./sourceItems";
  *      Only the parent/normal transaction carries an `imported_id` marker, so
  *      this must run before splits are exploded.
  *   2. item-level: date, cleared/reconciled, amount sign/range, payee/category
- *      include-exclude, notes-contains — applied per source item so each split
+ *      include-exclude, notes-contains - applied per source item so each split
  *      line is judged on its own fields.
  */
 
@@ -64,7 +64,7 @@ export function isGeneratedSourceTransaction(txn: SyncSourceTransaction): boolea
   return typeof txn.notes === "string" && txn.notes.toLowerCase().includes(NOTES_MARKER_HINT);
 }
 
-/** Phase 1 — drop sync-generated transactions before expansion. */
+/** Phase 1 - drop sync-generated transactions before expansion. */
 export function filterSourceTransactions(
   txns: SyncSourceTransaction[],
   filter: SyncSourceFilter
@@ -121,7 +121,7 @@ function matchesNotes(item: SyncSourceItem, filter: SyncSourceFilter): boolean {
   return typeof item.notes === "string" && item.notes.toLowerCase().includes(needle);
 }
 
-/** Phase 2 — item-level filtering after split expansion. */
+/** Phase 2 - item-level filtering after split expansion. */
 export function filterSourceItems(
   items: SyncSourceItem[],
   filter: SyncSourceFilter

--- a/src/lib/sync/sourceItems.ts
+++ b/src/lib/sync/sourceItems.ts
@@ -41,7 +41,7 @@ export type SyncSourceItem = {
 };
 
 const FINGERPRINT_VERSION = "v1";
-const FIELD_SEP = "␟"; // ␟ SYMBOL FOR UNIT SEPARATOR — safe against field collisions.
+const FIELD_SEP = "␟"; // ␟ SYMBOL FOR UNIT SEPARATOR - safe against field collisions.
 
 export function sourceTransactionItemKey(sourceTransactionId: string): string {
   return "txn:" + sourceTransactionId;
@@ -129,8 +129,8 @@ export function splitLineFingerprint(
  *   synced as its own item).
  * - Any other transaction contributes a single `transaction` item.
  *
- * Split children inherit the parent's date and — when the child has no payee of
- * its own — the parent's payee, since Actual split children commonly omit it.
+ * Split children inherit the parent's date and - when the child has no payee of
+ * its own - the parent's payee, since Actual split children commonly omit it.
  */
 export function expandSourceTransaction(
   txn: SyncSourceTransaction

--- a/src/lib/sync/syncKind.ts
+++ b/src/lib/sync/syncKind.ts
@@ -1,0 +1,137 @@
+import type { ActualBenchTransport } from "@/lib/actual/transport";
+import type { ConnectionInstance } from "@/store/connection";
+import type { JsonObject, SyncCapabilitySet, SyncDomain, SyncFlow, SyncMapping } from "@/lib/app-db/types";
+import type { SyncPlanResult } from "./plannedChanges";
+
+/**
+ * The unified Budget File Sync engine (RD-055): ONE preview/apply/automation
+ * pipeline across every data type. All type-specific behavior — what to read,
+ * how to match/classify, how to create — lives in a `SyncKindAdapter`, resolved
+ * by `flow.flowType`. The orchestrators (preview, apply, safe-sync, scheduler,
+ * review queue, flow health, history) stay generic and therefore work
+ * identically for transactions, payees, and categories.
+ *
+ * Do NOT add a parallel engine for a new data type — add an adapter.
+ */
+
+/** Error thrown by an adapter; the orchestrator maps `code` to its result. */
+export class SyncKindError extends Error {
+  constructor(
+    public readonly code:
+      | "missing_route"
+      | "connection_mismatch"
+      | "unsupported_connection"
+      | "source_load_failed"
+      | "target_load_failed",
+    message: string
+  ) {
+    super(message);
+    this.name = "SyncKindError";
+  }
+}
+
+/** Materialized, JSON-serializable source snapshot + scan stats for the summary. */
+export type AdapterSourceResult = {
+  materialized: unknown;
+  stats: { scanned: number; generatedExcluded: number; expandedCount: number; keptCount: number };
+};
+
+/** Coarse summary counts rendered in the preview/history (kind-agnostic keys). */
+export type AdapterSummary = {
+  sourceTransactionsScanned: number;
+  generatedTransactionsExcluded: number;
+  sourceItemsScanned: number;
+  sourceItemsFilteredOut: number;
+  plannedItems: number;
+  createCandidates: number;
+  alreadySynced: number;
+  duplicatesSkipped: number;
+  exactDuplicatesAutoMapped: number;
+  sourceChangedWarnings: number;
+  targetMarkerMatches: number;
+  blocked: number;
+};
+
+export type AdapterApplyContext = {
+  /** Transaction adapter fills this with the target imported_id index; empty otherwise. */
+  markerIndex: Map<string, string>;
+};
+
+/** One create request the orchestrator asks the adapter to perform on the target. */
+export type AdapterCreateInput = {
+  /** Run item id, echoed back so the orchestrator can match results. */
+  itemId: string;
+  /** The persisted planned payload (transaction or entity) as plain JSON. */
+  payload: JsonObject;
+};
+
+export type AdapterCreateResult = {
+  itemId: string;
+  targetId: string | null;
+  /** Fields the target changed vs. the plan (e.g. rules); drives the warning. */
+  changedFields?: string[];
+};
+
+export type AdapterValidateInput = {
+  flow: SyncFlow;
+  sourceConnection: ConnectionInstance;
+  targetConnection: ConnectionInstance;
+};
+
+/**
+ * A data-type plugin for the unified engine. Everything a data type needs to be
+ * previewed, applied, and automated is expressed here; nothing else in the
+ * pipeline is type-aware.
+ */
+export interface SyncKindAdapter {
+  readonly flowType: SyncDomain;
+
+  /** Route + capability validation; throws SyncKindError on failure. */
+  validate(input: AdapterValidateInput): void;
+
+  /** Read + materialize the source (runs on the source transport). */
+  loadSource(transport: ActualBenchTransport, flow: SyncFlow): Promise<AdapterSourceResult>;
+
+  /** Read the target snapshot (runs on the target transport). */
+  loadTarget(transport: ActualBenchTransport, flow: SyncFlow): Promise<unknown>;
+
+  /** Pure plan/classification from materialized source + target + mappings. */
+  plan(input: {
+    flow: SyncFlow;
+    materialized: unknown;
+    target: unknown;
+    mappings: SyncMapping[];
+    targetCapabilities: SyncCapabilitySet;
+  }): SyncPlanResult;
+
+  /** Non-secret source snapshot summary stored on the run. */
+  sourceSummary(flow: SyncFlow): JsonObject;
+
+  /** Coarse summary counts for the run/preview. */
+  buildSummary(plan: SyncPlanResult, stats: AdapterSourceResult["stats"]): AdapterSummary;
+
+  /** Prepare per-run apply state (e.g. load the marker index). */
+  prepareApply(transport: ActualBenchTransport, flow: SyncFlow): Promise<AdapterApplyContext>;
+
+  /** Capability check for apply; throws SyncKindError if the target can't create. */
+  assertCanApply(capabilities: SyncCapabilitySet, willCreate: boolean): void;
+
+  /** Create a batch of items on the target; results are matched back by itemId. */
+  createBatch(
+    transport: ActualBenchTransport,
+    flow: SyncFlow,
+    inputs: AdapterCreateInput[]
+  ): Promise<AdapterCreateResult[]>;
+}
+
+const registry = new Map<SyncDomain, SyncKindAdapter>();
+
+/** Register a data-type adapter (called once per adapter module at import). */
+export function registerSyncKindAdapter(adapter: SyncKindAdapter): void {
+  registry.set(adapter.flowType, adapter);
+}
+
+/** Resolve the adapter for a flow type, or null if the type is unsupported. */
+export function getSyncKindAdapter(flowType: SyncDomain): SyncKindAdapter | null {
+  return registry.get(flowType) ?? null;
+}

--- a/src/lib/sync/syncKind.ts
+++ b/src/lib/sync/syncKind.ts
@@ -5,13 +5,13 @@ import type { SyncPlanResult } from "./plannedChanges";
 
 /**
  * The unified Budget File Sync engine (RD-055): ONE preview/apply/automation
- * pipeline across every data type. All type-specific behavior — what to read,
- * how to match/classify, how to create — lives in a `SyncKindAdapter`, resolved
+ * pipeline across every data type. All type-specific behavior - what to read,
+ * how to match/classify, how to create - lives in a `SyncKindAdapter`, resolved
  * by `flow.flowType`. The orchestrators (preview, apply, safe-sync, scheduler,
  * review queue, flow health, history) stay generic and therefore work
  * identically for transactions, payees, and categories.
  *
- * Do NOT add a parallel engine for a new data type — add an adapter.
+ * Do NOT add a parallel engine for a new data type - add an adapter.
  */
 
 /** Error thrown by an adapter; the orchestrator maps `code` to its result. */

--- a/src/lib/sync/syncPlanner.test.ts
+++ b/src/lib/sync/syncPlanner.test.ts
@@ -103,7 +103,7 @@ function mapping(overrides: Partial<SyncMapping> = {}): SyncMapping {
   };
 }
 
-describe("planSyncFlow — new create", () => {
+describe("planSyncFlow - new create", () => {
   it("plans a new reversed, marker-tagged create with pre-selection", () => {
     const target = emptyTarget({
       payees: [{ id: "tp1", name: "Coffee Bar" }],
@@ -156,7 +156,7 @@ describe("planSyncFlow — new create", () => {
   });
 });
 
-describe("planSyncFlow — mappings and markers", () => {
+describe("planSyncFlow - mappings and markers", () => {
   it("skips an already-synced item whose fingerprint is unchanged", () => {
     const fingerprint = transactionFingerprint(txn());
     const plan = planSyncFlow(
@@ -191,7 +191,7 @@ describe("planSyncFlow — mappings and markers", () => {
   });
 });
 
-describe("planSyncFlow — duplicates", () => {
+describe("planSyncFlow - duplicates", () => {
   it("skips an exact duplicate", () => {
     const target = emptyTarget({
       payees: [{ id: "tp1", name: "Coffee Bar" }],
@@ -255,7 +255,7 @@ describe("planSyncFlow — duplicates", () => {
   });
 });
 
-describe("planSyncFlow — splits", () => {
+describe("planSyncFlow - splits", () => {
   it("explodes a split parent into separate planned creates with split keys", () => {
     const parent = txn({
       id: "p",
@@ -301,7 +301,7 @@ describe("planSyncFlow — splits", () => {
   });
 });
 
-describe("planSyncFlow — blocked", () => {
+describe("planSyncFlow - blocked", () => {
   it("blocks creates when the target cannot store a durable marker (HTTP mode)", () => {
     const plan = planSyncFlow(baseInput({ capabilities: httpCaps }));
     const item = plan.items[0];

--- a/src/lib/sync/syncPlanner.ts
+++ b/src/lib/sync/syncPlanner.ts
@@ -23,7 +23,7 @@ import type {
  *
  * Takes a flow config, a materialized source snapshot, target lookup data, and
  * existing mappings; produces classified planned items with target payloads.
- * Performs NO Actual writes and NO DB access — persistence is a separate step
+ * Performs NO Actual writes and NO DB access - persistence is a separate step
  * (`persistDraftPreviewRun`).
  *
  * Decision order per source item:
@@ -34,7 +34,7 @@ import type {
  * DB mappings are the primary source of truth; the marker is secondary.
  */
 /**
- * Plan from raw source transactions — expands splits internally. Convenience
+ * Plan from raw source transactions - expands splits internally. Convenience
  * entry point for headless/fixture use.
  */
 export function planSyncFlow(input: SyncPlannerInput): SyncPlanResult {
@@ -127,7 +127,7 @@ function planSourceItem(
 ): SyncPlannedItem {
   const { config, target } = input;
 
-  // 1. Existing mapping wins — this item was synced before.
+  // 1. Existing mapping wins - this item was synced before.
   const mapping = mappingByKey.get(item.itemKey);
   if (mapping) {
     if (mapping.sourceFingerprint === item.fingerprint) {


### PR DESCRIPTION
Refactors Budget File Sync into **one unified engine** that dispatches by data type via a `SyncKindAdapter`, then adds **payee and category (master-data) sync**. Because the orchestrators are generic over the run model, every data type gets the same feature set — preview, apply, run history, the review queue, and the entire safe-only automation layer — with **no parallel engines and no per-type feature gaps**.

## Unified engine
- New `SyncKindAdapter` interface + registry; adapters supply only the type-specific bits (load source/target, classify/plan, create).
- The existing transaction logic is extracted behind the interface as `transactionAdapter` — **behavior-preserving**: the full prior sync suite passes unchanged.
- `previewOrchestrator` and `applyOrchestrator` dispatch source/target/plan/create by flow type. Apply is generalized for marker-less entities (name-match repair, entity create batch, entity target mappings).

## Master data
- **Data-type selector** in the flow editor (Transactions / Payees / Categories). Payee/category flows sync at the **budget** level (no account).
- **Payees:** create missing / match existing by normalized name / map; no rename/delete/hide.
- **Categories:** match by name within a group; create missing under the matching or a chosen **default group**; **block** ambiguous placement (or create the group when enabled); income vs expense kept distinct.
- Mappings recorded so reruns skip already-synced entities. The review queue, run history, and auto-apply / auto-sync / flow-health automation apply to entity flows exactly as to transactions.

## Scope
Create-only, cross-budget, Direct mode, preview-first — unchanged. No renames/deletes/hides, no transactions created by master-data flows, no HTTP mode, no FX.

## Testing
- `jest` — 119 suites, 1164 tests passing. `tsc --noEmit` clean, `eslint` 0 errors.
- New tests: payee/category classification + create batch (group reuse, default group, ambiguous blocking); entity flow-type + options round-trip; budget-only route validation. The transaction suite is unchanged, guarding the refactor.
