### PR TITLE
Redesign the connection screen

### DIFF
--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -1,11 +1,24 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, AlertCircle, CheckCircle2, Server, Plus, Check, KeyRound, BookOpen, ExternalLink } from "lucide-react";
+import {
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  Server,
+  Plus,
+  Check,
+  KeyRound,
+  BookOpen,
+  ExternalLink,
+  X,
+  ChevronLeft,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import { useIsHydrated } from "@/hooks/useIsHydrated";
@@ -28,6 +41,20 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
   const router = useRouter();
   const hydrated = useIsHydrated();
   const connectedInstance = useConnectionStore(selectActiveInstance);
+  const vault = useConnectionVault();
+
+  // Budgets already reachable via a saved (vault) connection — lets us warn when
+  // reconnecting the same budget through a different mode/URL.
+  const savedBudgets = useMemo(
+    () =>
+      vault.budgets.flatMap((b) => {
+        const srv = vault.servers.find((s) => s.serverFingerprint === b.serverFingerprint);
+        return srv
+          ? [{ budgetSyncId: b.budgetSyncId, mode: srv.mode, baseUrl: srv.baseUrl, label: b.name || deriveLabel(srv.baseUrl) }]
+          : [];
+      }),
+    [vault.budgets, vault.servers]
+  );
 
   const {
     instances,
@@ -60,9 +87,6 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
     validateBusy,
     connectBusy,
     anyBusy,
-    step1Complete,
-    showManualForm,
-    connectedSyncIds,
     resetStep2,
     handleCredentialChange,
     handleSelectServer,
@@ -77,9 +101,7 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
     handleSelectBudget,
     pendingBudgetSwitch,
     dismissBudgetSwitch,
-  } = useConnectForm();
-
-  const vault = useConnectionVault();
+  } = useConnectForm({ savedBudgets });
 
   // One server-grouped view of everything openable: this-session connections +
   // the saved vault. Each budget appears once, deduped by server + sync id.
@@ -87,6 +109,15 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
     () => mergeConnections(instances, vault.servers, vault.budgets),
     [instances, vault.servers, vault.budgets]
   );
+
+  // Sync ids already open this session / saved in the vault — used to flag
+  // budgets in the picker so you can tell which are new and which you already have.
+  const openSyncIds = useMemo(() => new Set(instances.map((i) => i.budgetSyncId)), [instances]);
+  const savedSyncIds = useMemo(() => new Set(vault.budgets.map((b) => b.budgetSyncId)), [vault.budgets]);
+
+  // Whether the add-a-server workspace is expanded (returning users start on a
+  // calm CTA so the saved list stays the focus).
+  const [addingServer, setAddingServer] = useState(false);
 
   useEffect(() => {
     if (hydrated && connectedInstance) {
@@ -99,37 +130,54 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
   }
 
   const activeValidatedMode = validatedMode ?? connectionMode;
-
-  // Show the two-column layout when there's anything to continue from.
   const hasSideContent = mergedServers.length > 0;
+  const inFlow = budgets !== null; // budgets loaded → choosing a budget
+  const showForm = !hasSideContent || addingServer || inFlow;
+  const workspaceState = !showForm ? "idle" : inFlow ? "step2" : "step1";
 
-  // ── Panels ──────────────────────────────────────────────────────────────────
+  function openAdd() {
+    setAddingServer(true);
+  }
+  function closeAdd() {
+    setAddingServer(false);
+    resetStep2();
+    setBaseUrl("");
+    setApiKey("");
+    setServerPassword("");
+    setSelectedServerId(null);
+    setValidateStatus({ kind: "idle" });
+  }
 
-  const step1Panel = (
-    <div className="rounded-xl border border-border bg-background p-6 flex flex-col gap-5">
-      <div className="flex items-center gap-3">
-        <div
-          className={cn(
-            "flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold",
-            step1Complete ? "bg-green-500 text-white" : "bg-primary text-primary-foreground"
-          )}
-        >
-          {step1Complete ? <Check className="h-3.5 w-3.5" /> : "1"}
-        </div>
-        <h3 className="font-semibold">Choose a server</h3>
-        {step1Complete && (
+  // ── Step 1: choose a server ─────────────────────────────────────────────────
+  const step1 = (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center gap-2.5">
+        <span className="grid size-[22px] shrink-0 place-items-center rounded-[7px] bg-action text-[11px] font-bold text-action-foreground">
+          1
+        </span>
+        <h3 className="flex-1 text-sm font-semibold tracking-tight">
+          {hasSideContent ? "Add a server" : "Connect your Actual server"}
+        </h3>
+        {hasSideContent && (
           <button
             type="button"
-            onClick={() => { resetStep2(); setSelectedServerId(null); }}
+            onClick={closeAdd}
             disabled={anyBusy}
-            className="ml-auto text-xs text-muted-foreground underline-offset-2 hover:underline disabled:opacity-50"
+            aria-label="Cancel"
+            className="flex size-8 items-center justify-center rounded-[9px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
           >
-            Change
+            <X className="size-[15px]" />
           </button>
         )}
       </div>
 
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2" role="tablist" aria-label="Connection type">
+      <p className="-mt-1 text-sm leading-relaxed text-muted-foreground">
+        Point Actual Bench at your budget server to review, sync, and manage it. Choose{" "}
+        <span className="font-medium text-foreground">HTTP API</span> for a hosted API server, or{" "}
+        <span className="font-medium text-foreground">Direct</span> to talk to Actual itself.
+      </p>
+
+      <div className="grid grid-cols-2 gap-2" role="tablist" aria-label="Connection type">
         <button
           type="button"
           role="tab"
@@ -137,42 +185,47 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
           disabled={anyBusy}
           onClick={() => handleModeChange("http-api")}
           className={cn(
-            "flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+            "flex flex-col gap-1.5 rounded-xl border p-3 text-left transition disabled:cursor-not-allowed disabled:opacity-60",
             connectionMode === "http-api"
-              ? "border-primary bg-primary/5 text-primary"
-              : "border-border hover:bg-muted"
+              ? "border-action bg-action/[0.06] ring-3 ring-action/15"
+              : "border-input bg-muted/40 hover:border-muted-foreground/40"
           )}
         >
-          <Server className="h-4 w-4" />
-          <span className="whitespace-nowrap">HTTP API Server</span>
+          <span className="flex items-center gap-2 text-sm font-semibold">
+            <Server className="size-4 text-action" />
+            HTTP API Server
+          </span>
+          <span className="text-xs leading-snug text-muted-foreground">Through an actual-http-api server.</span>
         </button>
         <button
           type="button"
           role="tab"
           aria-selected={connectionMode === "browser-api"}
           disabled={anyBusy || !directBrowserApiEnabled}
-          title={
-            directBrowserApiEnabled
-              ? "Direct Actual Server"
-              : "Direct Actual Server mode is disabled for this deployment"
-          }
+          title={directBrowserApiEnabled ? "Direct Actual Server" : "Direct mode is disabled for this deployment"}
           onClick={() => handleModeChange("browser-api")}
           className={cn(
-            "flex min-h-11 items-center justify-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+            "flex flex-col gap-1.5 rounded-xl border p-3 text-left transition disabled:cursor-not-allowed disabled:opacity-60",
             connectionMode === "browser-api"
-              ? "border-primary bg-primary/5 text-primary"
-              : "border-border hover:bg-muted"
+              ? "border-action bg-action/[0.06] ring-3 ring-action/15"
+              : "border-input bg-muted/40 hover:border-muted-foreground/40"
           )}
         >
-          <KeyRound className="h-4 w-4" />
-          <span className="whitespace-nowrap">Direct Actual Server</span>
+          <span className="flex items-center gap-2 text-sm font-semibold">
+            <KeyRound className="size-4 text-action" />
+            Direct Actual Server
+          </span>
+          <span className="text-xs leading-snug text-muted-foreground">Actual&apos;s API runs in your browser.</span>
         </button>
       </div>
 
       {!directBrowserApiEnabled && (
-        <div className="flex items-start gap-2.5 rounded-lg border border-muted bg-muted/40 px-3.5 py-3 text-xs leading-5 text-muted-foreground">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>Direct Actual Server mode is disabled for this deployment. Remove <code>DIRECT_BROWSER_API=0</code> and restart the app to show both connection modes.</span>
+        <div className="flex items-start gap-2.5 rounded-lg border bg-muted/40 px-3 py-2.5 text-xs leading-5 text-muted-foreground">
+          <AlertCircle className="mt-0.5 size-4 shrink-0" />
+          <span>
+            Direct mode is disabled for this deployment. Remove <code>DIRECT_BROWSER_API=0</code> and restart to
+            show both modes.
+          </span>
         </div>
       )}
 
@@ -188,10 +241,10 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
                 "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                 selectedServerId === server.id
                   ? "bg-primary text-primary-foreground"
-                  : "border border-border bg-background hover:bg-muted"
+                  : "border bg-background hover:bg-muted"
               )}
             >
-              {selectedServerId === server.id && <Check className="h-3 w-3" />}
+              {selectedServerId === server.id && <Check className="size-3" />}
               {server.label}
             </button>
           ))}
@@ -202,240 +255,269 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
             className={cn(
               "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
               selectedServerId === null
-                ? "border border-primary text-primary bg-primary/5"
-                : "border border-dashed border-border text-muted-foreground hover:bg-muted"
+                ? "border border-action bg-action/5 text-action"
+                : "border border-dashed text-muted-foreground hover:bg-muted"
             )}
           >
-            <Plus className="h-3 w-3" />
+            <Plus className="size-3" />
             New server
           </button>
         </div>
       )}
 
-      {showManualForm && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="baseUrl">
-              {connectionMode === "browser-api" ? "Actual Server URL" : "HTTP API Server URL"}
-            </Label>
-            <Input
-              id="baseUrl"
-              type="text"
-              placeholder={connectionMode === "browser-api" ? "https://actual.example.com" : "https://budgetapi.example.com"}
-              autoComplete="off"
-              spellCheck={false}
-              value={baseUrl}
-              onChange={(e) => {
-                setBaseUrl(e.target.value);
-                if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
-                setSelectedServerId(null);
-                handleCredentialChange();
-              }}
-              onKeyDown={handleKeyDown}
-              disabled={anyBusy}
-            />
-          </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="baseUrl" className="text-sm text-muted-foreground">
+          {connectionMode === "browser-api" ? "Actual Server URL" : "HTTP API Server URL"}
+        </Label>
+        <Input
+          id="baseUrl"
+          type="text"
+          placeholder={connectionMode === "browser-api" ? "https://actual.example.com" : "https://budgetapi.example.com"}
+          autoComplete="off"
+          spellCheck={false}
+          value={baseUrl}
+          onChange={(e) => {
+            setBaseUrl(e.target.value);
+            if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
+            setSelectedServerId(null);
+            handleCredentialChange();
+          }}
+          onKeyDown={handleKeyDown}
+          disabled={anyBusy}
+        />
+      </div>
 
-          {connectionMode === "http-api" ? (
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="apiKey">API Key</Label>
-              <Input
-                id="apiKey"
-                type="password"
-                placeholder="••••••••••••••••"
-                autoComplete="current-password"
-                value={apiKey}
-                onChange={(e) => {
-                  setApiKey(e.target.value);
-                  if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
-                  handleCredentialChange();
-                }}
-                onKeyDown={handleKeyDown}
-                disabled={anyBusy}
-              />
-              <p className="text-xs text-muted-foreground">
-                The <code>ACTUAL_API_KEY</code> configured on your API server.
-              </p>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="serverPassword">Server password</Label>
-              <Input
-                id="serverPassword"
-                type="password"
-                placeholder="••••••••••••••••"
-                autoComplete="current-password"
-                value={serverPassword}
-                onChange={(e) => {
-                  setServerPassword(e.target.value);
-                  if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
-                  handleCredentialChange();
-                }}
-                onKeyDown={handleKeyDown}
-                disabled={anyBusy}
-              />
-            </div>
-          )}
+      {connectionMode === "http-api" ? (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="apiKey" className="text-sm text-muted-foreground">
+            API Key
+          </Label>
+          <Input
+            id="apiKey"
+            type="password"
+            placeholder="••••••••••••••••"
+            autoComplete="current-password"
+            value={apiKey}
+            onChange={(e) => {
+              setApiKey(e.target.value);
+              if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
+              handleCredentialChange();
+            }}
+            onKeyDown={handleKeyDown}
+            disabled={anyBusy}
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="serverPassword" className="text-sm text-muted-foreground">
+            Server password
+          </Label>
+          <Input
+            id="serverPassword"
+            type="password"
+            placeholder="••••••••••••••••"
+            autoComplete="current-password"
+            value={serverPassword}
+            onChange={(e) => {
+              setServerPassword(e.target.value);
+              if (validateStatus.kind === "error") setValidateStatus({ kind: "idle" });
+              handleCredentialChange();
+            }}
+            onKeyDown={handleKeyDown}
+            disabled={anyBusy}
+          />
         </div>
       )}
 
       {validateStatus.kind === "error" && (
-        <div className="flex items-start gap-2.5 rounded-lg bg-destructive/10 px-3.5 py-3 text-sm text-destructive">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="flex items-start gap-2.5 rounded-lg bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 size-4 shrink-0" />
           <span>{validateStatus.message}</span>
         </div>
       )}
 
-      <button
-        type="button"
-        disabled={anyBusy}
-        onClick={handleValidate}
-        className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-      >
+      <Button className="w-full" onClick={handleValidate} disabled={anyBusy}>
         {validateBusy ? (
-          <><Loader2 className="h-4 w-4 animate-spin" />Loading…</>
+          <>
+            <Loader2 className="size-4 animate-spin" />
+            Loading budgets…
+          </>
         ) : (
-          "Load Budgets"
+          "Load budgets"
         )}
-      </button>
+      </Button>
     </div>
   );
 
-  const step2Panel = budgets !== null ? (
-    <div className="rounded-xl border border-border bg-background p-6 flex flex-col gap-5">
-      <div className="flex items-center gap-3">
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-bold">
-          2
-        </div>
-        <h3 className="font-semibold">Choose a budget</h3>
-        <div className="ml-auto flex items-center gap-1.5 rounded-full bg-green-50 px-2.5 py-1 text-xs text-green-700">
-          <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
-          <span>{deriveLabel(validatedUrl)}</span>
-          <span className="text-green-600/70">· {getConnectionModeBadge(activeValidatedMode)}</span>
-          {validatedApiVersion && <span className="text-green-600/70">· API v{validatedApiVersion}</span>}
-          {validatedServerVersion && <span className="text-green-600/70">· Actual v{validatedServerVersion}</span>}
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2 max-h-70 overflow-y-auto pr-1">
-        {budgets.map((budget) => {
-          const selected = selectedGroupId === budget.groupId;
-          const alreadyConnected = connectedSyncIds.has(budget.groupId ?? "");
-          return (
+  // ── Step 2: choose a budget ─────────────────────────────────────────────────
+  const step2 =
+    budgets !== null ? (
+      <div className="flex flex-col gap-4 p-4">
+        <div className="flex items-center gap-2.5">
+          <button
+            type="button"
+            onClick={resetStep2}
+            disabled={connectBusy || !!reconnectBusyId}
+            aria-label="Back"
+            className="flex size-8 items-center justify-center rounded-[9px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <ChevronLeft className="size-[17px]" />
+          </button>
+          <span className="grid size-[22px] shrink-0 place-items-center rounded-[7px] bg-staged-new text-action-foreground">
+            <Check className="size-3" />
+          </span>
+          <h3 className="flex-1 text-sm font-semibold tracking-tight">Choose a budget</h3>
+          {hasSideContent && (
             <button
-              key={budget.groupId}
               type="button"
+              onClick={closeAdd}
               disabled={connectBusy || !!reconnectBusyId}
-              onClick={() => {
-                if (budget.groupId) handleSelectBudget(budget.groupId);
-                else setSelectedGroupId(null);
-              }}
-              className={cn(
-                "flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors disabled:opacity-50",
-                selected
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-muted-foreground/40 hover:bg-muted/40"
-              )}
+              aria-label="Cancel"
+              className="flex size-8 items-center justify-center rounded-[9px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
             >
-              <span
+              <X className="size-[15px]" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1.5 px-0.5 text-xs text-muted-foreground">
+          <CheckCircle2 className="size-3.5 shrink-0 text-staged-new" />
+          <span className="truncate">
+            Connected to <span className="font-mono font-medium text-foreground">{deriveLabel(validatedUrl)}</span> ·{" "}
+            {getConnectionModeBadge(activeValidatedMode)} · {budgets.length}{" "}
+            {budgets.length === 1 ? "budget" : "budgets"} found
+            {validatedApiVersion && ` · API v${validatedApiVersion}`}
+            {validatedServerVersion && ` · Actual v${validatedServerVersion}`}
+          </span>
+        </div>
+
+        <div className="-mx-1 flex max-h-[21rem] flex-col gap-2 overflow-y-auto px-1">
+          {budgets.map((budget) => {
+            const selected = selectedGroupId === budget.groupId;
+            return (
+              <button
+                key={budget.groupId}
+                type="button"
+                disabled={connectBusy || !!reconnectBusyId}
+                onClick={() => {
+                  if (budget.groupId) handleSelectBudget(budget.groupId);
+                  else setSelectedGroupId(null);
+                }}
                 className={cn(
-                  "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2 flex items-center justify-center",
-                  selected ? "border-primary" : "border-muted-foreground/40"
+                  "flex items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors disabled:opacity-50",
+                  selected
+                    ? "border-primary bg-muted"
+                    : "border-border hover:border-muted-foreground/40 hover:bg-muted/40"
                 )}
               >
-                {selected && <span className="h-2 w-2 rounded-full bg-primary block" />}
-              </span>
-              <span className="flex flex-col gap-1 min-w-0">
-                <span className="flex items-center gap-2">
-                  <span className="text-sm font-medium leading-tight">
+                <span
+                  className={cn(
+                    "grid size-[18px] shrink-0 place-items-center rounded-full transition-colors",
+                    selected ? "bg-primary text-primary-foreground" : "border-2 border-border"
+                  )}
+                >
+                  {selected && <Check className="size-3" strokeWidth={3} />}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">
                     {budget.name || budget.cloudFileId}
                   </span>
-                  {alreadyConnected && (
-                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                      {activeValidatedMode === "browser-api" ? "saved" : "connected"}
-                    </span>
-                  )}
+                  <span className="block truncate font-mono text-xs text-muted-foreground">
+                    Sync ID: {budget.groupId}
+                  </span>
                 </span>
-                <span className="text-xs text-muted-foreground font-mono truncate">
-                  Sync ID: {budget.groupId}
-                </span>
-              </span>
-            </button>
-          );
-        })}
-      </div>
+                {budget.groupId && openSyncIds.has(budget.groupId) ? (
+                  <span className="shrink-0 rounded-full bg-staged-new/12 px-2 py-0.5 text-[10px] font-medium text-staged-new">
+                    open now
+                  </span>
+                ) : budget.groupId && savedSyncIds.has(budget.groupId) ? (
+                  <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    saved
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
 
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="encryptionPassword">
-          Encryption password{" "}
-          <span className="font-normal text-muted-foreground">(optional)</span>
-        </Label>
-        <Input
-          id="encryptionPassword"
-          type="password"
-          placeholder="Leave blank if budget is not encrypted"
-          autoComplete="off"
-          value={encryptionPassword}
-          onChange={(e) => {
-            setEncryptionPassword(e.target.value);
-            if (connectStatus.kind === "error") setConnectStatus({ kind: "idle" });
-          }}
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="encryptionPassword" className="text-sm text-muted-foreground">
+            Encryption password <span className="text-muted-foreground/70">(optional)</span>
+          </Label>
+          <Input
+            id="encryptionPassword"
+            type="password"
+            placeholder="Only if this budget is end-to-end encrypted"
+            autoComplete="off"
+            value={encryptionPassword}
+            onChange={(e) => {
+              setEncryptionPassword(e.target.value);
+              if (connectStatus.kind === "error") setConnectStatus({ kind: "idle" });
+            }}
+            disabled={connectBusy || !!reconnectBusyId}
+          />
+        </div>
+
+        {connectStatus.kind === "error" && (
+          <div className="flex items-start gap-2.5 rounded-lg bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+            <AlertCircle className="mt-0.5 size-4 shrink-0" />
+            <span>{connectStatus.message}</span>
+          </div>
+        )}
+
+        <RememberToggle
+          vault={vault}
+          checked={rememberOnServer}
+          onCheckedChange={setRememberOnServer}
           disabled={connectBusy || !!reconnectBusyId}
         />
+
+        <Button className="w-full" onClick={handleConnect} disabled={connectBusy || !!reconnectBusyId || !selectedGroupId}>
+          {connectBusy ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Connecting…
+            </>
+          ) : (
+            "Connect"
+          )}
+        </Button>
       </div>
+    ) : null;
 
-      {connectStatus.kind === "error" && (
-        <div className="flex items-start gap-2.5 rounded-lg bg-destructive/10 px-3.5 py-3 text-sm text-destructive">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>{connectStatus.message}</span>
-        </div>
-      )}
-
-      {connectStatus.kind === "success" && activeValidatedMode === "browser-api" && (
-        <div className="flex items-start gap-2.5 rounded-lg bg-green-50 px-3.5 py-3 text-sm text-green-700">
-          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>Direct connection opened. Core entity pages and Budget Management now use the browser transport.</span>
-        </div>
-      )}
-
-      <RememberToggle
-        vault={vault}
-        checked={rememberOnServer}
-        onCheckedChange={setRememberOnServer}
-        disabled={connectBusy || !!reconnectBusyId}
-      />
-
-      <button
-        type="button"
-        disabled={connectBusy || !!reconnectBusyId || !selectedGroupId}
-        onClick={handleConnect}
-        className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        {connectBusy ? (
-          <>
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Connecting…
-          </>
-        ) : (
-          "Connect"
-        )}
-      </button>
+  // ── Idle CTA (returning users, form collapsed) ──────────────────────────────
+  const idleCta = (
+    <div className="px-5 py-7 text-center">
+      <div className="mx-auto mb-3.5 grid size-14 place-items-center rounded-2xl bg-action/10 text-action">
+        <Plus className="size-7" />
+      </div>
+      <h3 className="text-base font-semibold tracking-tight">Add a server</h3>
+      <p className="mx-auto mb-4 mt-1 max-w-[34ch] text-sm text-muted-foreground">
+        Connect another Actual server, Direct or through an HTTP API server.
+      </p>
+      <Button onClick={openAdd}>Add a server</Button>
     </div>
-  ) : null;
+  );
 
-  // ── Layout ──────────────────────────────────────────────────────────────────
+  const workspace = (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-lg lg:sticky lg:top-6">
+      <div key={workspaceState} className="animate-in fade-in slide-in-from-right-2 duration-300">
+        {workspaceState === "idle" ? idleCta : workspaceState === "step2" ? step2 : step1}
+      </div>
+    </div>
+  );
 
   return (
-    <div className={cn("w-full flex flex-col gap-8", hasSideContent ? "max-w-[68rem]" : "max-w-xl")}>
-      <div className="flex justify-center">
+    <div className={cn("flex w-full flex-col", hasSideContent ? "max-w-[70rem]" : "max-w-md")}>
+      {/* Brand header */}
+      <div className="mb-7 flex justify-center">
         <Image src="/logo.png" alt="Actual Bench" width={160} height={40} priority />
       </div>
 
       {hasSideContent ? (
-        /* ── Two-column layout ── */
-        <div className="grid grid-cols-1 lg:grid-cols-[9fr_11fr] gap-6 items-start">
-          {/* Left: everything you can open — this session + the saved vault */}
-          <div className="flex flex-col gap-6">
+        <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-2">
+          {/* Left: saved connections */}
+          <div className="flex flex-col gap-4">
             <ConnectionsList
               vault={vault}
               servers={mergedServers}
@@ -448,59 +530,41 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
             />
           </div>
 
-          {/* Right: add a connection */}
-          <section className="flex flex-col gap-4">
-            <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest">
-              Add a connection
-            </h2>
-            {step1Panel}
-            {step2Panel}
-          </section>
+          {/* Right: workspace */}
+          <div>{workspace}</div>
         </div>
       ) : (
-        /* ── Single-column layout (first-time user) ── */
-        <section className="flex flex-col gap-5">
-          <div className="flex flex-col items-center gap-2 text-center">
-            <h1 className="text-lg font-semibold">Connect your Actual server</h1>
-            <p className="max-w-md text-sm text-muted-foreground">
-              Point Actual Bench at your budget server to review, sync, and manage it. Choose{" "}
-              <span className="font-medium text-foreground">HTTP API</span> for a hosted API server, or{" "}
-              <span className="font-medium text-foreground">Direct</span> to talk to Actual itself.
-            </p>
-          </div>
-
-          {step1Panel}
-          {step2Panel}
-
-          {budgets === null && !validateBusy && (
-            <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 border-t border-border pt-4 text-xs text-muted-foreground">
-              <span>New here?</span>
-              <a
-                href={DOCS_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-1.5 hover:text-foreground"
-              >
-                <BookOpen className="h-3.5 w-3.5" />
-                Documentation
-              </a>
-              <a
-                href={GITHUB_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-1.5 hover:text-foreground"
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                GitHub
-              </a>
-            </div>
-          )}
-        </section>
+        /* First run — single centered column */
+        <section className="flex flex-col gap-4">{workspace}</section>
       )}
+
+      {/* Docs / GitHub — always available */}
+      <div className="mt-7 flex flex-wrap items-center justify-center gap-2">
+        <a
+          href={DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <BookOpen className="size-4" />
+          Documentation
+        </a>
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ExternalLink className="size-4" />
+          GitHub
+        </a>
+      </div>
 
       <ConfirmDialog
         open={!!pendingBudgetSwitch}
-        onOpenChange={(open) => { if (!open) dismissBudgetSwitch(); }}
+        onOpenChange={(open) => {
+          if (!open) dismissBudgetSwitch();
+        }}
         state={pendingBudgetSwitch}
       />
     </div>

--- a/src/components/connect/ConnectionsList.tsx
+++ b/src/components/connect/ConnectionsList.tsx
@@ -251,7 +251,13 @@ export function ConnectionsList({
             </div>
             {!locked && (
               <div className="flex shrink-0 gap-2">
-                <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={openChangePassphrase}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5"
+                  onClick={openChangePassphrase}
+                  aria-label="Change passphrase"
+                >
                   <Settings2 className="size-3.5" />
                   <span className="hidden sm:inline">Change passphrase</span>
                 </Button>

--- a/src/components/connect/ConnectionsList.tsx
+++ b/src/components/connect/ConnectionsList.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { KeyRound, Loader2, Lock, Plus, Server, Trash2, Unlock, X } from "lucide-react";
+import { KeyRound, Loader2, Lock, Plus, Server, Settings2, Trash2, Unlock, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Dialog,
@@ -28,8 +28,10 @@ type Vault = ReturnType<typeof useConnectionVault>;
  * Connections (RD-063) — one server-grouped list of everything you can open:
  * budgets loaded this session (instant, no unlock) and budgets saved in the
  * vault (unlock once, then reconnect without re-typing). Each budget appears
- * once with `open` / `saved` chips; "Open another budget" loads a saved server's
- * full list to reach a budget you haven't opened here yet.
+ * once with `open` / `saved` state; "Open another budget" loads a saved
+ * server's full list to reach a budget you haven't opened here yet. A dedicated
+ * security bar makes the vault state (and its lock / change-passphrase actions)
+ * unmistakable.
  */
 export function ConnectionsList({
   vault,
@@ -73,6 +75,21 @@ export function ConnectionsList({
 
   const locked = !vault.status.unlocked;
   const hasSaved = servers.some((s) => s.savedServer);
+  const budgetCount = servers.reduce((n, s) => n + s.budgets.length, 0);
+
+  async function handleUnlock() {
+    if (!passphrase) return;
+    setUnlocking(true);
+    setError(null);
+    try {
+      await vault.unlock(passphrase);
+      setPassphrase("");
+    } catch (err) {
+      setError(parseApiError(err));
+    } finally {
+      setUnlocking(false);
+    }
+  }
 
   async function handleLock() {
     setLocking(true);
@@ -83,6 +100,21 @@ export function ConnectionsList({
       toast.error(parseApiError(err));
     } finally {
       setLocking(false);
+    }
+  }
+
+  async function handleReset() {
+    setResetting(true);
+    setError(null);
+    try {
+      await vault.reset();
+      setConfirmReset(false);
+      setPassphrase("");
+      toast.success("Vault reset. Set a passphrase to start saving servers again.");
+    } catch (err) {
+      setError(parseApiError(err));
+    } finally {
+      setResetting(false);
     }
   }
 
@@ -120,35 +152,6 @@ export function ConnectionsList({
     }
   }
 
-  async function handleUnlock() {
-    if (!passphrase) return;
-    setUnlocking(true);
-    setError(null);
-    try {
-      await vault.unlock(passphrase);
-      setPassphrase("");
-    } catch (err) {
-      setError(parseApiError(err));
-    } finally {
-      setUnlocking(false);
-    }
-  }
-
-  async function handleReset() {
-    setResetting(true);
-    setError(null);
-    try {
-      await vault.reset();
-      setConfirmReset(false);
-      setPassphrase("");
-      toast.success("Vault reset. Set a passphrase to start saving servers again.");
-    } catch (err) {
-      setError(parseApiError(err));
-    } finally {
-      setResetting(false);
-    }
-  }
-
   async function runBusy(key: string, action: () => Promise<void>) {
     setBusyKey(key);
     setError(null);
@@ -181,7 +184,6 @@ export function ConnectionsList({
       } catch (err) {
         toast.error(parseApiError(err));
       }
-      // Don't leave an empty saved server behind once its last saved budget goes.
       const savedRemaining = server.budgets.filter((b) => b.saved && b.budgetSyncId !== budget.budgetSyncId);
       if (server.savedServer && savedRemaining.length === 0) {
         try {
@@ -209,137 +211,167 @@ export function ConnectionsList({
   }
 
   return (
-    <section className="flex flex-col gap-3">
-      <div className="flex min-h-6 items-center justify-between gap-2">
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-          Connections
-        </h2>
-        {!locked && hasSaved && (
-          <div className="flex items-center gap-1 text-xs">
-            <span className="flex items-center gap-1 text-muted-foreground">
-              <Unlock className="h-3 w-3" />
-              Unlocked
-            </span>
-            <span className="text-border">·</span>
-            <button
-              type="button"
-              onClick={openChangePassphrase}
-              className="rounded px-1 py-0.5 text-muted-foreground hover:text-foreground"
+    <section className="flex flex-col gap-4">
+      {/* ── Vault security bar ─────────────────────────────────────────────── */}
+      {hasSaved && (
+        <div
+          className={cn(
+            "overflow-hidden rounded-xl border bg-card shadow-sm",
+            locked ? "border-staged-updated/40" : "border-border"
+          )}
+        >
+          <div className="flex items-center gap-3 p-3">
+            <div
+              className={cn(
+                "flex size-9 shrink-0 items-center justify-center rounded-[10px]",
+                locked
+                  ? "bg-staged-updated/15 text-staged-updated"
+                  : "bg-staged-new/12 text-staged-new"
+              )}
             >
-              Change passphrase
-            </button>
-            <span className="text-border">·</span>
-            <button
-              type="button"
-              onClick={() => void handleLock()}
-              disabled={locking}
-              className="flex items-center gap-1 rounded px-1 py-0.5 text-muted-foreground hover:text-foreground disabled:opacity-50"
-            >
-              {locking ? <Loader2 className="h-3 w-3 animate-spin" /> : <Lock className="h-3 w-3" />}
-              Lock
-            </button>
-          </div>
-        )}
-      </div>
-
-      {locked && hasSaved && (
-        <div className="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 p-3">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Lock className="h-3.5 w-3.5" />
-            Unlock with your passphrase to reopen a saved budget.
-          </div>
-          <div className="flex gap-2">
-            <input
-              type="password"
-              value={passphrase}
-              onChange={(e) => setPassphrase(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") void handleUnlock(); }}
-              placeholder="Passphrase"
-              autoComplete="off"
-              disabled={unlocking}
-              className="h-9 flex-1 rounded-md border border-border bg-background px-3 text-sm"
-            />
-            <button
-              type="button"
-              onClick={() => void handleUnlock()}
-              disabled={unlocking || !passphrase}
-              className="flex h-9 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground disabled:opacity-50"
-            >
-              {unlocking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Unlock"}
-            </button>
-          </div>
-
-          {confirmReset ? (
-            <div className="flex flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2.5">
-              <p className="text-xs text-muted-foreground">
-                Forgot it? Resetting removes all saved servers and clears the passphrase so you can set a
-                new one. Your budgets and their data are untouched.
-              </p>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleReset()}
-                  disabled={resetting}
-                  className="flex h-8 items-center gap-1.5 rounded-md bg-destructive px-3 text-xs font-medium text-white disabled:opacity-50"
-                >
-                  {resetting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Reset vault"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setConfirmReset(false)}
-                  disabled={resetting}
-                  className="flex h-8 items-center rounded-md border border-border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50"
-                >
-                  Cancel
-                </button>
-              </div>
+              {locked ? <Lock className="size-[18px]" /> : <Unlock className="size-[18px]" />}
             </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setConfirmReset(true)}
-              className="self-start text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
-            >
-              Forgot passphrase?
-            </button>
+            <div className="min-w-0 flex-1">
+              <span className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+                <span
+                  className={cn(
+                    "size-2 rounded-full",
+                    locked
+                      ? "bg-staged-updated shadow-[0_0_0_3px] shadow-staged-updated/25"
+                      : "animate-pulse bg-staged-new shadow-[0_0_0_3px] shadow-staged-new/25"
+                  )}
+                />
+                {locked ? "Vault locked" : "Vault unlocked"}
+              </span>
+              {locked && (
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Unlock once to reopen your saved budgets.
+                </p>
+              )}
+            </div>
+            {!locked && (
+              <div className="flex shrink-0 gap-2">
+                <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={openChangePassphrase}>
+                  <Settings2 className="size-3.5" />
+                  <span className="hidden sm:inline">Change passphrase</span>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5"
+                  onClick={() => void handleLock()}
+                  disabled={locking}
+                >
+                  {locking ? <Loader2 className="size-3.5 animate-spin" /> : <Lock className="size-3.5" />}
+                  Lock
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {locked && (
+            <div className="px-3 pb-3">
+              <div className="flex gap-2">
+                <Input
+                  type="password"
+                  value={passphrase}
+                  onChange={(e) => setPassphrase(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void handleUnlock();
+                  }}
+                  placeholder="Enter your passphrase"
+                  aria-label="Vault passphrase"
+                  autoComplete="off"
+                  disabled={unlocking}
+                  className="h-9"
+                />
+                <Button className="h-9 shrink-0" onClick={() => void handleUnlock()} disabled={unlocking || !passphrase}>
+                  {unlocking ? <Loader2 className="size-4 animate-spin" /> : "Unlock"}
+                </Button>
+              </div>
+              {confirmReset ? (
+                <div className="mt-2.5 flex flex-col gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-2.5">
+                  <p className="text-xs text-muted-foreground">
+                    Forgot it? Resetting removes all saved servers and clears the passphrase so you can set a new
+                    one. Your budgets and their data are untouched.
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      className="h-8"
+                      onClick={() => void handleReset()}
+                      disabled={resetting}
+                    >
+                      {resetting ? <Loader2 className="size-3.5 animate-spin" /> : "Reset vault"}
+                    </Button>
+                    <Button variant="outline" size="sm" className="h-8" onClick={() => setConfirmReset(false)} disabled={resetting}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmReset(true)}
+                  className="mt-2.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                >
+                  Forgot passphrase?
+                </button>
+              )}
+            </div>
           )}
         </div>
       )}
 
+      {/* ── Section label ──────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between gap-2 px-0.5">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Your servers</h2>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {servers.length} {servers.length === 1 ? "server" : "servers"} · {budgetCount}{" "}
+          {budgetCount === 1 ? "budget" : "budgets"}
+        </span>
+      </div>
+
       {error && <p className="text-xs text-destructive">{error}</p>}
 
-      <div className="flex max-h-[26rem] flex-col gap-4 overflow-y-auto">
-        {servers.map((server) => {
+      {/* ── Servers ────────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-4">
+        {servers.map((server, i) => {
           const isDirect = server.mode === "browser-api";
           const openAnotherKey = `server:${server.serverFingerprint}`;
           return (
-            <div key={server.serverFingerprint} className="flex flex-col gap-1.5">
-              {/* Server header */}
+            <div
+              key={server.serverFingerprint}
+              className={cn("flex flex-col gap-1.5", i > 0 && "border-t pt-4")}
+            >
+              {/* Server header row */}
               <div className="flex items-center gap-2 px-0.5">
                 {isDirect ? (
-                  <KeyRound className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <KeyRound className="size-3.5 shrink-0 text-muted-foreground" />
                 ) : (
-                  <Server className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <Server className="size-3.5 shrink-0 text-muted-foreground" />
                 )}
-                <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                <span className="min-w-0 truncate font-mono text-xs font-medium">
                   {server.label || deriveLabel(server.baseUrl)}
                 </span>
-                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                <span className="shrink-0 rounded-full border bg-muted/60 px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
                   {isDirect ? "Direct" : "HTTP API"}
                 </span>
+                <span className="flex-1" />
                 <button
                   type="button"
                   onClick={() => void forgetServer(server)}
                   disabled={busy}
                   title="Forget this server and its saved budgets"
                   aria-label={`Forget ${server.label || deriveLabel(server.baseUrl)}`}
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                  className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
                 >
-                  <Trash2 className="h-3.5 w-3.5" />
+                  <Trash2 className="size-3.5" />
                 </button>
               </div>
 
-              {/* Budgets — one click to open */}
+              {/* Budget rows — the whole row connects */}
               {server.budgets.map((budget) => {
                 const key = `${server.serverFingerprint}:${budget.budgetSyncId}`;
                 const isOpen = !!budget.instance;
@@ -354,28 +386,25 @@ export function ConnectionsList({
                       onClick={() => openBudget(server, budget)}
                       disabled={busy || busyKey !== null || needsUnlock}
                       title={needsUnlock ? "Unlock the vault to open this saved budget" : undefined}
-                      className={cn(
-                        "flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-background px-3 py-2.5 text-left transition-colors",
-                        "hover:border-muted-foreground/40 hover:bg-muted/40 disabled:opacity-50"
-                      )}
+                      className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg border bg-background px-3 py-2.5 text-left transition-colors hover:border-muted-foreground/40 hover:bg-muted/40 disabled:opacity-50"
                     >
                       <span className="min-w-0 flex-1 truncate text-sm font-medium">
                         {budget.name || budget.budgetSyncId}
                       </span>
                       {isOpen && (
-                        <span className="shrink-0 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+                        <span className="shrink-0 rounded-full bg-staged-new/12 px-2 py-0.5 text-[10px] font-medium text-staged-new">
                           open
                         </span>
                       )}
-                      {isSaved && (
-                        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                      {isSaved && !isOpen && (
+                        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
                           saved
                         </span>
                       )}
                       {opening ? (
-                        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+                        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
                       ) : (
-                        <span className="shrink-0 text-xs font-medium text-primary">Connect</span>
+                        <span className="shrink-0 text-xs font-semibold text-action">Connect</span>
                       )}
                     </button>
                     <button
@@ -384,26 +413,25 @@ export function ConnectionsList({
                       disabled={busy || busyKey !== null}
                       title="Forget this budget"
                       aria-label={`Forget ${budget.name || budget.budgetSyncId}`}
-                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                      className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
                     >
-                      <X className="h-3.5 w-3.5" />
+                      <X className="size-3.5" />
                     </button>
                   </div>
                 );
               })}
 
-              {/* Open a budget not opened here yet (saved servers only) */}
               {server.savedServer && (
                 <button
                   type="button"
                   onClick={() => void runBusy(openAnotherKey, () => onOpenServer(server.savedServer!))}
                   disabled={locked || busy || busyKey !== null}
-                  className="flex items-center gap-1.5 self-start rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                  className="flex items-center gap-1.5 self-start rounded-md px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
                 >
                   {busyKey === openAnotherKey ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    <Loader2 className="size-3.5 animate-spin" />
                   ) : (
-                    <Plus className="h-3.5 w-3.5" />
+                    <Plus className="size-3.5" />
                   )}
                   Open another budget
                 </button>
@@ -413,13 +441,19 @@ export function ConnectionsList({
         })}
       </div>
 
-      <Dialog open={changeOpen} onOpenChange={(open) => { if (!open && !changing) setChangeOpen(false); }}>
+      {/* ── Change-passphrase dialog ───────────────────────────────────────── */}
+      <Dialog
+        open={changeOpen}
+        onOpenChange={(open) => {
+          if (!open && !changing) setChangeOpen(false);
+        }}
+      >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>Change passphrase</DialogTitle>
             <DialogDescription>
-              Enter your current passphrase and a new one. Your saved servers are re-encrypted with the
-              new passphrase, and other tabs are signed out of the vault.
+              Enter your current passphrase and a new one. Your saved servers are re-encrypted with the new
+              passphrase, and other tabs are signed out of the vault.
             </DialogDescription>
           </DialogHeader>
 
@@ -447,7 +481,9 @@ export function ConnectionsList({
               type="password"
               value={confirmPass}
               onChange={(e) => setConfirmPass(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") void handleChangePassphrase(); }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleChangePassphrase();
+              }}
               placeholder="Confirm new passphrase"
               aria-label="Confirm new passphrase"
               autoComplete="new-password"
@@ -464,7 +500,7 @@ export function ConnectionsList({
               onClick={() => void handleChangePassphrase()}
               disabled={changing || !currentPass || !nextPass || !confirmPass}
             >
-              {changing ? <Loader2 className="h-4 w-4 animate-spin" /> : "Change passphrase"}
+              {changing ? <Loader2 className="size-4 animate-spin" /> : "Change passphrase"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/connect/RememberToggle.tsx
+++ b/src/components/connect/RememberToggle.tsx
@@ -100,9 +100,9 @@ export function RememberToggle({
           className="mt-0.5 h-4 w-4"
         />
         <span className="flex flex-col">
-          <span className="text-sm font-medium">Remember this server</span>
+          <span className="text-sm font-medium">Remember this budget</span>
           <span className="text-xs text-muted-foreground">
-            Encrypted with your passphrase so you can open any of its budgets next time without re-typing.
+            Adds this budget to your saved connections for one-click reopen. Stored encrypted with your passphrase.
             {checked && !vault.status.unlocked && (
               <>
                 {" "}
@@ -126,7 +126,7 @@ export function RememberToggle({
             <DialogTitle>{setting ? "Protect saved credentials" : "Unlock the vault"}</DialogTitle>
             <DialogDescription>
               {setting
-                ? "Create a passphrase to encrypt your saved servers. You'll enter it once per session to reconnect. It is not stored — if you forget it, you can reset the vault and start over."
+                ? "Create a passphrase to encrypt your saved servers. You'll enter it once per session to reconnect. It is not stored; if you forget it, you can reset the vault and start over."
                 : "Enter your passphrase to unlock your saved servers for this session."}
             </DialogDescription>
           </DialogHeader>

--- a/src/components/connect/useConnectForm.test.tsx
+++ b/src/components/connect/useConnectForm.test.tsx
@@ -321,6 +321,45 @@ describe("useConnectForm Direct redirects", () => {
     });
   });
 
+  it("prompts to switch when connecting a budget already saved via a different mode", async () => {
+    mockListBudgets.mockResolvedValue([{ groupId: "budget-1", cloudFileId: "budget-1", name: "Budget One" }]);
+    mockGetApiVersion.mockResolvedValue("1.2.3");
+
+    const client = new QueryClient();
+    const { result } = renderHook(
+      () =>
+        useConnectForm({
+          savedBudgets: [
+            {
+              budgetSyncId: "budget-1",
+              mode: "browser-api",
+              baseUrl: "https://actual.example.com",
+              label: "Budget One (Direct)",
+            },
+          ],
+        }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    act(() => {
+      result.current.setBaseUrl("https://api.example.com");
+      result.current.setApiKey("api-key");
+    });
+    act(() => {
+      result.current.handleValidate();
+    });
+    await waitFor(() => expect(result.current.budgets).toHaveLength(1));
+
+    act(() => {
+      result.current.handleConnect();
+    });
+
+    // Same budget id, different mode → switch dialog instead of an immediate connect.
+    await waitFor(() => expect(result.current.pendingBudgetSwitch).not.toBeNull());
+    expect(result.current.pendingBudgetSwitch?.title).toMatch(/switch/i);
+    expect(mockPush).not.toHaveBeenCalledWith("/overview");
+  });
+
   it("redirects a successful Direct reconnect to overview", async () => {
     const instance: ConnectionInstance = {
       id: "direct-1",

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -549,7 +549,7 @@ export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudg
       const modeLabel = (m: ConnectionMode) => (m === "browser-api" ? "Direct" : "HTTP API");
       setPendingBudgetSwitch({
         title: "Switch this budget's connection?",
-        message: `"${replacedExisting.label}" is already connected in ${modeLabel(replacedExisting.mode)} mode. Continuing switches it to ${modeLabel(validatedMode)} mode and discards any unsaved changes.`,
+        message: `"${replacedExisting.label}" is already set up in ${modeLabel(replacedExisting.mode)} mode. Continuing switches it to ${modeLabel(validatedMode)} mode and discards any unsaved changes.`,
         destructiveLabel: "Switch mode",
         onConfirm: () => {
           confirmSwitchRef.current = true;

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -57,7 +57,15 @@ function toBudgetFile(budget: Awaited<ReturnType<typeof listBrowserApiBudgets>>[
   };
 }
 
-export function useConnectForm() {
+/** A budget already reachable via a saved (vault) connection, for switch detection. */
+export type SavedBudgetRef = {
+  budgetSyncId: string;
+  mode: ConnectionMode;
+  baseUrl: string;
+  label: string;
+};
+
+export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudgetRef[] } = {}) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const addInstance = useConnectionStore((s) => s.addInstance);
@@ -527,12 +535,16 @@ export function useConnectForm() {
     const selected = budgets.find((b) => b.groupId === selectedGroupId);
     if (!selected) return;
 
-    // If this budget is already connected via a different transport/URL,
-    // reconnecting will replace that entry (one connection per budget). Confirm
-    // the switch first - unless the user already confirmed it.
-    const replacedExisting = instances.find(
-      (i) => i.budgetSyncId === selected.groupId && !(i.mode === validatedMode && i.baseUrl === validatedUrl)
-    );
+    // If this budget is already reachable via a different transport/URL —
+    // either open this session or saved in the vault — reconnecting switches it
+    // (one connection per budget). Confirm first, unless already confirmed.
+    const replacedExisting =
+      instances.find(
+        (i) => i.budgetSyncId === selected.groupId && !(i.mode === validatedMode && i.baseUrl === validatedUrl)
+      ) ??
+      savedBudgets.find(
+        (s) => s.budgetSyncId === selected.groupId && !(s.mode === validatedMode && s.baseUrl === validatedUrl)
+      );
     if (replacedExisting && !confirmSwitchRef.current) {
       const modeLabel = (m: ConnectionMode) => (m === "browser-api" ? "Direct" : "HTTP API");
       setPendingBudgetSwitch({


### PR DESCRIPTION
## Summary

A ground-up visual redesign of the connection screen. Every feature and all the underlying logic (`useConnectForm`, the vault hooks, merge/switch behaviour) are unchanged — this is presentation plus one small correctness fix.

## Highlights

- **Vault security bar** — the vault state now reads unmistakably as a *status* (a coloured dot with "Vault unlocked" / "Vault locked"), while **Lock** and **Change passphrase** are clear buttons. The locked state folds the unlock field and the forgot-passphrase reset into the same bar.
- **Saved servers** — light header rows (server name + a neutral type badge) over crisp budget rows where the whole row connects, with a rule separating each server.
- **Add a server** opens in a sticky workspace on the **right** (idle prompt -> choose a server -> choose a budget) with an animated transition, so nothing pushes the page down. Both columns are equal width.
- **Choose a budget** flags each budget as **open now** or **saved** (matched by Sync ID) so you can tell which you already have and open the ones you don't.
- First-run guidance, a persistent Documentation / GitHub footer, and the full mode names (HTTP API Server / Direct Actual Server) are back.

## Correctness fix

The "switch this budget's connection?" confirmation now also fires when the same budget (by Sync ID) is reachable through a **saved** vault connection in a different mode, not only when it's open in the current session. Covered by a new hook test.

## Testing

- `tsc`, ESLint (0 errors), and the full Jest suite (144 suites / 1356 tests, incl. the new switch-confirm test) pass.
- Production build is clean.
- Light and dark themes verified via the app's design tokens.
