### PR TITLE
Budget grid: spending bars and orient-to-current-month

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -271,7 +271,7 @@ A multi-month budget editing workspace with staged cell editing, a draft review 
 - 12-month window navigator: back/forward by 1 month (`‹ ›`) or 1 year (`«»`), plus a "go to current month" calendar button; range label displays as "Jan '26 – Dec '26"
 - Opens oriented on the current month, and the current-month column is highlighted (bold + accent border, `aria-current`) so "now" is obvious at a glance
 - Cell-view toggle: **Budget** / **Actuals** / **Balance** — switches what value each month cell displays
-- **Spending bars** (toggle, on by default): a thin bar under each editable expense cell shows spent ÷ budgeted for that month — green under budget, amber approaching the limit, and a red overflow segment when over; a distinct red bar flags spending from an unfunded envelope. The bar keeps the 12-month width and row height; exact spent/balance stay in the cell tooltip and details panel. Income cells show no bar.
+- **Spending Bars** (toolbar toggle, on by default): a thin bar under each editable expense cell — and under each group-total cell — shows spent ÷ budgeted for that month — green under budget, amber approaching the limit, and a red overflow segment when over; a distinct red bar flags spending from an unfunded envelope/group. The bar keeps the 12-month width and row height; exact spent/balance stay in the cell tooltip and details panel. Income rows show no bar.
 - Expand all / Collapse all group buttons
 - Show / Hide hidden categories toggle
 - Import and Export buttons (UTF-8 CSV with BOM)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -268,8 +268,10 @@ A multi-month budget editing workspace with staged cell editing, a draft review 
 
 ### Toolbar
 - Budget mode badge (`Envelope`, `Tracking`, or `Unknown`) always visible at the left
-- 12-month window navigator: back/forward by 1 month (`‹ ›`) or 1 year (`«»`), plus a "go to current year" calendar button; range label displays as "Jan '26 – Dec '26"
+- 12-month window navigator: back/forward by 1 month (`‹ ›`) or 1 year (`«»`), plus a "go to current month" calendar button; range label displays as "Jan '26 – Dec '26"
+- Opens oriented on the current month, and the current-month column is highlighted (bold + accent border, `aria-current`) so "now" is obvious at a glance
 - Cell-view toggle: **Budget** / **Actuals** / **Balance** — switches what value each month cell displays
+- **Spending bars** (toggle, on by default): a thin bar under each editable expense cell shows spent ÷ budgeted for that month — green under budget, amber approaching the limit, and a red overflow segment when over; a distinct red bar flags spending from an unfunded envelope. The bar keeps the 12-month width and row height; exact spent/balance stay in the cell tooltip and details panel. Income cells show no bar.
 - Expand all / Collapse all group buttons
 - Show / Hide hidden categories toggle
 - Import and Export buttons (UTF-8 CSV with BOM)
@@ -282,7 +284,7 @@ A multi-month budget editing workspace with staged cell editing, a draft review 
 - Mode-specific summary section above the category groups:
   - **Envelope mode**: Available Funds (+), Overspent Last Month (−), Budgeted (−), Hold for next month (−), and a **To Budget / Overbudget** (=) total row
   - **Tracking mode**: compact status rows for Result, Spending vs Budgeted, and Income. Past months show actual performance, the current month is marked partial, and future months show budgeted context instead of zero-actual performance.
-- The 12-month window defaults to January of the current year; the user can navigate freely to any period
+- The 12-month window defaults to the current calendar year and opens scrolled to the current month; the user can navigate freely to any period, and the calendar button returns to the current month
 
 ### Staged Cell Editing
 - Click, double-click, Enter, or F2 to enter edit mode; blur or Enter to commit; Escape to cancel

--- a/docs-site/src/content/docs/user-guide/budget-management.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-management.mdx
@@ -37,10 +37,20 @@ Use the cell-view toggle in the toolbar (also the `V` key) to switch what every 
 - **Actuals** — actual activity.
 - **Balance** — the running balance.
 
+### See spending at a glance
+
+In the **Budget** view, a thin **spending bar** under each editable expense cell shows how much of that
+month's envelope you've spent — filling green as you spend, amber as you approach the limit, and adding a
+red segment when you go over. A cell you spent from without funding shows a distinct red bar. The exact
+spent and balance numbers stay in the cell's hover tooltip and the details panel. Turn the bars off or on
+with the **Bars** toggle in the toolbar (on by default); income rows never show a bar.
+
 ## Navigate months and years
 
+- The workspace opens on the current calendar year, scrolled to the **current month**, which is
+  highlighted so it's easy to find.
 - Move the 12-month window back/forward by one month with `‹` / `›`, or by a year with `«` / `»`.
-- Use the calendar button to jump to the current year.
+- Use the calendar button to jump back to the current month at any time.
 - The `[` and `]` keys pan the window backward/forward by one month.
 
 ## Expand, collapse, and hide

--- a/docs-site/src/content/docs/user-guide/budget-management.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-management.mdx
@@ -39,11 +39,12 @@ Use the cell-view toggle in the toolbar (also the `V` key) to switch what every 
 
 ### See spending at a glance
 
-In the **Budget** view, a thin **spending bar** under each editable expense cell shows how much of that
-month's envelope you've spent — filling green as you spend, amber as you approach the limit, and adding a
-red segment when you go over. A cell you spent from without funding shows a distinct red bar. The exact
-spent and balance numbers stay in the cell's hover tooltip and the details panel. Turn the bars off or on
-with the **Bars** toggle in the toolbar (on by default); income rows never show a bar.
+In the **Budget** view, a thin **spending bar** under each editable expense cell — and under each
+group-total cell — shows how much of that month's envelope you've spent — filling green as you spend,
+amber as you approach the limit, and adding a red segment when you go over. A cell you spent from without
+funding shows a distinct red bar. The exact spent and balance numbers stay in the cell's hover tooltip and
+the details panel. Turn the bars off or on with the **Spending Bars** toggle in the toolbar (on by
+default); income rows never show a bar.
 
 ## Navigate months and years
 

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -449,7 +449,7 @@ export function BudgetCell({
       className={`${cellClass}${dimClass}`}
       role="gridcell"
       tabIndex={0}
-      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}${spendingBar && spendingBar.tier !== "none" ? ` - spent ${formatMinor(spentMinor)}${overNote}` : ""}`}
+      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}${spendingBar && spentMinor > 0 ? ` - spent ${formatMinor(spentMinor)}${overNote}` : ""}`}
       aria-selected={isSelected}
       onPointerDown={handlePointerDown}
       onPointerEnter={handlePointerEnter}

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -5,7 +5,7 @@ import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useEffectiveMonthFromContext } from "../context/MonthsDataContext";
 import { parseBudgetExpression } from "../lib/budgetMath";
 import { formatMinor } from "../lib/format";
-import { computeSpendingBar } from "../lib/spendingBar";
+import { computeSpendingBar, spendingTierLabel } from "../lib/spendingBar";
 import { SpendingBarView } from "./grid/SpendingBarView";
 import { isIncomeBlocked, isLargeChange } from "../lib/budgetValidation";
 import { useCellKeymap, useCellEditKeymap } from "../keyboard/useBudgetKeymap";
@@ -319,6 +319,18 @@ export function BudgetCell({
       ? " (unbudgeted)"
       : "";
 
+  // Full spoken status for the cell: every tier (not just over/unbudgeted) plus
+  // budgeted / spent / balance, so the bar's colour is never the only signal and
+  // the balance promised in cell labels is present.
+  const barStatusNote =
+    spendingBar && spendingBar.tier !== "empty"
+      ? ` - budgeted ${formatMinor(currentBudgeted)}, spent ${formatMinor(
+          spentMinor
+        )}, balance ${formatMinor(effectiveCategory.balance)} (${spendingTierLabel(
+          spendingBar.tier
+        )})`
+      : "";
+
   // Hover tooltip: show spent/balance when in budgeted view (they aren't directly visible).
   const hoverTitle =
     isReadOnlyMonth && !hasMonthData
@@ -454,7 +466,7 @@ export function BudgetCell({
       className={`${cellClass}${dimClass}`}
       role="gridcell"
       tabIndex={0}
-      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}${spendingBar && spentMinor > 0 ? ` - spent ${formatMinor(spentMinor)}${overNote}` : ""}`}
+      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}${barStatusNote}`}
       aria-selected={isSelected}
       onPointerDown={handlePointerDown}
       onPointerEnter={handlePointerEnter}

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -125,7 +125,12 @@ export function BudgetCell({
   /** Returns true if commit succeeded (valid parse), false on error. */
   const commitEdit = (): boolean => {
     if (!editing) return true;
-    const result = parseBudgetExpression(inputValue);
+    // Clearing the cell and pressing Enter sets it to 0 rather than erroring —
+    // an empty field is a deliberate "no budget", not an invalid expression.
+    const result =
+      inputValue.trim() === ""
+        ? ({ ok: true, value: 0 } as const)
+        : parseBudgetExpression(inputValue);
     if (!result.ok) {
       setInputError(result.error);
       return false;

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -5,7 +5,8 @@ import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useEffectiveMonthFromContext } from "../context/MonthsDataContext";
 import { parseBudgetExpression } from "../lib/budgetMath";
 import { formatMinor } from "../lib/format";
-import { computeSpendingBar, type SpendingTier } from "../lib/spendingBar";
+import { computeSpendingBar } from "../lib/spendingBar";
+import { SpendingBarView } from "./grid/SpendingBarView";
 import { isIncomeBlocked, isLargeChange } from "../lib/budgetValidation";
 import { useCellKeymap, useCellEditKeymap } from "../keyboard/useBudgetKeymap";
 import type { BudgetCellKey, BudgetMode, CellView, LoadedCategory, NavDirection } from "../types";
@@ -38,16 +39,6 @@ type Props = {
   isReadOnlyMonth?: boolean;
   /** RD-065: draw the spent-vs-budget bar under editable expense cells. */
   showSpendingBars?: boolean;
-};
-
-/** Tailwind classes for the green/amber base fill by tier (RD-065). */
-const BAR_FILL_CLASS: Record<Exclude<SpendingTier, "none">, string> = {
-  under: "bg-emerald-500/70 dark:bg-emerald-400/60",
-  near: "bg-amber-500/80",
-  over: "bg-amber-500/80",
-  // Distinct from `over` (amber + red overflow): a solid muted red means money
-  // left an envelope that was never funded.
-  unbudgeted: "bg-red-500/45",
 };
 
 /** BM-16: minimum pointer travel (CSS px) before treating a drag as range-select. */
@@ -500,23 +491,7 @@ export function BudgetCell({
         />
       )}
 
-      {spendingBar && spendingBar.tier !== "none" && (
-        <span
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-foreground/5"
-          aria-hidden="true"
-        >
-          <span
-            className={`absolute bottom-0 left-0 h-full ${BAR_FILL_CLASS[spendingBar.tier]}`}
-            style={{ width: `${spendingBar.fill * 100}%` }}
-          />
-          {spendingBar.overflow > 0 && (
-            <span
-              className="absolute bottom-0 right-0 h-full bg-red-500"
-              style={{ width: `${spendingBar.overflow * 100}%` }}
-            />
-          )}
-        </span>
-      )}
+      {spendingBar && <SpendingBarView bar={spendingBar} />}
     </div>
   );
 }

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -5,6 +5,7 @@ import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useEffectiveMonthFromContext } from "../context/MonthsDataContext";
 import { parseBudgetExpression } from "../lib/budgetMath";
 import { formatMinor } from "../lib/format";
+import { computeSpendingBar, type SpendingTier } from "../lib/spendingBar";
 import { isIncomeBlocked, isLargeChange } from "../lib/budgetValidation";
 import { useCellKeymap, useCellEditKeymap } from "../keyboard/useBudgetKeymap";
 import type { BudgetCellKey, BudgetMode, CellView, LoadedCategory, NavDirection } from "../types";
@@ -35,6 +36,18 @@ type Props = {
   isDimmed?: boolean;
   /** Historical month missing from the API; visible for context but not editable. */
   isReadOnlyMonth?: boolean;
+  /** RD-065: draw the spent-vs-budget bar under editable expense cells. */
+  showSpendingBars?: boolean;
+};
+
+/** Tailwind classes for the green/amber base fill by tier (RD-065). */
+const BAR_FILL_CLASS: Record<Exclude<SpendingTier, "none">, string> = {
+  under: "bg-emerald-500/70 dark:bg-emerald-400/60",
+  near: "bg-amber-500/80",
+  over: "bg-amber-500/80",
+  // Distinct from `over` (amber + red overflow): a solid muted red means money
+  // left an envelope that was never funded.
+  unbudgeted: "bg-red-500/45",
 };
 
 /** BM-16: minimum pointer travel (CSS px) before treating a drag as range-select. */
@@ -63,6 +76,7 @@ export function BudgetCell({
   onContextMenuRequest,
   isDimmed,
   isReadOnlyMonth = false,
+  showSpendingBars = false,
 }: Props) {
   const dimClass = isDimmed ? " opacity-50" : "";
   const key: BudgetCellKey = `${month}:${category.id}`;
@@ -290,12 +304,31 @@ export function BudgetCell({
     />
   ) : null;
 
+  // RD-065 spending bar: spent as a positive magnitude (actuals are negative for
+  // expenses; a net inflow reads as zero spent). Only for editable expense cells
+  // that have month data, and only when the toggle is on.
+  const spentMinor = Math.max(0, -effectiveCategory.actuals);
+  const overByMinor = spentMinor - currentBudgeted;
+  const spendingBar =
+    showSpendingBars && !category.isIncome && hasMonthData
+      ? computeSpendingBar(currentBudgeted, spentMinor)
+      : null;
+
+  // A text signal for the bar so nothing is conveyed by colour alone (used in
+  // the aria-label and appended to the tooltip).
+  const overNote =
+    spendingBar?.tier === "over"
+      ? ` (over by ${formatMinor(overByMinor)})`
+      : spendingBar?.tier === "unbudgeted"
+      ? " (unbudgeted)"
+      : "";
+
   // Hover tooltip: show spent/balance when in budgeted view (they aren't directly visible).
   const hoverTitle =
     isReadOnlyMonth && !hasMonthData
       ? "No budget exists for this past month; budget cells are read-only."
       : cellView === "budgeted"
-      ? `Spent: ${formatMinor(effectiveCategory.actuals)} | Balance: ${formatMinor(effectiveCategory.balance)}`
+      ? `Spent: ${formatMinor(effectiveCategory.actuals)} | Balance: ${formatMinor(effectiveCategory.balance)}${overNote}`
       : undefined;
 
   // ─── Non-editable cell ───────────────────────────────────────────────────────
@@ -425,7 +458,7 @@ export function BudgetCell({
       className={`${cellClass}${dimClass}`}
       role="gridcell"
       tabIndex={0}
-      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}`}
+      aria-label={`${category.name} budget for ${month}${stagedEdit ? " (unsaved)" : ""}${hasSaveError ? " - save error" : ""}${spendingBar && spendingBar.tier !== "none" ? ` - spent ${formatMinor(spentMinor)}${overNote}` : ""}`}
       aria-selected={isSelected}
       onPointerDown={handlePointerDown}
       onPointerEnter={handlePointerEnter}
@@ -465,6 +498,24 @@ export function BudgetCell({
           aria-hidden="true"
           title={stagedEdit?.saveError}
         />
+      )}
+
+      {spendingBar && spendingBar.tier !== "none" && (
+        <span
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-foreground/5"
+          aria-hidden="true"
+        >
+          <span
+            className={`absolute bottom-0 left-0 h-full ${BAR_FILL_CLASS[spendingBar.tier]}`}
+            style={{ width: `${spendingBar.fill * 100}%` }}
+          />
+          {spendingBar.overflow > 0 && (
+            <span
+              className="absolute bottom-0 right-0 h-full bg-red-500"
+              style={{ width: `${spendingBar.overflow * 100}%` }}
+            />
+          )}
+        </span>
       )}
     </div>
   );

--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -40,6 +40,8 @@ type Props = {
   onToggleCollapse: (groupId: string) => void;
   /** When true, hidden groups/categories are rendered dimmed; when false they are omitted. */
   showHidden: boolean;
+  /** RD-065: draw the spent-vs-budget bar under editable expense cells. */
+  showSpendingBars?: boolean;
   onCellFocus: (categoryId: string, month: string) => void;
   onCellRangeSelect: (categoryId: string, month: string) => void;
   onCellNavigate?: (categoryId: string, month: string, dir: NavDirection) => void;
@@ -93,6 +95,7 @@ export function BudgetGrid({
   collapsedGroups,
   onToggleCollapse,
   showHidden,
+  showSpendingBars,
   onCellFocus,
   onCellRangeSelect,
   onCellNavigate,
@@ -261,6 +264,7 @@ export function BudgetGrid({
     dragStateRef,
     suppressNextClickRef: suppressNextClickClearRef,
     showHidden,
+    showSpendingBars,
     onCellFocus,
     onCellRangeSelect,
     onCellNavigate,

--- a/src/features/budget-management/components/BudgetManagementView.tsx
+++ b/src/features/budget-management/components/BudgetManagementView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { addMonths } from "@/lib/budget/monthMath";
+import { addMonths, currentMonth } from "@/lib/budget/monthMath";
 import type { CellView } from "../types";
 import { useBudgetMode } from "../hooks/useBudgetMode";
 import { useAvailableMonths } from "../hooks/useAvailableMonths";
@@ -78,6 +78,9 @@ export function BudgetManagementView() {
     () => new Set()
   );
   const [showHidden, setShowHidden] = useState(true);
+  // RD-065: spent-vs-budget bars under editable cells. On by default.
+  const [showSpendingBars, setShowSpendingBars] = useState(true);
+  const handleToggleSpendingBars = useCallback(() => setShowSpendingBars((v) => !v), []);
 
   const handleToggleGroupCollapse = useCallback((groupId: string) => {
     setCollapsedGroups((prev) => {
@@ -202,8 +205,33 @@ export function BudgetManagementView() {
     setWindowStart((s) => addMonths(s, 1));
   }, []);
 
+  // F-079 orient-to-now: bring the current-month column into view (centered).
+  const scrollCurrentMonthIntoView = useCallback(() => {
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-month-header="${currentMonth()}"]`)
+        ?.scrollIntoView({ inline: "center", block: "nearest" });
+    });
+  }, []);
+
+  // Calendar toolbar button: jump to the window containing the current month and
+  // scroll it into view (previously only reset to January of the current year).
+  const handleGoToCurrentMonth = useCallback(() => {
+    setWindowStart(defaultWindowStart());
+    scrollCurrentMonthIntoView();
+  }, [scrollCurrentMonthIntoView]);
+
+  // On first load, land oriented on "now" rather than on January.
+  const didInitialScroll = useRef(false);
+
   const isLoading = modeLoading || monthsLoading;
   const hasError = !!modeError || !!monthsError;
+
+  useEffect(() => {
+    if (didInitialScroll.current || isLoading || hasError || hasEntityChanges) return;
+    didInitialScroll.current = true;
+    scrollCurrentMonthIntoView();
+  }, [isLoading, hasError, hasEntityChanges, scrollCurrentMonthIntoView]);
 
   if (isLoading) {
     return (
@@ -250,12 +278,15 @@ export function BudgetManagementView() {
         budgetMode={budgetMode ?? "unidentified"}
         windowStart={windowStart}
         onWindowChange={setWindowStart}
+        onGoToCurrentMonth={handleGoToCurrentMonth}
         cellView={cellView}
         onCellViewChange={setCellView}
         onExpandAll={handleExpandAll}
         onCollapseAll={handleCollapseAll}
         showHidden={showHidden}
         onToggleShowHidden={handleToggleShowHidden}
+        showSpendingBars={showSpendingBars}
+        onToggleSpendingBars={handleToggleSpendingBars}
         onExport={handleOpenExport}
         onImport={handleOpenImport}
         onShowShortcuts={() => setShortcutsHelpOpen(true)}
@@ -276,6 +307,7 @@ export function BudgetManagementView() {
         collapsedGroups={collapsedGroups}
         onToggleCollapse={handleToggleGroupCollapse}
         showHidden={showHidden}
+        showSpendingBars={showSpendingBars}
         onOpenTransfer={budgetMode === "envelope" ? handleOpenTransfer : undefined}
       />
 

--- a/src/features/budget-management/components/BudgetManagementView.tsx
+++ b/src/features/budget-management/components/BudgetManagementView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { addMonths, currentMonth } from "@/lib/budget/monthMath";
+import { addMonths } from "@/lib/budget/monthMath";
 import type { CellView } from "../types";
 import { useBudgetMode } from "../hooks/useBudgetMode";
 import { useAvailableMonths } from "../hooks/useAvailableMonths";
@@ -206,12 +206,21 @@ export function BudgetManagementView() {
   }, []);
 
   // F-079 orient-to-now: bring the current-month column into view (centered).
+  // The grid loads its month data independently (its own useMonthsData), so on a
+  // cold load the header may not exist for several frames — retry until the
+  // marker mounts, capped at ~3s so we never spin. The marker is always present
+  // on the current-month header, even when that month isn't yet available.
   const scrollCurrentMonthIntoView = useCallback(() => {
-    requestAnimationFrame(() => {
-      document
-        .querySelector(`[data-month-header="${currentMonth()}"]`)
-        ?.scrollIntoView({ inline: "center", block: "nearest" });
-    });
+    const deadline = performance.now() + 3000;
+    const tick = () => {
+      const el = document.querySelector("[data-current-month-header]");
+      if (el) {
+        el.scrollIntoView({ inline: "center", block: "nearest" });
+        return;
+      }
+      if (performance.now() < deadline) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
   }, []);
 
   // Calendar toolbar button: jump to the window containing the current month and

--- a/src/features/budget-management/components/BudgetSelectionSummary.test.tsx
+++ b/src/features/budget-management/components/BudgetSelectionSummary.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { BudgetSelectionSummary } from "./BudgetSelectionSummary";
+import type { BudgetCellSelection, LoadedCategory } from "../types";
+
+// The summary reads effective per-month budgeted values from the months
+// context; provide a minimal fixture so the sum/average can be computed.
+const effective = new Map<string, { categoriesById: Record<string, { budgeted: number }> }>([
+  ["2026-08", { categoriesById: { a: { budgeted: 10_000 }, b: { budgeted: 30_000 } } }],
+]);
+
+jest.mock("../context/MonthsDataContext", () => ({
+  useMonthsData: () => ({ effective }),
+}));
+
+const categories = [
+  { id: "a", name: "Groceries" },
+  { id: "b", name: "Rent" },
+] as unknown as LoadedCategory[];
+
+describe("BudgetSelectionSummary sum/average", () => {
+  it("shows the sum and average of the selected cells' budgeted values", () => {
+    const selection: BudgetCellSelection = {
+      anchorCategoryId: "a",
+      anchorMonth: "2026-08",
+      focusCategoryId: "b",
+      focusMonth: "2026-08",
+    };
+
+    render(
+      <BudgetSelectionSummary
+        selection={selection}
+        activeMonths={["2026-08"]}
+        categories={categories}
+      />,
+    );
+
+    // Sum of 100.00 + 300.00, average 200.00.
+    expect(screen.getByLabelText(/Sum of selected: 400\.00/)).toHaveTextContent("Σ 400.00");
+    expect(screen.getByLabelText(/Average of selected: 200\.00/)).toHaveTextContent("avg 200.00");
+  });
+
+  it("shows no selection stats when nothing is selected", () => {
+    render(
+      <BudgetSelectionSummary selection={null} activeMonths={["2026-08"]} categories={categories} />,
+    );
+    expect(screen.queryByLabelText(/Sum of selected/)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/budget-management/components/BudgetSelectionSummary.tsx
+++ b/src/features/budget-management/components/BudgetSelectionSummary.tsx
@@ -3,7 +3,8 @@
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import type { BudgetCellKey, BudgetCellSelection, LoadedCategory } from "../types";
 import { resolveSelectionCells } from "../lib/budgetSelectionUtils";
-import { formatDelta } from "../lib/format";
+import { useMonthsData } from "../context/MonthsDataContext";
+import { formatDelta, formatMinor } from "../lib/format";
 
 type Props = {
   selection: BudgetCellSelection | null;
@@ -24,6 +25,8 @@ export function BudgetSelectionSummary({
   categories,
 }: Props) {
   const edits = useBudgetEditsStore((s) => s.edits);
+  // Effective (staged-or-server) per-month budgeted values, for the sum/average.
+  const { effective } = useMonthsData();
 
   // ── Global stats (no category lookup needed) ──────────────────────────────
   const editValues = Object.values(edits);
@@ -37,6 +40,7 @@ export function BudgetSelectionSummary({
   let selectionCells: { month: string; categoryId: string }[] = [];
   let selectionStagedCount = 0;
   let selectionDelta = 0;
+  let selectionSum = 0;
 
   if (selection && categories.length > 0) {
     selectionCells = resolveSelectionCells(selection, activeMonths, categories);
@@ -47,8 +51,13 @@ export function BudgetSelectionSummary({
         selectionStagedCount++;
         selectionDelta += edit.nextBudgeted - edit.previousBudgeted;
       }
+      selectionSum +=
+        effective.get(cell.month)?.categoriesById[cell.categoryId]?.budgeted ?? 0;
     }
   }
+
+  const selectionAvg =
+    selectionCells.length > 0 ? selectionSum / selectionCells.length : 0;
 
   const selectedMonthSet = new Set(selectionCells.map((c) => c.month));
   const selectedCatSet = new Set(selectionCells.map((c) => c.categoryId));
@@ -97,6 +106,18 @@ export function BudgetSelectionSummary({
           </span>
           <span aria-label={`${selectedMonthSet.size} months, ${selectedCatSet.size} categories`}>
             ({selectedMonthSet.size} mo × {selectedCatSet.size} cat)
+          </span>
+          <span
+            className="text-foreground font-medium tabular-nums"
+            aria-label={`Sum of selected: ${formatMinor(selectionSum)}`}
+          >
+            Σ {formatMinor(selectionSum)}
+          </span>
+          <span
+            className="tabular-nums"
+            aria-label={`Average of selected: ${formatMinor(selectionAvg)}`}
+          >
+            avg {formatMinor(selectionAvg)}
           </span>
           {selectionStagedCount > 0 && (
             <span

--- a/src/features/budget-management/components/BudgetSelectionSummary.tsx
+++ b/src/features/budget-management/components/BudgetSelectionSummary.tsx
@@ -108,7 +108,7 @@ export function BudgetSelectionSummary({
             ({selectedMonthSet.size} mo × {selectedCatSet.size} cat)
           </span>
           <span
-            className="text-foreground font-medium tabular-nums"
+            className="tabular-nums"
             aria-label={`Sum of selected: ${formatMinor(selectionSum)}`}
           >
             Σ {formatMinor(selectionSum)}

--- a/src/features/budget-management/components/BudgetToolbar.tsx
+++ b/src/features/budget-management/components/BudgetToolbar.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronsLeft, ChevronsRight, ChevronLeft, ChevronRight, CalendarDays, Upload, Download, ChevronsDownUp, ChevronsUpDown, Eye, EyeOff, Keyboard, BarChart2 } from "lucide-react";
 import { addMonths, formatMonthLabel } from "@/lib/budget/monthMath";
+import { cn } from "@/lib/utils";
 import type { BudgetMode, CellView } from "../types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -277,11 +278,12 @@ export function BudgetToolbar({
               aria-label={showSpendingBars ? "Hide spending bars" : "Show spending bars"}
               title={showSpendingBars ? "Hide spending bars" : "Show spending bars"}
               aria-pressed={showSpendingBars ?? false}
-              className={`inline-flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium transition-colors ${
+              className={cn(
+                "inline-flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium transition-colors",
                 showSpendingBars
                   ? "text-foreground bg-muted"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground"
-              }`}
+              )}
             >
               <BarChart2 className="h-3.5 w-3.5" aria-hidden="true" />
               Spending Bars

--- a/src/features/budget-management/components/BudgetToolbar.tsx
+++ b/src/features/budget-management/components/BudgetToolbar.tsx
@@ -284,7 +284,7 @@ export function BudgetToolbar({
               }`}
             >
               <BarChart2 className="h-3.5 w-3.5" aria-hidden="true" />
-              Bars
+              Spending Bars
             </button>
           )}
         </div>

--- a/src/features/budget-management/components/BudgetToolbar.tsx
+++ b/src/features/budget-management/components/BudgetToolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronsLeft, ChevronsRight, ChevronLeft, ChevronRight, CalendarDays, Upload, Download, ChevronsDownUp, ChevronsUpDown, Eye, EyeOff, Keyboard } from "lucide-react";
+import { ChevronsLeft, ChevronsRight, ChevronLeft, ChevronRight, CalendarDays, Upload, Download, ChevronsDownUp, ChevronsUpDown, Eye, EyeOff, Keyboard, BarChart2 } from "lucide-react";
 import { addMonths, formatMonthLabel } from "@/lib/budget/monthMath";
 import type { BudgetMode, CellView } from "../types";
 
@@ -39,12 +39,17 @@ type Props = {
   /** First month of the 12-month display window (YYYY-MM). */
   windowStart: string;
   onWindowChange: (start: string) => void;
+  /** Jump the window to include the current month and scroll it into view (F-079). */
+  onGoToCurrentMonth?: () => void;
   cellView: CellView;
   onCellViewChange: (view: CellView) => void;
   onExpandAll?: () => void;
   onCollapseAll?: () => void;
   showHidden?: boolean;
   onToggleShowHidden?: () => void;
+  /** RD-065: spent-vs-budget bars under editable cells. */
+  showSpendingBars?: boolean;
+  onToggleSpendingBars?: () => void;
   onExport?: () => void;
   onImport?: () => void;
   /** Open the keyboard-shortcuts cheatsheet modal. */
@@ -69,12 +74,15 @@ export function BudgetToolbar({
   budgetMode,
   windowStart,
   onWindowChange,
+  onGoToCurrentMonth,
   cellView,
   onCellViewChange,
   onExpandAll,
   onCollapseAll,
   showHidden,
   onToggleShowHidden,
+  showSpendingBars,
+  onToggleSpendingBars,
   onExport,
   onImport,
   onShowShortcuts,
@@ -156,15 +164,18 @@ export function BudgetToolbar({
           <ChevronsRight className="h-3.5 w-3.5" />
         </button>
 
-        {/* Jump to current year */}
+        {/* Jump to the current month */}
         <button
           type="button"
           onClick={() => {
-            const currentYear = new Date().getFullYear();
-            onWindowChange(`${currentYear}-01`);
+            if (onGoToCurrentMonth) {
+              onGoToCurrentMonth();
+            } else {
+              onWindowChange(`${new Date().getFullYear()}-01`);
+            }
           }}
-          aria-label="Go to current year"
-          title="Go to current year"
+          aria-label="Go to current month"
+          title="Go to current month"
           className="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-muted transition-colors ml-0.5"
         >
           <CalendarDays className="h-3.5 w-3.5" />
@@ -198,10 +209,10 @@ export function BudgetToolbar({
         ))}
       </div>
 
-      {(onExpandAll || onCollapseAll || onToggleShowHidden) && <Divider />}
+      {(onExpandAll || onCollapseAll || onToggleShowHidden || onToggleSpendingBars) && <Divider />}
 
-      {/* Expand / Collapse All + Show/Hide hidden */}
-      {(onExpandAll || onCollapseAll || onToggleShowHidden) && (
+      {/* Expand / Collapse All + Show/Hide hidden + Spending bars */}
+      {(onExpandAll || onCollapseAll || onToggleShowHidden || onToggleSpendingBars) && (
         <div
           className="flex items-center gap-0.5 shrink-0"
           role="group"
@@ -257,6 +268,23 @@ export function BudgetToolbar({
                   Show hidden
                 </>
               )}
+            </button>
+          )}
+          {onToggleSpendingBars && (
+            <button
+              type="button"
+              onClick={onToggleSpendingBars}
+              aria-label={showSpendingBars ? "Hide spending bars" : "Show spending bars"}
+              title={showSpendingBars ? "Hide spending bars" : "Show spending bars"}
+              aria-pressed={showSpendingBars ?? false}
+              className={`inline-flex items-center gap-1 h-6 px-2 rounded text-[11px] font-medium transition-colors ${
+                showSpendingBars
+                  ? "text-foreground bg-muted"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <BarChart2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Bars
             </button>
           )}
         </div>

--- a/src/features/budget-management/components/BudgetWorkspace.tsx
+++ b/src/features/budget-management/components/BudgetWorkspace.tsx
@@ -88,6 +88,8 @@ type Props = {
   onToggleCollapse: (groupId: string) => void;
   /** When true, hidden groups/categories are rendered (dimmed); when false they are hidden. */
   showHidden?: boolean;
+  /** RD-065: draw the spent-vs-budget bar under editable expense cells. */
+  showSpendingBars?: boolean;
   onOpenTransfer?: (categoryId: string, month: string, mode: "cover" | "transfer") => void;
   // ── Tier 3 view-state setters (keyboard shortcuts) ─────────────────────
   onCycleCellView: () => void;
@@ -130,6 +132,7 @@ function BudgetWorkspaceInner({
   collapsedGroups,
   onToggleCollapse,
   showHidden = false,
+  showSpendingBars = false,
   onOpenTransfer,
   onCycleCellView,
   onToggleShowHidden,
@@ -946,6 +949,7 @@ function BudgetWorkspaceInner({
           collapsedGroups={collapsedGroups}
           onToggleCollapse={onToggleCollapse}
           showHidden={showHidden}
+          showSpendingBars={showSpendingBars}
           onCellFocus={handleCellFocus}
           onCellRangeSelect={handleCellRangeSelect}
           onCellNavigate={handleCellNavigate}

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -5,6 +5,8 @@ import { useEffectiveMonthFromContext } from "../../context/MonthsDataContext";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useAllNotes } from "@/hooks/useAllNotes";
 import { formatMinor } from "../../lib/format";
+import { computeSpendingBar } from "../../lib/spendingBar";
+import { SpendingBarView } from "./SpendingBarView";
 import { dispatchRowLabel, useGroupCellKeymap } from "../../keyboard/useBudgetKeymap";
 import { BudgetCell, type BudgetCellDragState } from "../BudgetCell";
 import { isCellSelected, type SelectionBounds } from "./types";
@@ -31,6 +33,7 @@ function GroupMonthAggregate({
   onNavigate,
   onToggleCollapse,
   isReadOnlyMonth,
+  showSpendingBars,
 }: {
   month: string;
   groupId: string;
@@ -42,6 +45,7 @@ function GroupMonthAggregate({
   onNavigate?: (dir: NavDirection) => void;
   onToggleCollapse?: () => void;
   isReadOnlyMonth?: boolean;
+  showSpendingBars?: boolean;
 }) {
   const data = useEffectiveMonthFromContext(month);
   const group = data?.groupsById[groupId];
@@ -91,27 +95,44 @@ function GroupMonthAggregate({
   const effectiveView =
     budgetMode === "envelope" && group.isIncome ? "spent" : cellView;
 
-  let displayValue: number;
+  let groupBudgetedMinor: number;
+  let groupActualsMinor: number;
+  let groupBalanceMinor: number;
   if (budgetMode === "tracking") {
     // Tracking: sum non-hidden categories only.
     const cats = group.categoryIds
       .map((id) => data?.categoriesById[id])
       .filter((c): c is NonNullable<typeof c> => !!c && !c.hidden);
-    displayValue =
-      effectiveView === "spent"
-        ? cats.reduce((sum, c) => sum + c.actuals, 0)
-        : effectiveView === "balance"
-        ? cats.reduce((sum, c) => sum + c.balance, 0)
-        : cats.reduce((sum, c) => sum + c.budgeted, 0);
+    groupBudgetedMinor = cats.reduce((sum, c) => sum + c.budgeted, 0);
+    groupActualsMinor = cats.reduce((sum, c) => sum + c.actuals, 0);
+    groupBalanceMinor = cats.reduce((sum, c) => sum + c.balance, 0);
   } else {
     // Envelope: group-level aggregates include all hidden rows.
-    displayValue =
-      effectiveView === "spent"
-        ? group.actuals
-        : effectiveView === "balance"
-        ? group.balance
-        : group.budgeted;
+    groupBudgetedMinor = group.budgeted;
+    groupActualsMinor = group.actuals;
+    groupBalanceMinor = group.balance;
   }
+  const displayValue =
+    effectiveView === "spent"
+      ? groupActualsMinor
+      : effectiveView === "balance"
+      ? groupBalanceMinor
+      : groupBudgetedMinor;
+
+  // RD-065 group-level spending bar — same rules as category cells: Budgeted
+  // view only, non-income groups, not a read-only month, toggle on.
+  const groupSpentMinor = Math.max(0, -groupActualsMinor);
+  const groupOverByMinor = groupSpentMinor - groupBudgetedMinor;
+  const spendingBar =
+    showSpendingBars && cellView === "budgeted" && !group.isIncome && !isReadOnlyMonth
+      ? computeSpendingBar(groupBudgetedMinor, groupSpentMinor)
+      : null;
+  const overNote =
+    spendingBar?.tier === "over"
+      ? ` (over by ${formatMinor(groupOverByMinor)})`
+      : spendingBar?.tier === "unbudgeted"
+      ? " (unbudgeted)"
+      : "";
 
   return (
     <div
@@ -119,8 +140,8 @@ function GroupMonthAggregate({
       role="gridcell"
       tabIndex={0}
       aria-selected={isSelected}
-      aria-label={`${group.name} total for ${month}: ${formatMinor(displayValue)}`}
-      title={`Budgeted: ${formatMinor(group.budgeted)} | Actuals: ${formatMinor(Math.abs(group.actuals))} | Balance: ${formatMinor(group.balance)}${stagedChildCount > 0 ? ` | ${stagedChildCount} staged change${stagedChildCount !== 1 ? "s" : ""} in this group` : ""}`}
+      aria-label={`${group.name} total for ${month}: ${formatMinor(displayValue)}${overNote}`}
+      title={`Budgeted: ${formatMinor(group.budgeted)} | Actuals: ${formatMinor(Math.abs(group.actuals))} | Balance: ${formatMinor(group.balance)}${overNote}${stagedChildCount > 0 ? ` | ${stagedChildCount} staged change${stagedChildCount !== 1 ? "s" : ""} in this group` : ""}`}
       data-group-id={groupId}
       data-group-month={month}
       onClick={onFocus}
@@ -135,6 +156,7 @@ function GroupMonthAggregate({
         />
       )}
       {formatMinor(displayValue)}
+      {spendingBar && <SpendingBarView bar={spendingBar} />}
     </div>
   );
 }
@@ -280,6 +302,7 @@ export function BudgetGridGroupRows({
           onNavigate={(dir) => onGroupNavigate?.(group.id, month, dir)}
           onToggleCollapse={onToggleCollapse}
           isReadOnlyMonth={readOnlyMonths.has(month)}
+          showSpendingBars={showSpendingBars}
         />
       ))}
 

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -152,7 +152,7 @@ function GroupMonthAggregate({
       tabIndex={0}
       aria-selected={isSelected}
       aria-label={`${group.name} total for ${month}: ${formatMinor(displayValue)}${barStatusNote}`}
-      title={`Budgeted: ${formatMinor(group.budgeted)} | Actuals: ${formatMinor(Math.abs(group.actuals))} | Balance: ${formatMinor(group.balance)}${overNote}${stagedChildCount > 0 ? ` | ${stagedChildCount} staged change${stagedChildCount !== 1 ? "s" : ""} in this group` : ""}`}
+      title={`Budgeted: ${formatMinor(groupBudgetedMinor)} | Actuals: ${formatMinor(Math.abs(groupActualsMinor))} | Balance: ${formatMinor(groupBalanceMinor)}${overNote}${stagedChildCount > 0 ? ` | ${stagedChildCount} staged change${stagedChildCount !== 1 ? "s" : ""} in this group` : ""}`}
       data-group-id={groupId}
       data-group-month={month}
       onClick={onFocus}

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -5,7 +5,7 @@ import { useEffectiveMonthFromContext } from "../../context/MonthsDataContext";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useAllNotes } from "@/hooks/useAllNotes";
 import { formatMinor } from "../../lib/format";
-import { computeSpendingBar } from "../../lib/spendingBar";
+import { computeSpendingBar, spendingTierLabel } from "../../lib/spendingBar";
 import { SpendingBarView } from "./SpendingBarView";
 import { dispatchRowLabel, useGroupCellKeymap } from "../../keyboard/useBudgetKeymap";
 import { BudgetCell, type BudgetCellDragState } from "../BudgetCell";
@@ -134,13 +134,24 @@ function GroupMonthAggregate({
       ? " (unbudgeted)"
       : "";
 
+  // Full spoken status for the group bar so its tier is never colour-only
+  // (mirrors the category cell): budgeted / spent / balance + tier label.
+  const barStatusNote =
+    spendingBar && spendingBar.tier !== "empty"
+      ? ` - budgeted ${formatMinor(groupBudgetedMinor)}, spent ${formatMinor(
+          groupSpentMinor
+        )}, balance ${formatMinor(groupBalanceMinor)} (${spendingTierLabel(
+          spendingBar.tier
+        )})`
+      : "";
+
   return (
     <div
       className={`${baseClass}${dimClass} relative px-2 flex items-center justify-end text-xs font-sans tabular-nums text-black dark:text-zinc-200 cursor-default outline-none${isSelected ? " ring-2 ring-inset ring-foreground/80" : ""}`}
       role="gridcell"
       tabIndex={0}
       aria-selected={isSelected}
-      aria-label={`${group.name} total for ${month}: ${formatMinor(displayValue)}${overNote}`}
+      aria-label={`${group.name} total for ${month}: ${formatMinor(displayValue)}${barStatusNote}`}
       title={`Budgeted: ${formatMinor(group.budgeted)} | Actuals: ${formatMinor(Math.abs(group.actuals))} | Balance: ${formatMinor(group.balance)}${overNote}${stagedChildCount > 0 ? ` | ${stagedChildCount} staged change${stagedChildCount !== 1 ? "s" : ""} in this group` : ""}`}
       data-group-id={groupId}
       data-group-month={month}

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -156,6 +156,7 @@ export type GroupRowsProps = {
   dragStateRef: { current: BudgetCellDragState };
   suppressNextClickRef: { current: boolean };
   showHidden: boolean;
+  showSpendingBars?: boolean;
   groupSelection?: { groupId: string; month: string } | null;
   rowSelection?: RowSelection | null;
   readOnlyMonths: Set<string>;
@@ -193,6 +194,7 @@ export function BudgetGridGroupRows({
   dragStateRef,
   suppressNextClickRef,
   showHidden,
+  showSpendingBars,
   groupSelection,
   rowSelection,
   readOnlyMonths,
@@ -348,6 +350,7 @@ export function BudgetGridGroupRows({
                     suppressNextClickRef={suppressNextClickRef}
                     isDimmed={catDimmed}
                     isReadOnlyMonth={readOnlyMonths.has(month)}
+                    showSpendingBars={showSpendingBars}
                     onFocus={onCellFocus}
                     onRangeSelect={onCellRangeSelect}
                     onNavigate={(dir) => onCellNavigate?.(cat.id, month, dir)}

--- a/src/features/budget-management/components/grid/MonthColumnHeader.test.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { MonthColumnHeader } from "./MonthColumnHeader";
+import { currentMonth, addMonths } from "@/lib/budget/monthMath";
+
+describe("MonthColumnHeader current-month highlight (F-079)", () => {
+  const now = currentMonth();
+  const other = addMonths(now, -3);
+
+  it("marks the current month with aria-current and a non-color weight cue", () => {
+    render(<MonthColumnHeader month={now} availableMonths={[now]} />);
+    const header = screen.getByLabelText(/current month/i);
+    expect(header).toHaveAttribute("aria-current", "date");
+    // Non-color signal: bold weight (not just an accent colour).
+    expect(header.className).toMatch(/font-bold/);
+  });
+
+  it("does not mark a non-current month", () => {
+    render(<MonthColumnHeader month={other} availableMonths={[other]} />);
+    const header = screen.getByLabelText(/^Month:/);
+    expect(header).not.toHaveAttribute("aria-current");
+    expect(header.getAttribute("aria-label")).not.toMatch(/current month/i);
+  });
+});

--- a/src/features/budget-management/components/grid/MonthColumnHeader.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useBudgetEditsStore } from "@/store/budgetEdits";
-import { formatMonthLabel } from "@/lib/budget/monthMath";
+import { currentMonth, formatMonthLabel } from "@/lib/budget/monthMath";
 
 /**
  * Sticky column header for a single month: full-name label plus a status dot.
@@ -31,6 +31,7 @@ export function MonthColumnHeader({
     Object.keys(s.edits).some((k) => k.startsWith(`${month}:`))
   );
   const isAvailable = availableMonths.includes(month);
+  const isCurrentMonth = month === currentMonth();
 
   const label = formatMonthLabel(month, "long");
 
@@ -50,12 +51,17 @@ export function MonthColumnHeader({
 
   return (
     <div
-      className={`h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 text-xs font-semibold sticky top-0 z-20 ${
+      className={`h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 text-xs sticky top-0 z-20 ${
+        isCurrentMonth ? "font-bold" : "font-semibold"
+      } ${
         isSelected
           ? "border-primary/70 bg-muted text-foreground"
+          : isCurrentMonth
+          ? "border-primary bg-primary/5 text-foreground"
           : "border-border bg-muted text-foreground"
       } ${selectable ? "cursor-pointer hover:bg-muted/70" : ""}`}
-      aria-label={`Month: ${label}`}
+      aria-label={`Month: ${label}${isCurrentMonth ? " (current month)" : ""}`}
+      {...(isCurrentMonth ? { "aria-current": "date" as const } : {})}
       {...(selectable
         ? {
             role: "button",

--- a/src/features/budget-management/components/grid/MonthColumnHeader.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { currentMonth, formatMonthLabel } from "@/lib/budget/monthMath";
 
@@ -51,17 +52,20 @@ export function MonthColumnHeader({
 
   return (
     <div
-      className={`h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 text-xs sticky top-0 z-20 ${
-        isCurrentMonth ? "font-bold" : "font-semibold"
-      } ${
+      className={cn(
+        "h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 text-xs sticky top-0 z-20",
+        isCurrentMonth ? "font-bold" : "font-semibold",
         isSelected
           ? "border-primary/70 bg-muted text-foreground"
           : isCurrentMonth
           ? "border-primary bg-primary/5 text-foreground"
-          : "border-border bg-muted text-foreground"
-      } ${selectable ? "cursor-pointer hover:bg-muted/70" : ""}`}
+          : "border-border bg-muted text-foreground",
+        selectable && "cursor-pointer hover:bg-muted/70"
+      )}
       aria-label={`Month: ${label}${isCurrentMonth ? " (current month)" : ""}`}
-      {...(isCurrentMonth ? { "aria-current": "date" as const } : {})}
+      // Always present on the current-month header (even when the month is not
+      // yet available/selectable) so orientation can reliably scroll to it.
+      {...(isCurrentMonth ? { "aria-current": "date" as const, "data-current-month-header": "" } : {})}
       {...(selectable
         ? {
             role: "button",

--- a/src/features/budget-management/components/grid/SpendingBarView.test.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import { SpendingBarView } from "./SpendingBarView";
+
+describe("SpendingBarView", () => {
+  it("renders nothing when there is no bar", () => {
+    const { container } = render(
+      <SpendingBarView bar={{ tier: "none", fill: 0, overflow: 0 }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a decorative track with the fill width", () => {
+    const { container } = render(
+      <SpendingBarView bar={{ tier: "under", fill: 0.5, overflow: 0 }} />,
+    );
+    const track = container.firstChild as HTMLElement;
+    expect(track).not.toBeNull();
+    expect(track).toHaveAttribute("aria-hidden", "true");
+    const fill = track.firstChild as HTMLElement;
+    expect(fill.style.width).toBe("50%");
+  });
+
+  it("adds a red overflow segment when over budget", () => {
+    const { container } = render(
+      <SpendingBarView bar={{ tier: "over", fill: 1, overflow: 0.25 }} />,
+    );
+    const track = container.firstChild as HTMLElement;
+    // Base fill + overflow segment.
+    expect(track.childElementCount).toBe(2);
+    const overflow = track.children[1] as HTMLElement;
+    expect(overflow.style.width).toBe("25%");
+    expect(overflow.className).toMatch(/bg-red-500/);
+  });
+});

--- a/src/features/budget-management/components/grid/SpendingBarView.test.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.test.tsx
@@ -33,6 +33,6 @@ describe("SpendingBarView", () => {
     expect(track.childElementCount).toBe(2);
     const overflow = track.children[1] as HTMLElement;
     expect(overflow.style.width).toBe("25%");
-    expect(overflow.className).toMatch(/bg-red-500/);
+    expect(overflow.className).toMatch(/bg-destructive/);
   });
 });

--- a/src/features/budget-management/components/grid/SpendingBarView.test.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.test.tsx
@@ -2,11 +2,15 @@ import { render } from "@testing-library/react";
 import { SpendingBarView } from "./SpendingBarView";
 
 describe("SpendingBarView", () => {
-  it("renders nothing when there is no bar", () => {
+  it("renders a neutral track (no coloured fill) for an empty cell", () => {
     const { container } = render(
-      <SpendingBarView bar={{ tier: "none", fill: 0, overflow: 0 }} />,
+      <SpendingBarView bar={{ tier: "empty", fill: 0, overflow: 0 }} />,
     );
-    expect(container.firstChild).toBeNull();
+    const track = container.firstChild as HTMLElement;
+    expect(track).not.toBeNull();
+    // The track paints, but the fill is zero-width so no colour shows.
+    const fill = track.firstChild as HTMLElement;
+    expect(fill.style.width).toBe("0%");
   });
 
   it("renders a decorative track with the fill width", () => {

--- a/src/features/budget-management/components/grid/SpendingBarView.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.tsx
@@ -1,13 +1,15 @@
 import type { SpendingBar, SpendingTier } from "../../lib/spendingBar";
 
-/** Tailwind classes for the green/amber base fill by tier (RD-065). */
+// Tailwind classes for the green/amber base fill by tier (RD-065). Kept
+// deliberately low-opacity so a full column of bars reads as a soft glance
+// rather than a wall of saturated colour.
 const BAR_FILL_CLASS: Record<Exclude<SpendingTier, "none">, string> = {
-  under: "bg-emerald-500/70 dark:bg-emerald-400/60",
-  near: "bg-amber-500/80",
-  over: "bg-amber-500/80",
-  // Distinct from `over` (amber + red overflow): a solid muted red means money
-  // left an envelope/group that was never funded.
-  unbudgeted: "bg-red-500/45",
+  under: "bg-emerald-500/40 dark:bg-emerald-400/35",
+  near: "bg-amber-500/50 dark:bg-amber-500/45",
+  over: "bg-amber-500/50 dark:bg-amber-500/45",
+  // Distinct from `over` (amber + red overflow): a muted red means money left an
+  // envelope/group that was never funded.
+  unbudgeted: "bg-red-500/30 dark:bg-red-500/35",
 };
 
 /**
@@ -29,7 +31,7 @@ export function SpendingBarView({ bar }: { bar: SpendingBar }) {
       />
       {bar.overflow > 0 && (
         <span
-          className="absolute bottom-0 right-0 h-full bg-red-500"
+          className="absolute bottom-0 right-0 h-full bg-red-500/55 dark:bg-red-500/50"
           style={{ width: `${bar.overflow * 100}%` }}
         />
       )}

--- a/src/features/budget-management/components/grid/SpendingBarView.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.tsx
@@ -1,8 +1,12 @@
 import type { SpendingBar, SpendingTier } from "../../lib/spendingBar";
 
-// Tailwind classes for the green/amber base fill by tier (RD-065). Kept
-// deliberately low-opacity so a full column of bars reads as a soft glance
-// rather than a wall of saturated colour.
+// Fill classes by tier (RD-065). Kept deliberately low-opacity so a full column
+// of bars reads as a soft glance rather than a wall of saturated colour.
+//
+// The red tiers use the semantic `destructive` token. There is no semantic
+// success/warning token in the theme (only `destructive`), and raw emerald/amber
+// is the established convention across the budget grid (staged/carryover
+// indicators), so under/near stay on the raw palette here.
 const BAR_FILL_CLASS: Record<SpendingTier, string> = {
   // `empty` has zero fill width, so its colour never actually paints — it just
   // shows the neutral gray track (below) for a consistent, calm grid.
@@ -12,7 +16,7 @@ const BAR_FILL_CLASS: Record<SpendingTier, string> = {
   over: "bg-amber-500/50 dark:bg-amber-500/45",
   // Distinct from `over` (amber + red overflow): a muted red means money left an
   // envelope/group that was never funded.
-  unbudgeted: "bg-red-500/30 dark:bg-red-500/35",
+  unbudgeted: "bg-destructive/25",
 };
 
 /**
@@ -33,7 +37,7 @@ export function SpendingBarView({ bar }: { bar: SpendingBar }) {
       />
       {bar.overflow > 0 && (
         <span
-          className="absolute bottom-0 right-0 h-full bg-red-500/55 dark:bg-red-500/50"
+          className="absolute bottom-0 right-0 h-full bg-destructive/55"
           style={{ width: `${bar.overflow * 100}%` }}
         />
       )}

--- a/src/features/budget-management/components/grid/SpendingBarView.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.tsx
@@ -1,0 +1,38 @@
+import type { SpendingBar, SpendingTier } from "../../lib/spendingBar";
+
+/** Tailwind classes for the green/amber base fill by tier (RD-065). */
+const BAR_FILL_CLASS: Record<Exclude<SpendingTier, "none">, string> = {
+  under: "bg-emerald-500/70 dark:bg-emerald-400/60",
+  near: "bg-amber-500/80",
+  over: "bg-amber-500/80",
+  // Distinct from `over` (amber + red overflow): a solid muted red means money
+  // left an envelope/group that was never funded.
+  unbudgeted: "bg-red-500/45",
+};
+
+/**
+ * The spent-vs-budget bar (RD-065), shared by category cells and group-total
+ * cells. Renders a 3px track pinned to the host cell's bottom edge; the host
+ * must be `relative`. Decorative only — the text signal lives in the host's
+ * aria-label / tooltip, so nothing is conveyed by colour alone.
+ */
+export function SpendingBarView({ bar }: { bar: SpendingBar }) {
+  if (bar.tier === "none") return null;
+  return (
+    <span
+      className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-foreground/5"
+      aria-hidden="true"
+    >
+      <span
+        className={`absolute bottom-0 left-0 h-full ${BAR_FILL_CLASS[bar.tier]}`}
+        style={{ width: `${bar.fill * 100}%` }}
+      />
+      {bar.overflow > 0 && (
+        <span
+          className="absolute bottom-0 right-0 h-full bg-red-500"
+          style={{ width: `${bar.overflow * 100}%` }}
+        />
+      )}
+    </span>
+  );
+}

--- a/src/features/budget-management/components/grid/SpendingBarView.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.tsx
@@ -3,7 +3,10 @@ import type { SpendingBar, SpendingTier } from "../../lib/spendingBar";
 // Tailwind classes for the green/amber base fill by tier (RD-065). Kept
 // deliberately low-opacity so a full column of bars reads as a soft glance
 // rather than a wall of saturated colour.
-const BAR_FILL_CLASS: Record<Exclude<SpendingTier, "none">, string> = {
+const BAR_FILL_CLASS: Record<SpendingTier, string> = {
+  // `empty` has zero fill width, so its colour never actually paints — it just
+  // shows the neutral gray track (below) for a consistent, calm grid.
+  empty: "bg-transparent",
   under: "bg-emerald-500/40 dark:bg-emerald-400/35",
   near: "bg-amber-500/50 dark:bg-amber-500/45",
   over: "bg-amber-500/50 dark:bg-amber-500/45",
@@ -19,7 +22,6 @@ const BAR_FILL_CLASS: Record<Exclude<SpendingTier, "none">, string> = {
  * aria-label / tooltip, so nothing is conveyed by colour alone.
  */
 export function SpendingBarView({ bar }: { bar: SpendingBar }) {
-  if (bar.tier === "none") return null;
   return (
     <span
       className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-foreground/5"

--- a/src/features/budget-management/lib/spendingBar.test.ts
+++ b/src/features/budget-management/lib/spendingBar.test.ts
@@ -1,0 +1,54 @@
+import { computeSpendingBar, NEAR_THRESHOLD } from "./spendingBar";
+
+describe("computeSpendingBar", () => {
+  it("returns no bar when nothing is budgeted or spent", () => {
+    expect(computeSpendingBar(0, 0)).toEqual({ tier: "none", fill: 0, overflow: 0 });
+  });
+
+  it("treats spending against a zero budget as unbudgeted", () => {
+    expect(computeSpendingBar(0, 5000)).toEqual({ tier: "unbudgeted", fill: 1, overflow: 0 });
+    // Negative budget is also 'no budget'.
+    expect(computeSpendingBar(-100, 5000).tier).toBe("unbudgeted");
+  });
+
+  it("shows an empty under-bar when budgeted but nothing spent", () => {
+    expect(computeSpendingBar(60000, 0)).toEqual({ tier: "under", fill: 0, overflow: 0 });
+  });
+
+  it("fills proportionally and stays under below the near threshold", () => {
+    const bar = computeSpendingBar(100_00, 50_00); // 50%
+    expect(bar.tier).toBe("under");
+    expect(bar.fill).toBeCloseTo(0.5);
+    expect(bar.overflow).toBe(0);
+  });
+
+  it("flips to near within ~90–100%", () => {
+    expect(computeSpendingBar(100_00, 95_00).tier).toBe("near");
+    // Exactly at the threshold is 'near'.
+    expect(computeSpendingBar(100_00, NEAR_THRESHOLD * 100_00).tier).toBe("near");
+    // Exactly at budget is still 'near' (not over).
+    expect(computeSpendingBar(100_00, 100_00).tier).toBe("near");
+    expect(computeSpendingBar(100_00, 100_00).fill).toBe(1);
+  });
+
+  it("marks over budget with a clamped overflow segment", () => {
+    const slight = computeSpendingBar(600_00, 640_00); // 106.7%
+    expect(slight.tier).toBe("over");
+    expect(slight.fill).toBe(1);
+    expect(slight.overflow).toBeCloseTo(0.0667, 3);
+
+    // A big overspend clamps overflow to 1 (never renders off the track).
+    const big = computeSpendingBar(100_00, 500_00);
+    expect(big.overflow).toBe(1);
+  });
+
+  it("ignores a net inflow (negative spent already normalised by caller → 0)", () => {
+    expect(computeSpendingBar(100_00, 0).tier).toBe("under");
+    // Defensive: a stray negative spent is treated as zero.
+    expect(computeSpendingBar(100_00, -50_00)).toEqual({ tier: "under", fill: 0, overflow: 0 });
+  });
+
+  it("is robust to non-finite input", () => {
+    expect(computeSpendingBar(NaN, NaN)).toEqual({ tier: "none", fill: 0, overflow: 0 });
+  });
+});

--- a/src/features/budget-management/lib/spendingBar.test.ts
+++ b/src/features/budget-management/lib/spendingBar.test.ts
@@ -1,8 +1,8 @@
 import { computeSpendingBar, NEAR_THRESHOLD } from "./spendingBar";
 
 describe("computeSpendingBar", () => {
-  it("returns no bar when nothing is budgeted or spent", () => {
-    expect(computeSpendingBar(0, 0)).toEqual({ tier: "none", fill: 0, overflow: 0 });
+  it("shows a neutral empty track when nothing is budgeted or spent", () => {
+    expect(computeSpendingBar(0, 0)).toEqual({ tier: "empty", fill: 0, overflow: 0 });
   });
 
   it("treats spending against a zero budget as unbudgeted", () => {
@@ -49,6 +49,6 @@ describe("computeSpendingBar", () => {
   });
 
   it("is robust to non-finite input", () => {
-    expect(computeSpendingBar(NaN, NaN)).toEqual({ tier: "none", fill: 0, overflow: 0 });
+    expect(computeSpendingBar(NaN, NaN)).toEqual({ tier: "empty", fill: 0, overflow: 0 });
   });
 });

--- a/src/features/budget-management/lib/spendingBar.test.ts
+++ b/src/features/budget-management/lib/spendingBar.test.ts
@@ -1,4 +1,14 @@
-import { computeSpendingBar, NEAR_THRESHOLD } from "./spendingBar";
+import { computeSpendingBar, spendingTierLabel, NEAR_THRESHOLD } from "./spendingBar";
+
+describe("spendingTierLabel", () => {
+  it("gives a spoken status for every non-empty tier (never colour-only)", () => {
+    expect(spendingTierLabel("under")).toBe("under budget");
+    expect(spendingTierLabel("near")).toBe("near budget limit");
+    expect(spendingTierLabel("over")).toBe("over budget");
+    expect(spendingTierLabel("unbudgeted")).toBe("unbudgeted spending");
+    expect(spendingTierLabel("empty")).toBe("");
+  });
+});
 
 describe("computeSpendingBar", () => {
   it("shows a neutral empty track when nothing is budgeted or spent", () => {

--- a/src/features/budget-management/lib/spendingBar.ts
+++ b/src/features/budget-management/lib/spendingBar.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure model for the in-grid spending bar (RD-065).
+ *
+ * Given a category's budgeted amount and its spending for a month, derive a
+ * compact bar: how full it is (`fill`), how far past budget it went
+ * (`overflow`), and a `tier` that drives colour. Everything is in integer minor
+ * units; the caller is responsible for sign-normalising `spent` to a magnitude.
+ *
+ * Rendering (in BudgetCell): a 3px track pinned to the cell's bottom edge. The
+ * green/amber portion is `fill` of the track width; when over budget a red
+ * segment covering `overflow` of the width is drawn from the right. The exact
+ * numbers stay in the cell tooltip and details panel — the bar is a glanceable
+ * signal, never the source of truth.
+ */
+
+export type SpendingTier =
+  | "none" // nothing budgeted and nothing spent — no bar
+  | "under" // spent < ~90% of budget
+  | "near" // spent within ~90–100% of budget
+  | "over" // spent > budget
+  | "unbudgeted"; // spent against a zero/absent budget
+
+export type SpendingBar = {
+  tier: SpendingTier;
+  /** Filled fraction of the track, 0..1 (green/amber portion). */
+  fill: number;
+  /** Over-budget fraction drawn in red from the right, 0..1 (0 unless `over`). */
+  overflow: number;
+};
+
+/** Ratio at/after which the fill turns amber (approaching the limit). */
+export const NEAR_THRESHOLD = 0.9;
+
+const NONE: SpendingBar = { tier: "none", fill: 0, overflow: 0 };
+
+function clamp01(n: number): number {
+  if (n <= 0) return 0;
+  if (n >= 1) return 1;
+  return n;
+}
+
+/**
+ * Build the bar model.
+ *
+ * @param budgetedMinor Assigned amount (minor units). Expected >= 0; <= 0 is
+ *   treated as "no budget".
+ * @param spentMinor    Spending magnitude (minor units, >= 0). Callers pass
+ *   `Math.max(0, -actuals)` so a net inflow (refund) reads as zero spent.
+ */
+export function computeSpendingBar(budgetedMinor: number, spentMinor: number): SpendingBar {
+  const budgeted = Number.isFinite(budgetedMinor) ? budgetedMinor : 0;
+  const spent = Number.isFinite(spentMinor) && spentMinor > 0 ? spentMinor : 0;
+
+  if (budgeted <= 0) {
+    // No funded envelope. Spending against it is the notable case.
+    return spent > 0 ? { tier: "unbudgeted", fill: 1, overflow: 0 } : NONE;
+  }
+
+  if (spent <= 0) {
+    // Budgeted but nothing spent yet — an empty (all-remaining) bar.
+    return { tier: "under", fill: 0, overflow: 0 };
+  }
+
+  const ratio = spent / budgeted;
+
+  if (ratio > 1) {
+    return { tier: "over", fill: 1, overflow: clamp01(ratio - 1) };
+  }
+
+  return {
+    tier: ratio >= NEAR_THRESHOLD ? "near" : "under",
+    fill: clamp01(ratio),
+    overflow: 0,
+  };
+}

--- a/src/features/budget-management/lib/spendingBar.ts
+++ b/src/features/budget-management/lib/spendingBar.ts
@@ -14,7 +14,7 @@
  */
 
 export type SpendingTier =
-  | "none" // nothing budgeted and nothing spent — no bar
+  | "empty" // nothing budgeted and nothing spent — a neutral gray track
   | "under" // spent < ~90% of budget
   | "near" // spent within ~90–100% of budget
   | "over" // spent > budget
@@ -31,7 +31,7 @@ export type SpendingBar = {
 /** Ratio at/after which the fill turns amber (approaching the limit). */
 export const NEAR_THRESHOLD = 0.9;
 
-const NONE: SpendingBar = { tier: "none", fill: 0, overflow: 0 };
+const EMPTY: SpendingBar = { tier: "empty", fill: 0, overflow: 0 };
 
 function clamp01(n: number): number {
   if (n <= 0) return 0;
@@ -52,8 +52,9 @@ export function computeSpendingBar(budgetedMinor: number, spentMinor: number): S
   const spent = Number.isFinite(spentMinor) && spentMinor > 0 ? spentMinor : 0;
 
   if (budgeted <= 0) {
-    // No funded envelope. Spending against it is the notable case.
-    return spent > 0 ? { tier: "unbudgeted", fill: 1, overflow: 0 } : NONE;
+    // No funded envelope. Spending against it is the notable case; an untouched
+    // 0/0 cell still shows a neutral gray track for a consistent grid.
+    return spent > 0 ? { tier: "unbudgeted", fill: 1, overflow: 0 } : EMPTY;
   }
 
   if (spent <= 0) {

--- a/src/features/budget-management/lib/spendingBar.ts
+++ b/src/features/budget-management/lib/spendingBar.ts
@@ -33,6 +33,25 @@ export const NEAR_THRESHOLD = 0.9;
 
 const EMPTY: SpendingBar = { tier: "empty", fill: 0, overflow: 0 };
 
+/**
+ * Human-readable status for each tier, for accessible names / tooltips so the
+ * bar's meaning is never conveyed by colour alone.
+ */
+export function spendingTierLabel(tier: SpendingTier): string {
+  switch (tier) {
+    case "under":
+      return "under budget";
+    case "near":
+      return "near budget limit";
+    case "over":
+      return "over budget";
+    case "unbudgeted":
+      return "unbudgeted spending";
+    case "empty":
+      return "";
+  }
+}
+
 function clamp01(n: number): number {
   if (n <= 0) return 0;
   if (n >= 1) return 1;

--- a/src/lib/budget/monthMath.ts
+++ b/src/lib/budget/monthMath.ts
@@ -35,6 +35,11 @@ function fromDate(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
 }
 
+/** The current calendar month as `YYYY-MM`, in the viewer's local time. */
+export function currentMonth(): string {
+  return fromDate(new Date());
+}
+
 /** Add `delta` months (may be negative) to `month`. */
 export function addMonths(month: string, delta: number): string {
   const [year, mo] = parseMonth(month);


### PR DESCRIPTION
## What

Two everyday-friction fixes in the Budget Management grid, from the 2026.08 UX review — the grid now tells you where you stand at a glance.

### Spending bars

A cell shows only one of budgeted / spent / balance today. This adds a thin **spent ÷ budgeted bar** on the bottom edge of each editable expense cell in the **Budgeted** view:

- green under budget → amber approaching the limit → a **red overflow segment** when over;
- a distinct **red bar** when money left an envelope that was never funded;
- **income rows** and read-only/editing cells show no bar.

Crucially it keeps the 12-month column width **and** the row height (the bar is absolutely positioned, ~3px). The month columns are only `minmax(69px, 94px)` wide, so three numbers can't sit side by side — the spent/over signal is encoded visually, with the exact spent/balance staying in the cell tooltip and the details panel. A **Bars** toolbar toggle turns it off/on (on by default).

Accessibility: the bar is decorative; the cell `aria-label` and tooltip always carry the text (`spent X, over by Y`), so nothing is conveyed by colour alone.

### Orient to "now"

- The workspace opens **scrolled to the current month** instead of landing on January.
- The current-month column is **highlighted** (bold + accent border + `aria-current` — non-colour-only).
- The calendar toolbar button now **returns to the current month** (was: current year → January).

## Design of record

`agents/rd-specs/rd-065-in-grid-spending-bars.md` + `agents/reviews/2026.08-budget-management-ux-review.md`. Covers RD-065 (bars) and F-079 (orient-to-now). The bigger related bets — full variance/compare (RD-035), grid virtualization (RD-037), responsive grid (F-045) — are tracked separately.

## Validation

- `npm run lint` — 0 errors (pre-existing warnings only)
- `npx tsc --noEmit` — clean (src)
- `npm test` — full suite green (1383 tests); new unit tests for the `spendingBar` fill/tier lib and the current-month header highlight
- Local `next build` OOMs in the dev environment; the authoritative build runs in CI
