### PR TITLE
Details panel follow-ups: trajectory refactor, chart a11y, loading skeleton

### DIFF
--- a/src/features/budget-management/components/details/BudgetDetailsPanel.tsx
+++ b/src/features/budget-management/components/details/BudgetDetailsPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { buildBudgetTransactionBrowserOptions } from "../../lib/budgetTransactionBrowser";
 import { toCategoryMonthNoteId } from "@/lib/api/notes";
 import type { BudgetNoteTarget } from "./BudgetNoteSection";
+import { DetailsSkeleton } from "./DetailsPrimitives";
 import { BudgetMonthSummaryPanel } from "./BudgetMonthSummaryPanel";
 import { EnvelopeDetailsPanel } from "./EnvelopeDetailsPanel";
 import { TrackingDetailsPanel } from "./TrackingDetailsPanel";
@@ -198,7 +199,7 @@ export function BudgetDetailsPanel() {
   })();
 
   if (displayMonths.length === 0) {
-    return <EmptyDetailsState message="Loading..." />;
+    return <DetailsSkeleton />;
   }
 
   if (availableMonthsError) {
@@ -231,7 +232,7 @@ export function BudgetDetailsPanel() {
     isMonthLoading ||
     (isTracking && incomeBudgetsLoading);
   if (isLoading && statesByMonth.size === 0) {
-    return <EmptyDetailsState message="Loading..." />;
+    return <DetailsSkeleton />;
   }
 
   if (budgetMode === "unidentified") {

--- a/src/features/budget-management/components/details/BudgetMonthSummaryPanel.tsx
+++ b/src/features/budget-management/components/details/BudgetMonthSummaryPanel.tsx
@@ -19,6 +19,7 @@ import type { BudgetMonthSummary, LoadedMonthState } from "../../types";
 import {
   DetailsHeader,
   DetailsSection,
+  DetailsSkeleton,
   MetricLine,
   PrimaryMetric,
   toneFromValue,
@@ -124,11 +125,7 @@ export function BudgetMonthSummaryPanel({
           />
         )
       ) : (
-        <DetailsSection>
-          <p className="text-[11px] text-muted-foreground">
-            Month data is still loading.
-          </p>
-        </DetailsSection>
+        <DetailsSkeleton header={false} boxes={2} />
       )}
 
       <BudgetNoteSection target={{ kind: "budgetMonth", id: month }} />

--- a/src/features/budget-management/components/details/DetailsPrimitives.test.tsx
+++ b/src/features/budget-management/components/details/DetailsPrimitives.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { DetailsSkeleton } from "./DetailsPrimitives";
+
+describe("DetailsSkeleton", () => {
+  it("announces loading to assistive tech instead of showing bare text", () => {
+    render(<DetailsSkeleton />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(/Loading budget details/i);
+  });
+});

--- a/src/features/budget-management/components/details/DetailsPrimitives.tsx
+++ b/src/features/budget-management/components/details/DetailsPrimitives.tsx
@@ -20,6 +20,47 @@ export function toneClass(tone: DetailsTone): string {
   return "text-foreground";
 }
 
+/**
+ * Shimmer placeholder shown while the panel's month data loads, instead of a
+ * bare "Loading…" line. Announces itself once to assistive tech; the visual
+ * blocks are decorative.
+ */
+export function DetailsSkeleton({
+  header = true,
+  boxes = 3,
+}: {
+  header?: boolean;
+  boxes?: number;
+}) {
+  return (
+    <div
+      className={header ? "px-3 py-2 space-y-3" : "space-y-3"}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="sr-only">Loading budget details…</span>
+      {header && (
+        <div className="space-y-1.5 pb-2 border-b border-border/40" aria-hidden="true">
+          <div className="h-2.5 w-24 rounded bg-muted animate-pulse" />
+          <div className="h-2 w-40 rounded bg-muted animate-pulse" />
+          <div className="h-1 w-full rounded bg-muted animate-pulse" />
+        </div>
+      )}
+      {Array.from({ length: boxes }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded border border-border/60 px-2.5 py-2 space-y-2"
+          aria-hidden="true"
+        >
+          <div className="h-2 w-20 rounded bg-muted animate-pulse" />
+          <div className="h-2 w-full rounded bg-muted animate-pulse" />
+          <div className="h-2 w-3/4 rounded bg-muted animate-pulse" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /** Positive value → good, negative → bad, zero → neutral. */
 export function toneFromValue(value: number): DetailsTone {
   if (value > 0) return "positive";

--- a/src/features/budget-management/components/details/DetailsVisuals.test.tsx
+++ b/src/features/budget-management/components/details/DetailsVisuals.test.tsx
@@ -78,10 +78,12 @@ describe("TrajectorySection", () => {
     // Upcoming-plan line shows only the open-months contribution (no "Closed so far").
     expect(screen.getByText("Upcoming plan · 2 mo")).toBeInTheDocument();
     expect(screen.queryByText("Closed so far")).not.toBeInTheDocument();
-    // The sparkline is present and labelled, with the renamed legend + Now marker.
+    // The sparkline carries a data-rich accessible name (not just "a chart"),
+    // and a screen-reader list of the per-month values.
     expect(
-      screen.getByLabelText(/Cumulative actual to date/),
+      screen.getByLabelText(/Projected result 4,630, full-period plan 4,700/),
     ).toBeInTheDocument();
+    expect(screen.getByText(/plan 2,000, actual 2,400/)).toBeInTheDocument();
     expect(screen.getByText("Projection")).toBeInTheDocument();
     expect(screen.queryByText("Forecast")).not.toBeInTheDocument();
     expect(screen.getByText("Now")).toBeInTheDocument();

--- a/src/features/budget-management/components/details/DetailsVisuals.tsx
+++ b/src/features/budget-management/components/details/DetailsVisuals.tsx
@@ -152,13 +152,26 @@ function TrajectorySparkline({
     trajectory.projectedValue
   )}`;
 
+  // Self-describing chart: the accessible name states the actual figures (not
+  // just the shape), and the sr-only list below gives the per-month values that
+  // are otherwise only reachable by mouse hover.
+  const planWord = trajectory.isSpend ? "budget" : "plan";
+  const bankedThrough = pts[todayIdx]?.month;
+  const chartLabel =
+    `Projected ${trajectory.isSpend ? "spend" : "result"} ${formatSummary(
+      trajectory.projectedValue
+    )}, full-period ${planWord} ${formatSummary(trajectory.planValue)}, ` +
+    `${formatSummary(Math.abs(trajectory.variance))} ${trajectory.varianceLabel} ${planWord}` +
+    (bankedThrough ? `; actual banked through ${formatMonthLabel(bankedThrough)}.` : ".");
+
   return (
+    <>
     <svg
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="none"
       className="block w-full h-14 text-muted-foreground"
       role="img"
-      aria-label="Cumulative actual to date, with a projection (actuals plus remaining plan) shown against the plan line."
+      aria-label={chartLabel}
     >
       {/* "Now" divider between banked actuals and the projection. */}
       <line
@@ -197,7 +210,8 @@ function TrajectorySparkline({
         strokeWidth={2}
         vectorEffect="non-scaling-stroke"
       />
-      {/* Invisible hit targets: exact monthly values on hover / tap. */}
+      {/* Invisible hit targets: exact monthly values on mouse hover. Screen
+          readers use the sr-only list below instead (the svg is role=img). */}
       {pts.map((p, i) => (
         <circle key={p.month} cx={xAt(i)} cy={yAt(p.actual ?? p.plan)} r={7} fill="transparent">
           <title>
@@ -208,6 +222,16 @@ function TrajectorySparkline({
         </circle>
       ))}
     </svg>
+      <ul className="sr-only">
+        {pts.map((p) => (
+          <li key={p.month}>
+            {`${formatMonthLabel(p.month)}: plan ${formatSummary(p.plan)}${
+              p.actual != null ? `, actual ${formatSummary(p.actual)}` : ""
+            }`}
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }
 

--- a/src/features/budget-management/lib/budgetDetailsMetrics.ts
+++ b/src/features/budget-management/lib/budgetDetailsMetrics.ts
@@ -1150,49 +1150,103 @@ export function buildDayProgress(
   };
 }
 
+type TrajectoryAccumulation = {
+  points: TrajectoryPoint[];
+  /** Cumulative plan across every displayed month. */
+  cumPlan: number;
+  /** Cumulative banked actual (closed, plus the current month when banked). */
+  bankedActual: number;
+  /** Cumulative plan for the banked months. */
+  bankedPlan: number;
+  /** Index of the last banked month (where the actual line ends), or -1. */
+  lastBankedIndex: number;
+  /** Count of fully-closed (past) months. */
+  closedCount: number;
+  /** Elapsed-month total for run-rate: 1 per closed month + the current fraction. */
+  elapsedMonths: number;
+};
+
 /**
- * Net-result trajectory for the period summary: actuals are banked up to today,
- * and every month after today contributes its planned result. So the projection
- * answers "if the rest of the year goes to plan, where do we land?".
+ * Walks the visible months once, accumulating the cumulative plan and actual
+ * lines for a trajectory chart. `bankCurrentPartial` decides whether the
+ * in-progress month counts as banked (spend run-rate) or is left to be
+ * projected at plan (net result).
+ */
+function accumulateTrajectory(
+  model: BudgetDetailsModel,
+  monthValues: (state: LoadedMonthState) => { plan: number; actual: number } | null,
+  bankCurrentPartial: boolean,
+  now: Date = new Date()
+): TrajectoryAccumulation {
+  const points: TrajectoryPoint[] = [];
+  let cumPlan = 0;
+  let bankedActual = 0;
+  let bankedPlan = 0;
+  let lastBankedIndex = -1;
+  let closedCount = 0;
+  let elapsedMonths = 0;
+
+  model.months.forEach((entry, i) => {
+    const v = entry.state ? monthValues(entry.state) : null;
+    cumPlan += v?.plan ?? 0;
+    const isPast = entry.status === "past";
+    const banked = isPast || (bankCurrentPartial && entry.status === "current-partial");
+    if (banked) {
+      bankedActual += v?.actual ?? 0;
+      bankedPlan += v?.plan ?? 0;
+      lastBankedIndex = i;
+      if (isPast) {
+        closedCount++;
+        elapsedMonths += 1;
+      } else {
+        elapsedMonths += monthElapsedFraction(entry.month, now);
+      }
+    }
+    points.push({
+      month: entry.month,
+      plan: cumPlan,
+      actual: banked ? bankedActual : null,
+    });
+  });
+
+  return {
+    points,
+    cumPlan,
+    bankedActual,
+    bankedPlan,
+    lastBankedIndex,
+    closedCount,
+    elapsedMonths,
+  };
+}
+
+/**
+ * Net-result trajectory for the period summary: actuals are banked for closed
+ * months only, and every not-yet-closed month contributes its planned result —
+ * so a late paycheck can't drag the projection down. Answers "if the rest of
+ * the period goes to plan, where do we land?".
  */
 function buildResultTrajectory(
   model: BudgetDetailsModel
 ): TrajectoryMetrics | null {
   if (model.months.length === 0 || model.coverage.isFutureOnly) return null;
 
-  const points: TrajectoryPoint[] = [];
-  let cumPlan = 0;
-  let cumClosedActual = 0;
-  let closedPlan = 0;
-  let closedCount = 0;
-  let lastClosedIndex = -1;
+  const accum = accumulateTrajectory(
+    model,
+    (state) => {
+      const v = getTrackingPeriodValues(state);
+      return {
+        plan: v.incomeBudgeted - v.expenseBudgeted,
+        actual: v.incomeActuals - v.expenseActuals,
+      };
+    },
+    false
+  );
+  if (accum.lastBankedIndex === -1) return null;
 
-  model.months.forEach((entry, i) => {
-    const values = entry.state ? getTrackingPeriodValues(entry.state) : null;
-    const planned = values ? values.incomeBudgeted - values.expenseBudgeted : 0;
-    const actual = values ? values.incomeActuals - values.expenseActuals : 0;
-    cumPlan += planned;
-    // Only closed months are banked. The current partial month is projected at
-    // plan (not its income-starved partial actuals), so a late paycheck can't
-    // drag the year-end projection down.
-    if (entry.status === "past") {
-      cumClosedActual += actual;
-      closedPlan += planned;
-      closedCount++;
-      lastClosedIndex = i;
-    }
-    points.push({
-      month: entry.month,
-      plan: cumPlan,
-      actual: entry.status === "past" ? cumClosedActual : null,
-    });
-  });
-
-  if (lastClosedIndex === -1) return null;
-
-  const openPlan = cumPlan - closedPlan;
-  const projectedValue = cumClosedActual + openPlan;
-  const planValue = cumPlan;
+  const openPlan = accum.cumPlan - accum.bankedPlan;
+  const projectedValue = accum.bankedActual + openPlan;
+  const planValue = accum.cumPlan;
   const variance = projectedValue - planValue;
   const rel = planValue !== 0 ? variance / Math.abs(planValue) : 0;
 
@@ -1224,11 +1278,11 @@ function buildResultTrajectory(
     chipLabel,
     chipTone,
     isSpend: false,
-    todayIndex: lastClosedIndex,
-    points,
+    todayIndex: accum.lastBankedIndex,
+    points: accum.points,
     breakdown: {
       openPlan,
-      openMonthCount: model.months.length - closedCount,
+      openMonthCount: model.months.length - accum.closedCount,
     },
   };
 }
@@ -1246,46 +1300,25 @@ function buildSelectionTrajectory(
 ): TrajectoryMetrics | null {
   if (target.isIncome || model.coverage.isFutureOnly) return null;
 
-  const points: TrajectoryPoint[] = [];
-  let cumPlan = 0;
-  let cumActual = 0;
-  let todayIndex = -1;
-  let banked = 0;
-  let elapsedMonths = 0;
-  let closedCount = 0;
-
-  model.months.forEach((entry, i) => {
-    const values = entry.state ? getTrackingTargetValues(entry.state, target) : null;
-    const plan = values ? Math.abs(values.budgeted) : 0;
-    const actual = values ? Math.abs(values.actuals) : 0;
-    cumPlan += plan;
-    if (isActualLikeStatus(entry.status)) {
-      cumActual += actual;
-      todayIndex = i;
-      banked = cumActual;
-      if (entry.status === "past") {
-        elapsedMonths += 1;
-        closedCount++;
-      } else {
-        elapsedMonths += monthElapsedFraction(entry.month, now);
-      }
-    }
-    points.push({
-      month: entry.month,
-      plan: cumPlan,
-      actual: isActualLikeStatus(entry.status) ? cumActual : null,
-    });
-  });
+  const accum = accumulateTrajectory(
+    model,
+    (state) => {
+      const v = getTrackingTargetValues(state, target);
+      return v ? { plan: Math.abs(v.budgeted), actual: Math.abs(v.actuals) } : null;
+    },
+    true,
+    now
+  );
 
   // Run-rate needs a closed month to be stable — projecting from a sliver of
   // the current month alone produces wild numbers.
-  if (todayIndex === -1 || closedCount === 0) return null;
+  if (accum.lastBankedIndex === -1 || accum.closedCount === 0) return null;
 
   const periodElapsed =
-    model.months.length > 0 ? elapsedMonths / model.months.length : 0;
+    model.months.length > 0 ? accum.elapsedMonths / model.months.length : 0;
   const projectedValue =
-    periodElapsed > 0 ? Math.round(banked / periodElapsed) : banked;
-  const planValue = cumPlan;
+    periodElapsed > 0 ? Math.round(accum.bankedActual / periodElapsed) : accum.bankedActual;
+  const planValue = accum.cumPlan;
   const variance = projectedValue - planValue;
   const rel = planValue !== 0 ? variance / Math.abs(planValue) : 0;
   const atRisk = rel > TRAJECTORY_PLAN_TOLERANCE;
@@ -1303,8 +1336,8 @@ function buildSelectionTrajectory(
     chipLabel: atRisk ? "at risk" : "on track",
     chipTone,
     isSpend: true,
-    todayIndex,
-    points,
+    todayIndex: accum.lastBankedIndex,
+    points: accum.points,
     breakdown: null,
   };
 }


### PR DESCRIPTION
## Summary

Follow-ups to the budget details panel redesign: one internal refactor, one accessibility improvement, and a nicer loading state. Small, self-contained, and independent.

## Changes

- **Refactor — shared trajectory accumulator.** The result and spend trajectory builders walked the visible months with near-identical accumulation logic. Extracted a single `accumulateTrajectory` helper they both drive (differing only in how each month is valued and whether the current partial month is banked). Behaviour is unchanged.
- **Accessibility — the trajectory chart no longer needs a mouse.** Its figures were only reachable via hover-only SVG `<title>`s. The chart now has a data-rich accessible name (projected / plan / variance, and where actuals end) plus an `sr-only` per-month list, so keyboard and screen-reader users get the same data. Mouse hover tooltips are unchanged.
- **Loading state — shimmer skeleton.** Replaced the bare "Loading…" / "Month data is still loading." strings with a skeleton (header + placeholder boxes) that announces itself once to assistive tech. Empty-*selection* states already carry guiding helper text, so they're left as-is.

## Tests

Budget-management suites are green (357 tests); type-check and lint clean.
