### PR TITLE
Fix metadata database unavailable on the Vercel demo

### DIFF
--- a/src/lib/app-db/connection.test.ts
+++ b/src/lib/app-db/connection.test.ts
@@ -38,6 +38,56 @@ describe("app DB connection", () => {
     );
   });
 
+  it("falls back to a writable temp path on Vercel when no override is set", () => {
+    // On Vercel `/data` does not exist and the filesystem is read-only except
+    // the temp dir, so the default must not be the (unwritable) `/data` path.
+    expect(resolveAppDbPath({ VERCEL: "1" } as unknown as NodeJS.ProcessEnv)).toBe(
+      resolve(tmpdir(), "actual-bench.sqlite")
+    );
+    // An explicit override still wins on Vercel.
+    expect(
+      resolveAppDbPath({ VERCEL: "1", ACTUAL_BENCH_DB_PATH: "/mnt/app.sqlite" } as unknown as NodeJS.ProcessEnv)
+    ).toBe(resolve("/mnt/app.sqlite"));
+  });
+
+  it("reports a ready but non-durable metadata DB on the Vercel runtime", () => {
+    process.env.VERCEL = "1";
+    const { root, dbPath } = tempDbPath();
+
+    try {
+      const health = getAppDbHealth(dbPath);
+      expect(health.ready).toBe(true);
+      expect(health.writable).toBe(true);
+      expect(health.schemaVersion).toBe(5);
+      expect(health.runtime).toBe("vercel");
+      expect(health.durable).toBe(false);
+    } finally {
+      resetAppDbForTests();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("initializes the default metadata DB on Vercel without an override (the demo condition)", () => {
+    // Reproduces the exact demo setup: VERCEL set, no ACTUAL_BENCH_DB_PATH.
+    // Previously this defaulted to `/data` and failed with ENOENT.
+    process.env.VERCEL = "1";
+    delete process.env.ACTUAL_BENCH_DB_PATH;
+    const defaultPath = resolveAppDbPath();
+
+    try {
+      expect(defaultPath).toBe(resolve(tmpdir(), "actual-bench.sqlite"));
+      const health = getAppDbHealth(); // no arg → uses the resolved default
+      expect(health.ready).toBe(true);
+      expect(health.writable).toBe(true);
+      expect(health.error).toBeUndefined();
+    } finally {
+      resetAppDbForTests();
+      for (const suffix of ["", "-wal", "-shm"]) {
+        rmSync(`${defaultPath}${suffix}`, { force: true });
+      }
+    }
+  });
+
   it("initializes migrations idempotently and reports health", () => {
     const { root, dbPath } = tempDbPath();
 

--- a/src/lib/app-db/connection.ts
+++ b/src/lib/app-db/connection.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { accessSync, constants, existsSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { AppDbUnavailableError, errorMessage } from "./errors";
 import { LATEST_SCHEMA_VERSION, readMigrationMeta, runMigrations } from "./migrations";
 import type { AppDbHealth, SqliteDatabase } from "./types";
@@ -25,7 +26,14 @@ function runtime(): "node" | "vercel" {
 
 export function resolveAppDbPath(env: NodeJS.ProcessEnv = process.env): string {
   const configured = env.ACTUAL_BENCH_DB_PATH?.trim();
-  return configured ? resolve(configured) : DEFAULT_APP_DB_PATH;
+  if (configured) return resolve(configured);
+  // Vercel's serverless filesystem is read-only except for the OS temp dir, and
+  // `/data` does not exist there. With no explicit override, fall back to a
+  // writable (but non-durable) temp path so the metadata database can still
+  // initialize instead of failing with `ENOENT ... stat '/data'`. App Health
+  // already reports the Vercel runtime as non-durable.
+  if (env.VERCEL) return resolve(tmpdir(), "actual-bench.sqlite");
+  return DEFAULT_APP_DB_PATH;
 }
 
 export function hasAppDbPathOverride(env: NodeJS.ProcessEnv = process.env): boolean {


### PR DESCRIPTION
## Problem

On the Vercel-hosted demo, **App Health** shows the metadata database as **Unavailable** with:

```
ENOENT: no such file or directory, stat '/data'
```

Vercel's serverless filesystem is read-only except the OS temp dir, and `/data` does not exist there. With no `ACTUAL_BENCH_DB_PATH` override, the app defaulted to `/data/actual-bench.sqlite`, so `checkAppDbStorage` failed on `statSync('/data')` before the database was ever opened. As a result the metadata-backed features (Budget File Sync, FX Rates, run history) were unavailable and App Health reported an error.

## Fix

Resolve the default database path to the OS temp dir (`os.tmpdir()`, i.e. `/tmp`) when running on Vercel and no explicit path is configured. The database then initializes and migrates normally instead of erroring.

- This storage is **non-durable** — App Health already reports the Vercel runtime as non-durable ("Not durable without external storage"), which is correct for a serverless demo.
- An explicit `ACTUAL_BENCH_DB_PATH` still wins in every environment, so self-hosted/Docker behavior is unchanged (`/data` remains the default there).

## Verification

- New tests reproduce the exact demo condition (VERCEL set, no override): the default now resolves to the temp path, and `getAppDbHealth()` opens the DB there and reports `ready`/`writable` with no error.
- `src/lib/app-db` + health route suites pass (16 tests); `tsc` and lint clean.