### PR TITLE
Complete the documentation site (User Guide, Administration, Help, Contributing)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
 				{ label: 'User Guide', items: [{ autogenerate: { directory: 'user-guide' } }] },
 				{ label: 'Administration', items: [{ autogenerate: { directory: 'administration' } }] },
 				{ label: 'Help', items: [{ autogenerate: { directory: 'help' } }] },
+				{ label: 'Contributing', link: '/contributing/' },
 			],
 		}),
 	],

--- a/docs-site/src/content/docs/administration/configuration.mdx
+++ b/docs-site/src/content/docs/administration/configuration.mdx
@@ -1,0 +1,136 @@
+---
+title: Configuration
+description: Environment variables and runtime settings for Actual Bench — metadata database, Direct mode, unattended sync vault, logging, and secret handling.
+sidebar:
+  order: 2
+---
+
+Actual Bench needs **no environment variables for a basic setup**. This page documents the settings you
+can provide for specific features and deployments.
+
+## How configuration is loaded
+
+Configuration is provided as environment variables to the container. Server-side variables are read by
+the Node server; variables prefixed with `NEXT_PUBLIC_` are build/public values exposed to the browser.
+The app **version** is injected automatically from the build — you do not set it.
+
+:::caution[Restart to apply changes]
+Environment variables are read at server start. Change them and **restart** the container for the new
+values to take effect.
+:::
+
+## Environment variables
+
+Only variables verified in the current codebase are listed.
+
+| Variable | Default | Purpose | Secret | Restart |
+|---|---|---|:---:|:---:|
+| `ACTUAL_BENCH_DB_PATH` | `/data/actual-bench.sqlite` | Path to the metadata SQLite database. | No | Yes |
+| `DIRECT_BROWSER_API` | enabled | Set to `0` to disable Direct Actual Server mode (server-side). | No | Yes |
+| `NEXT_PUBLIC_DIRECT_BROWSER_API` | enabled | Set to `0` to disable Direct mode (build/public equivalent). | No | Yes |
+| `SYNC_VAULT_KEY` | *(unset)* | Enables unattended server-side sync; derives the encryption key for stored credentials. | **Yes** | Yes |
+| `SYNC_SCHEDULER_SECRET` | *(unset)* | Enables the external scheduler trigger endpoint; required in its request header. | **Yes** | Yes |
+| `LOG_LEVEL` | `info` | Server log verbosity. | No | Yes |
+| `NEXT_DEV_ALLOWED_ORIGINS` | *(unset)* | Dev-only: allow the HMR WebSocket through a reverse proxy (comma-separated hostnames). | No | Yes |
+
+Demo/analytics variables (such as `NEXT_PUBLIC_ANALYTICS`) exist for the public demo build and are inert
+in self-hosted deployments — you do not need them.
+
+## Minimum configuration
+
+A basic production deployment needs only a persistent `/data` volume; no variables are strictly
+required. Set `ACTUAL_BENCH_DB_PATH` only if you want the metadata database somewhere other than the
+default.
+
+## Direct-mode settings
+
+Direct Actual Server mode is enabled by default. To hide it (offer only HTTP API Server mode), set
+`DIRECT_BROWSER_API=0` **or** `NEXT_PUBLIC_DIRECT_BROWSER_API=0` and restart. See
+[Deployment](../deployment/#direct-mode-network-requirements) for the browser reachability and
+cross-origin requirements Direct mode needs.
+
+## Metadata database
+
+- Default path: `/data/actual-bench.sqlite` (override with `ACTUAL_BENCH_DB_PATH`).
+- Requires a **writable** persistent volume.
+- Schema **migrations run on boot**; App Health shows the current and latest schema version.
+- Stores Actual Bench workflow metadata only — **not** Actual credentials or budget data (with the
+  exception of explicitly enrolled, encrypted unattended-sync credentials, below).
+
+## Unattended sync settings
+
+For server-side scheduled sync (HTTP API Server mode flows only):
+
+- **`SYNC_VAULT_KEY`** — a strong operator secret. When set, the in-process scheduler runs and enrolled
+  credentials can be stored/decrypted. When unset, the feature is fully disabled: nothing is persisted
+  and the scheduler never runs. Enrolled credentials are stored **AES-256-GCM encrypted** in the
+  metadata database; the key is derived from this variable and never stored in the database.
+- **`SYNC_SCHEDULER_SECRET`** *(optional)* — enables an external trigger endpoint at
+  `POST /api/sync/scheduler/tick`, which requires the header `x-scheduler-secret`. Without it, that
+  endpoint returns `403`. Use this only if you want to drive the scheduler from an external cron instead
+  of (or in addition to) the built-in one.
+
+Generate strong values with, for example:
+
+```bash
+openssl rand -base64 48
+```
+
+:::danger[Rotating `SYNC_VAULT_KEY` invalidates stored credentials]
+Changing `SYNC_VAULT_KEY` makes all previously stored ciphertext undecryptable **by design**. After
+rotating, **re-enroll** each unattended flow's credentials. Flows whose credentials can't be decrypted
+are paused and shown on App Health until re-enrolled.
+:::
+
+See [Budget Sync → Automation](../../user-guide/budget-sync/#automation-opt-in) for how flows opt in, and
+the repository's `docs/UNATTENDED_SYNC.md` for the operator walkthrough.
+
+## Logging
+
+Set `LOG_LEVEL` to control server log verbosity (default `info`). Lower it to `warn` or `error` in
+production if you want quieter logs, or raise it for debugging.
+
+## Secret handling
+
+- Never commit a `.env` file with real secrets to version control.
+- Use your container platform's secret management for `SYNC_VAULT_KEY` and `SYNC_SCHEDULER_SECRET`.
+- Do not expose server secrets as `NEXT_PUBLIC_*` variables — those are shipped to the browser.
+- Redact secrets before sharing logs, and rotate any value you suspect is compromised.
+
+## Configuration examples
+
+**Minimal (Direct or HTTP mode, no unattended sync):**
+
+```yaml
+environment:
+  ACTUAL_BENCH_DB_PATH: /data/actual-bench.sqlite
+```
+
+**With unattended server-side sync:**
+
+```yaml
+environment:
+  ACTUAL_BENCH_DB_PATH: /data/actual-bench.sqlite
+  SYNC_VAULT_KEY: ${SYNC_VAULT_KEY}   # provided via your secret manager
+```
+
+**HTTP API Server mode only (Direct disabled):**
+
+```yaml
+environment:
+  DIRECT_BROWSER_API: "0"
+```
+
+Use placeholders and inject real secrets from your platform — never hard-code them.
+
+## Validation
+
+After changing configuration and restarting, open **App Health** to confirm the metadata database is
+writable, the schema is current, and (if configured) the unattended scheduler reports the expected
+vault state.
+
+## Related pages
+
+- [Deployment](../deployment/)
+- [Upgrading and Backups](../upgrading-and-backups/)
+- [Budget Sync](../../user-guide/budget-sync/)

--- a/docs-site/src/content/docs/administration/deployment.mdx
+++ b/docs-site/src/content/docs/administration/deployment.mdx
@@ -1,0 +1,143 @@
+---
+title: Deployment
+description: Production self-hosting guidance for Actual Bench — architecture, image tags, Compose, networking for both connection modes, reverse proxy, HTTPS, and hardening.
+sidebar:
+  order: 1
+---
+
+This guide covers running Actual Bench in production. For a first install, start with
+[Installation](../../getting-started/installation/); this page adds architecture, networking, reverse
+proxy, and hardening detail.
+
+## Deployment architecture
+
+Actual Bench is a Next.js application. How requests flow depends on the connection mode:
+
+- **Direct Actual Server mode** — the browser talks to your Actual Server directly and runs Actual's
+  engine in a browser worker. Actual Bench serves the app; it does not proxy budget traffic.
+- **HTTP API Server mode** — the browser talks only to Actual Bench, which forwards requests
+  server-side to `actual-http-api` through its internal proxy. The browser never calls `actual-http-api`
+  directly.
+
+Actual Bench also keeps a server-side **metadata database** (SQLite under `/data`) for its own workflow
+data.
+
+## Choose an image tag
+
+Multi-architecture images are published for `linux/amd64` and `linux/arm64`:
+
+- `xrous/actual-bench:latest` — stable, for normal production.
+- `xrous/actual-bench:<version>` (e.g. `:1.2.4`) — a pinned, unchanging version.
+- `xrous/actual-bench:edge` — unstable, rebuilt on every merge; for testing only.
+
+Pin a specific `:<version>` in production if you want fully controlled upgrades.
+
+## Docker Compose deployment
+
+```yaml
+services:
+  actual-bench:
+    image: xrous/actual-bench:1.2.4   # pin a version in production
+    container_name: actual-bench
+    ports:
+      - "3000:3000"
+    environment:
+      ACTUAL_BENCH_DB_PATH: /data/actual-bench.sqlite
+      # SYNC_VAULT_KEY: "..."   # only if you use unattended server-side sync
+    volumes:
+      - actual-bench-data:/data
+    restart: unless-stopped
+
+volumes:
+  actual-bench-data:
+```
+
+See [Configuration](../configuration/) for the full environment-variable reference.
+
+## Network design
+
+Two different reachability requirements exist, and confusing them is the most common deployment issue:
+
+- **Browser → service** (Direct mode): the user's browser must reach the Actual Server URL.
+- **Container → container** (HTTP API mode): the Actual Bench container must reach `actual-http-api`.
+
+:::caution[`localhost` inside a container is the container itself]
+In HTTP API mode, if `actual-http-api` runs in another container, do not point Actual Bench at
+`localhost` — that resolves to the Actual Bench container. Use the API's Docker service name (on a
+shared network) or a reachable host/URL.
+:::
+
+### Direct-mode network requirements
+
+Direct mode runs the Actual engine in the browser, so:
+
+- The **browser** must be able to reach your Actual Server URL.
+- The response must satisfy **CORS** (or be served same-origin via a reverse proxy).
+- Actual Bench sets the cross-origin isolation headers it needs on its own assets
+  (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`).
+- Serve Actual Bench (and ideally Actual Server) over **HTTPS**.
+
+If Direct mode can't be supported in your environment, disable it with `DIRECT_BROWSER_API=0` (or
+`NEXT_PUBLIC_DIRECT_BROWSER_API=0`) so only HTTP API Server mode is offered.
+
+### HTTP API network requirements
+
+- The Actual Bench **container** must reach the `actual-http-api` base URL.
+- Requests are proxied server-side through Actual Bench, so only Actual Bench needs that path — the
+  browser does not.
+- If both run in Docker, attach them to a shared network and use the API's service name.
+
+If the UI shows `fetch failed` or `502 Bad Gateway` in HTTP mode, check container-to-container
+networking first.
+
+## Reverse proxy and HTTPS
+
+Run Actual Bench behind a reverse proxy that terminates HTTPS:
+
+- Forward the correct **host** and **protocol** headers.
+- Use HTTPS end-to-end where possible — Direct mode in particular depends on a secure, isolated origin.
+- Serving Actual Server same-origin through the proxy is one way to satisfy Direct-mode CORS/isolation
+  without wide CORS rules.
+
+## App Health after deployment
+
+Open **App Health** (Tools sidebar) and confirm:
+
+- **Writable** is `Yes`.
+- **Schema** shows a version (migrations run on boot).
+- **Persistence** reads *Persistent when /data is mounted*.
+- If you use unattended sync, the **Unattended sync scheduler** section shows the vault state, enrolled
+  count, and last tick.
+
+## Production hardening
+
+- Terminate **HTTPS** at the proxy; don't expose the app over plain HTTP beyond localhost.
+- Keep server secrets (like `SYNC_VAULT_KEY`) out of the image and out of version control; use your
+  platform's secret management.
+- Persist and back up the `/data` volume; restrict its file permissions.
+- Pin a specific `:<version>` and upgrade deliberately (see [Upgrading and Backups](../upgrading-and-backups/)).
+- Don't publicly expose backend APIs (`actual-http-api`, Actual Server) more than necessary.
+- Redact secrets before sharing logs.
+
+## Scaling and the unattended scheduler
+
+The unattended sync scheduler runs **in-process** and ticks about once a minute; a **single instance is
+sufficient** and is the intended model. Do not assume distributed-lock behavior across multiple
+replicas. If you need external control, drive the trigger endpoint with `SYNC_SCHEDULER_SECRET` instead
+(see [Configuration](../configuration/#unattended-sync-settings)).
+
+## Deployment checklist
+
+- [ ] Pinned image `:<version>` chosen.
+- [ ] `/data` volume mounted, writable, and backed up.
+- [ ] HTTPS terminated at the proxy; host/protocol headers forwarded.
+- [ ] Direct mode: browser can reach Actual Server; CORS / cross-origin isolation satisfied.
+- [ ] HTTP mode: Actual Bench container can reach `actual-http-api`.
+- [ ] `SYNC_VAULT_KEY` set (only if using unattended sync) and stored securely.
+- [ ] App Health shows Writable = Yes and a valid schema version.
+
+## Related pages
+
+- [Configuration](../configuration/)
+- [Upgrading and Backups](../upgrading-and-backups/)
+- [Installation](../../getting-started/installation/)

--- a/docs-site/src/content/docs/administration/upgrading-and-backups.mdx
+++ b/docs-site/src/content/docs/administration/upgrading-and-backups.mdx
@@ -1,0 +1,131 @@
+---
+title: Upgrading and Backups
+description: Upgrade Actual Bench safely and protect its metadata — what to back up, upgrade procedures, database migrations, rollback, restore, and moving hosts.
+sidebar:
+  order: 3
+---
+
+This guide helps administrators upgrade Actual Bench safely and protect its data. The most important
+idea: **the only server-side state Actual Bench owns is its metadata database under `/data`** — your
+budget data lives in Actual Budget, not here.
+
+## What needs to be backed up
+
+| Data | Where | Back up? |
+|---|---|---|
+| Actual budget data | Your Actual Server | Yes — but backed up by **Actual Budget**, not Actual Bench |
+| Actual Bench metadata | `/data` volume (SQLite) | **Yes** |
+| Configuration | Your Compose file / environment | Yes |
+| `SYNC_VAULT_KEY` | Your secret manager | Yes — **store it separately and safely** |
+| Browser session state | The browser | No (transient; re-enter secrets on reconnect) |
+
+The metadata database holds sync flows, run history, and (if enabled) **encrypted** unattended-sync
+credentials. It does not contain your budget data or plaintext Actual credentials.
+
+## Before upgrading
+
+1. Read the [release notes](https://github.com/x-rous/actual-bench/releases) for the target version.
+2. Record your **current version** (shown in the sidebar footer).
+3. **Back up `/data`** (see [Backup](#back-up-the-metadata-database)).
+4. Back up your Compose file and environment configuration.
+5. Ensure `SYNC_VAULT_KEY` is safely retained (needed to keep unattended credentials usable).
+6. Prefer upgrading to a **pinned `:<version>`** rather than a moving tag, for a controlled change.
+
+## Upgrade procedures
+
+**Docker Compose:**
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+**Docker CLI:**
+
+```bash
+docker pull xrous/actual-bench:1.2.4
+docker stop actual-bench && docker rm actual-bench
+docker run -d \
+  --name actual-bench \
+  --restart unless-stopped \
+  -p 3000:3000 \
+  -v actual-bench-data:/data \
+  xrous/actual-bench:1.2.4
+```
+
+Pin the exact `:<version>` you intend to run so the upgrade is deterministic.
+
+### Moving from edge to stable
+
+If you were testing `edge`, switch the image tag to `latest` or a pinned `:<version>` and recreate the
+container. Keep the same `/data` volume so your metadata carries over.
+
+## Database migrations
+
+- Schema **migrations run automatically on boot** when a newer image starts against an existing
+  metadata database.
+- Check the result on **App Health**: the **Schema** row shows the current and latest version, and
+  **Writable** should be `Yes`.
+- If a migration fails, do **not** keep writing. Restore the `/data` backup you took before upgrading and
+  investigate before retrying.
+
+## Verify after upgrade
+
+1. The app loads and shows the new version in the sidebar footer.
+2. App Health: **Writable = Yes**, **Schema** current, **Persistence** as expected.
+3. Your sync flows and run history are present.
+4. If you use unattended sync, its scheduler section on App Health looks healthy.
+
+## Rollback
+
+- You can roll the **image** back to the previous `:<version>`.
+- Be aware that a newer version may have **migrated the schema**; an older image might not read a
+  newer database. If that happens, restore the pre-upgrade `/data` backup.
+- After a failed migration, prefer **restore from backup** over guessing.
+
+## Back up the metadata database
+
+Back up the `/data` volume (or at least the SQLite file at `ACTUAL_BENCH_DB_PATH`, default
+`/data/actual-bench.sqlite`).
+
+:::caution[Back up SQLite safely]
+For a consistent copy, stop the container first, or use a SQLite-safe backup method. Copying a live
+database file mid-write can produce a corrupt backup. Include any SQLite sidecar files (for example
+`-wal` / `-shm`) if present.
+:::
+
+Also back up your Compose/environment configuration, and store `SYNC_VAULT_KEY` **separately** in your
+secret manager.
+
+## Restore the metadata database
+
+1. Stop the container.
+2. Restore the metadata files to the `/data` volume with correct ownership/permissions.
+3. Restore your environment configuration.
+4. Provide the **same `SYNC_VAULT_KEY`** as before.
+5. Start the container and verify **App Health**.
+6. If the vault key was lost or changed, unattended credentials can't be decrypted — **re-enroll** them
+   per flow.
+
+## Move to another host
+
+1. Back up `/data` and your configuration on the old host.
+2. Restore `/data` on the new host with correct permissions.
+3. Recreate the container with the same image `:<version>` and environment.
+4. Provide the same `SYNC_VAULT_KEY`.
+5. Verify App Health and re-enroll any unattended credentials if the key changed.
+
+## Troubleshooting
+
+- **App started with empty metadata** — the `/data` volume isn't mounted (or points somewhere new);
+  check the mount and `ACTUAL_BENCH_DB_PATH`.
+- **Database not writable** — check volume permissions/ownership; App Health shows Writable = No.
+- **Migration failed** — restore the pre-upgrade backup and investigate.
+- **Old image can't read the new database** — roll forward again, or restore the matching backup.
+- **Unattended credentials fail after a move** — the `SYNC_VAULT_KEY` differs; re-enroll the flows.
+
+## Related pages
+
+- [Configuration](../configuration/)
+- [Deployment](../deployment/)
+- [Troubleshooting](../../help/troubleshooting/)

--- a/docs-site/src/content/docs/contributing.mdx
+++ b/docs-site/src/content/docs/contributing.mdx
@@ -1,0 +1,96 @@
+---
+title: Contributing
+description: How to contribute to Actual Bench — reporting bugs, suggesting features, improving docs, the branch and PR model, and validation.
+---
+
+Contributions are welcome — bug reports, feature requests, documentation improvements, and code alike.
+This is a concise entry point; the repository's [CONTRIBUTING.md](https://github.com/x-rous/actual-bench/blob/main/CONTRIBUTING.md)
+is the full reference.
+
+## Ways to contribute
+
+- Report a **bug**.
+- Suggest a **feature**.
+- Fix or improve **documentation**.
+- Contribute **screenshots** that match the current UI.
+- Contribute **code**.
+- Help by **testing** changes.
+
+## Report a bug or suggest a feature
+
+Open an issue on [GitHub Issues](https://github.com/x-rous/actual-bench/issues) using the appropriate
+template. For bugs, include your version, browser/OS, connection mode, exact steps, and expected vs.
+actual behavior. Check existing issues first to avoid duplicates. See
+[Troubleshooting](../help/troubleshooting/#reporting-a-bug) for what to include.
+
+## Set up the project
+
+```bash
+git clone https://github.com/x-rous/actual-bench.git
+cd actual-bench
+npm install
+npm run dev
+```
+
+Node.js `22.23.1` is recommended. HTTP API Server mode integration testing needs a running
+`actual-http-api` instance (or use a test budget).
+
+## Branch and PR model
+
+Work on short-lived branches that target `main`:
+
+| Type | Branch prefix |
+|---|---|
+| Feature | `feat/*` |
+| Bug fix | `fix/*` |
+| Refactor | `refactor/*` |
+| Docs | `docs/*` |
+
+All pull requests target `main`. Keep them focused, give them a clear user-facing title, and include
+screenshots for UI changes. Update `FEATURES.md` when a feature ships, and update this documentation
+when user-facing behavior changes.
+
+## Documentation contributions
+
+The documentation site is a standalone Astro Starlight project under `docs-site/`:
+
+```bash
+cd docs-site
+npm install
+npm run dev      # http://localhost:4321/actual-bench
+npm run build
+```
+
+When writing docs:
+
+- Treat the **current implementation and UI** as the source of truth; use exact in-app labels.
+- Keep each page substantial and task-oriented — smaller workflows are sections, not new pages.
+- Put images under `docs-site/src/assets/screenshots/` and reference them relatively.
+- Never include real secrets, credentials, private hostnames, or personal budget data.
+- Use base-safe links (relative, or prefixed with `/actual-bench/`).
+
+Every page has an **Edit** link that takes you straight to its source file on GitHub.
+
+## Validate before submitting
+
+From the repository root:
+
+```bash
+npm run lint      # 0 errors
+npx tsc --noEmit  # 0 errors
+npm test          # passes
+npm run build     # succeeds
+```
+
+For documentation-only changes, also run the docs build (`npm --prefix docs-site run build`). The
+documentation site has its own CI check on pull requests.
+
+## Security issues
+
+For a suspected security vulnerability, avoid posting exploit details in a public issue. Check the
+repository's security policy for the preferred private reporting channel before disclosing.
+
+## Related pages
+
+- [Introduction](../getting-started/introduction/)
+- [Troubleshooting](../help/troubleshooting/)

--- a/docs-site/src/content/docs/getting-started/installation.mdx
+++ b/docs-site/src/content/docs/getting-started/installation.mdx
@@ -96,7 +96,7 @@ You should land on the connection screen. Setting up the connection is covered i
 :::tip[Use HTTPS when it isn't just localhost]
 As soon as Actual Bench is reachable beyond your own machine, put it behind HTTPS (for example via a
 reverse proxy). Direct Actual Server mode in particular depends on secure, cross-origin-isolated
-context. See the **Administration → Deployment** guide.
+context. See the [Deployment](../../administration/deployment/) guide.
 :::
 
 ## Verify the installation
@@ -133,7 +133,7 @@ docker compose up -d
 ```
 
 For a safe upgrade — including backups, version pinning, and database migration notes — follow the
-**Administration → Upgrading and Backups** guide.
+[Upgrading and Backups](../../administration/upgrading-and-backups/) guide.
 
 ## Next step
 

--- a/docs-site/src/content/docs/help/glossary.mdx
+++ b/docs-site/src/content/docs/help/glossary.mdx
@@ -1,0 +1,82 @@
+---
+title: Glossary
+description: Definitions of Actual Bench and Actual Budget terms used throughout this documentation.
+sidebar:
+  order: 3
+---
+
+Short definitions of the terms used across this documentation. Where a term has its own guide, a link is
+included.
+
+## Products and connections
+
+- **Actual Bench** — the independent companion app this documentation describes.
+- **Actual Budget** — the budgeting application Actual Bench works with.
+- **Actual Server** — the server that hosts your Actual Budget data.
+- **actual-http-api** — a separate API server that Actual Bench can connect through in HTTP API Server
+  mode.
+- **Direct Actual Server mode** — connecting to your Actual Server and running Actual's engine in the
+  browser. See [Connecting](../../getting-started/connecting/).
+- **HTTP API Server mode** — connecting through `actual-http-api`. See
+  [Connecting](../../getting-started/connecting/).
+- **Browser worker** — the in-browser process that runs the Actual engine in Direct mode.
+- **CORS** — the browser rule set governing cross-origin requests; relevant to Direct mode.
+- **Cross-origin isolation** — the secure browsing context (COOP/COEP headers) Direct mode requires.
+
+## Budget concepts
+
+- **Account** — a place transactions live (for example a checking account).
+- **On-budget account** — an account included in budgeting.
+- **Off-budget account** — an account tracked but excluded from budgeting.
+- **Payee** — who a transaction is with.
+- **Transfer payee** — a system-managed payee representing an inter-account transfer.
+- **Category** — a budgeting bucket for transactions.
+- **Category group** — a group of categories (income or expense).
+- **Schedule** — a planned one-time or recurring transaction.
+- **Tag** — a label attached to transactions.
+- **Rule** — automation that changes transactions based on conditions.
+- **Rule stage** — when a rule runs: `pre`, `default`, or `post`.
+- **Condition / Action** — the "when" and the "what changes" parts of a rule.
+- **Template / Formula** — advanced action modes (Handlebars templates; Excel-style formulas).
+- **Budget mode** — **Envelope** or **Tracking**, the two Actual Budget budgeting styles.
+- **Budget cell** — a single category × month value in the budget grid.
+
+## Working in Actual Bench
+
+- **Staged change** — a local edit not yet written to the server.
+- **Draft Changes** — the panel/summary of pending staged changes.
+- **Save** — write staged changes to the server.
+- **Discard** — revert staged changes to the last saved state.
+- **Preview** — a dry-run that classifies items without writing (Budget Sync).
+- **Apply** — write the selected safe items from a sync preview.
+- **App Health** — the diagnostics page for Actual Bench's metadata database and scheduler.
+- **Metadata database** — the server-side SQLite store (under `/data`) for Actual Bench workflow data.
+- **ActualQL** — Actual Budget's JSON query language, used in the query workspace.
+- **Budget snapshot** — an exported copy of a budget, inspected read-only by Budget File Tools.
+- **SQLite** — the database format budgets and metadata use.
+- **Integrity check** — a deep SQLite validation in Budget File Health.
+
+## Budget Sync and FX
+
+- **Flow** — a saved one-way sync definition between a source and target.
+- **Source / Target** — the origin and destination of a flow.
+- **Mapping** — the app-owned link between a source item and its synced target item.
+- **Marker** — a durable target-side stamp (`imported_id`) recording that an item was synced.
+- **Duplicate candidate** — a possible duplicate on the target, held for review.
+- **Review queue** — where uncertain items collect for manual handling.
+- **Run history** — the record of a flow's past runs.
+- **Safe item** — an item safe to apply automatically (a new create or marker-match repair).
+- **FX rate** — an exchange rate used to convert amounts during cross-currency sync.
+- **Currency pair** — a source/target currency combination on the FX Rates page.
+- **Rate override** — a manually entered rate for a specific date.
+- **Locked rate** — a rate captured at first sync that won't silently change.
+- **Immutable rate snapshot** — the stored rate and amounts kept with a converted transaction.
+- **Vault** — the encrypted store for unattended-sync credentials.
+- **`SYNC_VAULT_KEY`** — the environment secret that enables and encrypts that vault.
+- **Unattended sync** — safe-only server-side sync that runs with the app closed (HTTP API mode).
+- **Auto-pause** — a flow automatically pausing after repeated failed automated runs.
+
+## Related pages
+
+- [Introduction](../../getting-started/introduction/)
+- [Core Concepts](../../getting-started/core-concepts/)

--- a/docs-site/src/content/docs/help/known-limitations.mdx
+++ b/docs-site/src/content/docs/help/known-limitations.mdx
@@ -1,0 +1,109 @@
+---
+title: Known Limitations
+description: Current boundaries of Actual Bench that affect what you can expect — by area, with alternatives where they exist.
+sidebar:
+  order: 2
+---
+
+This page lists current, confirmed limitations so you know what to expect. Each entry describes the
+impact and, where one exists, an alternative. Limitations are removed as they are resolved — this is not
+a roadmap and includes no delivery promises.
+
+## Product scope
+
+- **Actual Bench does not replace everyday budgeting.** It supplements Actual Budget for administration,
+  cleanup, diagnostics, queries, and cross-budget sync — not day-to-day transaction entry or
+  reconciliation.
+
+## Connection modes
+
+### Direct-mode unattended sync is not supported
+
+**Applies to:** Budget Sync using Direct Actual Server mode.
+
+Direct mode runs the Actual engine in the browser, so scheduled sync can't continue after the browser
+is closed.
+
+**Alternative:** Use the client-side schedule while Actual Bench is open, or configure both sides through
+HTTP API Server mode for unattended server-side sync.
+
+### ActualQL cURL is HTTP API Server-only
+
+**Applies to:** the ActualQL workspace.
+
+cURL generation targets `actual-http-api`'s `/run-query` endpoint, so it is available only for HTTP API
+Server executions, not Direct mode.
+
+## Browser and deployment
+
+- **Large budget snapshots depend on browser memory.** Budget File Tools process the exported snapshot
+  locally in the browser; very large files may be constrained by available memory.
+- **The unattended scheduler is single-instance.** It runs in-process and is designed for one instance;
+  it does not coordinate across multiple replicas.
+
+## Staged editing
+
+- **Notes save immediately.** Note edits are not part of the staged **Save** and are not reverted by
+  **Discard**. See [Core Concepts](../../getting-started/core-concepts/#immediate-save-exceptions).
+- **Query results reflect saved state.** ActualQL results do not include unsaved staged edits.
+
+## Master data
+
+- **Account budget type is fixed after creation.** On-budget / off-budget can't be changed later
+  (an Actual Budget constraint).
+- **Transfer payees are restricted.** They are system-managed and can't be edited or bulk-deleted like
+  regular payees.
+- **Income categories can't move groups.** They stay locked to the single income parent group.
+
+## Schedules and rules
+
+- **Schedule-generated rules are read-only** on the Rules page and can't be merged; manage them from the
+  Schedules page.
+- **The schedule `completed` flag is not a status.** It's retained for round-tripping but isn't shown as a
+  reliable paid/completed state.
+
+## Budget Management
+
+- **Carryover is toggled via the right-click menu**, not edited directly as a grid cell.
+- **Category-to-pool transfers are not supported** (transfers require both a source and destination
+  category).
+- **The grid is not virtualized**, so very large category lists may scroll slowly.
+
+## Budget File tools
+
+- **Read-only.** Budget File Health and the Data Browser never write back to your budget; they inspect an
+  exported snapshot.
+
+## Budget Sync
+
+Not currently in scope:
+
+- True Actual **transfer-linked** sync (same-budget flows use a plain copy).
+- **Automatic (non-review) target deletes** — deletion is always review-first.
+- **Category auto-create** during sync.
+- **Fuzzy duplicate auto-mapping** — only exact duplicates can be auto-mapped (opt-in); fuzzy duplicates
+  always go to the review queue.
+
+## FX / multi-currency
+
+- **No FX gain/loss accounting.**
+- **No silent recalculation** of past conversions — rates lock at first sync.
+- **No multi-currency within a single budget file** — conversion applies to cross-currency sync between
+  budgets.
+- **Rate availability** depends on the provider and the coverage you've filled or imported.
+
+## Version compatibility
+
+- Some features depend on your **Actual Budget server version** (for example, tags require Actual Budget
+  v26.3.0 or later).
+
+## Requesting an enhancement
+
+If a limitation is blocking you, open a feature request on
+[GitHub Issues](https://github.com/x-rous/actual-bench/issues) describing your use case.
+
+## Related pages
+
+- [Troubleshooting](../troubleshooting/)
+- [Budget Sync](../../user-guide/budget-sync/)
+- [FX Rates](../../user-guide/fx-rates/)

--- a/docs-site/src/content/docs/help/troubleshooting.mdx
+++ b/docs-site/src/content/docs/help/troubleshooting.mdx
@@ -1,0 +1,116 @@
+---
+title: Troubleshooting
+description: First-line troubleshooting for Actual Bench — connections, the metadata database, staged changes, feature areas, performance, and how to report a bug.
+sidebar:
+  order: 1
+---
+
+This page collects practical first-line fixes across Actual Bench. For area-specific issues, each
+feature guide also has its own troubleshooting section.
+
+:::caution[Don't start with destructive steps]
+Deleting the metadata database or clearing browser storage is a **last resort**, not a first step —
+both can lose data. Understand what a step removes before you take it.
+:::
+
+## Troubleshoot safely: collect basic information
+
+Before changing anything, note:
+
+1. The Actual Bench **version** (sidebar footer).
+2. The **connection mode** (Direct Actual Server or HTTP API Server).
+3. The **active budget/connection** (top bar).
+4. What **App Health** reports.
+5. The browser console — only if it helps.
+6. Container logs.
+7. The smallest safe action that reproduces the issue.
+
+Redact secrets before sharing any logs.
+
+## Installation and container
+
+- **Container exits on start** — check logs; verify the image tag and that the `/data` volume is
+  mountable.
+- **Port conflict** — another process holds the published port; change the host port mapping.
+- **Wrong architecture** — the images are multi-arch (`amd64`/`arm64`); ensure your host pulls a matching
+  variant.
+- **Reverse proxy returns 502/504** — check that the proxy can reach the container and forwards
+  host/protocol headers. See [Deployment](../../administration/deployment/).
+
+## Metadata database
+
+- **Database not writable** — App Health shows **Writable = No**; check `/data` volume permissions and
+  ownership.
+- **Unexpectedly empty history** — the `/data` volume isn't mounted or points to a new location; verify
+  `ACTUAL_BENCH_DB_PATH`.
+- **Migration issue after upgrade** — see [Upgrading and Backups](../../administration/upgrading-and-backups/#database-migrations).
+
+## Direct connection
+
+- **Browser can't reach Actual Server** — confirm the URL is reachable from the browser over HTTPS.
+- **CORS or cross-origin isolation errors** — allow CORS or serve Actual Server same-origin via a
+  reverse proxy; Actual Bench sets its own isolation headers.
+- **Only HTTP API Server mode is offered** — Direct mode is disabled via `DIRECT_BROWSER_API=0` /
+  `NEXT_PUBLIC_DIRECT_BROWSER_API=0`.
+- **Encrypted budget won't open** — confirm the **Encryption password**.
+
+## HTTP API connection
+
+- **`fetch failed` / `502 Bad Gateway`** — the Actual Bench container can't reach `actual-http-api`;
+  check container-to-container networking. Remember `localhost` is the Actual Bench container itself.
+- **Wrong URL or API key** — verify the **HTTP API Server URL** and that the **API Key** matches
+  `ACTUAL_API_KEY`.
+
+## Browser state
+
+- **Saved preset but must re-enter secrets** — expected: secrets are held in memory only and are never
+  saved.
+- **Refresh requires reconnecting** — expected, for the same reason.
+- **Stale worker/cache in Direct mode** — as a last resort, clear this site's browser data. This removes
+  saved presets and cached worker state and requires reconnecting.
+
+## Staged changes and Save
+
+- **Changes didn't persist** — you may not have clicked **Save**; failed items stay marked with an
+  error, with a retry option.
+- **A note "won't discard"** — notes save immediately and are not part of the staged Save. See
+  [Core Concepts](../../getting-started/core-concepts/#immediate-save-exceptions).
+- **Wrong budget affected** — confirm the active connection before saving; staged data is scoped per
+  connection.
+
+## Feature areas
+
+Each guide has a focused troubleshooting section:
+
+- [Budget Management](../../user-guide/budget-management/#troubleshooting)
+- [Accounts, Payees and Categories](../../user-guide/accounts-payees-categories/#common-problems)
+- [Rules](../../user-guide/rules/#troubleshooting)
+- [ActualQL](../../user-guide/actualql/#troubleshooting)
+- [Budget File Tools](../../user-guide/budget-file-tools/#troubleshooting)
+- [Budget Sync](../../user-guide/budget-sync/#troubleshooting)
+- [FX Rates](../../user-guide/fx-rates/#troubleshooting)
+
+## Performance
+
+Large budgets and large snapshots are the usual causes of slowness:
+
+- Entity pages load the full set; very large budgets feel slower on Accounts/Payees/Categories/Rules.
+- The full SQLite integrity check and large table exports take time.
+- Big sync previews and rule diagnostics over large rule sets are heavier.
+- Very large budget snapshots depend on available browser memory.
+
+## Reporting a bug
+
+Open an issue on [GitHub Issues](https://github.com/x-rous/actual-bench/issues) with:
+
+- Actual Bench **version**, **browser**, and **OS**.
+- **Connection mode** and deployment type.
+- Exact **steps to reproduce**, plus expected vs. actual behavior.
+- Screenshots and **sanitized** console/container logs.
+- Whether it reproduces in the [demo](https://actual-bench-demo.vercel.app) or another browser.
+
+## Related pages
+
+- [Known Limitations](../known-limitations/)
+- [Connect to Actual Budget](../../getting-started/connecting/)
+- [Deployment](../../administration/deployment/)

--- a/docs-site/src/content/docs/user-guide/accounts-payees-categories.mdx
+++ b/docs-site/src/content/docs/user-guide/accounts-payees-categories.mdx
@@ -1,0 +1,184 @@
+---
+title: Accounts, Payees and Categories
+description: Manage the core Actual Budget master data — accounts, payees, and categories — with inline editing, bulk actions, filters, impact-aware deletion, and CSV import/export.
+sidebar:
+  order: 2
+---
+
+Accounts, Payees, and Categories are Actual Bench's master-data pages. They share the same editing
+model, so this guide covers the concepts once and then the specifics of each page.
+
+Open them from the **Data Management** section of the sidebar (**Accounts**, **Payees**, **Categories**).
+
+## How master-data editing works
+
+All three pages behave consistently:
+
+- **Inline editing** — double-click, `Enter`, or `F2` to edit a cell; `Escape` cancels.
+- **Staged rows** — new, edited, and deleted rows are visually marked and only written on **Save**.
+- **Bulk selection** — select rows with checkboxes and apply bulk actions; system-managed rows show a
+  disabled checkbox with a tooltip.
+- **Filters** — filter and search each page; your filters persist per page and reset when you switch
+  connections.
+- **Duplicate warnings** — a visual warning appears when a name already exists.
+- **CSV import/export** — export or import rows; imports are staged before saving. See
+  [Budget File Tools](../budget-file-tools/) for read-only inspection, and the format details later on
+  this page.
+- **Impact-aware deletion** — destructive actions confirm first, showing transaction counts, rule
+  references, balances, or child counts where available.
+- **Usage Inspector** — an **Info** button on each row opens a drawer with the entity's full usage
+  profile without starting a delete.
+
+:::note[Rules counts are clickable]
+Accounts, payees, and categories show how many rules reference them. Click the count to jump to the
+Rules page filtered to that entity.
+:::
+
+## Quick Create
+
+You can stage a new entity from anywhere without leaving the current page:
+
+- Press `N` (when no input or dialog is focused) or `Ctrl/Cmd+Shift+N` (from anywhere) to open the
+  Quick Create dialog.
+- Choose **Payee**, **Category**, **Account**, or **Tag**.
+- Category requires a group; Account has an on-budget / off-budget toggle; Tag has an optional color.
+- On submit, the entity is staged (one undo step) and you stay on the current page.
+
+## Global Search
+
+Press `Ctrl/Cmd+K` (or the top-bar **Search** button) to search across accounts, payees, categories,
+rules, schedules, and tags. Results are grouped by type; selecting one navigates to that entity with
+the row highlighted. Search runs against loaded in-memory data and never writes anything.
+
+## Accounts
+
+Manage accounts, their balances, and their budget type.
+
+### Create an account
+
+1. Select **Add Account** to open the form drawer.
+2. Enter a **Name**.
+3. Optionally set an **Initial Balance** (seeds the account's starting balance on creation).
+4. Choose **on-budget** or **off-budget** with the toggle.
+5. Save to stage the new account.
+
+:::caution[Budget type is fixed after creation]
+Actual Budget does not allow an account's on-budget / off-budget type to change after creation, so
+Actual Bench shows it as a read-only badge afterward. Choose carefully at creation time.
+:::
+
+### Balances, closing, and deleting
+
+- The **Current balance** column shows the live balance (refreshed periodically or via **Refresh**);
+  negative balances are highlighted.
+- Open and close accounts individually or in bulk (close, reopen).
+- Every delete and close confirms first, showing the account's outstanding balance, transaction count,
+  and rule reference count. Non-zero balances get an explicit budget-consistency warning.
+
+### Notes
+
+Each account row has a note button beside the name. Read (Markdown-rendered), add, edit, or clear the
+note inline — note changes **save immediately**, independent of staged account edits.
+
+### Import and export
+
+Export accounts to CSV or import them (staged before saving). See [CSV formats](#csv-formats).
+
+## Payees
+
+Manage regular payees and understand transfer payees.
+
+### Regular and transfer payees
+
+Transfer payees are auto-generated for inter-account transfers. They appear as a separate, filterable
+type and cannot be edited or bulk-deleted like regular payees — their selection checkbox is disabled to
+make that explicit.
+
+### Create, rename, and delete
+
+- Create and rename payees inline.
+- Every delete (single or bulk) confirms, showing the payee's transaction count and rule reference
+  count. Transfer payees are excluded from bulk delete and counted separately in the dialog.
+
+### Merge duplicate payees
+
+1. Select **two or more regular payees**.
+2. Choose **Merge**.
+3. The **first payee you check** becomes the surviving target (regardless of table sort); the rest are
+   absorbed.
+4. The merge is staged and shown in the Draft Changes panel as "Merge Deleted" before you **Save**.
+   `Ctrl+Z` undoes it.
+
+## Categories and groups
+
+Manage income and expense category groups, categories, visibility, and hierarchy.
+
+### Groups and categories
+
+- Create category **groups** (income or expense type) and categories within them.
+- Rename groups and categories inline; collapse or expand group rows.
+- Group reassignment opens an on-demand editor rather than rendering every dropdown up front, keeping
+  large tables responsive.
+
+:::note[Income category constraints]
+Income categories stay locked to the single income parent group. Only expense categories can be moved
+between groups.
+:::
+
+### Hide, show, and delete
+
+- Toggle visibility (hidden / visible) per category or per whole group.
+- Deleting a **category** confirms with its transaction count and rule references. Deleting a **group**
+  additionally shows the child category count and aggregated transactions across all children, with a
+  cascade warning.
+
+### Notes
+
+Each category and group row has a note button. Read, add, edit, or clear notes inline — they **save
+immediately**, independent of staged category edits.
+
+### Import and export
+
+Export or import the full group hierarchy as CSV (staged before saving). See [CSV formats](#csv-formats).
+
+## The Usage Inspector
+
+The **Info** button on any row opens a drawer with a complete usage profile without starting a delete:
+
+- A stats row: Rules (always), Transactions (except tags), Balance (accounts, amber when non-zero), and
+  Categories (groups only).
+- An impact section describing what deletion would affect.
+- Quick links (e.g. **View rules →**) for entities with rule references.
+- An empty state ("No known references found.") when nothing references the entity.
+
+## CSV formats
+
+Every page supports CSV export and import. Exports are UTF-8 with a BOM (for Excel / Google Sheets);
+imports are staged with per-row validation and a 5 MB limit.
+
+- **Accounts** — `name` (required), `offBudget`, `closed`.
+- **Payees** — `name` (required).
+- **Categories** — `type` (`group` or `category`, required), `name` (required), `group`, `is_income`,
+  `hidden`. Group rows must appear before the categories that reference them.
+
+Sample files ship in the repository's `public/samples csv/` for testing with a fresh budget.
+
+## Review and Save
+
+Staged creates, edits, deletes, and merges appear in the Draft Changes panel and the top bar. Nothing
+is written to your Actual Server until you **Save**; **Discard** reverts to the last saved state.
+Remember that **note edits are the exception** — they save immediately.
+
+## Common problems
+
+- **"Can't change the account type"** — this is by design; type is fixed after creation.
+- **"Can't select a transfer payee"** — transfer payees are system-managed and not bulk-editable.
+- **"Can't move an income category"** — income categories are locked to the income group.
+- **A delete is blocked or warns** — read the impact dialog; groups warn about cascade deletion.
+- **A new row stays highlighted** — it is staged; click **Save** to persist it.
+- **A note "didn't discard"** — notes save immediately, separately from the staged Save.
+
+## Related pages
+
+- [Rules](../rules/) — see how rules reference these entities
+- [Core Concepts](../../getting-started/core-concepts/)

--- a/docs-site/src/content/docs/user-guide/actualql.mdx
+++ b/docs-site/src/content/docs/user-guide/actualql.mdx
@@ -1,0 +1,114 @@
+---
+title: ActualQL
+description: Run, explain, save, and export ActualQL queries against your budget in Actual Bench — editor, result views, saved queries, and mode differences.
+sidebar:
+  order: 5
+---
+
+The ActualQL workspace lets you run arbitrary ActualQL queries against the open budget for advanced
+analysis. Open it from **ActualQL Queries** under the **Tools** sidebar section (`/query`). It works in
+both Direct Actual Server mode and HTTP API Server mode.
+
+## What ActualQL is
+
+ActualQL is Actual Budget's query language, expressed as **JSON** (not SQL). In Actual Bench this
+workspace is used for reading and analyzing data.
+
+:::note[Read-only from Actual Bench's side]
+Running a query does not stage or write anything. Results reflect **saved server state**, not your
+unsaved staged edits.
+:::
+
+## Open the workspace and understand the editor
+
+- A syntax-highlighted JSON editor with line numbers and a JetBrains Mono font; you edit raw JSON with
+  no auto-correction.
+- The editor accepts bare ActualQL query objects and the wrapped `{ "ActualQLquery": ... }` shape used
+  by `actual-http-api`.
+- The editor/results split is resizable, and the divider position persists across reloads.
+
+## Run and format a query
+
+1. Type or paste a query.
+2. Select **Run** (or press `Ctrl/Cmd+Enter`).
+3. Use **Format JSON** to tidy the query.
+
+Parse errors are shown inline before any request is made. **Lint warnings** flag risky shapes — for
+example a broad `transactions` query with no `limit`, `groupBy`, or `calculate`; an empty `$oneof`; or a
+`groupBy` with no aggregate.
+
+## Use built-in examples and reference
+
+- **ActualQL Reference** — a six-section quick reference (basics, filter operators, joined fields,
+  aggregates, transactions options, and copyable snippets).
+- **Example packs** — one-click inserts grouped into Data inspection, Cleanup & validation, Aggregation,
+  and Targeted subset.
+
+## Understand result views
+
+Select a result view via tabs:
+
+- **Table** — columns from the union of keys across rows; nested values are JSON-stringified; capped at
+  500 rows with a warning banner. Dates render human-readably; `amount`/`balance` integers show as
+  decimals (cents ÷ 100), with the raw value on hover.
+- **Raw JSON** — the full syntax-highlighted payload.
+- **Scalar** — a large value card for `calculate` aggregate results.
+- **Tree** — a collapsible JSON tree, auto-selected for plain-object results.
+
+An execution metadata bar shows an OK / Error chip, elapsed time, row count, and payload size.
+
+## Explain a query
+
+Select **Explain** for a one-click plain-English summary of what the current query does — its target
+table, filters, grouping, aggregation, ordering, and whether the result is tabular or scalar. Explaining
+does not run the query.
+
+## Save, pin, and reuse queries
+
+- **Save** a query with a name (stored locally per budget). Load, rerun, duplicate, rename, delete, and
+  **pin as favorite**.
+- **Query history** keeps the last 10 executed queries per budget for one-click reload; re-running a
+  query bumps it to the top rather than duplicating it.
+
+## Export and copy results
+
+- **Copy result JSON** and **Copy query JSON** are available in all modes.
+- For **HTTP API Server** executions only, you can also copy **sanitized cURL** (secrets replaced with
+  placeholders) or **full cURL** (opt-in, clearly marked as containing real credentials). cURL is
+  generated from the last HTTP API Server request, not the current editor state.
+
+:::caution[Full cURL contains real credentials]
+The full-cURL option embeds your API key. Only copy it when you need it, and never paste it where others
+can see it.
+:::
+
+## Staged changes and query results
+
+If you have unsaved staged changes, a banner reminds you that query results reflect **saved** server
+state, not your pending local edits. Results bypass the staged store entirely.
+
+## Practical examples
+
+Start from the built-in example packs, which cover transactions, accounts, payees, categories, monthly
+spending, budget status, and rules. They are the most reliable, current examples to build on.
+
+## Mode differences
+
+- ActualQL runs in both Direct and HTTP API Server mode.
+- **cURL generation is HTTP API Server-only**, because it targets `actual-http-api`'s `/run-query`
+  endpoint.
+
+## Troubleshooting
+
+- **Invalid JSON** — the inline parse error points at the problem; fix it before running.
+- **Unsupported query** — check the lint warnings and the ActualQL Reference.
+- **Empty result** — verify filters and date ranges.
+- **Result isn't table-friendly** — use the Tree or Raw JSON view.
+- **Results look stale** — they reflect saved state; save your staged edits first.
+- **cURL option missing** — you're in Direct mode; cURL is HTTP API Server-only.
+
+## Related pages
+
+- [Rules](../rules/)
+- [Budget File Tools](../budget-file-tools/)
+- [Connect to Actual Budget](../../getting-started/connecting/)

--- a/docs-site/src/content/docs/user-guide/budget-file-tools.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-file-tools.mdx
@@ -1,0 +1,97 @@
+---
+title: Budget File Tools
+description: Inspect exported Actual Budget snapshots locally in the browser with Budget File Health and the Data Browser — read-only health checks, SQLite browsing, and CSV export.
+sidebar:
+  order: 6
+---
+
+Budget File Tools are **read-only** diagnostics for the exported budget snapshot: **Budget File Health**
+(metadata and health checks) and the **Data Browser** (raw SQLite tables and rows). Both process the
+snapshot **locally in your browser** and never write anything back to your budget.
+
+Open **Budget File Health** and **Data Browser** from the **Tools** sidebar section.
+
+:::caution[Snapshots contain your financial data]
+An exported snapshot can include personal financial information. Processing happens locally in your
+browser, but any ZIP or CSV you download becomes your responsibility — avoid sharing raw snapshots when
+reporting issues.
+:::
+
+## Load a budget snapshot
+
+The first time you open either tool, Actual Bench downloads and opens the active budget's exported
+snapshot. It is then **cached** across navigation (with a "loaded X ago" label and a **Reload** button)
+and **shared** between Budget File Health and the Data Browser — so once loaded, the other tool opens
+instantly.
+
+Snapshot opening shows a staged progress rail with retry on failure, plus a reminder that the contents
+stay local but may include personal budget data.
+
+## Budget File Health
+
+A workspace with top-level **Overview** and **Diagnostics** tabs.
+
+### Review snapshot metadata
+
+The **Overview** tab summarizes export metadata, snapshot object counts, ZIP and SQLite sizes, and
+source details, with a button to download the exported ZIP.
+
+### Run diagnostics
+
+The **Diagnostics** tab runs deterministic checks over the snapshot — schema, relationships, metadata,
+and SQLite health — and summarizes findings by severity. You can:
+
+- Run a full **SQLite integrity check** (a longer-running operation).
+- **Export findings to CSV**.
+
+No diagnostics action writes anything back to your budget.
+
+## Data Browser
+
+The Data Browser (`/data-browser`) opens the snapshot's raw SQLite objects. It reuses the cached
+snapshot, so it opens instantly once the budget has been loaded anywhere.
+
+### Browse tables, views, and schema
+
+- Lists **tables, views, indexes, and triggers** grouped by Actual Budget domain; `v_transactions` is
+  selected by default when present.
+- The row browser paginates through table/view rows with sticky headers, horizontal scrolling,
+  worker-side sorting, and URL state for the object, page, page size, and sort.
+- The **Schema** tab shows object type, parent table, row count, inferred row key, columns, indexes, and
+  the raw `CREATE …` SQL.
+- Indexes and triggers are listed but marked as not row-browsable.
+
+### Inspect rows and follow relationships
+
+- **Row actions** copy a row's JSON to the clipboard (BLOBs serialized as base64) and open a stackable
+  row-details panel.
+- **Relationship-aware drill-in** turns known linked cells into navigable references, using the same
+  relationship map as diagnostics.
+- Cell rendering keeps raw money-like integers, formats dates and obvious budget months, marks BLOBs as
+  binary with a hex-preview tooltip, and preserves raw values in tooltips.
+
+### Export tables and views
+
+Full table/view **CSV export** streams rows through worker-owned cursors, preserves UTF-8 for Excel,
+neutralizes formula-like text values, keeps numeric negatives raw, and caps BLOB cells as base64
+previews.
+
+## Safety and limitations
+
+- These tools are strictly read-only; they never modify your budget.
+- Very large snapshots depend on available browser memory.
+- The full SQLite integrity check can take a while on large files.
+
+## Troubleshooting
+
+- **Export or snapshot won't open** — retry from the progress rail; check browser memory for large
+  files.
+- **An object shows no rows** — indexes and triggers are not row-browsable.
+- **The snapshot looks stale** — use **Reload** to fetch a fresh export.
+- **A CSV opens oddly in a spreadsheet** — exports are UTF-8 with formula-injection protection; open
+  them as UTF-8.
+
+## Related pages
+
+- [ActualQL](../actualql/) — query live saved data instead of a snapshot
+- [Core Concepts](../../getting-started/core-concepts/)

--- a/docs-site/src/content/docs/user-guide/budget-management.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-management.mdx
@@ -1,0 +1,176 @@
+---
+title: Budget Management
+description: Edit a full-year budget in Actual Bench's spreadsheet-grade workspace — cells, multi-cell selection, fill actions, envelope and tracking modes, notes, and CSV import/export.
+sidebar:
+  order: 1
+---
+
+Budget Management is a full-width, 12-month budget editor for both envelope and tracking budgets. It
+behaves like a spreadsheet: select ranges, paste from Excel or Google Sheets, fill values, and review
+everything in a draft panel before you **Save**.
+
+Open it from the **Budget** item in the sidebar (under **Data Management**), or go to
+`/budget-management`.
+
+:::note[Staged like the rest of the app]
+Budget cell edits are staged locally and only written to your Actual Server when you **Save**. See
+[Core Concepts](../../getting-started/core-concepts/) for the staging model.
+:::
+
+## Understand the workspace
+
+The workspace shows a grid with one row per category (grouped under category groups) and one column per
+month in a 12-month window:
+
+- A **budget mode badge** (`Envelope`, `Tracking`, or `Unknown`) sits at the top-left.
+- The **category name column** and the **month header row** stay pinned while you scroll.
+- **Group rows** show per-month aggregate totals; collapsing a group hides its categories but keeps the
+  group total.
+- A **Budget Details** panel on the right shows details for the current selection and your staged
+  changes.
+
+## Choose Budget, Actuals, or Balance
+
+Use the cell-view toggle in the toolbar (also the `V` key) to switch what every month cell displays:
+
+- **Budget** — the budgeted amount.
+- **Actuals** — actual activity.
+- **Balance** — the running balance.
+
+## Navigate months and years
+
+- Move the 12-month window back/forward by one month with `‹` / `›`, or by a year with `«` / `»`.
+- Use the calendar button to jump to the current year.
+- The `[` and `]` keys pan the window backward/forward by one month.
+
+## Expand, collapse, and hide
+
+- Expand or collapse all groups with the toolbar buttons, or `E` / `Shift+E`.
+- Toggle a single group with `Space` on its label.
+- Show or hide hidden categories with the toolbar toggle, or the `H` key.
+
+## Edit one budget cell
+
+1. Select a cell and press `Enter`, `F2`, or start typing (a digit, `+`, `-`, `.`, or `(`).
+2. Type an amount **or an arithmetic expression** — `+`, `-`, `*`, `/`, and parentheses are supported
+   (for example `1200/12`).
+3. Press `Enter` to commit (and move down), `Tab` to commit sideways, or `Escape` to cancel.
+
+Staged edits show in amber. Reverting a cell to its original value removes the staged edit
+automatically. `Delete` or `Backspace` sets a focused cell to zero.
+
+:::note[Income in envelope mode]
+In envelope mode, income categories are not editable in the grid.
+:::
+
+## Select multiple cells
+
+- Click a cell to select it; `Shift+click` or drag to extend a rectangular selection.
+- Extend with `Shift+Arrow`, `Shift+PageUp/Down`, and `Shift+Home/End`.
+- The first column (category/group label) is selectable for row-aggregate views in the details panel.
+
+## Copy and paste
+
+- `Ctrl/Cmd+C` copies the selection as tab-delimited text that round-trips through Excel / Google
+  Sheets.
+- `Ctrl/Cmd+V` fills the selection from a single value, or expands a multi-cell paste from the top-left
+  cell.
+
+## Fill values
+
+With a range selected:
+
+- `Ctrl/Cmd+Enter` — fill the whole selection with the anchor cell's value.
+- `Ctrl/Cmd+D` — fill down.
+- `Ctrl/Cmd+R` — fill right.
+- `Alt+L` — fill each row with its previous-month value.
+- `Alt+A` — fill each row with its 3-month average.
+
+## Right-click bulk actions
+
+Right-click a category budget cell for a context menu:
+
+- **Cell actions** (mode-aware): in tracking mode, enable/disable rollover from that month forward; in
+  envelope mode, **Cover Overspending** or **Transfer to Another Category**.
+- **Set Budget**: Copy previous month, Copy specific month…, Set to zero, Set to fixed amount…, Apply
+  % change…, and 3-, 6-, or 12-month averages (averages use each prior month's **budgeted** amount).
+
+No-input actions run immediately as one undo step; actions that need input open a two-step
+(parameters → preview) dialog.
+
+## Review staged changes and Save
+
+- The Budget Details panel shows a **"N changes"** badge; open it for a list of staged changes grouped
+  by month (transfer pairs appear as a single linked row).
+- **Save** opens a review summary (change count, affected months, net delta), then a progress dialog
+  that sends changes sequentially. Transfer pairs post atomically; standalone edits and holds are sent
+  individually.
+- Partial failures are reported with a **Retry Failed** option; only changes the server accepted are
+  cleared.
+- Undo/redo works across staged edits (`Ctrl/Cmd+Z`, `Ctrl/Cmd+Shift+Z` / `Ctrl+Y`), up to 50 steps.
+
+## Use notes
+
+The details panel has an editable **Note** section for the current selection — a category, group,
+category × month cell, or a whole budget month (selected from its column header).
+
+:::caution[Notes save immediately]
+Note edits save to the server right away, independently of your staged budget edits and the **Save**
+button. See [Core Concepts](../../getting-started/core-concepts/#immediate-save-exceptions).
+:::
+
+## Envelope budget actions
+
+- **Hold for next month** — each *To Budget* cell shows the held amount; the toggle opens a dialog to
+  stage a hold (or clears an existing one). Holds are staged and saved with your other changes.
+- **Cover Overspending / Transfer to Another Category** — stage a category-to-category transfer; both
+  legs stage together as one undo step and post atomically on save.
+
+Holds and transfers are envelope-mode only.
+
+## Tracking budget behavior
+
+In tracking mode the workspace uses planning language rather than envelope balances. Past months show
+actual performance, the current month is marked partial, and future months show budgeted context
+instead of a zero-actual result. Rollover (carryover) is toggled per category from the right-click menu.
+
+## Import and export
+
+- **Export** opens a dialog with month-selection modes (Quick Range, Date Range, or Select), options to
+  include hidden categories / income groups / staged values, and a blank-template download. Files are
+  UTF-8 CSV with a BOM.
+- **Import** parses a CSV, lets you review exact / suggested / unmatched rows, previews before/after
+  values, and stages all changes as one undo step. Near-miss category names get fuzzy-match
+  suggestions; out-of-range months can extend the visible window.
+
+:::tip[Back up before large imports]
+A budget CSV import can stage many changes at once. Consider exporting your current budget first so you
+have a known-good snapshot to re-import if needed.
+:::
+
+## Keyboard shortcuts
+
+Press `?` (or `F1`, `Ctrl/Cmd+/`, or the toolbar **Shortcuts** button) to open the full cheatsheet,
+generated from the app's keymap. Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) don't fire while
+you're typing in a cell.
+
+## Safety and limitations
+
+- Carryover is toggled via the right-click menu (tracking mode); it is shown but not directly editable
+  as a grid cell.
+- Category-to-pool transfers (omitting a source or destination category) are not supported.
+- The grid is not virtualized, so very large category lists may scroll more slowly.
+
+## Troubleshooting
+
+- **Paste didn't apply** — make sure a cell is selected first; paste fills from the top-left cell.
+- **A value isn't visible** — check the cell-view toggle (Budget / Actuals / Balance) and whether the
+  month is inside the current 12-month window.
+- **A category is missing** — it may be hidden; toggle hidden categories with `H`.
+- **Changes didn't save** — failed cells stay staged with a red indicator; use **Retry Failed**.
+- **A note "won't discard"** — notes save immediately and are not part of the staged Save.
+
+## Related pages
+
+- [Core Concepts](../../getting-started/core-concepts/)
+- [Accounts, Payees and Categories](../accounts-payees-categories/)

--- a/docs-site/src/content/docs/user-guide/budget-sync.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-sync.mdx
@@ -162,8 +162,8 @@ Additional controls:
 :::note[Unattended sync needs operator setup]
 Unattended server-side sync requires an operator to set `SYNC_VAULT_KEY` and enroll the connection's API
 key in an encrypted server vault. Direct-mode flows can't run unattended (Actual runs in the browser)
-and keep the client-side interval. See **Administration → Configuration** and
-**Administration → Deployment**.
+and keep the client-side interval. See [Configuration](../../administration/configuration/) and
+[Deployment](../../administration/deployment/).
 :::
 
 ## Flow health and auto-pause

--- a/docs-site/src/content/docs/user-guide/budget-sync.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-sync.mdx
@@ -1,0 +1,206 @@
+---
+title: Budget Sync
+description: Sync data between budget files in Actual Bench — preview-first flows for transactions, payees, and categories, apply and mappings, the review queue, automation, and unattended server-side sync.
+sidebar:
+  order: 7
+---
+
+Budget File Sync copies data between budget files as saved, one-way **flows**. One unified engine covers
+**transactions, payees, and categories**, so preview, apply, run history, the review queue, and the
+safe-only automation layer work the same way for each. It is **preview-first** and conservative by
+default (**create-only**), with opt-in advanced modes that never write silently.
+
+Open it from **Budget File Sync** under the **Tools** sidebar section (`/sync`).
+
+## The safety model
+
+Read this first — it explains why sync is safe to run:
+
+- **Preview is required** before any write. A dry-run produces a persisted run with classified rows and
+  no changes to Actual.
+- **Create-only** is the conservative baseline. Update, delete, grouped splits, and same-budget are
+  opt-in and previewed.
+- **Automation applies only provably safe items**; anything uncertain goes to the **review queue**.
+- **Mappings and markers** protect against duplicates, so reruns skip already-synced items.
+
+## Supported data types
+
+Choose a flow's **data type** in the editor:
+
+- **Transactions** — sync at the **account** level (source and target accounts).
+- **Payees** and **Categories** — sync at the **budget** level (no account).
+
+Every data type syncs in **both Direct and HTTP API Server mode**, in any combination
+(Direct→HTTP, HTTP→Direct, or same-mode).
+
+## Create a flow
+
+1. On the Budget File Sync page, create a flow.
+2. Give it a **name** and choose the **data type**.
+3. Choose the **source** and **target** connections (and accounts, for transaction flows).
+4. Configure filters and transforms (below).
+5. Save the flow.
+
+A source and target on the same budget is allowed for transaction flows (between two different
+accounts); entity flows require two different budgets. A true self-sync (same account on both sides) is
+blocked.
+
+## Transaction flow settings
+
+### Filters
+
+- Date range, cleared/reconciled status, amount sign, payee/category include-exclude, and
+  notes-contains.
+- Sync-generated transactions are always excluded to prevent loops.
+
+### Transforms
+
+- **Amount direction** — reverse sign by default (a common cross-budget consolidation), or same-sign.
+- **Payee match-by-name** — create missing payees by default, or leave empty.
+- **Category match-by-name** — missing categories are left empty (categories are never auto-created).
+- **Notes marker** — a clean visible marker such as `[Synced from <budget> / <account>]`, on by
+  default.
+- **Split handling** — eligible split lines are exploded into separate target transactions by default,
+  or kept **grouped as one target split** when you enable *Keep splits grouped on the target*.
+- **Convert currency** — for multi-currency consolidation; see [FX Rates](../fx-rates/).
+
+## Payee and category flows
+
+- Entities are matched to the target by **normalized name**.
+- **Payees:** missing payees are created on the target; existing ones are mapped without duplicating.
+- **Categories:** matched by name within a group; missing categories are created under the matching
+  target group or a chosen **default group**. A category whose group can't be placed is **blocked for
+  review** unless you enable **create missing groups**. Income and expense categories stay distinct.
+- **No renames, deletes, or hides** — create-only. Mappings let reruns skip already-synced entities.
+
+## Preview a flow
+
+Select **Preview** to produce a dry-run. Each row is classified. The exact labels you'll see:
+
+| Label | Meaning |
+|---|---|
+| **New** | A safe new item to create on the target. |
+| **Already synced** | Already mapped from a previous run; skipped. |
+| **Duplicate** | A likely duplicate on the target; held for review. |
+| **Source changed** | The source changed since it was synced. |
+| **Source deleted** | The mapped source was deleted. |
+| **Marker match** / **Name match** | The target already carries this item's marker or matches by name. |
+| **Blocked** | Can't be applied safely (for example, ambiguous category group placement). |
+| **FX pending** | A converting row has no available rate yet (see [FX Rates](../fx-rates/)). |
+
+The preview shows source and transformed target amounts side by side, with no writes to Actual.
+Currency-converting flows also label amounts with their currency and show the applied rate.
+
+## Apply a run
+
+Select the safe **New** rows and **Apply**:
+
+- Only the selected safe items are written; each create is stamped with a durable target-side marker
+  (`imported_id`), and an app-owned **mapping** is recorded immediately after each success.
+- Partial failures are reported and never lose earlier successes.
+
+### Mappings and idempotency
+
+App-owned mappings are the source of truth (the target marker is a secondary recovery aid), so
+re-previewing after apply shows items as **Already synced** instead of creating duplicates.
+
+### Marker-match repair
+
+If a target already carries a flow's marker but the mapping was lost, select the **Marker match** row to
+repair the mapping without creating a duplicate.
+
+## Updates and deletion (opt-in)
+
+- **Update mapped targets** — when a source transaction changes after it was synced, push the change to
+  its mapped target. A stored field fingerprint prevents overwriting a target that was edited outside
+  sync.
+- **Delete when the source is removed** — when a synced source is deleted, the mapped target surfaces
+  under **Source deleted** for you to delete manually. Never automatic, never in bulk, and only for
+  whole-account flows.
+
+## Review queue
+
+Items that are not provably safe — duplicates, source-changed, source-missing, and blocked — are never
+auto-applied. They collect in a review queue for you to handle. From there you can resolve duplicates,
+retry, and act on changes.
+
+## Run history and retries
+
+- Run history per flow shows counts and item-level detail, including how many items were auto-applied
+  vs. left in the review queue vs. failed.
+- **Retry failed items** re-attempts just the failed items of a run; marker-based idempotency prevents
+  duplicates on retry.
+
+## Reverse flows and portability
+
+- The **reverse-flow** helper mirrors a flow (source/target swapped, created disabled for review) so two
+  one-way flows form a two-way sync.
+- **Export/import a flow definition** as JSON. Definitions carry no secrets or connections — re-select
+  connections on import.
+- **Export a run's audit** to CSV.
+
+## Automation (opt-in)
+
+Each flow has a **review policy**:
+
+1. **Manual** (default) — preview and apply yourself.
+2. **Auto-apply safe items on preview** — a run auto-applies only safe items (new creates and
+   marker-match repairs); everything uncertain is left for you.
+3. **Auto-sync on a schedule** — a client-side timer re-runs a safe-only sync at a chosen interval
+   (minimum 15 minutes) **while Actual Bench is open and the connection is unlocked**.
+4. **Auto-sync on a server schedule (unattended)** — for **HTTP API Server mode** flows, a server-side
+   scheduler runs the same safe-only sync **with the app closed**. It is opt-in and off by default and
+   requires operator setup (see the note below).
+5. **Run safe sync now** — a one-click safe-only run for any automated flow.
+
+Additional controls:
+
+- **Exact-duplicate auto-map** (opt-in, off by default) links a transaction that already exists on the
+  target with the same date, amount, payee, and category — mapping only, no new transaction. Fuzzy
+  duplicates always stay in the review queue.
+
+:::note[Unattended sync needs operator setup]
+Unattended server-side sync requires an operator to set `SYNC_VAULT_KEY` and enroll the connection's API
+key in an encrypted server vault. Direct-mode flows can't run unattended (Actual runs in the browser)
+and keep the client-side interval. See **Administration → Configuration** and
+**Administration → Deployment**.
+:::
+
+## Flow health and auto-pause
+
+After repeated failed or partial automated runs, a flow **auto-pauses** (and is badged) so it stops
+firing until you re-enable it. Auto-run outcomes that fail or leave items to review raise an in-app
+notice.
+
+## Target rules
+
+Because Actual Budget rules run when a transaction is created, an applied target transaction may differ
+from the preview (payee, category, notes, or cleared state). Actual Bench surfaces this as a **warning**,
+not an error.
+
+## Limitations
+
+Not in scope: true Actual transfer-linked sync (same-budget uses a plain copy), automatic (non-review)
+target deletes, category auto-create, fuzzy duplicate auto-mapping, unattended sync for **Direct**-mode
+flows, FX gain/loss accounting, and multi-currency within a single budget file. See
+[Known Limitations](../../help/known-limitations/).
+
+## Troubleshooting
+
+- **Preview is empty** — check the flow's filters (date range, status, sign) and that the source has
+  matching transactions.
+- **Source/target can't be selected** — a true self-sync is blocked; entity flows require two budgets.
+- **Duplicates appear** — resolve them in the review queue; enable exact-duplicate auto-map only if
+  appropriate.
+- **A category is Blocked** — its group can't be placed; choose a default group or enable create-missing
+  groups.
+- **A changed target wasn't overwritten** — the manual-edit fingerprint protected it.
+- **A mapping was lost** — use marker-match repair.
+- **Automation isn't running** — check the review policy, whether the flow is paused, and (for
+  unattended) the vault and App Health.
+
+## Related pages
+
+- [FX Rates](../fx-rates/) — multi-currency conversion
+- [Connect to Actual Budget](../../getting-started/connecting/)
+- [Known Limitations](../../help/known-limitations/)

--- a/docs-site/src/content/docs/user-guide/fx-rates.mdx
+++ b/docs-site/src/content/docs/user-guide/fx-rates.mdx
@@ -1,0 +1,114 @@
+---
+title: FX Rates
+description: Manage the exchange rates Actual Bench uses for multi-currency budget sync — automatic Frankfurter rates, overrides, CSV import, immutable snapshots, and rate locking.
+sidebar:
+  order: 8
+---
+
+When you consolidate budgets kept in **different currencies**, Actual Bench converts transaction amounts
+during sync. The **FX Rates** page manages the exchange rates it uses. Open it from **FX Rates** under
+the **Tools** sidebar section (`/fx-rates`).
+
+:::note[FX applies to cross-currency sync, not single-file multi-currency]
+Currency conversion is part of transaction [Budget Sync](../budget-sync/) between budgets configured
+with different currencies. Actual Bench does not add multi-currency accounts inside a single Actual
+budget file.
+:::
+
+## When currency conversion is used
+
+A transaction flow can convert amounts when you enable its **Convert currency** option and set a source
+and target currency. Only transaction flows convert — payee and category flows never do.
+
+## How rates are sourced
+
+Rates come from a database-backed registry, filled automatically from the free
+[Frankfurter](https://frankfurter.dev) provider:
+
+- **No API key** is required.
+- Rates are **date-specific**.
+- For a date with no published rate (weekends and holidays), Actual Bench falls back to the **latest
+  prior rate**.
+- If the provider is briefly unavailable, a converting sync doesn't fail — affected rows go to review as
+  **FX pending** (see [Budget Sync](../budget-sync/#preview-a-flow)).
+
+You can also override any date manually or import rates from a CSV.
+
+## Open the FX Rates page
+
+The page is organized per **currency pair**:
+
+- A hero card shows the **latest rate**, a **trend** sparkline, and **coverage** for the selected date
+  range.
+- Currency pairs are seeded from your FX-enabled flows, and you can **add your own**.
+
+## View rate history and coverage
+
+Below the hero, a **coverage ledger** lists every day in the range, calling out gaps, and labels each
+rate's source (**Frankfurter**, **Uploaded**, **Manual**, or **Derived**).
+
+## Fill missing rates
+
+Select **Fill range from Frankfurter** to backfill every missing day in the range in one click. Actual
+Bench reports how many days were **inserted** versus **already set**.
+
+## Override a rate
+
+Use **Set your rate** to enter a rate for a specific date manually.
+
+- Manual rates take precedence for that date and pair.
+- When your override affects **already-synced transactions**, an **impact preview** lists them with their
+  old → new converted amounts, so you can see the effect before deciding to update.
+
+:::note[Overrides don't silently rewrite the past]
+Setting a rate does not retroactively change already-synced transactions on its own. Past conversions
+keep their locked rate unless you explicitly update them through the previewed sync update path (the
+*Update synced transactions when the rate changes* flow option). See
+[Budget Sync](../budget-sync/#updates-and-deletion-opt-in).
+:::
+
+## Import rates from CSV
+
+Import a CSV of rates for a pair from the FX Rates page. Uploaded rows are labeled with the
+**Uploaded** source in the coverage ledger.
+
+## Preview a converted transaction
+
+In a converting flow's [sync preview](../budget-sync/#preview-a-flow), each row shows the **original
+amount**, the **applied rate**, and the **converted amount**, each labeled with its currency. A missing
+or future-dated rate is sent to the review queue as **FX pending** rather than failing the run.
+
+## Immutable snapshots and rate locking
+
+- Every converted transaction stores an **immutable snapshot** — the exact rate, source/target amounts,
+  provider, and dates — plus a compact **audit note** on the target transaction.
+- Rates **lock at first sync**, so a later rate change never silently rewrites past conversions.
+- To apply a corrected rate to already-synced transactions, use the opt-in *Update synced transactions
+  when the rate changes* flow option, which goes through the normal previewed, safety-checked update
+  path.
+
+## Limitations
+
+- No FX gain/loss accounting.
+- No silent recalculation of past conversions.
+- No multi-currency within a single Actual budget file.
+- Rate availability depends on the provider and on the coverage you've filled or imported.
+
+See [Known Limitations](../../help/known-limitations/) for the full list.
+
+## Troubleshooting
+
+- **"FX pending" in a preview** — no rate exists for that date/pair yet; **Fill range from Frankfurter**,
+  add an override, or import a CSV.
+- **A weekend or holiday date** — Actual Bench falls back to the latest prior rate; fill the range if you
+  want explicit coverage.
+- **A future-dated transaction** — a future rate isn't available; it stays FX pending until a rate
+  exists.
+- **CSV rejected** — check the columns and values against the in-app import guidance.
+- **Wrong pair direction** — confirm the source and target currencies on the flow.
+- **Converted amount differs slightly** — rounding is applied to the final converted amount.
+
+## Related pages
+
+- [Budget Sync](../budget-sync/)
+- [Connect to Actual Budget](../../getting-started/connecting/)

--- a/docs-site/src/content/docs/user-guide/rules.mdx
+++ b/docs-site/src/content/docs/user-guide/rules.mdx
@@ -1,0 +1,160 @@
+---
+title: Rules
+description: Build, edit, merge, and diagnose Actual Budget rules in Actual Bench — conditions and actions, stages, templates and formulas, merging duplicates, and the Rule Diagnostics linter.
+sidebar:
+  order: 4
+---
+
+Rules automate changes to transactions in Actual Budget. Actual Bench gives you a full condition/action
+builder with resolved entity names, plus a read-only **Rule Diagnostics** workspace to find problems.
+
+Open **Rules** from the **Data Management** sidebar section; open **Rule Diagnostics** from the
+**Tools** section or the **Diagnostics** button on the Rules toolbar.
+
+## What rules do
+
+A rule has **conditions** (when it applies) and **actions** (what it changes), and runs at a **stage**.
+Actual Budget applies rules when a transaction is created or imported.
+
+## Understand rule stages
+
+Rules run in three stages, in order: **`pre`**, **`default`**, then **`post`**. Use stages to control
+which rules run before others (for example, normalize an imported payee in `pre`, then categorize in
+`default`).
+
+## Create a basic rule
+
+1. On the **Rules** page, create a rule to open the editor.
+2. A new rule starts with a guided default condition (`Payee is`) and a default action row.
+3. Set the condition field, operator, and value.
+4. Add an action.
+5. Save to stage the rule.
+
+Validation stays neutral until you edit rows or attempt to save, then required fields are flagged, with
+inline warnings for risky catch-all or destructive combinations. Closing the drawer with unsaved edits
+prompts for confirmation.
+
+## Add conditions
+
+- Conditions support fields such as **payee**, **imported payee**, **category**, **account**,
+  **amount**, and **notes**.
+- Combine them with **AND** / **OR** logic (`conditions_op`).
+- Operators include `is`, `is not`, `contains`, `matches`, `lt`, `lte`, `gt`, `gte`, and `oneOf`, among
+  others. The `matches` operator shows a regex syntax hint.
+- **Entity-reference values** (payee, category, account) show as blue chips; plain string values show as
+  green chips — so you can tell an ID reference from literal text at a glance.
+
+## Add actions
+
+Common actions include **set payee**, **set category**, **set account**, **set amount**, **set notes**,
+and **link schedule**.
+
+### Templates
+
+Toggle the `{}` button on an action to enter **template mode** (Handlebars), for example
+`{{regex imported_payee 'foo' 'bar'}}`. Templates render as an amber monospace chip in the rules table.
+
+### Formulas
+
+Toggle the `ƒ` button on a **notes** or **payee_name** action to enter an **Excel-style formula**
+evaluated by HyperFormula, for example `=IF(ISBLANK(notes), imported_payee, notes)`. Formulas must
+start with `=`. Template and formula modes are mutually exclusive per action row.
+
+## Edit, duplicate, filter, and search
+
+- Duplicate a rule with one click.
+- Filter the list by stage, payee, or category.
+- **Search resolves entity names** — searching "Groceries" finds rules whose `oneOf` condition
+  references that payee or category by ID. Resolved names are shown throughout (no raw IDs).
+- Links from the Payees and Categories pages filter the rules list to that entity automatically.
+
+## Merge rules
+
+1. Select the rules to combine.
+2. Choose **Merge** to open the merge dialog (it shares the main editor's sections and validation).
+3. Review the merged result; the **Delete originals** checkbox is pre-ticked for full duplicates and
+   unticked for near-duplicates.
+4. Confirm to stage the merge.
+
+Merging from a diagnostics finding returns you to the diagnostics report afterward so cleanup flows
+naturally.
+
+## Schedule-generated rules
+
+Rules created by schedules (those with a `link-schedule` action) are shown **read-only** on the Rules
+page and are excluded from bulk selection and merge. Manage them from the
+[Schedules](../schedules-and-tags/) page.
+
+## Import and export
+
+Rules import/export uses a long CSV format — one condition or action per row, grouped by a `rule_id`.
+Key columns: `rule_id`, `stage`, `conditions_op`, `row_type` (`condition`/`action`), `field`, `op`, and
+`value` (use `|` to separate multi-value `oneOf` values). Formula values are exported with a leading
+`'` so spreadsheets don't evaluate them; the prefix is stripped on re-import.
+
+## Rule Diagnostics
+
+Rule Diagnostics is a **read-only, advisory** linter. It never modifies, creates, or deletes anything as
+a side effect, and it runs entirely in the browser against your current working set — including unsaved
+staged edits.
+
+### Run diagnostics and read findings
+
+1. Open **Rule Diagnostics** (Tools sidebar, or the **Diagnostics** button on the Rules toolbar). The
+   URL `/rules/diagnostics` is bookmarkable.
+2. Findings are grouped by severity with summary cards for **error**, **warning**, and **info**, plus
+   severity- and code-based filters.
+3. Each finding has a plain-language explanation, the affected rule's summary, and a copy-UUID button.
+
+### What it checks
+
+- Missing payee / category / account / category-group references.
+- Empty or no-op actions.
+- Impossibly contradictory conditions on `and`-rules.
+- Strictly shadowed rules within a stage.
+- Broad match criteria (very short `contains` / `matches` values).
+- Duplicate rule groups and near-duplicate pairs.
+- Unsupported field/operator combinations.
+
+Schedule-generated rules are excluded from editor-relevant checks but still surface missing-entity
+findings.
+
+### Act on findings
+
+- Click a finding's rule summary to **jump to the rule** (`/rules?highlight=<id>`) and open it.
+- Duplicate and near-duplicate findings have a one-click **Merge** button that opens the merge dialog
+  pre-filled.
+- A **stale-results** banner appears if the working set changes while the view is open; results stay
+  until you **Refresh**.
+
+## Examples
+
+A few practical patterns (use your own payees and categories):
+
+- **Categorize by payee** — condition `Payee is "Fresh Market"`, action `set category "Groceries"`.
+- **Normalize imported text** — a `pre`-stage template action on `payee_name`:
+  `{{regex imported_payee 'SQ \*' ''}}`.
+- **Fall back to imported payee** — a formula on `notes`: `=IF(ISBLANK(notes), imported_payee, notes)`.
+- **Route by amount** — condition `amount gt 100000`, action `set category "Large Purchases"`.
+
+## Safety and limitations
+
+- Because Actual Budget runs rules on transaction create, a saved rule can change a transaction
+  differently than you expect if other rules also apply. Use stages to order them.
+- Diagnostics is advisory — it never changes your rules.
+
+## Troubleshooting
+
+- **A rule doesn't run** — check its stage and whether an earlier-stage rule already changed the field.
+- **AND/OR confusion** — verify `conditions_op`; AND requires all conditions, OR any.
+- **A missing-entity finding** — the referenced payee/category/account was deleted or renamed.
+- **A regex isn't matching** — check the `matches` syntax hint.
+- **A template/formula won't save** — formulas must start with `=`; template and formula modes are
+  mutually exclusive per row.
+- **A schedule-linked rule can't be edited** — manage it from the Schedules page.
+
+## Related pages
+
+- [Schedules and Tags](../schedules-and-tags/)
+- [Accounts, Payees and Categories](../accounts-payees-categories/)
+- [ActualQL](../actualql/)

--- a/docs-site/src/content/docs/user-guide/schedules-and-tags.mdx
+++ b/docs-site/src/content/docs/user-guide/schedules-and-tags.mdx
@@ -1,0 +1,120 @@
+---
+title: Schedules and Tags
+description: Create and manage recurring schedules and transaction tags in Actual Bench — recurrence, amount modes, weekend adjustment, linked rules, colors, and CSV import/export.
+sidebar:
+  order: 3
+---
+
+This guide covers two lightweight but related areas: **Schedules** (recurring and one-time planned
+transactions) and **Tags** (metadata you attach to transactions). Open each from the **Data
+Management** section of the sidebar.
+
+## Schedules
+
+A schedule describes a planned transaction — one-time or recurring — with an amount, timing, and
+optional payee and account.
+
+### Create a schedule
+
+1. On the **Schedules** page, open the schedule drawer to add a schedule.
+2. Set the **name** (optional), **date** (or recurrence), and amount.
+3. Optionally assign a **payee** and **account**.
+4. Save to stage the schedule.
+
+Saving an unchanged schedule closes the drawer without staging a draft. Closing the drawer with unsaved
+edits prompts for confirmation.
+
+### Choose an amount mode
+
+Schedule amounts always use one of three modes:
+
+- **Exact** (`is`)
+- **Approximate** (`is approx.`)
+- **Range** (`is between`) — with a low and high amount
+
+Missing or null server amounts are treated as an approximate zero.
+
+### Configure recurrence
+
+- Frequencies: **daily**, **weekly**, **monthly**, **yearly**, each with a configurable interval.
+- Monthly schedules support a **specific day of the month** (including "last day") or a
+  **weekday-of-week position** (for example "2nd Friday").
+- The table's **Repeats** summary infers weekday/day anchors from the start date (for example
+  `Every 2 weeks on Wednesday`), and a **Recurring** column marks repeating schedules.
+
+### Weekend adjustment and end conditions
+
+- **Weekend adjustment** — when a scheduled date lands on a weekend, move it to the nearest **Friday
+  before** or **Monday after**.
+- **End conditions** — run forever, end after **N occurrences**, or end **on a date**.
+
+### Auto-add and linked rules
+
+- **Auto-add** — when enabled, Actual Budget automatically posts a transaction when the schedule is due.
+- Every schedule has an underlying **linked rule** managed by the server. Open it in the Rules editor
+  via **Edit as Rule** in the drawer.
+
+:::note[Schedule-generated rules are managed here]
+Rules linked to schedules appear read-only on the [Rules](../rules/) page — the `link-schedule` action
+shows the resolved schedule name and cannot be created or edited manually. Manage that behavior from
+the Schedules page instead.
+:::
+
+### Edit, delete, filter, and import/export
+
+- Edit schedules in the drawer; successfully saved edits stay visible while the background refresh
+  reconciles server data.
+- Deleting a schedule (single or bulk) confirms with an impact dialog showing its linked-rule status,
+  auto-post flag, and transaction count.
+- Filter by name, payee, account, frequency, and auto-add state.
+- Import and export schedules as CSV.
+
+:::note[No "completed" status column]
+The schedule `completed` flag is kept for round-tripping server data but is not shown as a status in the
+UI, because it does not represent a reliable paid/completed state. Imported schedules start active.
+:::
+
+## Tags
+
+Tags are simple labels (with an optional color and description) available in Actual Budget v26.3.0 and
+later.
+
+### Create and edit a tag
+
+1. On the **Tags** page, create a tag and give it a **name**.
+2. Optionally assign a **color** — click the swatch to open a native color picker; hover the row for a
+   clear button.
+3. Optionally add a **description**.
+4. Edit any name or description inline (`Enter` confirms, `Escape` cancels).
+
+### Filter, delete, and import/export
+
+- Filter by name or description, and by color presence (All / Has Color / No Color).
+- Bulk-select and delete; duplicate names show a warning.
+- Import and export tags as CSV — columns: `name` (required), `color` (optional hex, e.g. `#FF5733`),
+  `description` (optional).
+
+:::note[Tag usage data]
+The Usage Inspector shows a tag's rule references, but transaction data is not available for tags, so
+the drawer notes that explicitly.
+:::
+
+## Review and Save
+
+Schedule and tag edits are staged and written on **Save**; **Discard** reverts them. (Notes on other
+entity types save immediately, but that does not apply to schedules or tags themselves.)
+
+## Troubleshooting
+
+- **A schedule's rule looks read-only** — schedule-linked rules are managed from the Schedules page; use
+  **Edit as Rule** to open the editable parts.
+- **Can't merge a schedule-generated rule** — those rules are excluded from bulk selection and merge.
+- **The recurrence summary looks wrong** — it is inferred from the start date; check the day/weekday
+  anchor and interval.
+- **Tags are unavailable** — tags require Actual Budget v26.3.0 or later on the server.
+- **A tag color or description didn't stick** — confirm you saved; inline edits commit on `Enter`.
+
+## Related pages
+
+- [Rules](../rules/)
+- [Accounts, Payees and Categories](../accounts-payees-categories/)


### PR DESCRIPTION
Completes the end-user documentation site, building on the scaffold + Getting Started foundation. This adds the remaining **15 pages** to reach the full 20-page structure, all task-oriented and verified against current code and UI labels.

## What's included

**User Guide (8 pages)**
- Budget Management; Accounts, Payees and Categories; Schedules and Tags; Rules (incl. Rule Diagnostics); ActualQL; Budget File Tools (Health + Data Browser); Budget Sync; FX Rates.
- Budget Sync uses the exact in-app preview classification labels (New, Already synced, Duplicate, Source changed, Source deleted, Marker match, Name match, Blocked, FX pending).

**Administration (3 pages)**
- Deployment (architecture and networking per mode, reverse proxy, hardening); Configuration (verified environment-variable reference, unattended-sync vault); Upgrading and Backups (`/data` metadata backup/restore, migrations, rollback).

**Help (3 pages) + Contributing**
- Troubleshooting, Known Limitations, Glossary, and a concise Contributing page (with a top-level sidebar entry).

## Verification
- `npm --prefix docs-site run build` succeeds (21 pages incl. 404); `preview` serves all pages under `/actual-bench/`.
- Custom internal link audit across all built pages: **no broken links**.
- Cross-links the Getting Started install guide to the new Administration pages.
- No app code touched; docs remain isolated from the app build/CI.

Docs merged to `main` auto-deploy to https://x-rous.github.io/actual-bench/.