### PR TITLE
Fix remembered-connection unlock + add passphrase reset

### DIFF
--- a/src/app/api/connection-vault/connections/route.test.ts
+++ b/src/app/api/connection-vault/connections/route.test.ts
@@ -25,6 +25,7 @@ import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
 import { clearAllSessions } from "@/lib/connectionVault/session";
 import { connectionFingerprint } from "@/lib/sync/connectionRef";
 import { POST as setPassphrase } from "../passphrase/route";
+import { POST as resetVault } from "../reset/route";
 import { GET as listConnections, POST as remember, DELETE as forget } from "./route";
 import { POST as reveal } from "./reveal/route";
 
@@ -136,5 +137,20 @@ describe("remembered connections routes (RD-061 / PR-026d)", () => {
     // Locked session (no cookie) → 401, even for a known connection.
     cookieJar.clear();
     expect((await reveal(req({ body: { connectionFingerprint: directFp } }))).status).toBe(401);
+  });
+
+  it("resets the vault — removes all connections and clears the passphrase (forgotten-passphrase recovery)", async () => {
+    await remember(req({ body: httpInput }));
+    await remember(req({ body: directInput }));
+    expect(((await (await listConnections()).json()) as { connections: unknown[] }).connections).toHaveLength(2);
+
+    // Reset needs no passphrase (it's forgotten).
+    cookieJar.clear();
+    expect((await resetVault(req())).status).toBe(200);
+
+    const after = (await (await listConnections()).json()) as { connections: unknown[] };
+    expect(after.connections).toHaveLength(0);
+    // Passphrase was cleared, so a brand-new one can be set again.
+    expect((await setPassphrase(req({ body: { passphrase: "brand-new-passphrase" } }))).status).toBe(200);
   });
 });

--- a/src/app/api/connection-vault/reset/route.ts
+++ b/src/app/api/connection-vault/reset/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { rememberedCredentialsSupported } from "@/lib/app-db/connectionCredentialRepository";
+import { resetVault } from "@/lib/connectionVault/passphrase";
+import { clearAllSessions } from "@/lib/connectionVault/session";
+import { resetUnlockThrottle } from "@/lib/connectionVault/throttle";
+import { clearSessionCookie } from "@/lib/connectionVault/cookies";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Reset the remembered-connection vault (RD-061 / PR-026) — recovery for a
+ * forgotten passphrase. Removes all remembered connections and clears the
+ * passphrase so a new one can be set. Requires no passphrase (it's forgotten);
+ * only ever discards data, never exposes a secret.
+ */
+export function POST(request: NextRequest) {
+  try {
+    if (!rememberedCredentialsSupported()) {
+      return NextResponse.json(
+        { error: "Remembering credentials requires a durable metadata database." },
+        { status: 400 }
+      );
+    }
+    resetVault(getAppDb());
+    clearAllSessions();
+    resetUnlockThrottle();
+    void request;
+    const response = NextResponse.json({ ok: true, reset: true });
+    clearSessionCookie(response);
+    return response;
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/components/connect/RememberToggle.tsx
+++ b/src/components/connect/RememberToggle.tsx
@@ -13,7 +13,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { useConnectionVault } from "@/features/connect/useConnectionVault";
-import { parseApiError } from "./utils";
+
+/** Vault operations throw a plain Error carrying the server's message; surface it directly. */
+function vaultErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Something went wrong.";
+}
 
 type Vault = ReturnType<typeof useConnectionVault>;
 
@@ -84,7 +88,7 @@ export function RememberToggle({
       setDialogOpen(false);
       resetDialog();
     } catch (err) {
-      setError(parseApiError(err));
+      setError(vaultErrorMessage(err));
       setBusy(false);
     }
   }

--- a/src/components/connect/RememberedConnections.tsx
+++ b/src/components/connect/RememberedConnections.tsx
@@ -9,9 +9,14 @@ import type { ConnectionInstance } from "@/store/connection";
 import type { useConnectionVault } from "@/features/connect/useConnectionVault";
 import type { RevealedConnectionSecret } from "@/features/connect/vaultApi";
 import type { ConnectionCredentialMeta } from "@/lib/app-db/types";
-import { deriveLabel, parseApiError } from "./utils";
+import { deriveLabel } from "./utils";
 
 type Vault = ReturnType<typeof useConnectionVault>;
+
+/** Vault operations throw a plain Error carrying the server's message; surface it directly. */
+function vaultErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Something went wrong.";
+}
 
 function buildInstance(meta: ConnectionCredentialMeta, revealed: RevealedConnectionSecret): ConnectionInstance {
   const base = {
@@ -48,6 +53,8 @@ export function RememberedConnections({
   const [unlocking, setUnlocking] = useState(false);
   const [revealingId, setRevealingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [confirmingReset, setConfirmingReset] = useState(false);
+  const [resetting, setResetting] = useState(false);
 
   // A remembered connection that's already active this session lives under
   // "Your connections"; don't list it twice.
@@ -67,7 +74,7 @@ export function RememberedConnections({
       await vault.unlock(passphrase);
       setPassphrase("");
     } catch (err) {
-      setError(parseApiError(err));
+      setError(vaultErrorMessage(err));
     } finally {
       setUnlocking(false);
     }
@@ -80,7 +87,7 @@ export function RememberedConnections({
       const revealed = await vault.reveal(meta.connectionFingerprint);
       onReconnect(buildInstance(meta, revealed));
     } catch (err) {
-      setError(parseApiError(err));
+      setError(vaultErrorMessage(err));
     } finally {
       setRevealingId(null);
     }
@@ -91,7 +98,21 @@ export function RememberedConnections({
       await vault.forget(meta.connectionFingerprint);
       toast.success(`Forgot "${meta.label || deriveLabel(meta.baseUrl)}".`);
     } catch (err) {
-      toast.error(parseApiError(err));
+      toast.error(vaultErrorMessage(err));
+    }
+  }
+
+  async function handleReset() {
+    setResetting(true);
+    setError(null);
+    try {
+      await vault.reset();
+      toast.success("Vault reset. Set a new passphrase to remember connections again.");
+      setConfirmingReset(false);
+    } catch (err) {
+      setError(vaultErrorMessage(err));
+    } finally {
+      setResetting(false);
     }
   }
 
@@ -127,6 +148,42 @@ export function RememberedConnections({
               {unlocking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Unlock"}
             </button>
           </div>
+
+          {!confirmingReset ? (
+            <button
+              type="button"
+              onClick={() => setConfirmingReset(true)}
+              className="self-start text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Forgot your passphrase?
+            </button>
+          ) : (
+            <div className="flex flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2.5">
+              <p className="text-[11px] text-muted-foreground">
+                A forgotten passphrase can&apos;t be recovered. Resetting removes all{" "}
+                {vault.connections.length} remembered connection{vault.connections.length === 1 ? "" : "s"} and clears
+                the passphrase so you can set a new one. This can&apos;t be undone.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleReset()}
+                  disabled={resetting}
+                  className="flex h-8 items-center gap-1.5 rounded-md bg-destructive px-3 text-xs font-medium text-white disabled:opacity-50"
+                >
+                  {resetting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Reset & remove all"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingReset(false)}
+                  disabled={resetting}
+                  className="h-8 rounded-md border border-border px-3 text-xs hover:bg-muted disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/features/connect/useConnectionVault.ts
+++ b/src/features/connect/useConnectionVault.ts
@@ -8,6 +8,7 @@ import {
   listRememberedConnections,
   lockVault,
   rememberConnection,
+  resetVault,
   revealRememberedSecret,
   setVaultPassphrase,
   unlockVault,
@@ -72,6 +73,11 @@ export function useConnectionVault() {
     await refresh();
   }, [refresh]);
 
+  const reset = useCallback(async () => {
+    await resetVault();
+    await refresh();
+  }, [refresh]);
+
   const remember = useCallback(
     async (input: RememberConnectionInput) => {
       await rememberConnection(input);
@@ -94,5 +100,5 @@ export function useConnectionVault() {
     []
   );
 
-  return { status, connections, loading, refresh, setPassphrase, unlock, lock, remember, forget, reveal };
+  return { status, connections, loading, refresh, setPassphrase, unlock, lock, reset, remember, forget, reveal };
 }

--- a/src/features/connect/vaultApi.ts
+++ b/src/features/connect/vaultApi.ts
@@ -62,6 +62,11 @@ export function lockVault(): Promise<{ ok: true; unlocked: false }> {
   return jsonFetch("/api/connection-vault/lock", { method: "POST" });
 }
 
+/** Reset the vault — remove all remembered connections + clear the passphrase (forgotten-passphrase recovery). */
+export function resetVault(): Promise<{ ok: true; reset: true }> {
+  return jsonFetch("/api/connection-vault/reset", { method: "POST" });
+}
+
 /** Change the passphrase, re-sealing all remembered credentials. */
 export function changeVaultPassphrase(
   currentPassphrase: string,

--- a/src/lib/app-db/appMetaRepository.ts
+++ b/src/lib/app-db/appMetaRepository.ts
@@ -20,3 +20,7 @@ export function setAppMeta(db: SqliteDatabase, key: string, value: string): void
      ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
   ).run(key, value, new Date().toISOString());
 }
+
+export function deleteAppMeta(db: SqliteDatabase, key: string): void {
+  db.prepare("DELETE FROM app_meta WHERE key = ?").run(key);
+}

--- a/src/lib/app-db/connectionCredentialRepository.test.ts
+++ b/src/lib/app-db/connectionCredentialRepository.test.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
-import { deriveKeyFromPassphrase } from "@/lib/sync/vault";
+import { CONNECTION_KDF_PARAMS, deriveKeyFromPassphrase } from "@/lib/sync/vault";
+import { setAppMeta } from "./appMetaRepository";
 import { getAppDb, resetAppDbForTests } from "./connection";
 import {
   deleteConnectionCredential,
@@ -136,5 +137,21 @@ describe("connectionCredentialRepository (RD-061 / PR-026a)", () => {
     deleteConnectionCredential(db, "fp1");
     expect(hasConnectionCredential(db, "fp1")).toBe(false);
     expect(listConnectionCredentialMeta(db)).toHaveLength(0);
+  });
+
+  it("still unlocks a pre-versioning vault (salt with no stored KDF version → legacy params)", () => {
+    // Simulate an older build: a salt exists but no KDF version was stamped, and
+    // the data was sealed with the legacy (v0) scrypt defaults.
+    const salt = randomBytes(16);
+    setAppMeta(db, "connection_vault_salt", salt.toString("base64"));
+    const legacyKey = deriveKeyFromPassphrase("correct-pass", salt, CONNECTION_KDF_PARAMS[0]);
+    upsertConnectionCredential(db, input("legacy"), legacyKey);
+
+    // deriveConnectionVaultKey must reproduce the legacy key, not the current one.
+    const derived = deriveConnectionVaultKey(db, "correct-pass");
+    expect(derived.equals(legacyKey)).toBe(true);
+    expect(derived.equals(deriveKeyFromPassphrase("correct-pass", salt, CONNECTION_KDF_PARAMS[1]))).toBe(false);
+    // The pre-versioning credential opens again.
+    expect(getConnectionCredential(db, "legacy", derived)?.secret).toEqual({ apiKey: "key-legacy", encryptionPassword: "enc" });
   });
 });

--- a/src/lib/app-db/connectionCredentialRepository.ts
+++ b/src/lib/app-db/connectionCredentialRepository.ts
@@ -2,11 +2,12 @@ import { randomBytes } from "node:crypto";
 import {
   CONNECTION_KDF_PARAMS,
   CURRENT_KDF_VERSION,
+  LEGACY_KDF_VERSION,
   deriveKeyFromPassphrase,
   openWithKey,
   sealWithKey,
 } from "@/lib/sync/vault";
-import { getAppMeta, setAppMeta } from "./appMetaRepository";
+import { deleteAppMeta, getAppMeta, setAppMeta } from "./appMetaRepository";
 import { getAppDbHealth } from "./connection";
 import type {
   ConnectionCredential,
@@ -56,9 +57,14 @@ export function getOrCreateConnectionVaultSalt(db: SqliteDatabase): Buffer {
   return salt;
 }
 
-/** KDF params for this install's stored version (defaults to current if unset). */
+/**
+ * KDF params for this install's stored version. A **missing** version means the
+ * salt predates versioning and was sealed with the legacy (v0) defaults, so it
+ * must map to v0 — not the current version — or the vault can't be unlocked.
+ */
 function connectionKdfParams(db: SqliteDatabase) {
-  const version = Number(getAppMeta(db, KDF_VERSION_META_KEY) ?? CURRENT_KDF_VERSION);
+  const raw = getAppMeta(db, KDF_VERSION_META_KEY);
+  const version = raw === null ? LEGACY_KDF_VERSION : Number(raw);
   return CONNECTION_KDF_PARAMS[version] ?? CONNECTION_KDF_PARAMS[CURRENT_KDF_VERSION];
 }
 
@@ -183,6 +189,17 @@ export function listConnectionCredentialMeta(db: SqliteDatabase): ConnectionCred
 /** Remove a remembered credential. */
 export function deleteConnectionCredential(db: SqliteDatabase, connectionFingerprint: string): void {
   db.prepare("DELETE FROM connection_credentials WHERE connection_fingerprint = ?").run(connectionFingerprint);
+}
+
+/** Remove every remembered credential. */
+export function deleteAllConnectionCredentials(db: SqliteDatabase): void {
+  db.prepare("DELETE FROM connection_credentials").run();
+}
+
+/** Clear the per-install salt + stored KDF version (part of a full vault reset). */
+export function clearConnectionVaultSalt(db: SqliteDatabase): void {
+  deleteAppMeta(db, SALT_META_KEY);
+  deleteAppMeta(db, KDF_VERSION_META_KEY);
 }
 
 /**

--- a/src/lib/connectionVault/passphrase.ts
+++ b/src/lib/connectionVault/passphrase.ts
@@ -1,5 +1,7 @@
-import { getAppMeta, setAppMeta } from "@/lib/app-db/appMetaRepository";
+import { deleteAppMeta, getAppMeta, setAppMeta } from "@/lib/app-db/appMetaRepository";
 import {
+  clearConnectionVaultSalt,
+  deleteAllConnectionCredentials,
   deriveConnectionVaultKey,
   getConnectionVaultSalt,
   resealConnectionCredentials,
@@ -82,4 +84,20 @@ export function changePassphrase(db: SqliteDatabase, currentPassphrase: string, 
   });
   apply();
   return true;
+}
+
+/**
+ * Reset the vault: remove **all** remembered connections and clear the
+ * passphrase (salt + verifier + KDF version). For recovery when the passphrase
+ * is forgotten — the sealed secrets are unrecoverable anyway, so this only
+ * discards them. Deliberately requires no passphrase (you've lost it); the app
+ * is single-tenant and network-isolated, and no plaintext is exposed.
+ */
+export function resetVault(db: SqliteDatabase): void {
+  const apply = db.transaction(() => {
+    deleteAllConnectionCredentials(db);
+    clearConnectionVaultSalt(db);
+    deleteAppMeta(db, VERIFIER_META_KEY);
+  });
+  apply();
 }

--- a/src/lib/sync/vault.ts
+++ b/src/lib/sync/vault.ts
@@ -73,13 +73,20 @@ export type ScryptParams = { N: number; r: number; p: number; maxmem: number };
  * KDF parameter sets by version, so remembered-connection data stays decryptable
  * if the cost is raised later: bump `CURRENT_KDF_VERSION`, add a new entry, and
  * migrate on the next re-seal (existing salts keep deriving with their version).
- * v1 meets the OWASP scrypt floor (N=2^17, r=8, p=1); `maxmem` must cover
- * 128 * N * r (≈134 MiB) since Node's default cap is 32 MiB.
+ *
+ * - v0 = the legacy Node scrypt defaults (N=2^14, r=8, p=1). A salt with **no**
+ *   stored version predates versioning and was sealed with these, so a missing
+ *   version MUST map to v0 or that vault can never be unlocked again.
+ * - v1 = the OWASP scrypt floor (N=2^17, r=8, p=1); `maxmem` must cover
+ *   128 * N * r (≈134 MiB) since Node's default cap is 32 MiB.
  */
 export const CONNECTION_KDF_PARAMS: Record<number, ScryptParams> = {
+  0: { N: 16384, r: 8, p: 1, maxmem: 32 * 1024 * 1024 },
   1: { N: 131072, r: 8, p: 1, maxmem: 192 * 1024 * 1024 },
 };
 export const CURRENT_KDF_VERSION = 1;
+/** Version to assume when a salt has no stored KDF version (pre-versioning data). */
+export const LEGACY_KDF_VERSION = 0;
 
 /**
  * Derive a 32-byte key from a user passphrase and a per-install salt (scrypt).


### PR DESCRIPTION
Fixes a bug where unlocking a remembered connection failed with **"Incorrect passphrase"** (wrapped in a misleading **"Cannot reach the server"**) even with the correct passphrase, and adds recovery for a forgotten passphrase.

## Root causes
1. **KDF versioning migration.** The scrypt KDF was raised to the OWASP floor with a stored version, but a **missing** version defaulted to the *current* (new) params. Any vault sealed before versioning used the old Node-default scrypt, so unlock derived a different key → verifier wouldn't open → "Incorrect passphrase". Fixed: a missing version now maps to **v0 (legacy defaults)**; new salts still stamp and use the current version.
2. **Misleading error.** The vault client throws a plain `Error` (no `status`), and the connection-error formatter treats status-less errors as network failures → "Cannot reach the server." Vault UIs now surface the real message.

## New: forgotten-passphrase recovery
There was previously **no way out** if you forgot the passphrase — `Forget` leaves the salt/verifier, so you couldn't unlock, change, or set a new one. Added a **"Forgot your passphrase?" → Reset** flow that removes all remembered connections and clears the passphrase so you can start fresh. It requires no passphrase (it's forgotten), only ever discards data, and never exposes a secret. Gated on a durable metadata DB.

## Verification
`tsc`, `lint` (0 errors), full suite (1344), and production build all green. New tests: a pre-versioning vault unlocks with legacy params; reset clears the vault and lets a new passphrase be set.