### PR TITLE
Fix offline banner copy and add manual retry

### DIFF
--- a/src/components/layout/ConnectionOfflineBanner.test.tsx
+++ b/src/components/layout/ConnectionOfflineBanner.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ConnectionOfflineBanner } from "./ConnectionOfflineBanner";
+import {
+  ConnectionHealthContext,
+  type ConnectionHealthState,
+} from "@/hooks/useConnectionHealth";
+
+function renderBanner(overrides: Partial<ConnectionHealthState> = {}) {
+  const value: ConnectionHealthState = {
+    status: "offline",
+    latencyMs: null,
+    showBanner: true,
+    recheck: jest.fn(),
+    ...overrides,
+  };
+  render(
+    <ConnectionHealthContext.Provider value={value}>
+      <ConnectionOfflineBanner />
+    </ConnectionHealthContext.Provider>,
+  );
+  return value;
+}
+
+describe("ConnectionOfflineBanner", () => {
+  it("renders nothing when the banner is not active", () => {
+    renderBanner({ showBanner: false });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not claim saves are disabled (copy must match actual behavior)", () => {
+    renderBanner();
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/lost connection to server/i);
+    expect(alert).not.toHaveTextContent(/save disabled/i);
+  });
+
+  it("runs an immediate recheck when 'Retry now' is clicked", () => {
+    const { recheck } = renderBanner();
+    fireEvent.click(screen.getByRole("button", { name: /retry now/i }));
+    expect(recheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button while a check is in flight", () => {
+    renderBanner({ status: "checking" });
+    expect(screen.getByRole("button", { name: /checking/i })).toBeDisabled();
+  });
+});

--- a/src/components/layout/ConnectionOfflineBanner.test.tsx
+++ b/src/components/layout/ConnectionOfflineBanner.test.tsx
@@ -31,6 +31,9 @@ describe("ConnectionOfflineBanner", () => {
     renderBanner();
     const alert = screen.getByRole("alert");
     expect(alert).toHaveTextContent(/lost connection to server/i);
+    expect(alert).toHaveTextContent(
+      /changes may not save until the connection is restored/i,
+    );
     expect(alert).not.toHaveTextContent(/save disabled/i);
   });
 

--- a/src/components/layout/ConnectionOfflineBanner.tsx
+++ b/src/components/layout/ConnectionOfflineBanner.tsx
@@ -2,11 +2,16 @@
 
 import { AlertTriangle } from "lucide-react";
 import { useConnectionHealthContext } from "@/hooks/useConnectionHealth";
+import { Button } from "@/components/ui/button";
 
 export function ConnectionOfflineBanner() {
-  const { showBanner } = useConnectionHealthContext();
+  const { showBanner, status, recheck } = useConnectionHealthContext();
 
   if (!showBanner) return null;
+
+  // While a manual/scheduled check is running, reflect it on the button so the
+  // click has visible feedback (the check itself is guarded against overlap).
+  const checking = status === "checking";
 
   return (
     <div
@@ -15,7 +20,19 @@ export function ConnectionOfflineBanner() {
       className="flex items-center gap-2 border-b border-red-200 bg-red-50 px-4 py-1.5 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400"
     >
       <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-      <span>Lost connection to server - save disabled until reconnected.</span>
+      <span>
+        Lost connection to server - changes may not save until the connection
+        is restored.
+      </span>
+      <Button
+        variant="outline"
+        size="xs"
+        className="ml-auto"
+        onClick={recheck}
+        disabled={checking}
+      >
+        {checking ? "Checking..." : "Retry now"}
+      </Button>
     </div>
   );
 }

--- a/src/hooks/useConnectionHealth.ts
+++ b/src/hooks/useConnectionHealth.ts
@@ -21,6 +21,12 @@ export type ConnectionHealthState = {
   latencyMs: number | null;
   /** True only after 2+ consecutive offline checks — triggers the banner. */
   showBanner: boolean;
+  /**
+   * Run a health check immediately instead of waiting for the next poll.
+   * No-op while a check is already in flight, or when the active connection is
+   * not HTTP-API mode. Backs the banner's "Retry now" action.
+   */
+  recheck: () => void;
 };
 
 const POLL_INTERVAL_MS = 30_000;
@@ -31,6 +37,7 @@ export const ConnectionHealthContext = createContext<ConnectionHealthState>({
   status: "unknown",
   latencyMs: null,
   showBanner: false,
+  recheck: () => {},
 });
 
 export function useConnectionHealthContext(): ConnectionHealthState {
@@ -90,6 +97,12 @@ export function useConnectionHealth(): ConnectionHealthState {
     isChecking.current = false;
   }, []);
 
+  const recheck = useCallback(() => {
+    if (activeInstance && isHttpApiConnection(activeInstance)) {
+      void runCheck(activeInstance.baseUrl, activeInstance.apiKey);
+    }
+  }, [activeInstance, runCheck]);
+
   useEffect(() => {
     // Reset guards on connection change so a stale check doesn't block the new one.
     consecutiveFailures.current = 0;
@@ -134,12 +147,12 @@ export function useConnectionHealth(): ConnectionHealthState {
 
   // When no connection is active derive the reset values during render rather
   // than calling setState in the effect body (which triggers cascading renders).
-  if (!activeInstance) return { status: "unknown", latencyMs: null, showBanner: false };
+  if (!activeInstance) return { status: "unknown", latencyMs: null, showBanner: false, recheck };
   if (isBrowserApiConnection(activeInstance)) {
-    return { status: "direct", latencyMs: null, showBanner: false };
+    return { status: "direct", latencyMs: null, showBanner: false, recheck };
   }
   if (!isHttpApiConnection(activeInstance)) {
-    return { status: "unknown", latencyMs: null, showBanner: false };
+    return { status: "unknown", latencyMs: null, showBanner: false, recheck };
   }
-  return { status, latencyMs, showBanner };
+  return { status, latencyMs, showBanner, recheck };
 }


### PR DESCRIPTION
## What

While looking at reliability for the release, I found the connection-loss banner already exists and is wired into the app shell — but it over-promised and lacked a manual retry:

- **Corrected the copy.** The banner said "save disabled until reconnected," but nothing in the save pipeline (`staged.ts`, `budgetEdits.ts`, `useBudgetSave.ts`) actually gates on connection health — saves are never blocked. The message now matches real behavior: "Lost connection to server - changes may not save until the connection is restored."
- **Added a "Retry now" action.** `useConnectionHealth` now exposes `recheck()`, which runs an immediate health check instead of waiting for the next 30s poll. The button reflects the in-flight "Checking..." state and is disabled while a check runs (overlap is already guarded in the hook).

## Why not gate saves instead

The offline signal is a poll-lagged, HTTP-mode-only heuristic, and the save pipeline is intentionally designed to attempt writes and preserve per-item failures for retry. Hard-blocking Save on a false-positive would trap staged work, so truthful copy is the correct fix.

## Validation

- `npm run lint` — 0 errors on changed files
- `npx tsc --noEmit` — clean
- New `ConnectionOfflineBanner.test.tsx` (renders-nothing-when-inactive, copy-doesn't-claim-save-disabled, retry-calls-recheck, button-disabled-while-checking); existing `useConnectionHealth.test.tsx` still passes
- Local `next build` OOMs in this dev environment; authoritative build runs in CI
