### PR TITLE
Default release drafts to a patch bump

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,16 +25,21 @@ template: |
 
   **Full Changelog**: https://github.com/x-rous/actual-bench/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
+# Default every release to a patch bump. A minor/major bump is opt-in via an
+# explicit 'minor'/'major' label on a PR — feature PRs still appear under the
+# "🚀 Features" section above, but no longer force a minor version bump on their
+# own (which previously auto-proposed e.g. v1.3.0 instead of a patch v1.2.6).
 version-resolver:
   major:
     labels:
       - 'major'
   minor:
     labels:
-      - 'feature'
+      - 'minor'
   patch:
     labels:
       - 'fix'
       - 'maintenance'
       - 'docs'
+      - 'feature'
   default: patch


### PR DESCRIPTION
## What

Default release drafts to a **patch** bump.

Previously the `feature` label mapped to a **minor** bump in the release-drafter version resolver, so any release containing a feature PR auto-proposed the next *minor* version (e.g. `v1.3.0`) instead of a patch (`v1.2.6`). That repeatedly overrode the intended patch version on the draft.

## Change

In `.github/release-drafter.yml`:
- `minor` now requires an explicit **`minor`** label (and `major` an explicit `major` label).
- `feature` moves into the **`patch`** resolver, so feature PRs bump patch by default.
- Feature PRs still appear under the **🚀 Features** section of the notes (categories are independent of the version resolver).

Net effect: releases default to patch; a minor/major bump is an explicit opt-in via a label on a PR.
