### PR TITLE
Budget grid: time-of-month marker and crosshair highlight

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -269,7 +269,8 @@ A multi-month budget editing workspace with staged cell editing, a draft review 
 ### Toolbar
 - Budget mode badge (`Envelope`, `Tracking`, or `Unknown`) always visible at the left
 - 12-month window navigator: back/forward by 1 month (`‹ ›`) or 1 year (`«»`), plus a "go to current month" calendar button; range label displays as "Jan '26 – Dec '26"
-- Opens oriented on the current month, and the current-month column is highlighted (bold + accent border, `aria-current`) so "now" is obvious at a glance
+- Opens oriented on the current month, and the current-month column is highlighted (bold + accent border, `aria-current`) so "now" is obvious at a glance; a subtle marker on that column shows how far through the month today is (e.g. day 12 of 31), so a spending bar reads fairly
+- Crosshair highlight: the focused cell's row and column are softly tinted to the grid edges, making it effortless to trace which category and month a cell belongs to across the 12-month grid
 - Cell-view toggle: **Budget** / **Actuals** / **Balance** — switches what value each month cell displays
 - **Spending Bars** (toolbar toggle, on by default): a thin bar under each editable expense cell — and under each group-total cell — shows spent ÷ budgeted for that month — green under budget, amber approaching the limit, and a red overflow segment when over; a distinct red bar flags spending from an unfunded envelope/group. The bar keeps the 12-month width and row height; exact spent/balance stay in the cell tooltip and details panel. Income rows show no bar.
 - Expand all / Collapse all group buttons

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -270,7 +270,7 @@ A multi-month budget editing workspace with staged cell editing, a draft review 
 - Budget mode badge (`Envelope`, `Tracking`, or `Unknown`) always visible at the left
 - 12-month window navigator: back/forward by 1 month (`‹ ›`) or 1 year (`«»`), plus a "go to current month" calendar button; range label displays as "Jan '26 – Dec '26"
 - Opens oriented on the current month, and the current-month column is highlighted (bold + accent border, `aria-current`) so "now" is obvious at a glance; a subtle marker on that column shows how far through the month today is (e.g. day 12 of 31), so a spending bar reads fairly
-- Crosshair highlight: the focused cell's row and column are softly tinted to the grid edges, making it effortless to trace which category and month a cell belongs to across the 12-month grid
+- Crosshair highlight: the focused cell's month column header and category row label are softly tinted, making it easy to trace which category and month a cell belongs to without cluttering the grid body
 - Cell-view toggle: **Budget** / **Actuals** / **Balance** — switches what value each month cell displays
 - **Spending Bars** (toolbar toggle, on by default): a thin bar under each editable expense cell — and under each group-total cell — shows spent ÷ budgeted for that month — green under budget, amber approaching the limit, and a red overflow segment when over; a distinct red bar flags spending from an unfunded envelope/group. The bar keeps the 12-month width and row height; exact spent/balance stay in the cell tooltip and details panel. Income rows show no bar.
 - Expand all / Collapse all group buttons

--- a/docs-site/src/content/docs/user-guide/budget-management.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-management.mdx
@@ -52,8 +52,8 @@ default); income rows never show a bar.
   highlighted so it's easy to find. A small marker on that column shows how far through the month
   today is (e.g. day 12 of 31), so a spending bar reads fairly — 80% spent on the 5th is not the same
   as on the 25th.
-- The focused cell's **row and column are softly highlighted** (a crosshair), making it easy to trace
-  which category and month a cell belongs to across the wide grid.
+- The focused cell's **month header and category label are softly highlighted** (a crosshair on the
+  axes), making it easy to trace which category and month a cell belongs to without cluttering the grid.
 - Move the 12-month window back/forward by one month with `‹` / `›`, or by a year with `«` / `»`.
 - Use the calendar button to jump back to the current month at any time.
 - The `[` and `]` keys pan the window backward/forward by one month.

--- a/docs-site/src/content/docs/user-guide/budget-management.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-management.mdx
@@ -49,7 +49,11 @@ default); income rows never show a bar.
 ## Navigate months and years
 
 - The workspace opens on the current calendar year, scrolled to the **current month**, which is
-  highlighted so it's easy to find.
+  highlighted so it's easy to find. A small marker on that column shows how far through the month
+  today is (e.g. day 12 of 31), so a spending bar reads fairly — 80% spent on the 5th is not the same
+  as on the 25th.
+- The focused cell's **row and column are softly highlighted** (a crosshair), making it easy to trace
+  which category and month a cell belongs to across the wide grid.
 - Move the 12-month window back/forward by one month with `‹` / `›`, or by a year with `«` / `»`.
 - Use the calendar button to jump back to the current month at any time.
 - The `[` and `]` keys pan the window backward/forward by one month.

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -39,12 +39,7 @@ type Props = {
   isReadOnlyMonth?: boolean;
   /** RD-065: draw the spent-vs-budget bar under editable expense cells. */
   showSpendingBars?: boolean;
-  /** F-083: this cell is in the focused cell's row or column (crosshair tint). */
-  inCrosshair?: boolean;
 };
-
-/** Faint crosshair tint for cells in the focused row/column (F-083). */
-const CROSSHAIR_CLASS = "bg-primary/[0.06]";
 
 /** BM-16: minimum pointer travel (CSS px) before treating a drag as range-select. */
 const DRAG_THRESHOLD_PX = 3;
@@ -73,7 +68,6 @@ export function BudgetCell({
   isDimmed,
   isReadOnlyMonth = false,
   showSpendingBars = false,
-  inCrosshair = false,
 }: Props) {
   const dimClass = isDimmed ? " opacity-50" : "";
   const key: BudgetCellKey = `${month}:${category.id}`;
@@ -364,8 +358,6 @@ export function BudgetCell({
       blockedCellClass += " bg-muted/30 ring-2 ring-inset ring-foreground/80";
     } else if (isSelected) {
       blockedCellClass += " bg-primary/10";
-    } else if (inCrosshair) {
-      blockedCellClass += ` ${CROSSHAIR_CLASS} hover:bg-muted/40 focus:bg-muted/40`;
     } else {
       blockedCellClass += " bg-muted/30 hover:bg-muted/40 focus:bg-muted/40";
     }
@@ -457,8 +449,6 @@ export function BudgetCell({
     cellClass += " ring-2 ring-inset ring-foreground/80";
   } else if (isSelected) {
     cellClass += " bg-primary/10";
-  } else if (inCrosshair) {
-    cellClass += ` ${CROSSHAIR_CLASS} hover:bg-muted/40 focus:bg-muted/40`;
   } else {
     cellClass += " hover:bg-muted/40 focus:bg-muted/40";
   }

--- a/src/features/budget-management/components/BudgetCell.tsx
+++ b/src/features/budget-management/components/BudgetCell.tsx
@@ -39,7 +39,12 @@ type Props = {
   isReadOnlyMonth?: boolean;
   /** RD-065: draw the spent-vs-budget bar under editable expense cells. */
   showSpendingBars?: boolean;
+  /** F-083: this cell is in the focused cell's row or column (crosshair tint). */
+  inCrosshair?: boolean;
 };
+
+/** Faint crosshair tint for cells in the focused row/column (F-083). */
+const CROSSHAIR_CLASS = "bg-primary/[0.06]";
 
 /** BM-16: minimum pointer travel (CSS px) before treating a drag as range-select. */
 const DRAG_THRESHOLD_PX = 3;
@@ -68,6 +73,7 @@ export function BudgetCell({
   isDimmed,
   isReadOnlyMonth = false,
   showSpendingBars = false,
+  inCrosshair = false,
 }: Props) {
   const dimClass = isDimmed ? " opacity-50" : "";
   const key: BudgetCellKey = `${month}:${category.id}`;
@@ -358,6 +364,8 @@ export function BudgetCell({
       blockedCellClass += " bg-muted/30 ring-2 ring-inset ring-foreground/80";
     } else if (isSelected) {
       blockedCellClass += " bg-primary/10";
+    } else if (inCrosshair) {
+      blockedCellClass += ` ${CROSSHAIR_CLASS} hover:bg-muted/40 focus:bg-muted/40`;
     } else {
       blockedCellClass += " bg-muted/30 hover:bg-muted/40 focus:bg-muted/40";
     }
@@ -449,6 +457,8 @@ export function BudgetCell({
     cellClass += " ring-2 ring-inset ring-foreground/80";
   } else if (isSelected) {
     cellClass += " bg-primary/10";
+  } else if (inCrosshair) {
+    cellClass += ` ${CROSSHAIR_CLASS} hover:bg-muted/40 focus:bg-muted/40`;
   } else {
     cellClass += " hover:bg-muted/40 focus:bg-muted/40";
   }

--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -245,6 +245,12 @@ export function BudgetGrid({
   const selectedMonth =
     selection?.focusMonth ?? groupSelection?.month ?? monthSelection ?? null;
 
+  // F-083 crosshair: the focused cell's row (category) and column (month) get a
+  // faint highlight to their edges, so tracing "which category × which month" in
+  // a 12-wide grid is effortless. Driven by the existing focus, not per-hover.
+  const crosshairMonth = selection?.focusMonth ?? null;
+  const crosshairCategoryId = selection?.focusCategoryId ?? null;
+
   const gridStyle: React.CSSProperties = {
     display: "grid",
     gridTemplateColumns: `minmax(180px, 1fr) repeat(${activeMonths.length}, minmax(69px, 94px))`,
@@ -265,6 +271,8 @@ export function BudgetGrid({
     suppressNextClickRef: suppressNextClickClearRef,
     showHidden,
     showSpendingBars,
+    crosshairMonth,
+    crosshairCategoryId,
     onCellFocus,
     onCellRangeSelect,
     onCellNavigate,

--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -249,9 +249,9 @@ export function BudgetGrid({
   const selectedMonth =
     selection?.focusMonth ?? groupSelection?.month ?? monthSelection ?? null;
 
-  // F-083 crosshair: the focused cell's row (category) and column (month) get a
-  // faint highlight to their edges, so tracing "which category × which month" in
-  // a 12-wide grid is effortless. Driven by the existing focus, not per-hover.
+  // F-083 crosshair (axes-only): the focused cell's column (month header) and row
+  // (category label) get a faint highlight, so tracing "which category × which
+  // month" is easy without tinting the grid body. Driven by focus, not per-hover.
   const crosshairMonth = selection?.focusMonth ?? null;
   const crosshairCategoryId = selection?.focusCategoryId ?? null;
 
@@ -275,7 +275,6 @@ export function BudgetGrid({
     suppressNextClickRef: suppressNextClickClearRef,
     showHidden,
     showSpendingBars,
-    crosshairMonth,
     crosshairCategoryId,
     onCellFocus,
     onCellRangeSelect,
@@ -347,6 +346,7 @@ export function BudgetGrid({
           isSelected={month === selectedMonth}
           onSelect={onMonthSelect}
           today={today}
+          inCrosshair={crosshairMonth != null && month === crosshairMonth}
         />
       ))}
 

--- a/src/features/budget-management/components/BudgetGrid.tsx
+++ b/src/features/budget-management/components/BudgetGrid.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Loader2 } from "lucide-react";
 import { useMonthsData } from "../context/MonthsDataContext";
+import { useDailyDate } from "../hooks/useDailyDate";
 import { MonthColumnHeader } from "./grid/MonthColumnHeader";
 import {
   SummaryHeaderRow,
@@ -108,6 +109,9 @@ export function BudgetGrid({
   onMonthSelect,
 }: Props) {
   const firstMonth = activeMonths[0] ?? null;
+  // Daily-refreshed date so the current-month highlight + time-of-month marker
+  // (RD-067) don't go stale on a page left open across midnight.
+  const today = useDailyDate();
   const { merged, isLoading, errors } = useMonthsData();
   const hasAnyData = merged !== null;
   const firstMonthError = firstMonth ? errors.get(firstMonth) : undefined;
@@ -342,6 +346,7 @@ export function BudgetGrid({
           availableMonths={availableMonths}
           isSelected={month === selectedMonth}
           onSelect={onMonthSelect}
+          today={today}
         />
       ))}
 

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -34,7 +34,6 @@ function GroupMonthAggregate({
   onToggleCollapse,
   isReadOnlyMonth,
   showSpendingBars,
-  inCrosshair,
 }: {
   month: string;
   groupId: string;
@@ -47,7 +46,6 @@ function GroupMonthAggregate({
   onToggleCollapse?: () => void;
   isReadOnlyMonth?: boolean;
   showSpendingBars?: boolean;
-  inCrosshair?: boolean;
 }) {
   const data = useEffectiveMonthFromContext(month);
   const group = data?.groupsById[groupId];
@@ -86,9 +84,6 @@ function GroupMonthAggregate({
         onFocus={onFocus}
         onKeyDown={handleKeyDown}
       >
-        {inCrosshair && !isSelected && (
-          <span className="pointer-events-none absolute inset-0 bg-primary/[0.06]" aria-hidden="true" />
-        )}
         --
       </div>
     );
@@ -164,9 +159,6 @@ function GroupMonthAggregate({
       onFocus={onFocus}
       onKeyDown={handleKeyDown}
     >
-      {inCrosshair && !isSelected && (
-        <span className="pointer-events-none absolute inset-0 bg-primary/[0.06]" aria-hidden="true" />
-      )}
       {stagedChildCount > 0 && (
         <span
           className="absolute top-1 left-1 h-1.5 w-1.5 rounded-full bg-amber-400 dark:bg-amber-500"
@@ -198,8 +190,7 @@ export type GroupRowsProps = {
   suppressNextClickRef: { current: boolean };
   showHidden: boolean;
   showSpendingBars?: boolean;
-  /** F-083: focused cell's month/category, for the crosshair row+column tint. */
-  crosshairMonth?: string | null;
+  /** F-083: focused cell's category, for the crosshair row-label (axis) tint. */
   crosshairCategoryId?: string | null;
   groupSelection?: { groupId: string; month: string } | null;
   rowSelection?: RowSelection | null;
@@ -239,7 +230,6 @@ export function BudgetGridGroupRows({
   suppressNextClickRef,
   showHidden,
   showSpendingBars,
-  crosshairMonth,
   crosshairCategoryId,
   groupSelection,
   rowSelection,
@@ -327,7 +317,6 @@ export function BudgetGridGroupRows({
           onToggleCollapse={onToggleCollapse}
           isReadOnlyMonth={readOnlyMonths.has(month)}
           showSpendingBars={showSpendingBars}
-          inCrosshair={crosshairMonth != null && month === crosshairMonth}
         />
       ))}
 
@@ -374,7 +363,7 @@ export function BudgetGridGroupRows({
                 }
               >
                 {isCrosshairRow && !isCatRowSelected && (
-                  <span className="pointer-events-none absolute inset-0 bg-primary/[0.06]" aria-hidden="true" />
+                  <span className="pointer-events-none absolute inset-0 bg-primary/[0.08]" aria-hidden="true" />
                 )}
                 <span className="flex-1 min-w-0 truncate">{cat.name}</span>
                 {allNotes?.has(cat.id) && (
@@ -404,9 +393,6 @@ export function BudgetGridGroupRows({
                     isDimmed={catDimmed}
                     isReadOnlyMonth={readOnlyMonths.has(month)}
                     showSpendingBars={showSpendingBars}
-                    inCrosshair={
-                      (crosshairMonth != null && month === crosshairMonth) || isCrosshairRow
-                    }
                     onFocus={onCellFocus}
                     onRangeSelect={onCellRangeSelect}
                     onNavigate={(dir) => onCellNavigate?.(cat.id, month, dir)}

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -34,6 +34,7 @@ function GroupMonthAggregate({
   onToggleCollapse,
   isReadOnlyMonth,
   showSpendingBars,
+  inCrosshair,
 }: {
   month: string;
   groupId: string;
@@ -46,6 +47,7 @@ function GroupMonthAggregate({
   onToggleCollapse?: () => void;
   isReadOnlyMonth?: boolean;
   showSpendingBars?: boolean;
+  inCrosshair?: boolean;
 }) {
   const data = useEffectiveMonthFromContext(month);
   const group = data?.groupsById[groupId];
@@ -159,6 +161,9 @@ function GroupMonthAggregate({
       onFocus={onFocus}
       onKeyDown={handleKeyDown}
     >
+      {inCrosshair && !isSelected && (
+        <span className="pointer-events-none absolute inset-0 bg-primary/[0.06]" aria-hidden="true" />
+      )}
       {stagedChildCount > 0 && (
         <span
           className="absolute top-1 left-1 h-1.5 w-1.5 rounded-full bg-amber-400 dark:bg-amber-500"
@@ -190,6 +195,9 @@ export type GroupRowsProps = {
   suppressNextClickRef: { current: boolean };
   showHidden: boolean;
   showSpendingBars?: boolean;
+  /** F-083: focused cell's month/category, for the crosshair row+column tint. */
+  crosshairMonth?: string | null;
+  crosshairCategoryId?: string | null;
   groupSelection?: { groupId: string; month: string } | null;
   rowSelection?: RowSelection | null;
   readOnlyMonths: Set<string>;
@@ -228,6 +236,8 @@ export function BudgetGridGroupRows({
   suppressNextClickRef,
   showHidden,
   showSpendingBars,
+  crosshairMonth,
+  crosshairCategoryId,
   groupSelection,
   rowSelection,
   readOnlyMonths,
@@ -314,6 +324,7 @@ export function BudgetGridGroupRows({
           onToggleCollapse={onToggleCollapse}
           isReadOnlyMonth={readOnlyMonths.has(month)}
           showSpendingBars={showSpendingBars}
+          inCrosshair={crosshairMonth != null && month === crosshairMonth}
         />
       ))}
 
@@ -332,6 +343,8 @@ export function BudgetGridGroupRows({
           const catRowSelectedClass = isCatRowSelected
             ? " ring-2 ring-inset ring-foreground/80"
             : "";
+          const isCrosshairRow =
+            crosshairCategoryId != null && crosshairCategoryId === cat.id;
 
           return (
             <div
@@ -342,7 +355,7 @@ export function BudgetGridGroupRows({
             >
               {/* Category label - clickable / focusable to select the row */}
               <div
-                className={`h-7 pl-4 pr-2 flex items-center border-r border-b border-border/50 text-xs sticky left-0 bg-background cursor-default outline-none${catDimClass}${catRowSelectedClass}`}
+                className={`relative h-7 pl-4 pr-2 flex items-center border-r border-b border-border/50 text-xs sticky left-0 bg-background cursor-default outline-none${catDimClass}${catRowSelectedClass}`}
                 role="gridcell"
                 tabIndex={0}
                 aria-selected={isCatRowSelected}
@@ -357,6 +370,9 @@ export function BudgetGridGroupRows({
                   })
                 }
               >
+                {isCrosshairRow && !isCatRowSelected && (
+                  <span className="pointer-events-none absolute inset-0 bg-primary/[0.06]" aria-hidden="true" />
+                )}
                 <span className="flex-1 min-w-0 truncate">{cat.name}</span>
                 {allNotes?.has(cat.id) && (
                   <StickyNote className="ml-1.5 h-3 w-3 shrink-0 text-muted-foreground/50" aria-hidden="true" />
@@ -385,6 +401,9 @@ export function BudgetGridGroupRows({
                     isDimmed={catDimmed}
                     isReadOnlyMonth={readOnlyMonths.has(month)}
                     showSpendingBars={showSpendingBars}
+                    inCrosshair={
+                      (crosshairMonth != null && month === crosshairMonth) || isCrosshairRow
+                    }
                     onFocus={onCellFocus}
                     onRangeSelect={onCellRangeSelect}
                     onNavigate={(dir) => onCellNavigate?.(cat.id, month, dir)}

--- a/src/features/budget-management/components/grid/GroupRows.tsx
+++ b/src/features/budget-management/components/grid/GroupRows.tsx
@@ -72,7 +72,7 @@ function GroupMonthAggregate({
   if (!group && isReadOnlyMonth) {
     return (
       <div
-        className={`${baseClass}${dimClass} px-2 flex items-center justify-end text-xs font-sans tabular-nums text-muted-foreground cursor-not-allowed outline-none${isSelected ? " ring-2 ring-inset ring-foreground/80" : ""}`}
+        className={`relative ${baseClass}${dimClass} px-2 flex items-center justify-end text-xs font-sans tabular-nums text-muted-foreground cursor-not-allowed outline-none${isSelected ? " ring-2 ring-inset ring-foreground/80" : ""}`}
         role="gridcell"
         tabIndex={0}
         aria-selected={isSelected}
@@ -86,6 +86,9 @@ function GroupMonthAggregate({
         onFocus={onFocus}
         onKeyDown={handleKeyDown}
       >
+        {inCrosshair && !isSelected && (
+          <span className="pointer-events-none absolute inset-0 bg-primary/[0.06]" aria-hidden="true" />
+        )}
         --
       </div>
     );

--- a/src/features/budget-management/components/grid/MonthColumnHeader.test.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.test.tsx
@@ -17,7 +17,10 @@ describe("MonthColumnHeader current-month highlight (F-079)", () => {
   it("includes the elapsed day-of-month in the current-month accessible name (RD-067)", () => {
     render(<MonthColumnHeader month={now} availableMonths={[now]} />);
     // e.g. "... (current month, day 12 of 31)"
-    expect(screen.getByLabelText(/current month, day \d+ of \d+/i)).toBeInTheDocument();
+    const header = screen.getByLabelText(/current month, day \d+ of \d+/i);
+    expect(header).toBeInTheDocument();
+    // The day text is also on a hit-testable header title (not just the 1px marker).
+    expect(header.getAttribute("title")).toMatch(/today, day \d+ of \d+/i);
   });
 
   it("does not add an elapsed marker on a non-current month", () => {

--- a/src/features/budget-management/components/grid/MonthColumnHeader.test.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.test.tsx
@@ -14,6 +14,17 @@ describe("MonthColumnHeader current-month highlight (F-079)", () => {
     expect(header.className).toMatch(/font-bold/);
   });
 
+  it("includes the elapsed day-of-month in the current-month accessible name (RD-067)", () => {
+    render(<MonthColumnHeader month={now} availableMonths={[now]} />);
+    // e.g. "... (current month, day 12 of 31)"
+    expect(screen.getByLabelText(/current month, day \d+ of \d+/i)).toBeInTheDocument();
+  });
+
+  it("does not add an elapsed marker on a non-current month", () => {
+    render(<MonthColumnHeader month={other} availableMonths={[other]} />);
+    expect(screen.getByLabelText(/^Month:/).getAttribute("aria-label")).not.toMatch(/day \d+ of/i);
+  });
+
   it("does not mark a non-current month", () => {
     render(<MonthColumnHeader month={other} availableMonths={[other]} />);
     const header = screen.getByLabelText(/^Month:/);

--- a/src/features/budget-management/components/grid/MonthColumnHeader.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { useBudgetEditsStore } from "@/store/budgetEdits";
-import { currentMonth, formatMonthLabel } from "@/lib/budget/monthMath";
+import { currentMonth, formatMonthLabel, monthElapsedFraction } from "@/lib/budget/monthMath";
 
 /**
  * Sticky column header for a single month: full-name label plus a status dot.
@@ -34,6 +34,14 @@ export function MonthColumnHeader({
   const isAvailable = availableMonths.includes(month);
   const isCurrentMonth = month === currentMonth();
 
+  // RD-067: how far through the current month "today" is, for a subtle marker on
+  // the current-month column (so a spending bar reads as fair — 80% spent on the
+  // 5th ≠ on the 25th). Only meaningful for the current month.
+  const now = new Date();
+  const elapsedFraction = isCurrentMonth ? monthElapsedFraction(month, now) : null;
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  const elapsedText = isCurrentMonth ? `, day ${now.getDate()} of ${daysInMonth}` : "";
+
   const label = formatMonthLabel(month, "long");
 
   const dotColor = !isAvailable
@@ -53,7 +61,7 @@ export function MonthColumnHeader({
   return (
     <div
       className={cn(
-        "h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 text-xs sticky top-0 z-20",
+        "relative h-8 px-2 flex items-center justify-end gap-1.5 border-b-2 text-xs sticky top-0 z-20",
         isCurrentMonth ? "font-bold" : "font-semibold",
         isSelected
           ? "border-primary/70 bg-muted text-foreground"
@@ -62,7 +70,7 @@ export function MonthColumnHeader({
           : "border-border bg-muted text-foreground",
         selectable && "cursor-pointer hover:bg-muted/70"
       )}
-      aria-label={`Month: ${label}${isCurrentMonth ? " (current month)" : ""}`}
+      aria-label={`Month: ${label}${isCurrentMonth ? ` (current month${elapsedText})` : ""}`}
       // Always present on the current-month header (even when the month is not
       // yet available/selectable) so orientation can reliably scroll to it.
       {...(isCurrentMonth ? { "aria-current": "date" as const, "data-current-month-header": "" } : {})}
@@ -89,6 +97,15 @@ export function MonthColumnHeader({
         aria-hidden="true"
       />
       <span className="truncate">{label}</span>
+
+      {elapsedFraction !== null && (
+        <span
+          className="pointer-events-none absolute bottom-0 w-px h-2 bg-primary/70 rounded-t"
+          style={{ left: `${elapsedFraction * 100}%` }}
+          title={`Today${elapsedText}`}
+          aria-hidden="true"
+        />
+      )}
     </div>
   );
 }

--- a/src/features/budget-management/components/grid/MonthColumnHeader.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.tsx
@@ -22,22 +22,30 @@ export function MonthColumnHeader({
   availableMonths,
   isSelected,
   onSelect,
+  /** Current date, passed daily-refreshed from the grid so the marker doesn't
+   *  go stale on a long-lived page. Defaults to now for standalone/test use. */
+  today,
 }: {
   month: string;
   availableMonths: string[];
   isSelected?: boolean;
   onSelect?: (month: string) => void;
+  today?: Date;
 }) {
   const hasStagedEdits = useBudgetEditsStore((s) =>
     Object.keys(s.edits).some((k) => k.startsWith(`${month}:`))
   );
   const isAvailable = availableMonths.includes(month);
-  const isCurrentMonth = month === currentMonth();
 
   // RD-067: how far through the current month "today" is, for a subtle marker on
   // the current-month column (so a spending bar reads as fair — 80% spent on the
-  // 5th ≠ on the 25th). Only meaningful for the current month.
-  const now = new Date();
+  // 5th ≠ on the 25th). Derived from the same `today` used for the current-month
+  // check so both stay in sync across a midnight/month boundary.
+  const now = today ?? new Date();
+  const nowMonth = Number.isFinite(now.getTime())
+    ? `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`
+    : currentMonth();
+  const isCurrentMonth = month === nowMonth;
   const elapsedFraction = isCurrentMonth ? monthElapsedFraction(month, now) : null;
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
   const elapsedText = isCurrentMonth ? `, day ${now.getDate()} of ${daysInMonth}` : "";
@@ -58,6 +66,15 @@ export function MonthColumnHeader({
 
   const selectable = isAvailable && onSelect != null;
 
+  // Hit-testable tooltip on the whole header (the 1px marker itself can't reliably
+  // receive hover): surfaces "today, day X of Y" for the current month, plus the
+  // select hint when selectable.
+  const headerTitle = isCurrentMonth
+    ? `Today${elapsedText}${selectable ? ` — select ${label}` : ""}`
+    : selectable
+    ? `Select ${label}`
+    : undefined;
+
   return (
     <div
       className={cn(
@@ -71,6 +88,7 @@ export function MonthColumnHeader({
         selectable && "cursor-pointer hover:bg-muted/70"
       )}
       aria-label={`Month: ${label}${isCurrentMonth ? ` (current month${elapsedText})` : ""}`}
+      {...(headerTitle ? { title: headerTitle } : {})}
       // Always present on the current-month header (even when the month is not
       // yet available/selectable) so orientation can reliably scroll to it.
       {...(isCurrentMonth ? { "aria-current": "date" as const, "data-current-month-header": "" } : {})}
@@ -80,7 +98,6 @@ export function MonthColumnHeader({
             tabIndex: 0,
             "data-month-header": month,
             "aria-pressed": isSelected ?? false,
-            title: `Select ${label}`,
             onClick: () => onSelect(month),
             onKeyDown: (e: React.KeyboardEvent) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -102,7 +119,6 @@ export function MonthColumnHeader({
         <span
           className="pointer-events-none absolute bottom-0 w-px h-2 bg-primary/70 rounded-t"
           style={{ left: `${elapsedFraction * 100}%` }}
-          title={`Today${elapsedText}`}
           aria-hidden="true"
         />
       )}

--- a/src/features/budget-management/components/grid/MonthColumnHeader.tsx
+++ b/src/features/budget-management/components/grid/MonthColumnHeader.tsx
@@ -25,12 +25,15 @@ export function MonthColumnHeader({
   /** Current date, passed daily-refreshed from the grid so the marker doesn't
    *  go stale on a long-lived page. Defaults to now for standalone/test use. */
   today,
+  inCrosshair,
 }: {
   month: string;
   availableMonths: string[];
   isSelected?: boolean;
   onSelect?: (month: string) => void;
   today?: Date;
+  /** F-083: this is the focused cell's column (crosshair axis tint). */
+  inCrosshair?: boolean;
 }) {
   const hasStagedEdits = useBudgetEditsStore((s) =>
     Object.keys(s.edits).some((k) => k.startsWith(`${month}:`))
@@ -108,6 +111,9 @@ export function MonthColumnHeader({
           }
         : {})}
     >
+      {inCrosshair && !isSelected && (
+        <span className="pointer-events-none absolute inset-0 bg-primary/[0.08]" aria-hidden="true" />
+      )}
       <span
         className={`h-1.5 w-1.5 rounded-full shrink-0 ${dotColor}`}
         title={dotTitle}

--- a/src/features/budget-management/components/grid/SpendingBarView.tsx
+++ b/src/features/budget-management/components/grid/SpendingBarView.tsx
@@ -11,12 +11,12 @@ const BAR_FILL_CLASS: Record<SpendingTier, string> = {
   // `empty` has zero fill width, so its colour never actually paints — it just
   // shows the neutral gray track (below) for a consistent, calm grid.
   empty: "bg-transparent",
-  under: "bg-emerald-500/40 dark:bg-emerald-400/35",
-  near: "bg-amber-500/50 dark:bg-amber-500/45",
-  over: "bg-amber-500/50 dark:bg-amber-500/45",
+  under: "bg-emerald-500/25 dark:bg-emerald-400/25",
+  near: "bg-amber-500/30 dark:bg-amber-500/30",
+  over: "bg-amber-500/30 dark:bg-amber-500/30",
   // Distinct from `over` (amber + red overflow): a muted red means money left an
   // envelope/group that was never funded.
-  unbudgeted: "bg-destructive/25",
+  unbudgeted: "bg-destructive/15",
 };
 
 /**
@@ -37,7 +37,7 @@ export function SpendingBarView({ bar }: { bar: SpendingBar }) {
       />
       {bar.overflow > 0 && (
         <span
-          className="absolute bottom-0 right-0 h-full bg-destructive/55"
+          className="absolute bottom-0 right-0 h-full bg-destructive/35"
           style={{ width: `${bar.overflow * 100}%` }}
         />
       )}

--- a/src/features/budget-management/hooks/useDailyDate.ts
+++ b/src/features/budget-management/hooks/useDailyDate.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns the current `Date`, re-rendering once at each local midnight so that
+ * date-derived UI (e.g. the current-month highlight and the time-of-month
+ * marker, RD-067) doesn't go stale on a long-lived page left open across a day
+ * or month boundary.
+ */
+export function useDailyDate(): Date {
+  const [date, setDate] = useState(() => new Date());
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      const now = new Date();
+      // A second past the next local midnight, so we're safely into the new day.
+      const nextMidnight = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() + 1,
+        0,
+        0,
+        1
+      );
+      timer = setTimeout(() => {
+        setDate(new Date());
+        schedule();
+      }, nextMidnight.getTime() - now.getTime());
+    };
+    schedule();
+    return () => clearTimeout(timer);
+  }, []);
+
+  return date;
+}

--- a/src/lib/budget/monthMath.test.ts
+++ b/src/lib/budget/monthMath.test.ts
@@ -26,6 +26,10 @@ describe("monthElapsedFraction", () => {
     expect(f).toBeLessThan(0.52);
   });
 
+  it("falls back to 0 for an invalid Date", () => {
+    expect(monthElapsedFraction("2026-06", new Date(""))).toBe(0);
+  });
+
   it("handles a leap-year February (29 days)", () => {
     // 2028 is a leap year; end-of-day Feb 15 ≈ just over half of 29 days.
     const f = monthElapsedFraction("2028-02", new Date(2028, 1, 15, 12, 0, 0));

--- a/src/lib/budget/monthMath.test.ts
+++ b/src/lib/budget/monthMath.test.ts
@@ -6,7 +6,35 @@ import {
   compareMonths,
   formatMonthLabel,
   isValidMonth,
+  monthElapsedFraction,
 } from "./monthMath";
+
+describe("monthElapsedFraction", () => {
+  it("is 0 before the month and 1 after it", () => {
+    expect(monthElapsedFraction("2026-06", new Date(2026, 4, 20))).toBe(0); // May, before June
+    expect(monthElapsedFraction("2026-06", new Date(2026, 6, 3))).toBe(1); // July, after June
+  });
+
+  it("is 0 at the first instant of the month", () => {
+    expect(monthElapsedFraction("2026-06", new Date(2026, 5, 1, 0, 0, 0))).toBe(0);
+  });
+
+  it("is ~0.5 at mid-month", () => {
+    // June has 30 days; midday of the 16th is ~half elapsed.
+    const f = monthElapsedFraction("2026-06", new Date(2026, 5, 16, 0, 0, 0));
+    expect(f).toBeGreaterThan(0.48);
+    expect(f).toBeLessThan(0.52);
+  });
+
+  it("handles a leap-year February (29 days)", () => {
+    // 2028 is a leap year; end-of-day Feb 15 ≈ just over half of 29 days.
+    const f = monthElapsedFraction("2028-02", new Date(2028, 1, 15, 12, 0, 0));
+    expect(f).toBeGreaterThan(0.48);
+    expect(f).toBeLessThan(0.55);
+    // The 29th exists and is within the month (fraction < 1).
+    expect(monthElapsedFraction("2028-02", new Date(2028, 1, 29, 0, 0, 0))).toBeLessThan(1);
+  });
+});
 
 describe("isValidMonth", () => {
   it.each([

--- a/src/lib/budget/monthMath.ts
+++ b/src/lib/budget/monthMath.ts
@@ -40,6 +40,25 @@ export function currentMonth(): string {
   return fromDate(new Date());
 }
 
+/**
+ * Fraction of `month` that has elapsed as of `now`, in [0, 1].
+ *
+ * `0` if `now` is at/before the month's first instant, `1` if the month has
+ * fully passed, otherwise the elapsed time within the month divided by the
+ * month's length. Timestamp-based, so leap years and month lengths are handled
+ * by `Date`. Used to show "where are we in the month?" on the current-month
+ * column (RD-067).
+ */
+export function monthElapsedFraction(month: string, now: Date): number {
+  const [year, mo] = parseMonth(month);
+  const start = new Date(year, mo - 1, 1).getTime();
+  const end = new Date(year, mo, 1).getTime(); // first instant of the next month
+  const t = now.getTime();
+  if (t <= start) return 0;
+  if (t >= end) return 1;
+  return (t - start) / (end - start);
+}
+
 /** Add `delta` months (may be negative) to `month`. */
 export function addMonths(month: string, delta: number): string {
   const [year, mo] = parseMonth(month);

--- a/src/lib/budget/monthMath.ts
+++ b/src/lib/budget/monthMath.ts
@@ -47,13 +47,14 @@ export function currentMonth(): string {
  * fully passed, otherwise the elapsed time within the month divided by the
  * month's length. Timestamp-based, so leap years and month lengths are handled
  * by `Date`. Used to show "where are we in the month?" on the current-month
- * column (RD-067).
+ * column (RD-067). An invalid `now` (e.g. `new Date("")`) falls back to `0`.
  */
 export function monthElapsedFraction(month: string, now: Date): number {
+  const t = now.getTime();
+  if (!Number.isFinite(t)) return 0; // invalid Date → treat as "not started"
   const [year, mo] = parseMonth(month);
   const start = new Date(year, mo - 1, 1).getTime();
   const end = new Date(year, mo, 1).getTime(); // first instant of the next month
-  const t = now.getTime();
   if (t <= start) return 0;
   if (t >= end) return 1;
   return (t - start) / (end - start);


### PR DESCRIPTION
## What

Two calm, additive budget-grid visuals from the 2026.08 visual-enhancement proposals — the no-virtualization-dependency first slice.

### Time-of-month marker (RD-067)

The spending bars show *how much* of an envelope is spent, but not whether that's alarming — 80% spent on the 5th ≠ on the 25th. A subtle marker on the **current-month column** shows how far through the month today is, positioned at the elapsed fraction. The day-of-month ("day 12 of 31") is in the column's accessible name and tooltip, so it's never conveyed by position/colour alone. Non-current months are unmarked.

- New `monthElapsedFraction(month, now)` in `monthMath.ts` — timestamp-based, leap-year safe, with unit tests.

### Crosshair highlight (F-083)

Tracing "which category × which month" across a 12-wide grid is real friction. The **focused cell's row and column** now get a faint `primary` tint to the grid edges — across category cells, group-total cells, and the category row label. Selection/anchor styling always wins over the crosshair.

Driven by the existing focus state (`focusMonth`/`focusCategoryId`), **not per-hover**, so it adds no re-render cost beyond what selection already incurs. (Per-hover was deliberately avoided until virtualization — RD-037 — lands.)

## Validation

- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean (src)
- `npm test` — budget + monthMath suites green (348); new tests for `monthElapsedFraction` and the current-month marker's accessible name
- Local `next build` OOMs in the dev environment; the authoritative build runs in CI
