### PR TITLE
Add vault lock and change-passphrase controls

### DIFF
--- a/src/components/connect/ConnectionsList.tsx
+++ b/src/components/connect/ConnectionsList.tsx
@@ -2,13 +2,25 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { KeyRound, Loader2, Lock, Plus, Server, Trash2, X } from "lucide-react";
+import { KeyRound, Loader2, Lock, Plus, Server, Trash2, Unlock, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import type { ConnectionInstance } from "@/store/connection";
 import type { RememberedBudget, ServerCredentialMeta } from "@/lib/app-db/types";
 import type { useConnectionVault } from "@/features/connect/useConnectionVault";
 import type { MergedBudget, MergedServer } from "./mergeConnections";
 import { deriveLabel, parseApiError } from "./utils";
+
+const MIN_PASSPHRASE_LENGTH = 8;
 
 type Vault = ReturnType<typeof useConnectionVault>;
 
@@ -49,11 +61,60 @@ export function ConnectionsList({
   const [error, setError] = useState<string | null>(null);
   const [confirmReset, setConfirmReset] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [locking, setLocking] = useState(false);
+  const [changeOpen, setChangeOpen] = useState(false);
+  const [currentPass, setCurrentPass] = useState("");
+  const [nextPass, setNextPass] = useState("");
+  const [confirmPass, setConfirmPass] = useState("");
+  const [changing, setChanging] = useState(false);
+  const [changeError, setChangeError] = useState<string | null>(null);
 
   if (servers.length === 0) return null;
 
   const locked = !vault.status.unlocked;
   const hasSaved = servers.some((s) => s.savedServer);
+
+  async function handleLock() {
+    setLocking(true);
+    try {
+      await vault.lock();
+      toast.success("Vault locked.");
+    } catch (err) {
+      toast.error(parseApiError(err));
+    } finally {
+      setLocking(false);
+    }
+  }
+
+  function openChangePassphrase() {
+    setCurrentPass("");
+    setNextPass("");
+    setConfirmPass("");
+    setChangeError(null);
+    setChangeOpen(true);
+  }
+
+  async function handleChangePassphrase() {
+    setChangeError(null);
+    if (nextPass.length < MIN_PASSPHRASE_LENGTH) {
+      setChangeError(`New passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters.`);
+      return;
+    }
+    if (nextPass !== confirmPass) {
+      setChangeError("New passphrases do not match.");
+      return;
+    }
+    setChanging(true);
+    try {
+      await vault.changePassphrase(currentPass, nextPass);
+      setChangeOpen(false);
+      toast.success("Passphrase changed. Your saved servers were re-encrypted.");
+    } catch (err) {
+      setChangeError(parseApiError(err));
+    } finally {
+      setChanging(false);
+    }
+  }
 
   async function handleUnlock() {
     if (!passphrase) return;
@@ -145,9 +206,37 @@ export function ConnectionsList({
 
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-        Connections
-      </h2>
+      <div className="flex min-h-6 items-center justify-between gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Connections
+        </h2>
+        {!locked && hasSaved && (
+          <div className="flex items-center gap-1 text-xs">
+            <span className="flex items-center gap-1 text-muted-foreground">
+              <Unlock className="h-3 w-3" />
+              Unlocked
+            </span>
+            <span className="text-border">·</span>
+            <button
+              type="button"
+              onClick={openChangePassphrase}
+              className="rounded px-1 py-0.5 text-muted-foreground hover:text-foreground"
+            >
+              Change passphrase
+            </button>
+            <span className="text-border">·</span>
+            <button
+              type="button"
+              onClick={() => void handleLock()}
+              disabled={locking}
+              className="flex items-center gap-1 rounded px-1 py-0.5 text-muted-foreground hover:text-foreground disabled:opacity-50"
+            >
+              {locking ? <Loader2 className="h-3 w-3 animate-spin" /> : <Lock className="h-3 w-3" />}
+              Lock
+            </button>
+          </div>
+        )}
+      </div>
 
       {locked && hasSaved && (
         <div className="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 p-3">
@@ -228,11 +317,12 @@ export function ConnectionsList({
                 ) : (
                   <Server className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 )}
-                <span className="truncate text-xs font-medium">{server.label || deriveLabel(server.baseUrl)}</span>
+                <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                  {server.label || deriveLabel(server.baseUrl)}
+                </span>
                 <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
                   {isDirect ? "Direct" : "HTTP API"}
                 </span>
-                <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{server.baseUrl}</span>
                 <button
                   type="button"
                   onClick={() => void forgetServer(server)}
@@ -318,6 +408,60 @@ export function ConnectionsList({
           );
         })}
       </div>
+
+      <Dialog open={changeOpen} onOpenChange={(open) => { if (!open && !changing) setChangeOpen(false); }}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Change passphrase</DialogTitle>
+            <DialogDescription>
+              Enter your current passphrase and a new one. Your saved servers are re-encrypted with the
+              new passphrase, and other tabs are signed out of the vault.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            <Input
+              type="password"
+              value={currentPass}
+              onChange={(e) => setCurrentPass(e.target.value)}
+              placeholder="Current passphrase"
+              autoComplete="current-password"
+              autoFocus
+              disabled={changing}
+            />
+            <Input
+              type="password"
+              value={nextPass}
+              onChange={(e) => setNextPass(e.target.value)}
+              placeholder="New passphrase"
+              autoComplete="new-password"
+              disabled={changing}
+            />
+            <Input
+              type="password"
+              value={confirmPass}
+              onChange={(e) => setConfirmPass(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") void handleChangePassphrase(); }}
+              placeholder="Confirm new passphrase"
+              autoComplete="new-password"
+              disabled={changing}
+            />
+            {changeError && <p className="text-xs text-destructive">{changeError}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setChangeOpen(false)} disabled={changing}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleChangePassphrase()}
+              disabled={changing || !currentPass || !nextPass || !confirmPass}
+            >
+              {changing ? <Loader2 className="h-4 w-4 animate-spin" /> : "Change passphrase"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }

--- a/src/components/connect/ConnectionsList.tsx
+++ b/src/components/connect/ConnectionsList.tsx
@@ -96,6 +96,10 @@ export function ConnectionsList({
 
   async function handleChangePassphrase() {
     setChangeError(null);
+    if (!currentPass) {
+      setChangeError("Current passphrase is required.");
+      return;
+    }
     if (nextPass.length < MIN_PASSPHRASE_LENGTH) {
       setChangeError(`New passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters.`);
       return;
@@ -425,6 +429,7 @@ export function ConnectionsList({
               value={currentPass}
               onChange={(e) => setCurrentPass(e.target.value)}
               placeholder="Current passphrase"
+              aria-label="Current passphrase"
               autoComplete="current-password"
               autoFocus
               disabled={changing}
@@ -434,6 +439,7 @@ export function ConnectionsList({
               value={nextPass}
               onChange={(e) => setNextPass(e.target.value)}
               placeholder="New passphrase"
+              aria-label="New passphrase"
               autoComplete="new-password"
               disabled={changing}
             />
@@ -443,6 +449,7 @@ export function ConnectionsList({
               onChange={(e) => setConfirmPass(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") void handleChangePassphrase(); }}
               placeholder="Confirm new passphrase"
+              aria-label="Confirm new passphrase"
               autoComplete="new-password"
               disabled={changing}
             />

--- a/src/components/connect/RememberToggle.tsx
+++ b/src/components/connect/RememberToggle.tsx
@@ -126,8 +126,8 @@ export function RememberToggle({
             <DialogTitle>{setting ? "Protect saved credentials" : "Unlock the vault"}</DialogTitle>
             <DialogDescription>
               {setting
-                ? "Create a passphrase to encrypt remembered connections. You'll enter it once per session to reconnect. It is not stored — if you forget it, you'll re-enter and re-remember."
-                : "Enter your passphrase to unlock remembered connections for this session."}
+                ? "Create a passphrase to encrypt your saved servers. You'll enter it once per session to reconnect. It is not stored — if you forget it, you can reset the vault and start over."
+                : "Enter your passphrase to unlock your saved servers for this session."}
             </DialogDescription>
           </DialogHeader>
 

--- a/src/features/connect/useConnectionVault.ts
+++ b/src/features/connect/useConnectionVault.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { RememberedBudget, ServerCredentialMeta } from "@/lib/app-db/types";
 import {
+  changeVaultPassphrase,
   forgetBudget,
   forgetBudgetEncryption,
   forgetRememberedServer,
@@ -89,6 +90,14 @@ export function useConnectionVault() {
     await refresh();
   }, [refresh]);
 
+  const changePassphrase = useCallback(
+    async (currentPassphrase: string, newPassphrase: string) => {
+      await changeVaultPassphrase(currentPassphrase, newPassphrase);
+      await refresh();
+    },
+    [refresh]
+  );
+
   // ── Server-scoped actions (RD-063) ─────────────────────────────────────────
 
   const rememberSrv = useCallback(
@@ -155,6 +164,7 @@ export function useConnectionVault() {
     unlock,
     lock,
     reset,
+    changePassphrase,
     rememberServer: rememberSrv,
     forgetServer: forgetSrv,
     revealServer: revealSrv,


### PR DESCRIPTION
Surfaces two vault capabilities that already existed in the backend but had no UI, and tidies the Connections list.

## What's new
- **Lock the vault** — when unlocked, a **Lock** control drops the session key so saved budgets require the passphrase again (handy on a shared machine).
- **Change passphrase** — a current → new → confirm dialog wired to the existing change-passphrase route, which re-encrypts all saved servers and re-unlocks the current tab.
- Both live in an unobtrusive **"Unlocked · Change passphrase · Lock"** row under the Connections heading, shown only when the vault is unlocked and there are saved servers.

## Polish
- The server group title showed the domain twice (the host **and** the full `https://` URL) — now shows the host once.
- Refreshed the passphrase-dialog copy ("saved servers"; a forgotten passphrase points to **Reset** rather than "re-enter and re-remember").

No new backend; the change-passphrase route and `vault.lock` were already implemented and tested. `tsc`, lint, and the connect + passphrase suites pass.