### PR TITLE
Persist saved queries in the database, global across budgets

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -442,7 +442,7 @@ Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) are scoped so they never fi
 - **Explain this query** — one-click plain-English summary of what the current query does: target table, filters, grouping, aggregation, ordering, and whether the result is tabular or scalar
 - **ActualQL Reference** dialog — six-section quick reference covering basics, filter operators, joined fields, aggregates, transactions-specific options, and copyable snippets
 - Built-in example packs in four groups (Data inspection, Cleanup & validation, Aggregation, Targeted subset) — one-click insert into the editor
-- Saved queries — name and save any query locally per budget; load, rerun, duplicate, rename, delete, and pin as favorite
+- Saved queries — name and save any query; persisted in the Actual Bench database and shared across every budget in the instance (not per-browser or per-budget), so they are always available wherever you connect; load, rerun, duplicate, rename, delete, and pin as favorite. Queries saved in earlier versions (previously stored per-budget in the browser) are imported into the database automatically the first time you open the workspace
 - Query history — last 10 executed queries stored per budget in session storage; one-click reload into the editor; deduplicated (re-running the same query bumps it to the top rather than adding a duplicate)
 - Favorites — pin saved queries for fast access; shown at the top of the saved queries panel
 - Banner warns when unsaved staged changes exist — query results reflect saved server state, not pending local edits

--- a/docs-site/src/content/docs/user-guide/actualql.mdx
+++ b/docs-site/src/content/docs/user-guide/actualql.mdx
@@ -65,8 +65,11 @@ does not run the query.
 
 ## Save, pin, and reuse queries
 
-- **Save** a query with a name (stored locally per budget). Load, rerun, duplicate, rename, delete, and
-  **pin as favorite**.
+- **Save** a query with a name. Saved queries are stored in the Actual Bench database and shared
+  across **every budget** in your instance, so they are available wherever you connect (not tied to
+  one browser or budget). Load, rerun, duplicate, rename, delete, and **pin as favorite**. Queries
+  you saved in an earlier version — previously kept per-budget in your browser — are imported into
+  the database automatically the first time you open the workspace.
 - **Query history** keeps the last 10 executed queries per budget for one-click reload; re-running a
   query bumps it to the top rather than duplicating it.
 

--- a/src/app/api/app-db/health/route.test.ts
+++ b/src/app/api/app-db/health/route.test.ts
@@ -33,6 +33,6 @@ describe("GET /api/app-db/health", () => {
 
     expect(response.status).toBe(200);
     expect(body.ready).toBe(true);
-    expect(body.schemaVersion).toBe(9);
+    expect(body.schemaVersion).toBe(10);
   });
 });

--- a/src/app/api/saved-queries/[id]/route.ts
+++ b/src/app/api/saved-queries/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { deleteSavedQuery, updateSavedQuery } from "@/lib/app-db/savedQueryRepository";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const body = await readJsonBody(request);
+    const savedQuery = updateSavedQuery(getAppDb(), id, body);
+    if (!savedQuery) return NextResponse.json({ error: "Saved query not found" }, { status: 404 });
+    return NextResponse.json({ savedQuery });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const deleted = deleteSavedQuery(getAppDb(), id);
+    if (!deleted) return NextResponse.json({ error: "Saved query not found" }, { status: 404 });
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/saved-queries/import/route.ts
+++ b/src/app/api/saved-queries/import/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { importSavedQueries } from "@/lib/app-db/savedQueryRepository";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * One-time migration endpoint (RD-064 / PR-029): accepts the user's legacy
+ * localStorage saved queries as `{ queries: [...] }` and inserts the ones not
+ * already present, deduping by name+query so re-running is harmless.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await readJsonBody(request);
+    const result = importSavedQueries(getAppDb(), body);
+    return NextResponse.json(result);
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/saved-queries/route.ts
+++ b/src/app/api/saved-queries/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  createSavedQuery,
+  listSavedQueries,
+} from "@/lib/app-db/savedQueryRepository";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export function GET() {
+  try {
+    return NextResponse.json({ savedQueries: listSavedQueries(getAppDb()) });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await readJsonBody(request);
+    const savedQuery = createSavedQuery(getAppDb(), body);
+    return NextResponse.json({ savedQuery }, { status: 201 });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/features/query/components/QueryWorkspace.test.tsx
+++ b/src/features/query/components/QueryWorkspace.test.tsx
@@ -1,6 +1,18 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { QueryWorkspace } from "./QueryWorkspace";
 import { useConnectionStore, type BrowserApiConnection } from "@/store/connection";
+
+function renderWorkspace() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <QueryWorkspace />
+    </QueryClientProvider>,
+  );
+}
 
 jest.mock("sonner", () => ({
   toast: Object.assign(jest.fn(), {
@@ -29,6 +41,13 @@ describe("QueryWorkspace", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    // Saved queries are now fetched from the app-DB route; stub it so the
+    // workspace's TanStack query resolves to an empty list in the test env.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ savedQueries: [] })),
+    }) as unknown as typeof fetch;
     useConnectionStore.setState({
       instances: [directConnection],
       activeInstanceId: directConnection.id,
@@ -42,7 +61,7 @@ describe("QueryWorkspace", () => {
   });
 
   it("opens the ActualQL workspace for Direct connections", () => {
-    render(<QueryWorkspace />);
+    renderWorkspace();
 
     expect(screen.getByRole("heading", { name: "ActualQL Queries" })).toBeInTheDocument();
     expect(

--- a/src/features/query/components/QueryWorkspace.tsx
+++ b/src/features/query/components/QueryWorkspace.tsx
@@ -22,16 +22,8 @@ import dynamic from "next/dynamic";
 import { parseQuery, lintQuery } from "../lib/queryValidation";
 import { formatJson } from "../lib/queryFormatting";
 import { explainQuery } from "../lib/queryExplain";
-import {
-  getHistory,
-  addToHistory,
-  clearHistory,
-  getSavedQueries,
-  saveQuery,
-  updateSavedQuery,
-  deleteSavedQuery,
-  duplicateSavedQuery,
-} from "../lib/queryStorage";
+import { getHistory, addToHistory, clearHistory } from "../lib/queryStorage";
+import { useSavedQueries } from "../hooks/useSavedQueries";
 import type { SavedQuery, QueryHistoryEntry, LintWarning, LastExecutedRequest } from "../types";
 
 const DEFAULT_QUERY = JSON.stringify(
@@ -141,7 +133,7 @@ function LeftPanel({
       {activeTab === "saved" && savedQueries.length > 0 && (
         <div className="flex shrink-0 items-center border-b border-border/60 px-3 py-1.5">
           <span className="text-[11px] text-muted-foreground/60">
-            {savedQueries.length} saved · local to this browser
+            {savedQueries.length} saved · available in every budget
           </span>
         </div>
       )}
@@ -202,7 +194,15 @@ export function QueryWorkspace() {
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [saveDefaultName, setSaveDefaultName] = useState("");
   const [history, setHistory] = useState<QueryHistoryEntry[]>([]);
-  const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
+  // Saved/favorite queries are global and DB-backed (RD-064), owned by the hook.
+  const {
+    savedQueries,
+    saveQuery: persistSavedQuery,
+    renameQuery,
+    toggleFavorite,
+    deleteQuery,
+    duplicateQuery,
+  } = useSavedQueries();
 
   // ─── Phase 2 state ────────────────────────────────────────────────────────────
   const [lastExecutedRequest, setLastExecutedRequest] =
@@ -282,7 +282,6 @@ export function QueryWorkspace() {
     setPayloadBytes(null);
     if (!connection) return;
     setHistory(getHistory(connection.budgetSyncId));
-    setSavedQueries(getSavedQueries(connection.budgetSyncId));
   }, [connection]);
 
   // Lint as the user types; also keeps the inline parse-error banner in sync.
@@ -435,10 +434,9 @@ export function QueryWorkspace() {
   }, []);
 
   function handleSaveConfirm(name: string) {
-    if (!connection) return;
-    saveQuery(connection.budgetSyncId, name, editorValue);
-    setSavedQueries(getSavedQueries(connection.budgetSyncId));
-    toast.success(`Saved "${name}"`);
+    persistSavedQuery(name, editorValue)
+      .then(() => toast.success(`Saved "${name}"`))
+      .catch(() => toast.error("Failed to save query"));
   }
 
   // ─── Sidebar actions ─────────────────────────────────────────────────────────
@@ -467,29 +465,23 @@ export function QueryWorkspace() {
   }
 
   function handleDeleteSaved(id: string) {
-    if (!connection) return;
-    deleteSavedQuery(connection.budgetSyncId, id);
-    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+    deleteQuery(id).catch(() => toast.error("Failed to delete query"));
   }
 
   function handleToggleFavorite(id: string) {
-    if (!connection) return;
     const q = savedQueries.find((s) => s.id === id);
     if (!q) return;
-    updateSavedQuery(connection.budgetSyncId, id, { isFavorite: !q.isFavorite });
-    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+    toggleFavorite(id, !q.isFavorite).catch(() => toast.error("Failed to update query"));
   }
 
   function handleRenameSaved(id: string, name: string) {
-    if (!connection) return;
-    updateSavedQuery(connection.budgetSyncId, id, { name });
-    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+    renameQuery(id, name).catch(() => toast.error("Failed to rename query"));
   }
 
   function handleDuplicateSaved(id: string) {
-    if (!connection) return;
-    duplicateSavedQuery(connection.budgetSyncId, id);
-    setSavedQueries(getSavedQueries(connection.budgetSyncId));
+    const q = savedQueries.find((s) => s.id === id);
+    if (!q) return;
+    duplicateQuery(q).catch(() => toast.error("Failed to duplicate query"));
   }
 
   function handleClearHistory() {

--- a/src/features/query/hooks/useSavedQueries.ts
+++ b/src/features/query/hooks/useSavedQueries.ts
@@ -37,9 +37,14 @@ export function useSavedQueries() {
   useEffect(() => {
     if (migrationRan.current) return;
     migrationRan.current = true;
-    void migrateLegacySavedQueriesOnce(api.importSavedQueries).then((imported) => {
-      if (imported > 0) void invalidate();
-    });
+    migrateLegacySavedQueriesOnce(api.importSavedQueries)
+      .then((imported) => {
+        if (imported > 0) void invalidate();
+      })
+      .catch((error) => {
+        // Non-fatal: the flag is only set on success, so this retries next mount.
+        console.error("Legacy saved-query migration failed:", error);
+      });
   }, [invalidate]);
 
   const create = useMutation({

--- a/src/features/query/hooks/useSavedQueries.ts
+++ b/src/features/query/hooks/useSavedQueries.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { SavedQueryRecord } from "@/lib/app-db/types";
+import * as api from "../lib/savedQueriesApi";
+import { migrateLegacySavedQueriesOnce } from "../lib/savedQueriesMigration";
+
+const SAVED_QUERIES_KEY = ["saved-queries"] as const;
+
+/**
+ * Persistent, cross-budget saved ActualQL queries (RD-064 / PR-029).
+ *
+ * Backed by the server-side app DB rather than per-budget localStorage, so the
+ * same list is available from every budget and survives across devices. Exposes
+ * the granular operations the query workspace needs; all writes invalidate the
+ * single global list.
+ */
+export function useSavedQueries() {
+  const queryClient = useQueryClient();
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: SAVED_QUERIES_KEY }),
+    [queryClient]
+  );
+
+  const query = useQuery({
+    queryKey: SAVED_QUERIES_KEY,
+    queryFn: async () => (await api.listSavedQueries()).savedQueries,
+  });
+
+  const savedQueries: SavedQueryRecord[] = query.data ?? [];
+
+  // One-time import of pre-RD-064 per-budget localStorage saved queries into the
+  // global DB. Runs at most once per browser; refetch afterwards so any imported
+  // rows appear. The migration itself is idempotent (dedupes server-side).
+  const migrationRan = useRef(false);
+  useEffect(() => {
+    if (migrationRan.current) return;
+    migrationRan.current = true;
+    void migrateLegacySavedQueriesOnce(api.importSavedQueries).then((imported) => {
+      if (imported > 0) void invalidate();
+    });
+  }, [invalidate]);
+
+  const create = useMutation({
+    mutationFn: (input: api.SavedQueryCreateInput) => api.createSavedQuery(input),
+    onSuccess: invalidate,
+  });
+  const update = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: api.SavedQueryPatch }) =>
+      api.updateSavedQuery(id, patch),
+    onSuccess: invalidate,
+  });
+  const remove = useMutation({
+    mutationFn: (id: string) => api.deleteSavedQuery(id),
+    onSuccess: invalidate,
+  });
+
+  const saveQuery = useCallback(
+    (name: string, queryText: string) => create.mutateAsync({ name, query: queryText }),
+    [create]
+  );
+
+  const renameQuery = useCallback(
+    (id: string, name: string) => update.mutateAsync({ id, patch: { name } }),
+    [update]
+  );
+
+  const toggleFavorite = useCallback(
+    (id: string, isFavorite: boolean) => update.mutateAsync({ id, patch: { isFavorite } }),
+    [update]
+  );
+
+  const deleteQuery = useCallback((id: string) => remove.mutateAsync(id), [remove]);
+
+  const duplicateQuery = useCallback(
+    (source: SavedQueryRecord) =>
+      create.mutateAsync({ name: `${source.name} (copy)`, query: source.query }),
+    [create]
+  );
+
+  return {
+    savedQueries,
+    isLoading: query.isLoading,
+    saveQuery,
+    renameQuery,
+    toggleFavorite,
+    deleteQuery,
+    duplicateQuery,
+  };
+}

--- a/src/features/query/lib/queryStorage.ts
+++ b/src/features/query/lib/queryStorage.ts
@@ -1,108 +1,22 @@
 /**
- * Persistence layer for the ActualQL query workspace.
+ * Session-history persistence for the ActualQL query workspace.
  *
- * Saved queries:  localStorage  — `actualql-saved-queries:${budgetSyncId}`
- * History:        sessionStorage — `actualql-history:${budgetSyncId}`
+ * History: sessionStorage — `actualql-history:${budgetSyncId}`, keyed per budget
+ * and cleared when the browser tab closes, matching the lifetime of the
+ * connection credentials.
  *
- * Both are keyed by `budgetSyncId` so each budget has its own independent
- * set of saved queries and history. History is session-scoped (cleared when
- * the browser tab closes), matching the lifetime of the connection credentials.
+ * Saved/favorite queries are NOT here — as of RD-064 they live in the app DB
+ * (global, cross-budget) and are accessed through `useSavedQueries` /
+ * `savedQueriesApi`, not localStorage.
  */
 
 import { generateId } from "@/lib/uuid";
-import type { SavedQuery, QueryHistoryEntry } from "../types";
+import type { QueryHistoryEntry } from "../types";
 
-// ─── Key helpers ──────────────────────────────────────────────────────────────
-
-function savedKey(budgetSyncId: string): string {
-  return `actualql-saved-queries:${budgetSyncId}`;
-}
+// ─── Key helper ───────────────────────────────────────────────────────────────
 
 function historyKey(budgetSyncId: string): string {
   return `actualql-history:${budgetSyncId}`;
-}
-
-// ─── Saved queries (localStorage) ────────────────────────────────────────────
-
-function readSaved(budgetSyncId: string): SavedQuery[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = localStorage.getItem(savedKey(budgetSyncId));
-    return raw ? (JSON.parse(raw) as SavedQuery[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeSaved(budgetSyncId: string, queries: SavedQuery[]): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.setItem(savedKey(budgetSyncId), JSON.stringify(queries));
-  } catch {
-    // Storage quota exceeded or access denied — degrade gracefully.
-  }
-}
-
-export function getSavedQueries(budgetSyncId: string): SavedQuery[] {
-  return readSaved(budgetSyncId);
-}
-
-export function saveQuery(
-  budgetSyncId: string,
-  name: string,
-  query: string
-): SavedQuery {
-  const existing = readSaved(budgetSyncId);
-  const now = new Date().toISOString();
-  const entry: SavedQuery = {
-    id: generateId(),
-    name,
-    query,
-    createdAt: now,
-    updatedAt: now,
-  };
-  writeSaved(budgetSyncId, [...existing, entry]);
-  return entry;
-}
-
-export function updateSavedQuery(
-  budgetSyncId: string,
-  id: string,
-  patch: Partial<Pick<SavedQuery, "name" | "query" | "isFavorite">>
-): void {
-  const queries = readSaved(budgetSyncId);
-  writeSaved(
-    budgetSyncId,
-    queries.map((q) =>
-      q.id === id ? { ...q, ...patch, updatedAt: new Date().toISOString() } : q
-    )
-  );
-}
-
-export function deleteSavedQuery(budgetSyncId: string, id: string): void {
-  writeSaved(
-    budgetSyncId,
-    readSaved(budgetSyncId).filter((q) => q.id !== id)
-  );
-}
-
-export function duplicateSavedQuery(
-  budgetSyncId: string,
-  id: string
-): SavedQuery | null {
-  const source = readSaved(budgetSyncId).find((q) => q.id === id);
-  if (!source) return null;
-  const now = new Date().toISOString();
-  const copy: SavedQuery = {
-    ...source,
-    id: generateId(),
-    name: `${source.name} (copy)`,
-    createdAt: now,
-    updatedAt: now,
-    isFavorite: false,
-  };
-  writeSaved(budgetSyncId, [...readSaved(budgetSyncId), copy]);
-  return copy;
 }
 
 // ─── History (sessionStorage) ─────────────────────────────────────────────────

--- a/src/features/query/lib/savedQueriesApi.ts
+++ b/src/features/query/lib/savedQueriesApi.ts
@@ -1,0 +1,67 @@
+import type { SavedQueryRecord } from "@/lib/app-db/types";
+
+/**
+ * Thin client for the persistent saved-queries routes (RD-064 / PR-029).
+ *
+ * Saved queries live in the server-side app DB and are global to the instance —
+ * no budget identifier is ever sent. This module is the only bridge between the
+ * query workspace and those routes.
+ */
+
+async function jsonFetch<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    cache: "no-store",
+    headers: init?.body ? { "Content-Type": "application/json" } : undefined,
+    ...init,
+  });
+  const text = await response.text();
+  let data: (T & { error?: string }) | null = null;
+  try {
+    data = (text ? JSON.parse(text) : {}) as T & { error?: string };
+  } catch {
+    // Non-JSON body (e.g. an HTML 500 page): fall through to a status-based error.
+  }
+  if (!response.ok) {
+    throw new Error(data?.error ?? `Request to ${input} failed (${response.status})`);
+  }
+  if (data === null) {
+    throw new Error(`Request to ${input} returned a malformed response.`);
+  }
+  return data;
+}
+
+export type SavedQueryCreateInput = { name: string; query: string; isFavorite?: boolean };
+export type SavedQueryPatch = Partial<Pick<SavedQueryRecord, "name" | "query" | "isFavorite">>;
+
+export function listSavedQueries(): Promise<{ savedQueries: SavedQueryRecord[] }> {
+  return jsonFetch("/api/saved-queries");
+}
+
+export function createSavedQuery(body: SavedQueryCreateInput): Promise<{ savedQuery: SavedQueryRecord }> {
+  return jsonFetch("/api/saved-queries", { method: "POST", body: JSON.stringify(body) });
+}
+
+export function updateSavedQuery(
+  id: string,
+  patch: SavedQueryPatch
+): Promise<{ savedQuery: SavedQueryRecord }> {
+  return jsonFetch(`/api/saved-queries/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+export function deleteSavedQuery(id: string): Promise<void> {
+  return jsonFetch(`/api/saved-queries/${encodeURIComponent(id)}`, { method: "DELETE" }).then(
+    () => undefined
+  );
+}
+
+export function importSavedQueries(
+  queries: SavedQueryCreateInput[]
+): Promise<{ imported: number }> {
+  return jsonFetch("/api/saved-queries/import", {
+    method: "POST",
+    body: JSON.stringify({ queries }),
+  });
+}

--- a/src/features/query/lib/savedQueriesMigration.test.ts
+++ b/src/features/query/lib/savedQueriesMigration.test.ts
@@ -1,0 +1,70 @@
+import {
+  collectLegacySavedQueries,
+  hasMigratedLegacySavedQueries,
+  migrateLegacySavedQueriesOnce,
+} from "./savedQueriesMigration";
+
+describe("saved queries legacy migration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("collects and dedupes saved queries across per-budget keys", () => {
+    localStorage.setItem(
+      "actualql-saved-queries:budget-a",
+      JSON.stringify([
+        { id: "1", name: "Txns", query: '{"table":"transactions"}', isFavorite: true },
+        { id: "2", name: "  ", query: "{}" }, // blank name → skipped
+      ]),
+    );
+    localStorage.setItem(
+      "actualql-saved-queries:budget-b",
+      JSON.stringify([
+        { id: "3", name: "Txns", query: '{"table":"transactions"}' }, // dup across budgets
+        { id: "4", name: "Payees", query: '{"table":"payees"}' },
+      ]),
+    );
+    localStorage.setItem("unrelated-key", JSON.stringify([{ name: "nope", query: "{}" }]));
+
+    const collected = collectLegacySavedQueries();
+    expect(collected.map((q) => q.name).sort()).toEqual(["Payees", "Txns"]);
+    expect(collected.find((q) => q.name === "Txns")?.isFavorite).toBe(true);
+  });
+
+  it("runs the import once and sets the migrated flag on success", async () => {
+    localStorage.setItem(
+      "actualql-saved-queries:budget-a",
+      JSON.stringify([{ id: "1", name: "A", query: "{}" }]),
+    );
+    const importFn = jest.fn().mockResolvedValue({ imported: 1 });
+
+    const first = await migrateLegacySavedQueriesOnce(importFn);
+    expect(first).toBe(1);
+    expect(importFn).toHaveBeenCalledTimes(1);
+    expect(hasMigratedLegacySavedQueries()).toBe(true);
+
+    // Second call is a no-op — already migrated.
+    const second = await migrateLegacySavedQueriesOnce(importFn);
+    expect(second).toBe(0);
+    expect(importFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks migrated without calling import when there is nothing to migrate", async () => {
+    const importFn = jest.fn().mockResolvedValue({ imported: 0 });
+    const result = await migrateLegacySavedQueriesOnce(importFn);
+    expect(result).toBe(0);
+    expect(importFn).not.toHaveBeenCalled();
+    expect(hasMigratedLegacySavedQueries()).toBe(true);
+  });
+
+  it("does not set the flag if the import throws, so it retries next load", async () => {
+    localStorage.setItem(
+      "actualql-saved-queries:budget-a",
+      JSON.stringify([{ id: "1", name: "A", query: "{}" }]),
+    );
+    const importFn = jest.fn().mockRejectedValue(new Error("network"));
+
+    await expect(migrateLegacySavedQueriesOnce(importFn)).rejects.toThrow("network");
+    expect(hasMigratedLegacySavedQueries()).toBe(false);
+  });
+});

--- a/src/features/query/lib/savedQueriesMigration.ts
+++ b/src/features/query/lib/savedQueriesMigration.ts
@@ -1,0 +1,91 @@
+import type { SavedQuery } from "../types";
+import type { SavedQueryCreateInput } from "./savedQueriesApi";
+
+/**
+ * One-time migration of pre-RD-064 saved queries from per-budget localStorage
+ * into the global app DB. Runs once per browser; the flag is only set after a
+ * successful import so a transient failure retries on the next load.
+ */
+
+const LEGACY_KEY_PREFIX = "actualql-saved-queries:";
+const MIGRATED_FLAG = "actualql-saved-queries-migrated";
+
+export function hasMigratedLegacySavedQueries(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return localStorage.getItem(MIGRATED_FLAG) === "1";
+  } catch {
+    // Storage unavailable — treat as migrated so we never loop trying.
+    return true;
+  }
+}
+
+function markMigrated(): void {
+  try {
+    localStorage.setItem(MIGRATED_FLAG, "1");
+  } catch {
+    // Best effort; if we can't persist the flag the import simply re-runs (the
+    // server-side import dedupes by name+query, so re-running is harmless).
+  }
+}
+
+/**
+ * Read and flatten every `actualql-saved-queries:<budgetSyncId>` entry into a
+ * single deduped list. Deduping here keeps the import payload small; the server
+ * dedupes again against existing rows.
+ */
+export function collectLegacySavedQueries(): SavedQueryCreateInput[] {
+  if (typeof window === "undefined") return [];
+  const seen = new Set<string>();
+  const collected: SavedQueryCreateInput[] = [];
+
+  try {
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key?.startsWith(LEGACY_KEY_PREFIX)) continue;
+
+      let entries: SavedQuery[];
+      try {
+        entries = JSON.parse(localStorage.getItem(key) ?? "[]") as SavedQuery[];
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(entries)) continue;
+
+      for (const entry of entries) {
+        if (!entry || typeof entry.name !== "string" || typeof entry.query !== "string") continue;
+        const name = entry.name.trim();
+        if (!name || !entry.query.trim()) continue;
+        const dedupeKey = `${name} ${entry.query}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        collected.push({ name, query: entry.query, isFavorite: entry.isFavorite === true });
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return collected;
+}
+
+/**
+ * Import legacy saved queries once. Returns the number imported (0 if already
+ * migrated or nothing to import). `importFn` is injected so the caller supplies
+ * the app's client (keeps this module free of a fetch dependency to test).
+ */
+export async function migrateLegacySavedQueriesOnce(
+  importFn: (queries: SavedQueryCreateInput[]) => Promise<{ imported: number }>
+): Promise<number> {
+  if (hasMigratedLegacySavedQueries()) return 0;
+
+  const legacy = collectLegacySavedQueries();
+  if (legacy.length === 0) {
+    markMigrated();
+    return 0;
+  }
+
+  const { imported } = await importFn(legacy);
+  markMigrated();
+  return imported;
+}

--- a/src/features/query/lib/savedQueriesMigration.ts
+++ b/src/features/query/lib/savedQueriesMigration.ts
@@ -56,7 +56,9 @@ export function collectLegacySavedQueries(): SavedQueryCreateInput[] {
         if (!entry || typeof entry.name !== "string" || typeof entry.query !== "string") continue;
         const name = entry.name.trim();
         if (!name || !entry.query.trim()) continue;
-        const dedupeKey = `${name} ${entry.query}`;
+        // NUL separator (matches the server-side importSavedQueries dedupe) so
+        // "A"+"B C" and "A B"+"C" never collide and silently drop a query.
+        const dedupeKey = `${name}\u0000${entry.query}`;
         if (seen.has(dedupeKey)) continue;
         seen.add(dedupeKey);
         collected.push({ name, query: entry.query, isFavorite: entry.isFavorite === true });

--- a/src/lib/app-db/connection.test.ts
+++ b/src/lib/app-db/connection.test.ts
@@ -58,7 +58,7 @@ describe("app DB connection", () => {
       const health = getAppDbHealth(dbPath);
       expect(health.ready).toBe(true);
       expect(health.writable).toBe(true);
-      expect(health.schemaVersion).toBe(9);
+      expect(health.schemaVersion).toBe(10);
       expect(health.runtime).toBe("vercel");
       expect(health.durable).toBe(false);
     } finally {
@@ -96,7 +96,7 @@ describe("app DB connection", () => {
       const version = db
         .prepare("SELECT value FROM app_meta WHERE key = ?")
         .get<{ value: string }>("schema_version");
-      expect(version?.value).toBe("9");
+      expect(version?.value).toBe("10");
 
       const sameDb = getAppDb(dbPath);
       expect(sameDb).toBe(db);
@@ -104,7 +104,7 @@ describe("app DB connection", () => {
       const health = getAppDbHealth(dbPath);
       expect(health.ready).toBe(true);
       expect(health.writable).toBe(true);
-      expect(health.schemaVersion).toBe(9);
+      expect(health.schemaVersion).toBe(10);
       expect(health.configuredPath).toBe(dbPath);
     } finally {
       resetAppDbForTests();
@@ -136,7 +136,7 @@ describe("app DB connection", () => {
         .prepare("SELECT COUNT(*) AS count FROM sqlite_schema WHERE type = 'table' AND name = ?")
         .get<{ count: number }>("sync_mappings");
 
-      expect(version?.value).toBe("9");
+      expect(version?.value).toBe("10");
       expect(flowTypeColumn.some((column) => column.name === "flow_type")).toBe(true);
       expect(mappingTable?.count).toBe(1);
     } finally {

--- a/src/lib/app-db/migrations.ts
+++ b/src/lib/app-db/migrations.ts
@@ -4,6 +4,7 @@ import {
   BUDGET_ENCRYPTION_CREDENTIAL_TABLE_SQL,
   CONNECTION_CREDENTIAL_TABLE_SQL,
   REMEMBERED_BUDGET_TABLE_SQL,
+  SAVED_QUERY_TABLE_SQL,
   SERVER_CREDENTIAL_TABLE_SQL,
   FX_INDEX_SQL,
   FX_RATES_TABLE_SQL,
@@ -22,7 +23,7 @@ import {
 import { KDF_VERSION_META_KEY, SALT_META_KEY, VERIFIER_META_KEY } from "./vaultMetaKeys";
 import { AppDbUnavailableError } from "./errors";
 
-export const LATEST_SCHEMA_VERSION = 9;
+export const LATEST_SCHEMA_VERSION = 10;
 
 type Migration = {
   version: number;
@@ -152,6 +153,11 @@ const MIGRATIONS: readonly Migration[] = [
     version: 9,
     // Remembered budgets (RD-063 / PR-028f): one-click reconnect into a budget.
     statements: [REMEMBERED_BUDGET_TABLE_SQL],
+  },
+  {
+    version: 10,
+    // Persistent, cross-budget saved ActualQL queries (RD-064 / PR-029).
+    statements: [SAVED_QUERY_TABLE_SQL],
   },
 ];
 

--- a/src/lib/app-db/savedQueryRepository.test.ts
+++ b/src/lib/app-db/savedQueryRepository.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AppDbValidationError } from "./errors";
+import { getAppDb, resetAppDbForTests } from "./connection";
+import {
+  createSavedQuery,
+  deleteSavedQuery,
+  getSavedQuery,
+  importSavedQueries,
+  listSavedQueries,
+  updateSavedQuery,
+} from "./savedQueryRepository";
+import type { SqliteDatabase } from "./types";
+
+function tempDb(): SqliteDatabase {
+  const root = mkdtempSync(join(tmpdir(), "actual-bench-saved-query-db-"));
+  return getAppDb(join(root, "metadata.sqlite"));
+}
+
+describe("saved query repository", () => {
+  afterEach(() => {
+    resetAppDbForTests();
+  });
+
+  it("creates, lists, updates, and deletes saved queries", () => {
+    const db = tempDb();
+
+    const created = createSavedQuery(db, {
+      name: "Uncategorized",
+      query: '{"table":"transactions"}',
+    });
+    expect(created.id).toBeTruthy();
+    expect(created.isFavorite).toBe(false);
+    expect(created.createdAt).toBe(created.updatedAt);
+
+    expect(listSavedQueries(db)).toHaveLength(1);
+
+    const updated = updateSavedQuery(db, created.id, { name: "All txns", isFavorite: true });
+    expect(updated?.name).toBe("All txns");
+    expect(updated?.isFavorite).toBe(true);
+    expect(updated?.query).toBe('{"table":"transactions"}'); // unchanged fields preserved
+
+    expect(deleteSavedQuery(db, created.id)).toBe(true);
+    expect(deleteSavedQuery(db, created.id)).toBe(false);
+    expect(listSavedQueries(db)).toHaveLength(0);
+  });
+
+  it("is global — a single list is shared regardless of budget", () => {
+    const db = tempDb();
+    createSavedQuery(db, { name: "A", query: '{"table":"payees"}' });
+    createSavedQuery(db, { name: "B", query: '{"table":"accounts"}' });
+    // No budget parameter exists anywhere in the API — the list is instance-wide.
+    expect(listSavedQueries(db).map((q) => q.name).sort()).toEqual(["A", "B"]);
+  });
+
+  it("orders favorites first", () => {
+    const db = tempDb();
+    createSavedQuery(db, { name: "plain", query: "{}" });
+    const fav = createSavedQuery(db, { name: "starred", query: "{}", isFavorite: true });
+    expect(listSavedQueries(db)[0].id).toBe(fav.id);
+  });
+
+  it("rejects empty names and empty queries", () => {
+    const db = tempDb();
+    expect(() => createSavedQuery(db, { name: "  ", query: "{}" })).toThrow(AppDbValidationError);
+    expect(() => createSavedQuery(db, { name: "ok", query: "" })).toThrow(AppDbValidationError);
+  });
+
+  it("returns null when updating a missing query", () => {
+    const db = tempDb();
+    expect(updateSavedQuery(db, "does-not-exist", { name: "x" })).toBeNull();
+  });
+
+  it("imports legacy queries, deduping by name+query and skipping malformed rows", () => {
+    const db = tempDb();
+    createSavedQuery(db, { name: "Existing", query: "{}" });
+
+    const result = importSavedQueries(db, {
+      queries: [
+        { name: "Existing", query: "{}" }, // dup of existing → skip
+        { name: "New one", query: '{"table":"rules"}', isFavorite: true },
+        { name: "New one", query: '{"table":"rules"}' }, // dup within batch → skip
+        { name: "", query: "{}" }, // malformed → skip
+        { totally: "wrong" }, // malformed → skip
+      ],
+    });
+
+    expect(result.imported).toBe(1);
+    const names = listSavedQueries(db).map((q) => q.name).sort();
+    expect(names).toEqual(["Existing", "New one"]);
+    expect(getSavedQuery(db, listSavedQueries(db).find((q) => q.name === "New one")!.id)?.isFavorite).toBe(true);
+  });
+});

--- a/src/lib/app-db/savedQueryRepository.ts
+++ b/src/lib/app-db/savedQueryRepository.ts
@@ -1,0 +1,187 @@
+import { generateId } from "@/lib/uuid";
+import { AppDbValidationError } from "./errors";
+import type { SavedQueryRecord, SqliteDatabase } from "./types";
+
+/**
+ * Persistence for saved ActualQL queries (RD-064 / PR-029).
+ *
+ * These are global to the Actual Bench instance — not scoped to any budget — so
+ * a query saved while connected to one budget is available from every budget.
+ * The table stores only user-authored ActualQL text; there are no secrets or
+ * copied budget data here.
+ */
+
+type SavedQueryRow = {
+  id: string;
+  name: string;
+  query: string;
+  is_favorite: number;
+  created_at: string;
+  updated_at: string;
+};
+
+const NAME_MAX = 200;
+const QUERY_MAX = 100_000;
+
+function rowToRecord(row: SavedQueryRow): SavedQueryRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    query: row.query,
+    isFavorite: row.is_favorite === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeName(value: unknown, required: boolean): string | undefined {
+  if (value === undefined && !required) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new AppDbValidationError("Saved query name is required");
+  }
+  const name = value.trim();
+  if (name.length > NAME_MAX) {
+    throw new AppDbValidationError(`Saved query name must be ${NAME_MAX} characters or fewer`);
+  }
+  return name;
+}
+
+function normalizeQuery(value: unknown, required: boolean): string | undefined {
+  if (value === undefined && !required) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new AppDbValidationError("Saved query text is required");
+  }
+  if (value.length > QUERY_MAX) {
+    throw new AppDbValidationError(`Saved query text must be ${QUERY_MAX} characters or fewer`);
+  }
+  return value;
+}
+
+function normalizeFavorite(value: unknown, defaultValue?: boolean): boolean | undefined {
+  if (value === undefined) return defaultValue;
+  if (typeof value !== "boolean") {
+    throw new AppDbValidationError("Saved query isFavorite must be true or false");
+  }
+  return value;
+}
+
+export function listSavedQueries(db: SqliteDatabase): SavedQueryRecord[] {
+  return db
+    .prepare(
+      "SELECT * FROM saved_queries ORDER BY is_favorite DESC, updated_at DESC, name COLLATE NOCASE ASC"
+    )
+    .all<SavedQueryRow>()
+    .map(rowToRecord);
+}
+
+export function getSavedQuery(db: SqliteDatabase, id: string): SavedQueryRecord | null {
+  const row = db.prepare("SELECT * FROM saved_queries WHERE id = ?").get<SavedQueryRow>(id);
+  return row ? rowToRecord(row) : null;
+}
+
+export function createSavedQuery(db: SqliteDatabase, input: unknown): SavedQueryRecord {
+  if (!isRecord(input)) {
+    throw new AppDbValidationError("Request body must be an object");
+  }
+  const name = normalizeName(input.name, true)!;
+  const query = normalizeQuery(input.query, true)!;
+  const isFavorite = normalizeFavorite(input.isFavorite, false)!;
+  const now = new Date().toISOString();
+  const id = generateId();
+
+  db.prepare(
+    `INSERT INTO saved_queries (id, name, query, is_favorite, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(id, name, query, isFavorite ? 1 : 0, now, now);
+
+  const created = getSavedQuery(db, id);
+  if (!created) throw new AppDbValidationError("Failed to create saved query");
+  return created;
+}
+
+export function updateSavedQuery(
+  db: SqliteDatabase,
+  id: string,
+  input: unknown
+): SavedQueryRecord | null {
+  const existing = getSavedQuery(db, id);
+  if (!existing) return null;
+  if (!isRecord(input)) {
+    throw new AppDbValidationError("Request body must be an object");
+  }
+
+  const name = normalizeName(input.name, false);
+  const query = normalizeQuery(input.query, false);
+  const isFavorite = normalizeFavorite(input.isFavorite);
+  const now = new Date().toISOString();
+
+  db.prepare(
+    `UPDATE saved_queries
+     SET name = ?, query = ?, is_favorite = ?, updated_at = ?
+     WHERE id = ?`
+  ).run(
+    name ?? existing.name,
+    query ?? existing.query,
+    (isFavorite === undefined ? existing.isFavorite : isFavorite) ? 1 : 0,
+    now,
+    id
+  );
+
+  return getSavedQuery(db, id);
+}
+
+export function deleteSavedQuery(db: SqliteDatabase, id: string): boolean {
+  const result = db.prepare("DELETE FROM saved_queries WHERE id = ?").run(id);
+  return result.changes > 0;
+}
+
+/**
+ * Bulk-insert legacy queries during the one-time localStorage → DB migration.
+ * Deduplicates by exact (name, query) against both the incoming batch and the
+ * rows already present, so re-running is safe. Returns the number inserted.
+ */
+export function importSavedQueries(db: SqliteDatabase, input: unknown): { imported: number } {
+  if (!isRecord(input) || !Array.isArray(input.queries)) {
+    throw new AppDbValidationError("Import body must be { queries: [...] }");
+  }
+
+  const existing = listSavedQueries(db);
+  const seen = new Set(existing.map((q) => `${q.name}\u0000${q.query}`));
+
+  const insert = db.prepare(
+    `INSERT INTO saved_queries (id, name, query, is_favorite, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  );
+
+  const items: unknown[] = input.queries;
+  let imported = 0;
+  const run = db.transaction(() => {
+    for (const item of items) {
+      if (!isRecord(item)) continue;
+      // Skip malformed legacy entries silently — a bad row must not abort import.
+      let name: string;
+      let query: string;
+      try {
+        name = normalizeName(item.name, true)!;
+        query = normalizeQuery(item.query, true)!;
+      } catch {
+        continue;
+      }
+      const key = `${name}\u0000${query}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const isFavorite = item.isFavorite === true;
+      const now = new Date().toISOString();
+      insert.run(generateId(), name, query, isFavorite ? 1 : 0, now, now);
+      imported += 1;
+    }
+  });
+
+  run();
+  return { imported };
+}

--- a/src/lib/app-db/schema.ts
+++ b/src/lib/app-db/schema.ts
@@ -194,6 +194,21 @@ CREATE TABLE IF NOT EXISTS remembered_budgets (
 );
 `;
 
+// ── Saved ActualQL queries (RD-064 / PR-029) ─────────────────────────────────
+// Global to the Actual Bench instance — intentionally NOT budget-scoped, so a
+// saved query written against one budget is available from every budget. Holds
+// only user-authored ActualQL text (no secrets, no copied budget data).
+export const SAVED_QUERY_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS saved_queries (
+  id text PRIMARY KEY,
+  name text NOT NULL,
+  query text NOT NULL,
+  is_favorite integer NOT NULL DEFAULT 0,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+`;
+
 // ── FX / multi-currency consolidation (RD-056 / PR-025a) ─────────────────────
 // The database is the authoritative FX registry; Frankfurter only populates it.
 export const FX_RATE_IMPORT_BATCH_TABLE_SQL = `

--- a/src/lib/app-db/types.ts
+++ b/src/lib/app-db/types.ts
@@ -374,3 +374,17 @@ export type RememberedBudgetInput = {
   budgetSyncId: string;
   name?: string;
 };
+
+// ── Saved ActualQL queries (RD-064 / PR-029) ─────────────────────────────────
+// Global (not budget-scoped). `isFavorite` is stored as an integer column and
+// normalized to boolean by the repository. Shape is structurally compatible
+// with the query feature's client-side `SavedQuery` type.
+export type SavedQueryRecord = {
+  id: string;
+  name: string;
+  /** Raw ActualQL JSON string as the user wrote it. */
+  query: string;
+  isFavorite: boolean;
+  createdAt: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
## What

Saved and favorite ActualQL queries were persisted only in per-budget browser `localStorage`, so they were invisible from other budgets, other browsers, and other devices, and lost if browser storage was cleared. This moves them into the server-side app database as **global, cross-budget records** — the same saved-query list is available wherever you connect.

## Changes

- **Schema v10** — new global `saved_queries` table (no budget column, intentionally instance-wide).
- **Repository** `savedQueryRepository.ts` — list/get/create/update/delete/importMany with validation (favorites ordered first) + colocated tests.
- **API routes** — `GET/POST /api/saved-queries`, `PATCH/DELETE /api/saved-queries/[id]`, `POST /api/saved-queries/import`.
- **Client** — `savedQueriesApi.ts` (jsonFetch) + `useSavedQueries` TanStack hook (single global key, invalidate-on-write).
- **One-time migration** — `savedQueriesMigration.ts` collects all `actualql-saved-queries:*` localStorage entries, dedupes, imports them once on first workspace open, and sets a flag only on success (so a transient failure retries) + tests.
- **Workspace** — `QueryWorkspace` wired to the hook; `budgetSyncId` dropped from saved-query calls; panel copy updated ("local to this browser" → "available in every budget"). `queryStorage.ts` keeps only session **history** (unchanged).

## Notes

- Query **history** is intentionally out of scope — it stays session-scoped and per-budget.
- Like all app-DB features (sync, FX), cross-device persistence depends on a durable DB — durable self-hosted (`/data`), non-durable on Vercel unless configured.

## Validation

- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm test` — full suite green (1373 tests); four app-DB schema-version pins updated 9 → 10
- Local `next build` OOMs in the dev environment; the docs-site build was not run locally — both are covered by CI
