### PR TITLE
Bank reconciliation: navigation, keyboard decisions, and clearer status

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -71,7 +71,12 @@ type SidebarSection =
   | { type: "item"; item: NavItem }
   | { type: "group"; group: NavGroup };
 
-const SIDEBAR_SECTIONS: SidebarSection[] = [
+/**
+ * Exported so the overview page's cards can be checked against this order
+ * rather than drifting from it — two lists of the same destinations in two
+ * different orders read as two different sets of tools.
+ */
+export const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
     type: "item",
     item: {

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -146,6 +146,10 @@ export function SearchableCombobox({
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    // A search that matches nothing leaves nothing to walk: moving would set an
+    // index no option has, and point `aria-activedescendant` at an id that is
+    // not on the page.
+    if (navigable.length === 0) return;
     if (event.key === "ArrowDown") {
       event.preventDefault();
       moveTo(activeIndex >= navigable.length - 1 ? 0 : activeIndex + 1);
@@ -212,7 +216,7 @@ export function SearchableCombobox({
               role="combobox"
               aria-expanded
               aria-controls={listId}
-              aria-activedescendant={optionId(activeIndex)}
+              aria-activedescendant={navigable[activeIndex] === undefined ? undefined : optionId(activeIndex)}
               aria-label="Search options"
               className="h-5 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
@@ -327,6 +331,10 @@ export function MultiSearchableCombobox({
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    // A search that matches nothing leaves nothing to walk: moving would set an
+    // index no option has, and point `aria-activedescendant` at an id that is
+    // not on the page.
+    if (navigable.length === 0) return;
     if (event.key === "ArrowDown") {
       event.preventDefault();
       moveTo(activeIndex >= navigable.length - 1 ? 0 : activeIndex + 1);
@@ -406,7 +414,7 @@ export function MultiSearchableCombobox({
               role="combobox"
               aria-expanded
               aria-controls={listId}
-              aria-activedescendant={optionId(activeIndex)}
+              aria-activedescendant={navigable[activeIndex] === undefined ? undefined : optionId(activeIndex)}
               aria-label="Search options"
               className="h-5 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none"
             />

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useId, useRef } from "react";
 import { Search, Check, ChevronsUpDown, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -119,6 +119,49 @@ export function SearchableCombobox({
   const selectedLabel = options.find((o) => !o.isGroupHeader && o.id === value)?.name ?? "";
   const filtered = filterGroupedOptions(options, search);
 
+  /*
+   * Everything the arrow keys can land on, in the order it is drawn. Group
+   * headers are labels rather than choices, so they are skipped — pressing Down
+   * should always move to something selectable, never park on a heading.
+   *
+   * The empty id is the "- none -" row, which is a real choice: it clears the
+   * field.
+   */
+  const navigable = ["", ...filtered.filter((o) => !o.isGroupHeader).map((o) => o.id)];
+  const indexOf = new Map(navigable.map((id, index) => [id, index]));
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+  // Ties the highlighted row to the input, so assistive technology announces
+  // what the arrow keys are moving over instead of silence.
+  const listId = useId();
+  const optionId = (index: number) => `${listId}-option-${index}`;
+
+  /** Keeps the highlighted row on screen as it moves past the visible window. */
+  function moveTo(index: number) {
+    setActiveIndex(index);
+    listRef.current
+      ?.querySelector(`[data-index="${index}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveTo(activeIndex >= navigable.length - 1 ? 0 : activeIndex + 1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveTo(activeIndex <= 0 ? navigable.length - 1 : activeIndex - 1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const id = navigable[activeIndex];
+      if (id !== undefined) select(id);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeDropdown();
+    }
+  }
+
   function select(id: string) {
     onChange(id);
     closeDropdown();
@@ -129,7 +172,18 @@ export function SearchableCombobox({
       <button
         type="button"
         aria-label={ariaLabel}
-        onClick={() => (open ? closeDropdown() : openDropdown())}
+        onClick={() => {
+          if (open) {
+            closeDropdown();
+          } else {
+            // Start on the selected option, so Down moves on from where the
+            // user already is rather than from the top of the list.
+            setActiveIndex(indexOf.get(value) ?? 0);
+            openDropdown();
+          }
+        }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
         className={cn(
           "flex h-8 w-full items-center justify-between rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring/50",
           !selectedLabel && "text-muted-foreground",
@@ -147,17 +201,36 @@ export function SearchableCombobox({
             <input
               ref={searchRef}
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                // The list underneath just changed, so the old highlight no
+                // longer refers to the same row.
+                setActiveIndex(0);
+              }}
+              onKeyDown={handleKeyDown}
               placeholder="Search…"
+              role="combobox"
+              aria-expanded
+              aria-controls={listId}
+              aria-activedescendant={optionId(activeIndex)}
+              aria-label="Search options"
               className="h-5 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
           </div>
-          <ul className="max-h-48 overflow-y-auto py-1">
+          <ul ref={listRef} id={listId} role="listbox" className="max-h-48 overflow-y-auto py-1">
             <li>
               <button
                 type="button"
+                id={optionId(0)}
+                role="option"
+                aria-selected={value === ""}
+                data-index={0}
                 onClick={() => select("")}
-                className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                onMouseEnter={() => setActiveIndex(0)}
+                className={cn(
+                  "flex w-full items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                  activeIndex === 0 && "bg-accent text-accent-foreground"
+                )}
               >
                 <Check className={cn("h-3 w-3 shrink-0", value === "" ? "opacity-100" : "opacity-0")} />
                 - none -
@@ -181,10 +254,16 @@ export function SearchableCombobox({
                   <li key={o.id}>
                     <button
                       type="button"
+                      data-index={indexOf.get(o.id)}
+                      id={optionId(indexOf.get(o.id) ?? 0)}
+                      role="option"
+                      aria-selected={value === o.id}
                       onClick={() => select(o.id)}
+                      onMouseEnter={() => setActiveIndex(indexOf.get(o.id) ?? 0)}
                       className={cn(
                         "flex w-full items-center gap-2 pl-4 pr-2 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground",
-                        o.hidden ? "text-foreground/60" : "text-foreground"
+                        o.hidden ? "text-foreground/60" : "text-foreground",
+                        activeIndex === indexOf.get(o.id) && "bg-accent text-accent-foreground"
                       )}
                     >
                       <Check
@@ -229,6 +308,42 @@ export function MultiSearchableCombobox({
   const filtered = filterGroupedOptions(options, search);
 
   const selectedOptions = options.filter((o) => !o.isGroupHeader && values.includes(o.id));
+
+  // Same arrow-key walk as the single-select, minus the "- none -" row: with
+  // several selections, clearing is what the chips' own buttons are for.
+  const navigable = filtered.filter((o) => !o.isGroupHeader).map((o) => o.id);
+  const indexOf = new Map(navigable.map((id, index) => [id, index]));
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+  const listId = useId();
+  const optionId = (index: number) => `${listId}-option-${index}`;
+
+  function moveTo(index: number) {
+    setActiveIndex(index);
+    listRef.current
+      ?.querySelector(`[data-index="${index}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveTo(activeIndex >= navigable.length - 1 ? 0 : activeIndex + 1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveTo(activeIndex <= 0 ? navigable.length - 1 : activeIndex - 1);
+    } else if (event.key === "Enter") {
+      // Toggling rather than closing: picking several in a row is the whole
+      // point of a multi-select.
+      event.preventDefault();
+      const id = navigable[activeIndex];
+      if (id !== undefined) toggle(id);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeDropdown();
+    }
+  }
 
   function toggle(id: string) {
     onChange(values.includes(id) ? values.filter((v) => v !== id) : [...values, id]);
@@ -280,12 +395,29 @@ export function MultiSearchableCombobox({
             <input
               ref={searchRef}
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                // The list underneath just changed, so the old highlight no
+                // longer refers to the same row.
+                setActiveIndex(0);
+              }}
+              onKeyDown={handleKeyDown}
               placeholder="Search…"
+              role="combobox"
+              aria-expanded
+              aria-controls={listId}
+              aria-activedescendant={optionId(activeIndex)}
+              aria-label="Search options"
               className="h-5 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
           </div>
-          <ul className="max-h-48 overflow-y-auto py-1">
+          <ul
+            ref={listRef}
+            id={listId}
+            role="listbox"
+            aria-multiselectable
+            className="max-h-48 overflow-y-auto py-1"
+          >
             {filtered.filter((o) => !o.isGroupHeader).length === 0 ? (
               <li className="px-3 py-2 text-xs text-muted-foreground italic">No results</li>
             ) : (
@@ -304,10 +436,16 @@ export function MultiSearchableCombobox({
                   <li key={o.id}>
                     <button
                       type="button"
+                      data-index={indexOf.get(o.id)}
+                      id={optionId(indexOf.get(o.id) ?? 0)}
+                      role="option"
+                      aria-selected={values.includes(o.id)}
                       onClick={() => toggle(o.id)}
+                      onMouseEnter={() => setActiveIndex(indexOf.get(o.id) ?? 0)}
                       className={cn(
                         "flex w-full items-center gap-2 pl-4 pr-2 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground",
-                        o.hidden ? "text-foreground/60" : "text-foreground"
+                        o.hidden ? "text-foreground/60" : "text-foreground",
+                        activeIndex === indexOf.get(o.id) && "bg-accent text-accent-foreground"
                       )}
                     >
                       <Check

--- a/src/features/overview/lib/overviewCards.test.ts
+++ b/src/features/overview/lib/overviewCards.test.ts
@@ -1,0 +1,56 @@
+import { SIDEBAR_SECTIONS } from "@/components/layout/Sidebar";
+import { ENTITY_CARDS, TOOL_CARDS } from "./overviewCards";
+
+/**
+ * The overview's cards are a second route to the same destinations as the
+ * sidebar. Listing them in a different order makes the page read as a different
+ * set of tools, and it drifts silently: nothing fails when someone adds a
+ * navigation entry and forgets the card, or adds a card in the wrong place.
+ */
+
+function navHrefs(sectionLabel: string): string[] {
+  const section = SIDEBAR_SECTIONS.find(
+    (entry) => entry.type === "group" && entry.group.label === sectionLabel
+  );
+  if (!section || section.type !== "group") throw new Error(`no ${sectionLabel} section`);
+  return section.group.items.map((item) => item.href);
+}
+
+/** Card order must appear in nav order, though not every entry needs a card. */
+function isSubsequence(cards: string[], nav: string[]): boolean {
+  let index = 0;
+  for (const href of nav) {
+    if (href === cards[index]) index += 1;
+  }
+  return index === cards.length;
+}
+
+describe("overview cards follow the sidebar", () => {
+  it("lists the data-management cards in navigation order", () => {
+    const cards = ENTITY_CARDS.map((card) => card.href!);
+    expect(isSubsequence(cards, navHrefs("Data Management"))).toBe(true);
+  });
+
+  it("lists the tool cards in navigation order", () => {
+    const cards = TOOL_CARDS.map((card) => card.href!);
+    expect(isSubsequence(cards, navHrefs("Tools"))).toBe(true);
+  });
+
+  it("points every card at a real navigation destination", () => {
+    const known = new Set([...navHrefs("Data Management"), ...navHrefs("Tools")]);
+    for (const card of [...ENTITY_CARDS, ...TOOL_CARDS]) {
+      expect(known.has(card.href!)).toBe(true);
+    }
+  });
+
+  it("offers a card for bank reconciliation", () => {
+    expect(TOOL_CARDS.some((card) => card.href === "/reconciliation")).toBe(true);
+  });
+
+  it("leaves FX Rates to the sidebar", () => {
+    // It supports currency conversion in Budget File Sync rather than being
+    // somewhere to go in its own right.
+    expect(TOOL_CARDS.some((card) => card.href === "/fx-rates")).toBe(false);
+    expect(navHrefs("Tools")).toContain("/fx-rates");
+  });
+});

--- a/src/features/overview/lib/overviewCards.ts
+++ b/src/features/overview/lib/overviewCards.ts
@@ -1,6 +1,7 @@
 import {
   ArrowLeftRight,
   Calendar,
+  ClipboardCheck,
   Database,
   FileSearch,
   Landmark,
@@ -88,24 +89,26 @@ export const ENTITY_CARDS: OverviewActionCard[] = [
   },
 ];
 
+/**
+ * In the same order as the Tools section of the sidebar.
+ *
+ * Two lists of the same links in two different orders makes the overview read
+ * as a different set of tools rather than the same ones — so this follows the
+ * navigation.
+ *
+ * Not every navigation entry earns a card: FX Rates exists to support currency
+ * conversion in Budget File Sync rather than as somewhere to go in its own
+ * right, so it stays in the sidebar and out of here.
+ */
 export const TOOL_CARDS: OverviewActionCard[] = [
   {
-    id: "query",
-    label: "ActualQL Queries",
+    id: "rule-diagnostics",
+    label: "Rule Diagnostics",
     description:
-      "Explore budget data with custom ActualQL queries, inspect the results, and export the output.",
-    href: "/query",
-    icon: Terminal,
+      "Analyse rule coverage and conflicts across your transactions to identify gaps and overlapping conditions.",
+    icon: ShieldCheck,
     tone: "tool",
-  },
-  {
-    id: "diagnostics",
-    label: "Budget File Health",
-    description:
-      "Inspect the exported budget file in a read-only workspace with an overview and deterministic health checks.",
-    icon: FileSearch,
-    tone: "tool",
-    href: "/budget-diagnostics",
+    href: "/rules/diagnostics",
   },
   {
     id: "sync",
@@ -117,6 +120,24 @@ export const TOOL_CARDS: OverviewActionCard[] = [
     href: "/sync",
   },
   {
+    id: "reconciliation",
+    label: "Bank Reconciliation",
+    description:
+      "Check a bank statement against an account, settle the differences row by row, and apply only what you have reviewed.",
+    icon: ClipboardCheck,
+    tone: "tool",
+    href: "/reconciliation",
+  },
+  {
+    id: "query",
+    label: "ActualQL Queries",
+    description:
+      "Explore budget data with custom ActualQL queries, inspect the results, and export the output.",
+    href: "/query",
+    icon: Terminal,
+    tone: "tool",
+  },
+  {
     id: "data-browser",
     label: "Data Browser",
     description:
@@ -126,12 +147,12 @@ export const TOOL_CARDS: OverviewActionCard[] = [
     href: "/data-browser",
   },
   {
-    id: "rule-diagnostics",
-    label: "Rule Diagnostics",
+    id: "diagnostics",
+    label: "Budget File Health",
     description:
-      "Analyse rule coverage and conflicts across your transactions to identify gaps and overlapping conditions.",
-    icon: ShieldCheck,
+      "Inspect the exported budget file in a read-only workspace with an overview and deterministic health checks.",
+    icon: FileSearch,
     tone: "tool",
-    href: "/rules/diagnostics",
+    href: "/budget-diagnostics",
   },
 ];

--- a/src/features/reconciliation/components/ApplyResultPanel.tsx
+++ b/src/features/reconciliation/components/ApplyResultPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ApplyConfig } from "@/lib/reconciliation/session/plan";
 import { prospectiveTransaction } from "@/lib/reconciliation/session/prospective";
@@ -39,8 +38,6 @@ export type ApplyResultPanelProps = {
   /** The read-back check, once it has run. `null` while it is still running. */
   verification: VerificationReport | null;
   isVerifying: boolean;
-  isApplying: boolean;
-  onRetry: () => void;
 };
 
 export function ApplyResultPanel({
@@ -53,8 +50,6 @@ export function ApplyResultPanel({
   result,
   verification,
   isVerifying,
-  isApplying,
-  onRetry,
 }: ApplyResultPanelProps) {
   const failures = result.results.filter((entry) => entry.status === "failed");
 
@@ -335,16 +330,6 @@ export function ApplyResultPanel({
         </section>
       )}
 
-      {/* No back button here: the progress header and the page toolbar both
-          already lead out of this screen. */}
-      <div className="flex items-center justify-end gap-2 border-t border-border/50 pt-3">
-        {!result.complete && (
-          <Button onClick={onRetry} disabled={isApplying}>
-            <RefreshCw className="mr-1 h-3.5 w-3.5" />
-            Retry what failed
-          </Button>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/features/reconciliation/components/ApplyResultPanel.tsx
+++ b/src/features/reconciliation/components/ApplyResultPanel.tsx
@@ -158,7 +158,7 @@ export function ApplyResultPanel({
                 return (
                   <li key={`${issue.operationId}-${issue.kind}`}>
                     <span className="font-medium">{operation?.kind ?? "Change"}</span>
-                    <span className="text-muted-foreground"> — {issue.detail}</span>
+                    <span className="text-muted-foreground"> - {issue.detail}</span>
                   </li>
                 );
               })}
@@ -168,7 +168,7 @@ export function ApplyResultPanel({
       ) : null}
 
       {/*
-        What was written, row by row, with the statement it came from beside it.
+        What was applied, row by row, with the statement it came from beside it.
 
         The panel previously listed only failures, which left a successful apply
         — and every reopened session — showing a headline and nothing at all.
@@ -178,7 +178,7 @@ export function ApplyResultPanel({
       {written.length > 0 && (
         <section className="-mx-4 flex min-h-[18rem] flex-1 flex-col border-y border-border/60">
           <h3 className="shrink-0 border-b border-border/50 px-3 py-2 text-xs font-semibold">
-            What was written
+            What was applied
           </h3>
           <div className="min-h-0 flex-1 overflow-auto">
             <table className="w-full border-collapse text-xs">
@@ -252,13 +252,13 @@ export function ApplyResultPanel({
                   return (
                     <tr key={entry.operationId} className="border-b border-border/20">
                       <td className="whitespace-nowrap px-3 py-1 tabular-nums text-muted-foreground">
-                        {statementRow ? formatShortDate(statementRow.postedDate) : "—"}
+                        {statementRow ? formatShortDate(statementRow.postedDate) : "-"}
                       </td>
                       <td className="max-w-0 truncate px-3 py-1" title={statementRow?.description}>
-                        {statementRow?.description ?? "—"}
+                        {statementRow?.description ?? "-"}
                       </td>
                       <td className="whitespace-nowrap px-3 py-1 text-right tabular-nums">
-                        {statementRow ? formatMinorUnits(statementRow.amount) : "—"}
+                        {statementRow ? formatMinorUnits(statementRow.amount) : "-"}
                       </td>
 
                       <td
@@ -281,21 +281,21 @@ export function ApplyResultPanel({
                       ) : (
                         <>
                           <td className="whitespace-nowrap px-3 py-1 tabular-nums text-muted-foreground">
-                            {pending?.date ? formatShortDate(pending.date) : "—"}
+                            {pending?.date ? formatShortDate(pending.date) : "-"}
                           </td>
                           <td className="max-w-0 truncate px-3 py-1">
                             {payeeName(pending?.payeeId ?? null) ??
                               (pending?.isNew && applyConfig.descriptionTarget === "payee"
-                                ? statementRow?.description ?? "—"
-                                : "—")}
+                                ? statementRow?.description ?? "-"
+                                : "-")}
                           </td>
                           <td className="max-w-0 truncate px-3 py-1" title={pending?.notes ?? undefined}>
-                            {pending?.notes ?? "—"}
+                            {pending?.notes ?? "-"}
                           </td>
                           <td className="whitespace-nowrap px-3 py-1 text-right tabular-nums">
                             {pending && pending.amount !== null
                               ? formatMinorUnits(pending.amount)
-                              : "—"}
+                              : "-"}
                           </td>
                         </>
                       )}

--- a/src/features/reconciliation/components/CoverageSummary.tsx
+++ b/src/features/reconciliation/components/CoverageSummary.tsx
@@ -22,7 +22,17 @@ type Segment = {
   dot: string;
 };
 
-function segmentsFor(side: SideCoverage, unaccountedLabel: string): Segment[] {
+/**
+ * `unaccountedTone` is passed in because the third segment means something
+ * different on each side — missing from Actual, versus missing from the
+ * statement — and they were sharing a colour while the filters gave them two.
+ * Each now matches the filter that selects it.
+ */
+function segmentsFor(
+  side: SideCoverage,
+  unaccountedLabel: string,
+  unaccountedTone: string
+): Segment[] {
   return [
     {
       key: "matched",
@@ -42,8 +52,8 @@ function segmentsFor(side: SideCoverage, unaccountedLabel: string): Segment[] {
       key: "unaccounted",
       label: unaccountedLabel,
       value: side.unaccounted,
-      bar: "bg-sky-500/60",
-      dot: "bg-sky-500/60",
+      bar: unaccountedTone,
+      dot: unaccountedTone,
     },
   ];
 }
@@ -107,10 +117,56 @@ function Side({
   );
 }
 
+/**
+ * How much of the work is done, as a compact meter.
+ *
+ * Separate from coverage, and deliberately small. Coverage answers "how much of
+ * the statement is accounted for" and is a composition; this answers "how far
+ * through am I", which is the only figure here that climbs to 100% as the user
+ * works — so it belongs beside the rows rather than in the header, and it is a
+ * short meter rather than a third full-width bar competing with the two above.
+ */
+export function DecisionProgressMeter({ coverage }: { coverage: ReconciliationCoverage }) {
+  const { decisions } = coverage;
+  const total = decisions.decided + decisions.pending;
+  if (total === 0) return null;
+
+  const percent = Math.round((decisions.decided / total) * 100);
+
+  return (
+    <div
+      className="flex items-center gap-2 text-xs"
+      title={`${decisions.automatic} more matched automatically and needed no decision`}
+    >
+      <span className="whitespace-nowrap tabular-nums">
+        <span className="font-medium">{decisions.decided}</span>
+        <span className="text-muted-foreground"> of {total} decided</span>
+      </span>
+      <div
+        className="h-1.5 w-16 overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuenow={decisions.decided}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-label="Rows decided"
+      >
+        <div
+          className={cn(
+            "h-full transition-all",
+            decisions.pending === 0 ? "bg-emerald-500/70" : "bg-amber-500/70"
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      {decisions.pending === 0 && (
+        <span className="whitespace-nowrap text-emerald-600 dark:text-emerald-400">All decided</span>
+      )}
+    </div>
+  );
+}
+
 export function CoverageSummary({ coverage }: { coverage: ReconciliationCoverage }) {
-  const { statement, actual, decisions } = coverage;
-  const statementOpen = statement.needsReview + statement.unaccounted;
-  const needingDecision = decisions.decided + decisions.pending;
+  const { statement, actual } = coverage;
 
   const actualNote = [
     coverage.outsideStatementPeriod > 0
@@ -130,48 +186,23 @@ export function CoverageSummary({ coverage }: { coverage: ReconciliationCoverage
           title="Statement"
           total={statement.total}
           totalLabel="rows"
-          segments={segmentsFor(statement, "Not in Actual")}
-          note={
-            statementOpen === 0
-              ? "Every statement row is accounted for."
-              : `${statementOpen} still need a decision.`
-          }
+          segments={segmentsFor(statement, "Not in Actual", "bg-sky-500/60")}
+          /*
+           * No note here. It claimed to count work outstanding, but these
+           * segments are classified by *why* a row landed where it did, not by
+           * what the user has since decided — so the figure never moved as they
+           * worked. The bar and its legend already say what this side is made
+           * of, and how much is left to decide is the meter's job.
+           */
         />
         <Side
           title="Actual"
           total={actual.total}
           totalLabel="transactions in view"
-          segments={segmentsFor(actual, "Not on statement")}
+          segments={segmentsFor(actual, "Not on statement", "bg-violet-500/60")}
           note={actualNote || undefined}
         />
       </div>
-
-      {/*
-        Coverage answers "how much of the statement is accounted for". This
-        answers "how much is left for me to do", which is the question someone
-        working through a reconciliation is actually asking. An automatic match
-        is counted apart from both: it never needed deciding, and folding it in
-        would flatter the number.
-      */}
-      {needingDecision > 0 && (
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md bg-muted/40 px-3 py-2 text-xs">
-          <span className="font-medium">
-            {decisions.decided} of {needingDecision} decided
-          </span>
-          {decisions.pending > 0 ? (
-            <span className="text-amber-600 dark:text-amber-400">
-              {decisions.pending} still to decide
-            </span>
-          ) : (
-            <span className="text-emerald-600 dark:text-emerald-400">
-              Everything has been decided
-            </span>
-          )}
-          <span className="text-muted-foreground">
-            {decisions.automatic} matched without needing you
-          </span>
-        </div>
-      )}
     </section>
   );
 }

--- a/src/features/reconciliation/components/ImportPanel.tsx
+++ b/src/features/reconciliation/components/ImportPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AlertTriangle, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -90,8 +90,12 @@ export type ImportPanelProps = {
   onApplyProfile: (profile: ReconciliationProfileRecord) => void;
   onSaveProfile: (name: string, mapping: ColumnMapping) => void;
   isSavingProfile?: boolean;
-  onCancel: () => void;
-  onParsed: (result: NormalizedStatement, statementName: string | null) => void;
+  /**
+   * Reports the parsed statement upward as it changes, so the phase button can
+   * live in the page toolbar with the other navigation rather than at the foot
+   * of this panel where it reads as one more control among many.
+   */
+  onReadyChange: (result: NormalizedStatement | null, statementName: string | null) => void;
   /**
    * Statements already imported, by fingerprint. Held here rather than resolved
    * by the caller because only this panel knows what has been parsed yet.
@@ -102,7 +106,6 @@ export type ImportPanelProps = {
     tag: string | null;
     createdAt: string;
   }[];
-  isSaving?: boolean;
 };
 
 export function ImportPanel({
@@ -114,10 +117,8 @@ export function ImportPanel({
   onApplyProfile,
   onSaveProfile,
   isSavingProfile,
-  onCancel,
-  onParsed,
+  onReadyChange,
   knownStatements,
-  isSaving,
 }: ImportPanelProps) {
   const [text, setText] = useState("");
   const [fileName, setFileName] = useState<string | null>(null);
@@ -179,6 +180,12 @@ export function ImportPanel({
 
   const totals = parsed?.totals;
   const canContinue = Boolean(parsed && parsed.rows.length > 0);
+
+  // Reported rather than acted on here: the panel owns parsing, the page owns
+  // moving to the next phase.
+  useEffect(() => {
+    onReadyChange(canContinue && parsed ? parsed : null, fileName);
+  }, [canContinue, parsed, fileName, onReadyChange]);
 
   // Recognised by the rows themselves, so a statement pasted last month and
   // uploaded this month is still the same statement.
@@ -525,17 +532,7 @@ export function ImportPanel({
         </div>
       )}
 
-      <div className="flex items-center justify-end gap-2">
-        <Button variant="ghost" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button
-          disabled={!canContinue || isSaving}
-          onClick={() => parsed && onParsed(parsed, fileName)}
-        >
-          {isSaving ? "Matching…" : "Match against Actual"}
-        </Button>
-      </div>
+
     </div>
   );
 }

--- a/src/features/reconciliation/components/ImportPanel.tsx
+++ b/src/features/reconciliation/components/ImportPanel.tsx
@@ -69,7 +69,7 @@ function ColumnSelect({ id, label, value, columns, onChange, optional }: ColumnS
           onChange(event.target.value === "" ? undefined : Number(event.target.value))
         }
       >
-        <option value="">—</option>
+        <option value="">-</option>
         {columns.map((column, index) => (
           <option key={`${column}-${index}`} value={index}>
             {column}
@@ -432,7 +432,7 @@ export function ImportPanel({
                     <tr key={row.id} className="border-b border-border/20 last:border-0">
                       <td className="px-3 py-1.5 tabular-nums">{row.postedDate}</td>
                       <td className="max-w-0 truncate px-3 py-1.5">{row.description}</td>
-                      <td className="px-3 py-1.5 text-muted-foreground">{row.reference ?? "—"}</td>
+                      <td className="px-3 py-1.5 text-muted-foreground">{row.reference ?? "-"}</td>
                       <td className="px-3 py-1.5 text-right tabular-nums">
                         {formatMinorUnits(row.amount)}
                       </td>
@@ -525,8 +525,8 @@ export function ImportPanel({
           <p className="mt-0.5 text-muted-foreground">
             The same rows were imported for {duplicateOf.accountName ?? "this account"}
             {duplicateOf.tag ? ` (${duplicateOf.tag})` : ""} on{" "}
-            {new Date(duplicateOf.createdAt).toLocaleDateString()}. Carrying on is fine — matching
-            reads what is in Actual now, and anything already applied is recognised and skipped —
+            {new Date(duplicateOf.createdAt).toLocaleDateString()}. Carrying on is fine - matching
+            reads what is in Actual now, and anything already applied is recognised and skipped -
             but if you meant to resume that reconciliation, go back and open it instead.
           </p>
         </div>

--- a/src/features/reconciliation/components/Inspector.tsx
+++ b/src/features/reconciliation/components/Inspector.tsx
@@ -41,7 +41,7 @@ function Field({
   return (
     <div className="grid grid-cols-[5.5rem_1fr] items-baseline gap-2">
       <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</dt>
-      <dd className={cn("break-words text-xs", numeric && "tabular-nums")}>{value || "—"}</dd>
+      <dd className={cn("break-words text-xs", numeric && "tabular-nums")}>{value || "-"}</dd>
     </div>
   );
 }
@@ -71,7 +71,7 @@ function Compared({
   return (
     <div className="grid grid-cols-[3.5rem_1fr_1fr] items-baseline gap-2">
       <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</dt>
-      <dd className="tabular-nums text-xs">{statement || "—"}</dd>
+      <dd className="tabular-nums text-xs">{statement || "-"}</dd>
       <dd
         className={cn(
           "tabular-nums text-xs",
@@ -79,7 +79,7 @@ function Compared({
         )}
         title={note ?? undefined}
       >
-        {actual || "—"}
+        {actual || "-"}
         {differs && note && <span className="block text-[10px]">{note}</span>}
       </dd>
     </div>
@@ -107,6 +107,8 @@ export type InspectorProps = {
   onCorrectAmount: (transactionId: string, amount: number) => void;
   onStage: (field: StageableField, value: string | null) => void;
   onUnstage: (field: StageableField) => void;
+  /** The session has been applied: show the record, offer no more decisions. */
+  readOnly?: boolean;
 };
 
 export function Inspector({
@@ -121,6 +123,7 @@ export function Inspector({
   onCorrectAmount,
   onStage,
   onUnstage,
+  readOnly = false,
 }: InspectorProps) {
   const primary = transactions[0];
   const reasons = item.match?.reasons ?? [];
@@ -251,20 +254,28 @@ export function Inspector({
         </section>
       )}
 
-      <ItemActions
-        item={item}
-        statementRow={statementRow}
-        transactions={transactions}
-        onDisposition={onDisposition}
-        onUseCandidate={onUseCandidate}
-        onCorrectAmount={onCorrectAmount}
-      />
+      {readOnly ? (
+        <p className="rounded-md border border-border/60 bg-muted/30 px-2.5 py-2 text-[11px] text-muted-foreground">
+          This reconciliation has been applied, so its decisions are a record rather than something
+          still to settle. Start a new reconciliation to check the account as it stands now.
+        </p>
+      ) : (
+        <ItemActions
+          item={item}
+          statementRow={statementRow}
+          transactions={transactions}
+          onDisposition={onDisposition}
+          onUseCandidate={onUseCandidate}
+          onCorrectAmount={onCorrectAmount}
+        />
+      )}
 
       {/* Editing is offered once the row is about a specific transaction, or is
           going to become one. Until then there is nothing to edit. */}
-      {(item.disposition === "create" ||
-        item.disposition === "matched" ||
-        item.disposition === "correct-amount") && (
+      {!readOnly &&
+        (item.disposition === "create" ||
+          item.disposition === "matched" ||
+          item.disposition === "correct-amount") && (
         <StagedFields
           item={item}
           current={{

--- a/src/features/reconciliation/components/ItemActions.tsx
+++ b/src/features/reconciliation/components/ItemActions.tsx
@@ -82,7 +82,7 @@ export function ItemActions({
         <div className="flex flex-col gap-1.5">
           {isDuplicate ? (
             <p className="text-[11px] text-muted-foreground">
-              These look like the same transaction recorded more than once. Keep one — the others
+              These look like the same transaction recorded more than once. Keep one - the others
               become rows of their own, to delete or keep as you decide.
             </p>
           ) : (
@@ -128,7 +128,7 @@ export function ItemActions({
               className="justify-start text-xs"
               onClick={() => onUseCandidate(null)}
             >
-              None of these — this row is not in Actual
+              None of these - this row is not in Actual
             </Button>
           )}
         </div>

--- a/src/features/reconciliation/components/MatchOptions.tsx
+++ b/src/features/reconciliation/components/MatchOptions.tsx
@@ -21,7 +21,7 @@ const PRESETS: { id: TextTargetPreset; label: string; hint: string }[] = [
   {
     id: "all-best-match",
     label: "All fields, best match wins",
-    hint: "Safest default — an empty or irrelevant field simply contributes nothing.",
+    hint: "Safest default - an empty or irrelevant field simply contributes nothing.",
   },
   {
     id: "notes",

--- a/src/features/reconciliation/components/PhaseNav.tsx
+++ b/src/features/reconciliation/components/PhaseNav.tsx
@@ -36,8 +36,20 @@ export type PhaseNavProps = {
 export function PhaseNav({ back, secondary, next }: PhaseNavProps) {
   return (
     <>
+      {/*
+        Announced, not just shown. This is the only status in the feature that
+        changes on its own during a wait of any length — writing 200 rows,
+        checking for drift, matching a statement — and it was silent to anyone
+        not watching the pixels.
+      */}
       {next?.progress && (
-        <span className="mr-1 text-xs tabular-nums text-muted-foreground">{next.progress}</span>
+        <span
+          role="status"
+          aria-live="polite"
+          className="mr-1 text-xs tabular-nums text-muted-foreground"
+        >
+          {next.progress}
+        </span>
       )}
       {back && (
         <Button variant="ghost" size="sm" onClick={back.onClick} disabled={back.disabled}>
@@ -55,6 +67,11 @@ export function PhaseNav({ back, secondary, next }: PhaseNavProps) {
         >
           {secondary.label}
         </Button>
+      )}
+      {/* Divider so retreating and finishing do not read as one row of equal
+          choices — the primary sits apart from the ways out. */}
+      {(back || secondary) && next && (
+        <span className="mx-1 h-4 w-px bg-border" aria-hidden="true" />
       )}
       {next && (
         <Button size="sm" onClick={next.onClick} disabled={next.disabled || next.busy}>

--- a/src/features/reconciliation/components/PhaseNav.tsx
+++ b/src/features/reconciliation/components/PhaseNav.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Moving between the phases of a reconciliation.
+ *
+ * The phase buttons used to live wherever each screen happened to put them —
+ * the bottom of the import panel, the right of the workbench's tool row, above
+ * the review table — so "how do I go on" and "how do I go back" had a different
+ * answer on every screen.
+ *
+ * They now sit in one place, in a fixed order: leaving on the left, the next
+ * phase on the right, with the primary action always last. Tools that act on
+ * the current screen rather than moving between phases (re-run, transform,
+ * matching options) deliberately stay where they are — they are not navigation.
+ */
+
+export type PhaseNavProps = {
+  /** Leaves the phase. Labelled with where it goes, never just "Back". */
+  back?: { label: string; onClick: () => void; disabled?: boolean };
+  /** A second way out, offered where one exists — e.g. re-importing. */
+  secondary?: { label: string; onClick: () => void; disabled?: boolean; title?: string };
+  /** The next phase. Absent on the last one. */
+  next?: {
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+    busy?: boolean;
+    /** Shown beside the button while it works, since a spinner cannot say how far. */
+    progress?: string | null;
+  };
+};
+
+export function PhaseNav({ back, secondary, next }: PhaseNavProps) {
+  return (
+    <>
+      {next?.progress && (
+        <span className="mr-1 text-xs tabular-nums text-muted-foreground">{next.progress}</span>
+      )}
+      {back && (
+        <Button variant="ghost" size="sm" onClick={back.onClick} disabled={back.disabled}>
+          <ArrowLeft className="mr-1 h-3.5 w-3.5" />
+          {back.label}
+        </Button>
+      )}
+      {secondary && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={secondary.onClick}
+          disabled={secondary.disabled}
+          title={secondary.title}
+        >
+          {secondary.label}
+        </Button>
+      )}
+      {next && (
+        <Button size="sm" onClick={next.onClick} disabled={next.disabled || next.busy}>
+          {next.busy && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+          {next.label}
+          {!next.busy && <ArrowRight className="ml-1 h-3.5 w-3.5" />}
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/features/reconciliation/components/ReconciliationView.tsx
+++ b/src/features/reconciliation/components/ReconciliationView.tsx
@@ -135,6 +135,8 @@ export function ReconciliationView() {
   const [statementName, setStatementName] = useState<string | null>(null);
   const [matchError, setMatchError] = useState<string | null>(null);
   const [isMatching, setIsMatching] = useState(false);
+  /** Which part of matching is running, so a long wait explains itself. */
+  const [matchStage, setMatchStage] = useState<string | null>(null);
   /**
    * Which session the in-memory rows and items belong to.
    *
@@ -518,7 +520,7 @@ export function ReconciliationView() {
     const rematchBlockedReason =
       appliedSession &&
       (appliedSession.status === "completed" || appliedSession.status === "partial")
-        ? "This reconciliation has already been applied. Matching again would lose the record of what was written — start a new reconciliation to check the account as it stands now."
+        ? "This reconciliation has already been applied. Matching again would lose the record of what was written - start a new reconciliation to check the account as it stands now."
         : null;
 
     /**
@@ -613,6 +615,14 @@ export function ReconciliationView() {
       if (!connection) return;
       setIsMatching(true);
       setMatchError(null);
+      /*
+       * Staged, because this is the longest unexplained wait in the feature.
+       * Applying says "Writing 12 of 200"; matching said only "Matching…" while
+       * it fetched a candidate window over the network and then scored several
+       * hundred rows against it — seconds of silence with no sense of progress
+       * or of which part was slow.
+       */
+      setMatchStage("Loading transactions from Actual…");
 
       try {
         const window = await loadCandidateWindow(connection, {
@@ -622,6 +632,15 @@ export function ReconciliationView() {
           matchToleranceDays: input.config.dateToleranceDays,
           paddingDays: input.config.candidatePaddingDays,
         });
+
+        setMatchStage(
+          `Matching ${input.statementRows.length} statement row${
+            input.statementRows.length === 1 ? "" : "s"
+          } against ${window.transactions.length}…`
+        );
+        // Yielded to the browser so the stage above actually paints before the
+        // matcher takes the thread for a few hundred rows.
+        await new Promise((resolve) => setTimeout(resolve, 0));
 
         const graph = match({
           statementRows: input.statementRows,
@@ -646,6 +665,7 @@ export function ReconciliationView() {
         setLoadedSessionId(input.sessionId);
         if (input.statementName !== undefined) setStatementName(input.statementName);
 
+        setMatchStage("Saving the results…");
         await mutations.saveParsedStatement.mutateAsync({
           sessionId: input.sessionId,
           statementRows: input.statementRows,
@@ -677,6 +697,7 @@ export function ReconciliationView() {
         setMatchError(error instanceof Error ? error.message : "Could not match the statement");
       } finally {
         setIsMatching(false);
+        setMatchStage(null);
       }
     }
 
@@ -1094,16 +1115,21 @@ export function ReconciliationView() {
           title="Bank Reconciliation"
           actions={
             <PhaseNav
-              back={{
-                label: hasParsedStatement ? "Back to the workbench" : "All reconciliations",
-                onClick: () =>
-                  hasParsedStatement
-                    ? setScreen({ name: "workbench", sessionId: screen.sessionId })
-                    : setScreen({ name: "home" }),
-                disabled: isMatching,
-              }}
+              back={
+                // Only when there is a workbench to go back to. On a first
+                // import there is no previous phase; leaving is what the exit
+                // in the header is for.
+                hasParsedStatement
+                  ? {
+                      label: "Back to the workbench",
+                      onClick: () => setScreen({ name: "workbench", sessionId: screen.sessionId }),
+                      disabled: isMatching,
+                    }
+                  : undefined
+              }
               next={{
                 label: isMatching ? "Matching…" : "Match against Actual",
+                progress: matchStage,
                 onClick: () => {
                   if (pendingStatement) {
                     void handleParsed(pendingStatement.result, pendingStatement.fileName);
@@ -1125,6 +1151,7 @@ export function ReconciliationView() {
             onNavigate={
               hasParsedStatement ? (step) => goToStep(step, screen.sessionId) : undefined
             }
+            onExit={() => setScreen({ name: "home" })}
           />
           {matchError && (
             <p role="alert" className="px-4 pt-3 text-xs text-destructive">
@@ -1196,6 +1223,17 @@ export function ReconciliationView() {
                   setScreen({ name: "workbench", sessionId: screen.sessionId });
                 },
               }}
+              /*
+               * Finishing is a step, and it had no button. On the result screen
+               * the primary slot stood empty exactly when the user was most
+               * likely to be done, so leaving meant retreating through the
+               * workbench — a screen an applied session can no longer use.
+               */
+              secondary={
+                screen.name === "result" && applyResult && !applyResult.complete
+                  ? { label: "Done", onClick: () => setScreen({ name: "home" }) }
+                  : undefined
+              }
               next={
                 screen.name === "review"
                   ? {
@@ -1211,11 +1249,16 @@ export function ReconciliationView() {
                     }
                   : applyResult && !applyResult.complete
                     ? {
+                        // Still something to put right, so retrying stays the
+                        // primary and finishing sits beside it.
                         label: "Retry what failed",
                         onClick: () => void handleApply(),
                         busy: isApplying,
                       }
-                    : undefined
+                    : {
+                        label: "Done",
+                        onClick: () => setScreen({ name: "home" }),
+                      }
               }
             />
           }
@@ -1230,6 +1273,7 @@ export function ReconciliationView() {
             blockedSteps={
               rematchBlockedReason ? { import: rematchBlockedReason } : undefined
             }
+            onExit={() => setScreen({ name: "home" })}
           />
           {matchError && (
             <p role="alert" className="px-4 pt-3 text-xs text-destructive">
@@ -1292,7 +1336,6 @@ export function ReconciliationView() {
           title="Bank Reconciliation"
           actions={
             <PhaseNav
-              back={{ label: "All reconciliations", onClick: () => setScreen({ name: "home" }) }}
               secondary={
                 session
                   ? {
@@ -1330,6 +1373,7 @@ export function ReconciliationView() {
             blockedSteps={
               rematchBlockedReason ? { import: rematchBlockedReason } : undefined
             }
+            onExit={() => setScreen({ name: "home" })}
           />
           {matchError && (
             <p role="alert" className="px-4 pt-3 text-xs text-destructive">
@@ -1346,6 +1390,7 @@ export function ReconciliationView() {
             isMatching={isMatching}
             canRematch={canRematch}
             rematchBlockedReason={rematchBlockedReason}
+          readOnly={Boolean(rematchBlockedReason)}
             payees={payeeOptions}
             categories={categoryOptions}
             onDisposition={handleDisposition}

--- a/src/features/reconciliation/components/ReconciliationView.tsx
+++ b/src/features/reconciliation/components/ReconciliationView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, Plus } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { getBudgetFileSyncCapabilities } from "@/lib/sync/capabilities";
@@ -64,6 +64,7 @@ import { createReconciliationTransport } from "@/lib/reconciliation/transportAda
 import { getTransport } from "@/lib/actual";
 import { ApplyResultPanel } from "./ApplyResultPanel";
 import { ReviewPanel } from "./ReviewPanel";
+import { PhaseNav } from "./PhaseNav";
 import { SessionHeader, type SessionStep } from "./SessionHeader";
 import {
   useReconciliationMutations,
@@ -71,7 +72,10 @@ import {
   useReconciliationSession,
   useReconciliationSessions,
 } from "../hooks/useReconciliation";
-import type { ReconciliationProfileRecord } from "../lib/reconciliationApi";
+import type {
+  ReconciliationProfileRecord,
+  ReconciliationSessionRecord,
+} from "../lib/reconciliationApi";
 import type { ColumnMapping } from "@/lib/reconciliation/statement/normalize";
 import { ImportPanel } from "./ImportPanel";
 import { ConfirmDialog, type ConfirmState } from "@/components/ui/confirm-dialog";
@@ -158,6 +162,28 @@ export function ReconciliationView() {
   const [verification, setVerification] = useState<VerificationReport | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
+  /**
+   * The statement the import screen has parsed, lifted so the toolbar's phase
+   * button can act on it. `null` until it parses to at least one row.
+   */
+  const [pendingStatement, setPendingStatement] = useState<{
+    result: NormalizedStatement;
+    fileName: string | null;
+  } | null>(null);
+
+  /**
+   * Stable, because the import panel reports upward from an effect that depends
+   * on it. An inline arrow would be a new function every render, so the effect
+   * would fire every render, store a fresh object, and re-render — a loop.
+   * React Compiler would probably memoise it away, but a render loop is not
+   * something to leave resting on that.
+   */
+  const handleStatementReady = useCallback(
+    (result: NormalizedStatement | null, fileName: string | null) => {
+      setPendingStatement(result ? { result, fileName } : null);
+    },
+    []
+  );
   const [confirm, setConfirm] = useState<ConfirmState | null>(null);
 
   // Matching options live with the session (and, once saved, the import
@@ -415,715 +441,64 @@ export function ReconciliationView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, derivedStatus, sessionStatus, loadedSessionId]);
 
-  if (!connection) {
-    return (
-      <PageLayout title="Bank Reconciliation">
-        <p className="px-4 py-8 text-sm text-muted-foreground">
-          Connect to a budget to reconcile a bank statement.
-        </p>
-      </PageLayout>
-    );
-  }
-
-  // Capability-gated rather than mode-gated: both transports support the
-  // transaction primitives this feature needs, but a future one might not.
-  if (capabilities && !capabilities.capabilities.listTransactions) {
-    return (
-      <PageLayout title="Bank Reconciliation">
-        <p className="px-4 py-8 text-sm text-muted-foreground">
-          This connection cannot read transactions, so reconciliation is unavailable.
-        </p>
-      </PageLayout>
-    );
-  }
-
   /**
-   * `chosenId` is passed rather than read from state: the dialog sets the
-   * account and starts in the same handler, and reading the state it just set
-   * would read the previous render's value.
-   */
-  async function startSession(chosenId?: string, tag?: string | null) {
-    const account = visibleAccounts.find((entry) => entry.id === (chosenId ?? accountId));
-    if (!account) return;
-    setNewSessionOpen(false);
-    const { session } = await mutations.createSession.mutateAsync({
-      accountId: account.id,
-      accountName: account.name,
-      tag: tag ?? null,
-    });
-    setParsedRows([]);
-    setItems([]);
-    setPeriod(null);
-    setSnapshot([]);
-    setApplyResult(null);
-    setLoadedSessionId(null);
-    setScreen({
-      name: "import",
-      sessionId: session.id,
-      accountId: account.id,
-      accountName: account.name,
-    });
-  }
-
-  /**
-   * Move between the steps of a session from its progress header.
+   * Which screen to show.
    *
-   * Only ever backwards or to somewhere already reached — the header reports
-   * progress, it does not skip work.
+   * Wrapped so that anything rendered for the whole feature — the
+   * confirmation dialog especially — mounts on every screen. It used to sit
+   * inside the last branch, so a confirmation raised from the workbench set
+   * its state and rendered nothing until the user happened to navigate home.
    */
-  function goToStep(step: SessionStep, id: string) {
-    setDriftReport(null);
-    setDriftAcknowledged(false);
-    if (step === "reconcile") setScreen({ name: "workbench", sessionId: id });
-    else if (step === "review") setScreen({ name: "review", sessionId: id });
-    else if (step === "applied") setScreen({ name: "result", sessionId: id });
-  }
-
-  /**
-   * Load the candidate window, match, and persist.
-   *
-   * Shared by the first run and by re-running from the workbench, so changing a
-   * matching option never means re-importing the statement.
-   */
-  async function runMatch(input: {
-    sessionId: string;
-    accountId: string;
-    statementRows: StatementRow[];
-    statementPeriod: { start: string; end: string };
-    totals?: unknown;
-    statementName?: string | null;
-    config: MatchConfig;
-  }) {
-    if (!connection) return;
-    setIsMatching(true);
-    setMatchError(null);
-
-    try {
-      const window = await loadCandidateWindow(connection, {
-        accountId: input.accountId,
-        statementStart: input.statementPeriod.start,
-        statementEnd: input.statementPeriod.end,
-        matchToleranceDays: input.config.dateToleranceDays,
-        paddingDays: input.config.candidatePaddingDays,
-      });
-
-      const graph = match({
-        statementRows: input.statementRows,
-        actualTransactions: window.transactions,
-        config: input.config,
-      });
-
-      const built = buildReconciliationItems({
-        statementRows: input.statementRows,
-        actualTransactions: window.transactions,
-        graph,
-        transfersReported: window.transfersReported,
-        statementPeriod: input.statementPeriod,
-        visibleWindow: window.visible,
-        makeId: () => generateId(),
-      });
-
-      setSnapshot(window.transactions);
-      setParsedRows(input.statementRows);
-      setPeriod(input.statementPeriod);
-      setItems(built);
-      setLoadedSessionId(input.sessionId);
-      if (input.statementName !== undefined) setStatementName(input.statementName);
-
-      await mutations.saveParsedStatement.mutateAsync({
-        sessionId: input.sessionId,
-        statementRows: input.statementRows,
-        items: built.map((item) => ({
-          id: item.id,
-          statementRowIds: item.statementRowIds,
-          actualTransactionIds: item.actualTransactionIds,
-          disposition: item.disposition,
-          reasonCode: item.reasonCode ?? null,
-          match: item.match,
-          guards: item.guards,
-          actualSnapshot: transactionsSnapshotFor(item, window.transactions) ?? null,
-        })),
-        patch: {
-          status: "needs_review",
-          statementStart: input.statementPeriod.start,
-          statementEnd: input.statementPeriod.end,
-          // Recorded so importing the same statement again can be recognised
-          // and questioned rather than quietly reconciled twice.
-          statementFingerprint: fingerprintStatement(input.statementRows),
-          matchConfig: input.config,
-          ...(input.statementName !== undefined ? { statementName: input.statementName } : {}),
-          ...(input.totals !== undefined ? { totals: input.totals } : {}),
-        },
-      });
-
-      setScreen({ name: "workbench", sessionId: input.sessionId });
-    } catch (error) {
-      setMatchError(error instanceof Error ? error.message : "Could not match the statement");
-    } finally {
-      setIsMatching(false);
-    }
-  }
-
-  /**
-   * Apply a change to one item, in memory and in the database.
-   *
-   * Updated locally first so the workbench responds immediately, then persisted;
-   * a decision the user can see but that was never saved is worse than a slow
-   * one, so a failed write surfaces rather than being swallowed.
-   */
-  function updateItem(
-    itemId: string,
-    change: (item: ReconciliationItem) => ReconciliationItem
-  ) {
-    const current = items.find((entry) => entry.id === itemId);
-    if (!current) return;
-    const next = change(current);
-
-    setItems((previous) => previous.map((entry) => (entry.id === itemId ? next : entry)));
-
-    void mutations.patchItem
-      .mutateAsync({
-        id: itemId,
-        sessionId: sessionId ?? "",
-        payload: {
-          disposition: next.disposition,
-          reasonCode: next.reasonCode ?? null,
-          actualTransactionIds: next.actualTransactionIds,
-          stagedChanges: next.stagedChanges ?? null,
-          match: next.match,
-        },
-      })
-      .catch((error: unknown) => {
-        setMatchError(
-          error instanceof Error ? error.message : "Could not save that decision"
-        );
-      });
-  }
-
-  function snapshotFor(item: ReconciliationItem): ActualTransactionSnapshot | undefined {
-    return transactionsById.get(item.actualTransactionIds[0] ?? "");
-  }
-
-  function handleDisposition(itemId: string, disposition: ReconciliationDisposition) {
-    updateItem(itemId, (item) => ({
-      ...item,
-      disposition,
-      // Returning a row to undecided drops what was staged for it: keeping edits
-      // attached to a decision the user withdrew would apply them by surprise.
-      stagedChanges: disposition === "unresolved" ? undefined : item.stagedChanges,
-    }));
-  }
-
-  /**
-   * Pick one of several competing candidates, or none of them.
-   *
-   * The transactions not picked are returned to rows of their own. They were
-   * only ever visible through the item that offered them, so simply dropping
-   * the reference would leave them in the budget and absent from the screen.
-   */
-  function handleUseCandidate(itemId: string, transactionId: string | null) {
-    const current = items.find((entry) => entry.id === itemId);
-    if (!current) return;
-
-    const { item, released } = resolveToTransaction({
-      item: current,
-      transactionId,
-      transactions: transactionsById,
-      transfersReported: true,
-      makeId: () => generateId(),
-    });
-
-    const next = items.flatMap((entry) =>
-      entry.id === itemId ? [item, ...released] : [entry]
-    );
-    setItems(next);
-
-    // Rows were added, so the whole set is rewritten rather than patched.
-    void mutations.replaceItems
-      .mutateAsync({
-        sessionId: sessionId ?? "",
-        items: next.map((entry) => ({
-          id: entry.id,
-          statementRowIds: entry.statementRowIds,
-          actualTransactionIds: entry.actualTransactionIds,
-          disposition: entry.disposition,
-          reasonCode: entry.reasonCode ?? null,
-          match: entry.match,
-          guards: entry.guards,
-          actualSnapshot: transactionsSnapshotFor(entry, snapshot) ?? null,
-          stagedChanges: entry.stagedChanges ?? null,
-        })),
-      })
-      .catch((error: unknown) => {
-        setMatchError(error instanceof Error ? error.message : "Could not save that decision");
-      });
-  }
-
-  /**
-   * Everything a transformation rule needs to judge one row, resolved to the
-   * names the user sees rather than the ids the model holds.
-   */
-  function transformContextFor(entry: ReconciliationItem) {
-    const statementRow = statementRowsById.get(entry.statementRowIds[0] ?? "");
-    const transaction = transactionsById.get(entry.actualTransactionIds[0] ?? "");
-    return {
-      item: entry,
-      statementRow,
-      transaction,
-      pending: prospectiveTransaction({ item: entry, statementRow, transaction, applyConfig }),
-      categoryName: (id: string | null) =>
-        categoryOptions.find((option) => option.id === id)?.name ?? null,
-      payeeName: (id: string | null) =>
-        payeeOptions.find((option) => option.id === id)?.name ?? null,
-    };
-  }
-
-  /** Stage what a transformation produced, one write per changed row. */
-  function handleTransform(changes: { itemId: string; patch: StagedPatch | undefined }[]) {
-    for (const change of changes) {
-      updateItem(change.itemId, (entry) => ({ ...entry, stagedChanges: change.patch }));
-    }
-  }
-
-  function handleBulkDisposition(itemIds: string[], disposition: ReconciliationDisposition) {
-    for (const itemId of itemIds) handleDisposition(itemId, disposition);
-  }
-
-  function handleBulkCorrectAmount(
-    entries: { itemId: string; transactionId: string; amount: number }[]
-  ) {
-    for (const entry of entries) {
-      handleCorrectAmount(entry.itemId, entry.transactionId, entry.amount);
-    }
-  }
-
-  function handleCorrectAmount(itemId: string, transactionId: string, amount: number) {
-    updateItem(itemId, (item) => {
-      const snapshot = transactionsById.get(transactionId);
-      if (!snapshot) return item;
-      const { patch } = stageField({
-        patch: item.stagedChanges,
-        field: "amount",
-        original: snapshot.amount,
-        next: amount,
-        source: "manual",
-      });
-      return {
-        ...item,
-        actualTransactionIds: [transactionId],
-        disposition: "correct-amount",
-        stagedChanges: patch,
-      };
-    });
-  }
-
-  function handleStage(itemId: string, field: StageableField, value: string | null) {
-    updateItem(itemId, (item) => {
-      const snapshot = snapshotFor(item);
-      const original =
-        field === "payeeId"
-          ? snapshot?.payeeId ?? null
-          : field === "notes"
-            ? snapshot?.notes ?? null
-            : snapshot?.date ?? null;
-
-      const { patch } = stageField({
-        patch: item.stagedChanges,
-        field,
-        original,
-        next: value,
-        source: "manual",
-      });
-      return { ...item, stagedChanges: patch };
-    });
-  }
-
-  function handleUnstage(itemId: string, field: StageableField) {
-    updateItem(itemId, (item) => {
-      const patch = unstageField(item.stagedChanges, field);
-      return {
-        ...item,
-        stagedChanges: Object.keys(patch).length > 0 ? patch : undefined,
-        // Withdrawing the amount change withdraws the decision it was made for.
-        disposition:
-          field === "amount" && item.disposition === "correct-amount"
-            ? "unresolved"
-            : item.disposition,
-      };
-    });
-  }
-
-  /**
-   * Write the plan.
-   *
-   * Before anything is written, every row the plan touches is re-read and
-   * compared against what this session saw when it loaded. A session can be
-   * hours or days old, and Actual is not frozen in the meantime: a note edited
-   * elsewhere would otherwise be overwritten by a staged change, and an amount
-   * corrected elsewhere would be reverted by an update that was never about the
-   * amount at all. Rows that moved harmlessly are brought up to date and applied;
-   * rows where the user's own edit is at stake are withheld and reported, and
-   * writing proceeds only when they press Apply a second time.
-   *
-   * Markers already in the account are read too, so a create that succeeded in
-   * an earlier attempt is recognised and skipped even if this session's own
-   * record of it was lost. Each outcome is persisted as it happens rather than
-   * in one write at the end, so an interruption leaves a truthful record.
-   */
-  async function handleApply() {
-    const session = sessionQuery.data?.session;
-    if (!connection || !session || applyPlan.operations.length === 0) return;
-
-    setMatchError(null);
-    // A previous run's check describes a previous run.
-    setVerification(null);
-    const transport = createReconciliationTransport(getTransport(connection));
-
-    let plan = applyPlan;
-    try {
-      setIsCheckingDrift(true);
-      const targets = driftTargets(applyPlan);
-      const dates = snapshot.map((transaction) => transaction.date).sort();
-      const latest = await loadLatestForDrift({
-        transport,
-        accountId: session.accountId,
-        transactionIds: targets,
-        startDate: dates[0] ?? session.statementStart ?? "",
-        endDate: dates[dates.length - 1] ?? session.statementEnd ?? "",
-      });
-
-      const checked = reconcilePlanWithDrift({
-        plan: applyPlan,
-        snapshots: transactionsById,
-        latest,
-      });
-      plan = checked.plan;
-      setDriftReport(checked.report);
-
-      // Something is at stake that only the user can settle. Report it and
-      // write nothing; pressing Apply again proceeds with the rest.
-      //
-      // The screen is set explicitly because a retry can arrive from the result
-      // screen, and a warning shown somewhere the user is not looking is the
-      // same as no warning at all.
-      if (checked.report.withheld.length > 0 && !driftAcknowledged) {
-        setDriftAcknowledged(true);
-        setScreen({ name: "review", sessionId: session.id });
-        return;
-      }
-      if (plan.operations.length === 0) return;
-    } catch (error) {
-      setMatchError(
-        error instanceof Error
-          ? `Could not check for changes made in Actual: ${error.message}`
-          : "Could not check for changes made in Actual"
+  function renderScreen() {
+    if (!connection) {
+      return (
+        <PageLayout title="Bank Reconciliation">
+          <p className="px-4 py-8 text-sm text-muted-foreground">
+            Connect to a budget to reconcile a bank statement.
+          </p>
+        </PageLayout>
       );
-      return;
-    } finally {
-      setIsCheckingDrift(false);
     }
 
-    setIsApplying(true);
-    setApplyProgress({ done: 0, total: plan.operations.length });
-
-    try {
-      const existingMarkers = await transport.readExistingMarkers({
-        accountId: session.accountId,
-        startDate: session.statementStart ?? undefined,
-        endDate: session.statementEnd ?? undefined,
-      });
-
-      const collected: OperationResult[] = [];
-      const previousResults = Array.isArray(session.applyResults)
-        ? (session.applyResults as OperationResult[])
-        : [];
-
-      /*
-       * Progress is written straight through the API rather than through a
-       * mutation, and in batches.
-       *
-       * A mutation per operation invalidated the session query, so every write
-       * dragged a refetch of the whole session and a re-render of the workbench
-       * along behind it — between writes. On a real statement that turns a
-       * few seconds of work into minutes of thrashing.
-       *
-       * Batching costs nothing in safety: the record is the fast path for a
-       * retry, and the durable marker in the account is what actually prevents
-       * a duplicate create. Losing the last few results means a retry re-checks
-       * them, not that it repeats them.
-       */
-      let lastFlush = 0;
-      let lastProgressAt = 0;
-      let pending = false;
-
-      const flush = async (force: boolean) => {
-        if (!pending && !force) return;
-        const now = Date.now();
-        if (!force && now - lastFlush < PROGRESS_FLUSH_MS) return;
-        lastFlush = now;
-        pending = false;
-        // Merged, not replaced: a retry's results describe only what it ran,
-        // and overwriting would erase every operation that already succeeded.
-        await updateSessionQuietly(session.id, {
-          applyResults: mergeOperationResults(previousResults, collected),
-        });
-      };
-
-      const result = await executeApplyPlan({
-        plan,
-        transport,
-        existingMarkers,
-        previousResults,
-        onResult: async (entry) => {
-          collected.push(entry);
-          pending = true;
-          await flush(false);
-        },
-        onProgress: (progress) => {
-          // Throttled: the review screen stays mounted during a run, and its
-          // comparison table redraws every row on each state change. Updating
-          // per operation makes the UI the bottleneck rather than the writes.
-          const now = Date.now();
-          const finished = progress.completed >= progress.total;
-          if (!finished && now - lastProgressAt < PROGRESS_UI_MS) return;
-          lastProgressAt = now;
-          setApplyProgress({ done: progress.completed, total: progress.total });
-        },
-      });
-
-      await flush(true);
-
-      // The session's whole history, not just this run's part of it. The result
-      // screen reports what the *session* did, and the plan reads this back to
-      // decide what is left — so a retry that replaced it would resurrect work
-      // that had already been written.
-      const history = mergeOperationResults(previousResults, result.results);
-      const totals = summarizeResults(history);
-      setApplyResult({ results: history, ...totals });
-
-      // One invalidating write at the end, so the session list and the
-      // workbench refresh once rather than once per operation.
-      await mutations.updateSession.mutateAsync({
-        id: session.id,
-        payload: {
-          applyResults: history,
-          status: totals.complete ? "completed" : "partial",
-          appliedAt: new Date().toISOString(),
-        },
-      });
-
-      // Direct-mode writes need the browser runtime told about them.
-      await getTransport(connection).sync();
-
-      // Read the account back and compare it against what was approved. A
-      // transport reporting success for a field it dropped, or a create that
-      // landed twice, is invisible from the write side alone.
-      setIsVerifying(true);
-      try {
-        const dates = plan.operations.map((operation) => operation.date).sort();
-        const window = await transport.loadTransactions({
-          accountId: session.accountId,
-          startDate: dates[0] ?? session.statementStart ?? "",
-          endDate: dates[dates.length - 1] ?? session.statementEnd ?? "",
-        });
-        setVerification(
-          verifyApply({
-            plan,
-            results: result.results,
-            latest: window.transactions,
-            snapshots: transactionsById,
-          })
-        );
-      } catch {
-        // A check that cannot run is not a failed apply, and saying nothing is
-        // better than reporting problems it did not actually find.
-        setVerification(null);
-      } finally {
-        setIsVerifying(false);
-      }
-
-      // A retry is a fresh decision: whatever was withheld a moment ago has to
-      // be put in front of the user again rather than carried through on an
-      // acknowledgement they gave about a different run.
-      setDriftAcknowledged(false);
-      setScreen({ name: "result", sessionId: session.id });
-    } catch (error) {
-      setMatchError(error instanceof Error ? error.message : "Could not apply the changes");
-    } finally {
-      setIsApplying(false);
-      setApplyProgress(null);
+    // Capability-gated rather than mode-gated: both transports support the
+    // transaction primitives this feature needs, but a future one might not.
+    if (capabilities && !capabilities.capabilities.listTransactions) {
+      return (
+        <PageLayout title="Bank Reconciliation">
+          <p className="px-4 py-8 text-sm text-muted-foreground">
+            This connection cannot read transactions, so reconciliation is unavailable.
+          </p>
+        </PageLayout>
+      );
     }
-  }
 
-  async function handleParsed(result: NormalizedStatement, fileName: string | null) {
-    if (screen.name !== "import" || !result.period) return;
-    await runMatch({
-      sessionId: screen.sessionId,
-      accountId: screen.accountId,
-      statementRows: result.rows,
-      statementPeriod: result.period,
-      totals: result.totals,
-      statementName: fileName,
-      config: matchConfig,
-    });
-  }
-
-  if (screen.name === "import") {
-    return (
-      <PageLayout
-        title="Bank Reconciliation"
-        actions={
-          <Button variant="ghost" size="sm" onClick={() => setScreen({ name: "home" })}>
-            <ArrowLeft className="mr-1 h-3.5 w-3.5" />
-            Back
-          </Button>
-        }
-        scrollManaged
-      >
-        <SessionHeader session={sessionQuery.data?.session} current="import" />
-        {matchError && (
-          <p role="alert" className="px-4 pt-3 text-xs text-destructive">
-            {matchError}
-          </p>
-        )}
-        <ImportPanel
-          accountName={screen.accountName}
-          matchConfig={matchConfig}
-          matchPreset={matchPreset}
-          profiles={profilesQuery.data ?? []}
-          isSavingProfile={mutations.saveProfile.isPending}
-          onApplyProfile={(profile: ReconciliationProfileRecord) => {
-            const saved = profile.matchConfig as MatchConfig | null;
-            if (saved) setMatchConfig({ ...DEFAULT_MATCH_CONFIG, ...saved });
-          }}
-          onSaveProfile={(name: string, mapping: ColumnMapping) => {
-            void mutations.saveProfile.mutateAsync({
-              accountId: screen.accountId,
-              name,
-              mapping,
-              matchConfig,
-            });
-          }}
-          onMatchConfigChange={(preset, config) => {
-            setMatchPreset(preset);
-            setMatchConfig(config);
-          }}
-          knownStatements={(sessionsQuery.data ?? [])
-            // The session being imported into has no statement yet, so it can
-            // never be its own duplicate.
-            .filter((entry) => entry.statementFingerprint && entry.id !== screen.sessionId)
-            .map((entry) => ({
-              fingerprint: entry.statementFingerprint!,
-              accountName: entry.accountName,
-              tag: entry.tag,
-              createdAt: entry.createdAt,
-            }))}
-          onCancel={() => setScreen({ name: "home" })}
-          onParsed={(result, fileName) => void handleParsed(result, fileName)}
-          isSaving={isMatching}
-        />
-      </PageLayout>
-    );
-  }
-
-  if (screen.name === "review" || screen.name === "result") {
-    const session = sessionQuery.data?.session;
-    return (
-      <PageLayout
-        title="Bank Reconciliation"
-        // Leaving is a navigation action, and navigation lives in the toolbar
-        // on every other page.
-        actions={
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={isApplying || isCheckingDrift}
-            onClick={() => {
-              setDriftReport(null);
-              setDriftAcknowledged(false);
-              setScreen({ name: "workbench", sessionId: screen.sessionId });
-            }}
-          >
-            <ArrowLeft className="mr-1 h-3.5 w-3.5" />
-            Back to the workbench
-          </Button>
-        }
-        scrollManaged
-      >
-        <SessionHeader
-          session={session}
-          current={screen.name === "review" ? "review" : "applied"}
-          period={period}
-          statementName={statementName}
-          onNavigate={(step) => goToStep(step, screen.sessionId)}
-        />
-        {matchError && (
-          <p role="alert" className="px-4 pt-3 text-xs text-destructive">
-            {matchError}
-          </p>
-        )}
-        {screen.name === "review" ? (
-          <ReviewPanel
-            plan={applyPlan}
-            items={items}
-            statementRows={statementRowsById}
-            transactions={transactionsById}
-            payees={payeeOptions}
-            categories={categoryOptions}
-            isApplying={isApplying}
-            isCheckingDrift={isCheckingDrift}
-            drift={driftReport}
-            progress={applyProgress}
-            applyConfig={applyConfig}
-            onApplyConfigChange={(config) => {
-              setApplyConfig(config);
-              if (sessionId) {
-                void mutations.updateSession.mutateAsync({
-                  id: sessionId,
-                  payload: { applyConfig: config },
-                });
-              }
-            }}
-            onBack={() => {
-              // Decisions can change on the workbench, so a drift check made
-              // against the old plan no longer describes what would be written.
-              setDriftReport(null);
-              setDriftAcknowledged(false);
-              setScreen({ name: "workbench", sessionId: screen.sessionId });
-            }}
-            onApply={() => void handleApply()}
-          />
-        ) : (
-          applyResult && (
-            <ApplyResultPanel
-              plan={fullPlan}
-              items={items}
-              statementRows={statementRowsById}
-              transactions={transactionsById}
-              payees={payeeOptions}
-              applyConfig={applyConfig}
-              result={applyResult}
-              verification={verification}
-              isVerifying={isVerifying}
-              isApplying={isApplying}
-              onRetry={() => void handleApply()}
-            />
-          )
-        )}
-        {screen.name === "result" && !applyResult && (
-          <p className="px-4 py-6 text-sm text-muted-foreground">
-            {session?.appliedAt
-              ? "This reconciliation has already been applied."
-              : "Nothing has been applied yet."}
-          </p>
-        )}
-      </PageLayout>
-    );
-  }
-
-  if (screen.name === "workbench") {
-    const session = sessionQuery.data?.session;
-    const canRematch = Boolean(session && period && parsedRows.length > 0);
+    /**
+     * `chosenId` is passed rather than read from state: the dialog sets the
+     * account and starts in the same handler, and reading the state it just set
+     * would read the previous render's value.
+     */
+    async function startSession(chosenId?: string, tag?: string | null) {
+      const account = visibleAccounts.find((entry) => entry.id === (chosenId ?? accountId));
+      if (!account) return;
+      setNewSessionOpen(false);
+      const { session } = await mutations.createSession.mutateAsync({
+        accountId: account.id,
+        accountName: account.name,
+        tag: tag ?? null,
+      });
+      setParsedRows([]);
+      setItems([]);
+      setPeriod(null);
+      setSnapshot([]);
+      setApplyResult(null);
+      setLoadedSessionId(null);
+      setScreen({
+        name: "import",
+        sessionId: session.id,
+        accountId: account.id,
+        accountName: account.name,
+      });
+    }
 
     /*
      * Re-matching rebuilds the items from scratch, which mints new item ids —
@@ -1134,167 +509,971 @@ export function ReconciliationView() {
      * So it is refused once a session has applied, and the user is pointed at
      * the operation that is actually correct: a fresh reconciliation, which
      * reads Actual as it stands now rather than as it stood before the writes.
+     *
+     * Held here rather than beside the button it disables, because re-importing
+     * is reachable from the progress header too — a guard that lives on one
+     * control is not a guard.
      */
+    const appliedSession = sessionQuery.data?.session;
     const rematchBlockedReason =
-      session && (session.status === "completed" || session.status === "partial")
+      appliedSession &&
+      (appliedSession.status === "completed" || appliedSession.status === "partial")
         ? "This reconciliation has already been applied. Matching again would lose the record of what was written — start a new reconciliation to check the account as it stands now."
         : null;
+
+    /**
+     * Go back to the statement and import it again.
+     *
+     * The case this exists for: the statement was pasted short a few rows, and
+     * without this the only way forward is to delete the session and redo every
+     * decision. Re-importing replaces the statement rows and re-runs matching,
+     * which does discard the decisions staged against the old rows — so the cost
+     * is stated plainly and confirmed before anything moves.
+     */
+    function reimport(session: ReconciliationSessionRecord) {
+      // Enforced here, not only on the button: the progress header offers this
+      // too, and an applied session must refuse it from either.
+      if (rematchBlockedReason) return;
+
+      const decided = items.filter((item) => item.disposition !== "unresolved").length;
+      const staged = items.filter(
+        (item) => item.stagedChanges && Object.keys(item.stagedChanges).length > 0
+      ).length;
+
+      const go = () => {
+        // Cleared on the way in: the panel reports its own state on mount, but
+        // until that first effect runs the toolbar would otherwise still be
+        // holding — and willing to match — the statement parsed last time.
+        setPendingStatement(null);
+        setScreen({
+          name: "import",
+          sessionId: session.id,
+          accountId: session.accountId,
+          accountName: session.accountName ?? "Account",
+        });
+      };
+
+      // Nothing decided yet, so there is nothing to warn about.
+      if (decided === 0 && staged === 0) {
+        go();
+        return;
+      }
+
+      setConfirm({
+        title: "Import this statement again?",
+        message: (
+          <>
+            Matching will run again from scratch against the new statement, so the{" "}
+            {decided} decision{decided === 1 ? "" : "s"}
+            {staged > 0 ? ` and ${staged} edited row${staged === 1 ? "" : "s"}` : ""} on this
+            reconciliation will be discarded. Nothing in your budget changes, and anything already
+            applied stays applied.
+          </>
+        ),
+        destructiveLabel: "Discard and re-import",
+        onConfirm: go,
+      });
+    }
+
+    /**
+     * Move between the steps of a session from its progress header.
+     *
+     * Only ever backwards or to somewhere already reached — the header reports
+     * progress, it does not skip work.
+     */
+    function goToStep(step: SessionStep, id: string) {
+      setDriftReport(null);
+      setDriftAcknowledged(false);
+      if (step === "import") {
+        // Through the same confirmation as the toolbar's Import again: going
+        // back to the statement discards the decisions made against the old
+        // rows, whichever control the user reached it by.
+        const current = sessionQuery.data?.session;
+        if (current) reimport(current);
+      } else if (step === "reconcile") setScreen({ name: "workbench", sessionId: id });
+      else if (step === "review") setScreen({ name: "review", sessionId: id });
+      else if (step === "applied") setScreen({ name: "result", sessionId: id });
+    }
+
+    /**
+     * Load the candidate window, match, and persist.
+     *
+     * Shared by the first run and by re-running from the workbench, so changing a
+     * matching option never means re-importing the statement.
+     */
+    async function runMatch(input: {
+      sessionId: string;
+      accountId: string;
+      statementRows: StatementRow[];
+      statementPeriod: { start: string; end: string };
+      totals?: unknown;
+      statementName?: string | null;
+      config: MatchConfig;
+    }) {
+      if (!connection) return;
+      setIsMatching(true);
+      setMatchError(null);
+
+      try {
+        const window = await loadCandidateWindow(connection, {
+          accountId: input.accountId,
+          statementStart: input.statementPeriod.start,
+          statementEnd: input.statementPeriod.end,
+          matchToleranceDays: input.config.dateToleranceDays,
+          paddingDays: input.config.candidatePaddingDays,
+        });
+
+        const graph = match({
+          statementRows: input.statementRows,
+          actualTransactions: window.transactions,
+          config: input.config,
+        });
+
+        const built = buildReconciliationItems({
+          statementRows: input.statementRows,
+          actualTransactions: window.transactions,
+          graph,
+          transfersReported: window.transfersReported,
+          statementPeriod: input.statementPeriod,
+          visibleWindow: window.visible,
+          makeId: () => generateId(),
+        });
+
+        setSnapshot(window.transactions);
+        setParsedRows(input.statementRows);
+        setPeriod(input.statementPeriod);
+        setItems(built);
+        setLoadedSessionId(input.sessionId);
+        if (input.statementName !== undefined) setStatementName(input.statementName);
+
+        await mutations.saveParsedStatement.mutateAsync({
+          sessionId: input.sessionId,
+          statementRows: input.statementRows,
+          items: built.map((item) => ({
+            id: item.id,
+            statementRowIds: item.statementRowIds,
+            actualTransactionIds: item.actualTransactionIds,
+            disposition: item.disposition,
+            reasonCode: item.reasonCode ?? null,
+            match: item.match,
+            guards: item.guards,
+            actualSnapshot: transactionsSnapshotFor(item, window.transactions) ?? null,
+          })),
+          patch: {
+            status: "needs_review",
+            statementStart: input.statementPeriod.start,
+            statementEnd: input.statementPeriod.end,
+            // Recorded so importing the same statement again can be recognised
+            // and questioned rather than quietly reconciled twice.
+            statementFingerprint: fingerprintStatement(input.statementRows),
+            matchConfig: input.config,
+            ...(input.statementName !== undefined ? { statementName: input.statementName } : {}),
+            ...(input.totals !== undefined ? { totals: input.totals } : {}),
+          },
+        });
+
+        setScreen({ name: "workbench", sessionId: input.sessionId });
+      } catch (error) {
+        setMatchError(error instanceof Error ? error.message : "Could not match the statement");
+      } finally {
+        setIsMatching(false);
+      }
+    }
+
+    /**
+     * Apply a change to one item, in memory and in the database.
+     *
+     * Updated locally first so the workbench responds immediately, then persisted;
+     * a decision the user can see but that was never saved is worse than a slow
+     * one, so a failed write surfaces rather than being swallowed.
+     */
+    function updateItem(
+      itemId: string,
+      change: (item: ReconciliationItem) => ReconciliationItem
+    ) {
+      const current = items.find((entry) => entry.id === itemId);
+      if (!current) return;
+      const next = change(current);
+
+      setItems((previous) => previous.map((entry) => (entry.id === itemId ? next : entry)));
+
+      void mutations.patchItem
+        .mutateAsync({
+          id: itemId,
+          sessionId: sessionId ?? "",
+          payload: {
+            disposition: next.disposition,
+            reasonCode: next.reasonCode ?? null,
+            actualTransactionIds: next.actualTransactionIds,
+            stagedChanges: next.stagedChanges ?? null,
+            match: next.match,
+          },
+        })
+        .catch((error: unknown) => {
+          setMatchError(
+            error instanceof Error ? error.message : "Could not save that decision"
+          );
+        });
+    }
+
+    function snapshotFor(item: ReconciliationItem): ActualTransactionSnapshot | undefined {
+      return transactionsById.get(item.actualTransactionIds[0] ?? "");
+    }
+
+    function handleDisposition(itemId: string, disposition: ReconciliationDisposition) {
+      updateItem(itemId, (item) => ({
+        ...item,
+        disposition,
+        // Returning a row to undecided drops what was staged for it: keeping edits
+        // attached to a decision the user withdrew would apply them by surprise.
+        stagedChanges: disposition === "unresolved" ? undefined : item.stagedChanges,
+      }));
+    }
+
+    /**
+     * Pick one of several competing candidates, or none of them.
+     *
+     * The transactions not picked are returned to rows of their own. They were
+     * only ever visible through the item that offered them, so simply dropping
+     * the reference would leave them in the budget and absent from the screen.
+     */
+    function handleUseCandidate(itemId: string, transactionId: string | null) {
+      const current = items.find((entry) => entry.id === itemId);
+      if (!current) return;
+
+      const { item, released } = resolveToTransaction({
+        item: current,
+        transactionId,
+        transactions: transactionsById,
+        transfersReported: true,
+        makeId: () => generateId(),
+      });
+
+      const next = items.flatMap((entry) =>
+        entry.id === itemId ? [item, ...released] : [entry]
+      );
+      setItems(next);
+
+      // Rows were added, so the whole set is rewritten rather than patched.
+      void mutations.replaceItems
+        .mutateAsync({
+          sessionId: sessionId ?? "",
+          items: next.map((entry) => ({
+            id: entry.id,
+            statementRowIds: entry.statementRowIds,
+            actualTransactionIds: entry.actualTransactionIds,
+            disposition: entry.disposition,
+            reasonCode: entry.reasonCode ?? null,
+            match: entry.match,
+            guards: entry.guards,
+            actualSnapshot: transactionsSnapshotFor(entry, snapshot) ?? null,
+            stagedChanges: entry.stagedChanges ?? null,
+          })),
+        })
+        .catch((error: unknown) => {
+          setMatchError(error instanceof Error ? error.message : "Could not save that decision");
+        });
+    }
+
+    /**
+     * Everything a transformation rule needs to judge one row, resolved to the
+     * names the user sees rather than the ids the model holds.
+     */
+    function transformContextFor(entry: ReconciliationItem) {
+      const statementRow = statementRowsById.get(entry.statementRowIds[0] ?? "");
+      const transaction = transactionsById.get(entry.actualTransactionIds[0] ?? "");
+      return {
+        item: entry,
+        statementRow,
+        transaction,
+        pending: prospectiveTransaction({ item: entry, statementRow, transaction, applyConfig }),
+        categoryName: (id: string | null) =>
+          categoryOptions.find((option) => option.id === id)?.name ?? null,
+        payeeName: (id: string | null) =>
+          payeeOptions.find((option) => option.id === id)?.name ?? null,
+      };
+    }
+
+    /** Stage what a transformation produced, one write per changed row. */
+    function handleTransform(changes: { itemId: string; patch: StagedPatch | undefined }[]) {
+      for (const change of changes) {
+        updateItem(change.itemId, (entry) => ({ ...entry, stagedChanges: change.patch }));
+      }
+    }
+
+    function handleBulkDisposition(itemIds: string[], disposition: ReconciliationDisposition) {
+      for (const itemId of itemIds) handleDisposition(itemId, disposition);
+    }
+
+    function handleBulkCorrectAmount(
+      entries: { itemId: string; transactionId: string; amount: number }[]
+    ) {
+      for (const entry of entries) {
+        handleCorrectAmount(entry.itemId, entry.transactionId, entry.amount);
+      }
+    }
+
+    function handleCorrectAmount(itemId: string, transactionId: string, amount: number) {
+      updateItem(itemId, (item) => {
+        const snapshot = transactionsById.get(transactionId);
+        if (!snapshot) return item;
+        const { patch } = stageField({
+          patch: item.stagedChanges,
+          field: "amount",
+          original: snapshot.amount,
+          next: amount,
+          source: "manual",
+        });
+        return {
+          ...item,
+          actualTransactionIds: [transactionId],
+          disposition: "correct-amount",
+          stagedChanges: patch,
+        };
+      });
+    }
+
+    function handleStage(itemId: string, field: StageableField, value: string | null) {
+      updateItem(itemId, (item) => {
+        const snapshot = snapshotFor(item);
+        const original =
+          field === "payeeId"
+            ? snapshot?.payeeId ?? null
+            : field === "notes"
+              ? snapshot?.notes ?? null
+              : snapshot?.date ?? null;
+
+        const { patch } = stageField({
+          patch: item.stagedChanges,
+          field,
+          original,
+          next: value,
+          source: "manual",
+        });
+        return { ...item, stagedChanges: patch };
+      });
+    }
+
+    function handleUnstage(itemId: string, field: StageableField) {
+      updateItem(itemId, (item) => {
+        const patch = unstageField(item.stagedChanges, field);
+        return {
+          ...item,
+          stagedChanges: Object.keys(patch).length > 0 ? patch : undefined,
+          // Withdrawing the amount change withdraws the decision it was made for.
+          disposition:
+            field === "amount" && item.disposition === "correct-amount"
+              ? "unresolved"
+              : item.disposition,
+        };
+      });
+    }
+
+    /**
+     * Write the plan.
+     *
+     * Before anything is written, every row the plan touches is re-read and
+     * compared against what this session saw when it loaded. A session can be
+     * hours or days old, and Actual is not frozen in the meantime: a note edited
+     * elsewhere would otherwise be overwritten by a staged change, and an amount
+     * corrected elsewhere would be reverted by an update that was never about the
+     * amount at all. Rows that moved harmlessly are brought up to date and applied;
+     * rows where the user's own edit is at stake are withheld and reported, and
+     * writing proceeds only when they press Apply a second time.
+     *
+     * Markers already in the account are read too, so a create that succeeded in
+     * an earlier attempt is recognised and skipped even if this session's own
+     * record of it was lost. Each outcome is persisted as it happens rather than
+     * in one write at the end, so an interruption leaves a truthful record.
+     */
+    async function handleApply() {
+      const session = sessionQuery.data?.session;
+      if (!connection || !session || applyPlan.operations.length === 0) return;
+
+      setMatchError(null);
+      // A previous run's check describes a previous run.
+      setVerification(null);
+      const transport = createReconciliationTransport(getTransport(connection));
+
+      let plan = applyPlan;
+      try {
+        setIsCheckingDrift(true);
+        const targets = driftTargets(applyPlan);
+        const dates = snapshot.map((transaction) => transaction.date).sort();
+        const latest = await loadLatestForDrift({
+          transport,
+          accountId: session.accountId,
+          transactionIds: targets,
+          startDate: dates[0] ?? session.statementStart ?? "",
+          endDate: dates[dates.length - 1] ?? session.statementEnd ?? "",
+        });
+
+        const checked = reconcilePlanWithDrift({
+          plan: applyPlan,
+          snapshots: transactionsById,
+          latest,
+        });
+        plan = checked.plan;
+        setDriftReport(checked.report);
+
+        // Something is at stake that only the user can settle. Report it and
+        // write nothing; pressing Apply again proceeds with the rest.
+        //
+        // The screen is set explicitly because a retry can arrive from the result
+        // screen, and a warning shown somewhere the user is not looking is the
+        // same as no warning at all.
+        if (checked.report.withheld.length > 0 && !driftAcknowledged) {
+          setDriftAcknowledged(true);
+          setScreen({ name: "review", sessionId: session.id });
+          return;
+        }
+        if (plan.operations.length === 0) return;
+      } catch (error) {
+        setMatchError(
+          error instanceof Error
+            ? `Could not check for changes made in Actual: ${error.message}`
+            : "Could not check for changes made in Actual"
+        );
+        return;
+      } finally {
+        setIsCheckingDrift(false);
+      }
+
+      setIsApplying(true);
+      setApplyProgress({ done: 0, total: plan.operations.length });
+
+      try {
+        const existingMarkers = await transport.readExistingMarkers({
+          accountId: session.accountId,
+          startDate: session.statementStart ?? undefined,
+          endDate: session.statementEnd ?? undefined,
+        });
+
+        const collected: OperationResult[] = [];
+        const previousResults = Array.isArray(session.applyResults)
+          ? (session.applyResults as OperationResult[])
+          : [];
+
+        /*
+         * Progress is written straight through the API rather than through a
+         * mutation, and in batches.
+         *
+         * A mutation per operation invalidated the session query, so every write
+         * dragged a refetch of the whole session and a re-render of the workbench
+         * along behind it — between writes. On a real statement that turns a
+         * few seconds of work into minutes of thrashing.
+         *
+         * Batching costs nothing in safety: the record is the fast path for a
+         * retry, and the durable marker in the account is what actually prevents
+         * a duplicate create. Losing the last few results means a retry re-checks
+         * them, not that it repeats them.
+         */
+        let lastFlush = 0;
+        let lastProgressAt = 0;
+        let pending = false;
+
+        const flush = async (force: boolean) => {
+          if (!pending && !force) return;
+          const now = Date.now();
+          if (!force && now - lastFlush < PROGRESS_FLUSH_MS) return;
+          lastFlush = now;
+          pending = false;
+          // Merged, not replaced: a retry's results describe only what it ran,
+          // and overwriting would erase every operation that already succeeded.
+          await updateSessionQuietly(session.id, {
+            applyResults: mergeOperationResults(previousResults, collected),
+          });
+        };
+
+        const result = await executeApplyPlan({
+          plan,
+          transport,
+          existingMarkers,
+          previousResults,
+          onResult: async (entry) => {
+            collected.push(entry);
+            pending = true;
+            await flush(false);
+          },
+          onProgress: (progress) => {
+            // Throttled: the review screen stays mounted during a run, and its
+            // comparison table redraws every row on each state change. Updating
+            // per operation makes the UI the bottleneck rather than the writes.
+            const now = Date.now();
+            const finished = progress.completed >= progress.total;
+            if (!finished && now - lastProgressAt < PROGRESS_UI_MS) return;
+            lastProgressAt = now;
+            setApplyProgress({ done: progress.completed, total: progress.total });
+          },
+        });
+
+        await flush(true);
+
+        // The session's whole history, not just this run's part of it. The result
+        // screen reports what the *session* did, and the plan reads this back to
+        // decide what is left — so a retry that replaced it would resurrect work
+        // that had already been written.
+        const history = mergeOperationResults(previousResults, result.results);
+        const totals = summarizeResults(history);
+        setApplyResult({ results: history, ...totals });
+
+        // One invalidating write at the end, so the session list and the
+        // workbench refresh once rather than once per operation.
+        await mutations.updateSession.mutateAsync({
+          id: session.id,
+          payload: {
+            applyResults: history,
+            status: totals.complete ? "completed" : "partial",
+            appliedAt: new Date().toISOString(),
+          },
+        });
+
+        // Direct-mode writes need the browser runtime told about them.
+        await getTransport(connection).sync();
+
+        // Read the account back and compare it against what was approved. A
+        // transport reporting success for a field it dropped, or a create that
+        // landed twice, is invisible from the write side alone.
+        setIsVerifying(true);
+        try {
+          const dates = plan.operations.map((operation) => operation.date).sort();
+          const window = await transport.loadTransactions({
+            accountId: session.accountId,
+            startDate: dates[0] ?? session.statementStart ?? "",
+            endDate: dates[dates.length - 1] ?? session.statementEnd ?? "",
+          });
+          setVerification(
+            verifyApply({
+              plan,
+              results: result.results,
+              latest: window.transactions,
+              snapshots: transactionsById,
+            })
+          );
+        } catch {
+          // A check that cannot run is not a failed apply, and saying nothing is
+          // better than reporting problems it did not actually find.
+          setVerification(null);
+        } finally {
+          setIsVerifying(false);
+        }
+
+        // A retry is a fresh decision: whatever was withheld a moment ago has to
+        // be put in front of the user again rather than carried through on an
+        // acknowledgement they gave about a different run.
+        setDriftAcknowledged(false);
+        setScreen({ name: "result", sessionId: session.id });
+      } catch (error) {
+        setMatchError(error instanceof Error ? error.message : "Could not apply the changes");
+      } finally {
+        setIsApplying(false);
+        setApplyProgress(null);
+      }
+    }
+
+    async function handleParsed(result: NormalizedStatement, fileName: string | null) {
+      if (screen.name !== "import" || !result.period) return;
+      await runMatch({
+        sessionId: screen.sessionId,
+        accountId: screen.accountId,
+        statementRows: result.rows,
+        statementPeriod: result.period,
+        totals: result.totals,
+        statementName: fileName,
+        config: matchConfig,
+      });
+    }
+
+    if (screen.name === "import") {
+      // A session that has already matched can be re-imported, so leaving here
+      // should return to the work rather than abandoning it.
+      const hasParsedStatement = Boolean(sessionQuery.data?.session.statementStart);
+
+      return (
+        <PageLayout
+          title="Bank Reconciliation"
+          actions={
+            <PhaseNav
+              back={{
+                label: hasParsedStatement ? "Back to the workbench" : "All reconciliations",
+                onClick: () =>
+                  hasParsedStatement
+                    ? setScreen({ name: "workbench", sessionId: screen.sessionId })
+                    : setScreen({ name: "home" }),
+                disabled: isMatching,
+              }}
+              next={{
+                label: isMatching ? "Matching…" : "Match against Actual",
+                onClick: () => {
+                  if (pendingStatement) {
+                    void handleParsed(pendingStatement.result, pendingStatement.fileName);
+                  }
+                },
+                disabled: !pendingStatement,
+                busy: isMatching,
+              }}
+            />
+          }
+          scrollManaged
+        >
+          <SessionHeader
+            session={sessionQuery.data?.session}
+            current="import"
+            // Navigable only once the session has a statement to go back to.
+            // On a first import there is no workbench yet, so the steps would
+            // lead nowhere.
+            onNavigate={
+              hasParsedStatement ? (step) => goToStep(step, screen.sessionId) : undefined
+            }
+          />
+          {matchError && (
+            <p role="alert" className="px-4 pt-3 text-xs text-destructive">
+              {matchError}
+            </p>
+          )}
+          <ImportPanel
+            accountName={screen.accountName}
+            matchConfig={matchConfig}
+            matchPreset={matchPreset}
+            profiles={profilesQuery.data ?? []}
+            isSavingProfile={mutations.saveProfile.isPending}
+            onApplyProfile={(profile: ReconciliationProfileRecord) => {
+              const saved = profile.matchConfig as MatchConfig | null;
+              if (saved) setMatchConfig({ ...DEFAULT_MATCH_CONFIG, ...saved });
+            }}
+            onSaveProfile={(name: string, mapping: ColumnMapping) => {
+              void mutations.saveProfile.mutateAsync({
+                accountId: screen.accountId,
+                name,
+                mapping,
+                matchConfig,
+              });
+            }}
+            onMatchConfigChange={(preset, config) => {
+              setMatchPreset(preset);
+              setMatchConfig(config);
+            }}
+            knownStatements={(sessionsQuery.data ?? [])
+              // The session being imported into has no statement yet, so it can
+              // never be its own duplicate.
+              .filter((entry) => entry.statementFingerprint && entry.id !== screen.sessionId)
+              .map((entry) => ({
+                fingerprint: entry.statementFingerprint!,
+                accountName: entry.accountName,
+                tag: entry.tag,
+                createdAt: entry.createdAt,
+              }))}
+            onReadyChange={handleStatementReady}
+          />
+        </PageLayout>
+      );
+    }
+
+    if (screen.name === "review" || screen.name === "result") {
+      const session = sessionQuery.data?.session;
+
+      // What Apply will actually do, once drift has withheld anything it must.
+      const withheldCount = driftReport?.withheld.length ?? 0;
+      const applicableChanges = Math.max(applyPlan.operations.length - withheldCount, 0);
+      const applyButtonLabel =
+        applicableChanges === 0
+          ? "Nothing to apply"
+          : withheldCount > 0
+            ? `Apply the other ${applicableChanges} change${applicableChanges === 1 ? "" : "s"}`
+            : `Apply ${applicableChanges} change${applicableChanges === 1 ? "" : "s"}`;
+
+      return (
+        <PageLayout
+          title="Bank Reconciliation"
+          actions={
+            <PhaseNav
+              back={{
+                label: "Back to the workbench",
+                disabled: isApplying || isCheckingDrift,
+                onClick: () => {
+                  setDriftReport(null);
+                  setDriftAcknowledged(false);
+                  setScreen({ name: "workbench", sessionId: screen.sessionId });
+                },
+              }}
+              next={
+                screen.name === "review"
+                  ? {
+                      label: applyButtonLabel,
+                      onClick: () => void handleApply(),
+                      disabled: applicableChanges === 0,
+                      busy: isApplying || isCheckingDrift,
+                      progress: isCheckingDrift
+                        ? "Checking what has changed in Actual…"
+                        : applyProgress
+                          ? `Writing ${applyProgress.done} of ${applyProgress.total}…`
+                          : null,
+                    }
+                  : applyResult && !applyResult.complete
+                    ? {
+                        label: "Retry what failed",
+                        onClick: () => void handleApply(),
+                        busy: isApplying,
+                      }
+                    : undefined
+              }
+            />
+          }
+          scrollManaged
+        >
+          <SessionHeader
+            session={session}
+            current={screen.name === "review" ? "review" : "applied"}
+            period={period}
+            statementName={statementName}
+            onNavigate={(step) => goToStep(step, screen.sessionId)}
+            blockedSteps={
+              rematchBlockedReason ? { import: rematchBlockedReason } : undefined
+            }
+          />
+          {matchError && (
+            <p role="alert" className="px-4 pt-3 text-xs text-destructive">
+              {matchError}
+            </p>
+          )}
+          {screen.name === "review" ? (
+            <ReviewPanel
+              plan={applyPlan}
+              items={items}
+              statementRows={statementRowsById}
+              transactions={transactionsById}
+              payees={payeeOptions}
+              categories={categoryOptions}
+              drift={driftReport}
+              applyConfig={applyConfig}
+              onApplyConfigChange={(config) => {
+                setApplyConfig(config);
+                if (sessionId) {
+                  void mutations.updateSession.mutateAsync({
+                    id: sessionId,
+                    payload: { applyConfig: config },
+                  });
+                }
+              }}
+            />
+          ) : (
+            applyResult && (
+              <ApplyResultPanel
+                plan={fullPlan}
+                items={items}
+                statementRows={statementRowsById}
+                transactions={transactionsById}
+                payees={payeeOptions}
+                applyConfig={applyConfig}
+                result={applyResult}
+                verification={verification}
+                isVerifying={isVerifying}
+              />
+            )
+          )}
+          {screen.name === "result" && !applyResult && (
+            <p className="px-4 py-6 text-sm text-muted-foreground">
+              {session?.appliedAt
+                ? "This reconciliation has already been applied."
+                : "Nothing has been applied yet."}
+            </p>
+          )}
+        </PageLayout>
+      );
+    }
+
+    if (screen.name === "workbench") {
+      const session = sessionQuery.data?.session;
+      const canRematch = Boolean(session && period && parsedRows.length > 0);
+
+
+      return (
+        <PageLayout
+          title="Bank Reconciliation"
+          actions={
+            <PhaseNav
+              back={{ label: "All reconciliations", onClick: () => setScreen({ name: "home" }) }}
+              secondary={
+                session
+                  ? {
+                      label: "Import again",
+                      onClick: () => reimport(session),
+                      // Refused on an applied session for the same reason
+                      // re-running the match is: importing again rebuilds the
+                      // rows, which orphans the record of what was written and
+                      // would offer the same transactions for a second write.
+                      disabled: isMatching || Boolean(rematchBlockedReason),
+                      title: rematchBlockedReason ?? undefined,
+                    }
+                  : undefined
+              }
+              next={{
+                label:
+                  applyPlan.operations.length === 0
+                    ? "Nothing to review"
+                    : `Review ${applyPlan.operations.length} change${
+                        applyPlan.operations.length === 1 ? "" : "s"
+                      }`,
+                onClick: () => setScreen({ name: "review", sessionId: screen.sessionId }),
+                disabled: applyPlan.operations.length === 0,
+              }}
+            />
+          }
+          scrollManaged
+        >
+          <SessionHeader
+            session={session}
+            current="reconcile"
+            period={period}
+            statementName={statementName}
+            onNavigate={(step) => goToStep(step, screen.sessionId)}
+            blockedSteps={
+              rematchBlockedReason ? { import: rematchBlockedReason } : undefined
+            }
+          />
+          {matchError && (
+            <p role="alert" className="px-4 pt-3 text-xs text-destructive">
+              {matchError}
+            </p>
+          )}
+          <Workbench
+            items={items}
+            statementRows={statementRowsById}
+            transactions={transactionsById}
+            coverage={coverage}
+            matchConfig={matchConfig}
+            matchPreset={matchPreset}
+            isMatching={isMatching}
+            canRematch={canRematch}
+            rematchBlockedReason={rematchBlockedReason}
+            payees={payeeOptions}
+            categories={categoryOptions}
+            onDisposition={handleDisposition}
+            onUseCandidate={handleUseCandidate}
+            onCorrectAmount={handleCorrectAmount}
+            onStage={handleStage}
+            onUnstage={handleUnstage}
+            onBulkDisposition={handleBulkDisposition}
+            onBulkCorrectAmount={handleBulkCorrectAmount}
+            transformContextFor={transformContextFor}
+            onTransform={handleTransform}
+            onViewResult={
+              applyResult
+                ? () => setScreen({ name: "result", sessionId: screen.sessionId })
+                : undefined
+            }
+            onMatchConfigChange={(preset, config) => {
+              setMatchPreset(preset);
+              setMatchConfig(config);
+            }}
+            onRematch={() => {
+              if (!session || !period) return;
+              void runMatch({
+                sessionId: session.id,
+                accountId: session.accountId,
+                statementRows: parsedRows,
+                statementPeriod: period,
+                config: matchConfig,
+              });
+            }}
+          />
+        </PageLayout>
+      );
+    }
 
     return (
       <PageLayout
         title="Bank Reconciliation"
+        count={
+          sessionsQuery.data?.length
+            ? `${sessionsQuery.data.length} session${sessionsQuery.data.length === 1 ? "" : "s"}`
+            : undefined
+        }
+        isLoading={sessionsQuery.isLoading}
+        isError={sessionsQuery.isError}
+        error={sessionsQuery.error}
+        onRetry={() => void sessionsQuery.refetch()}
+        scrollManaged
         actions={
-          <Button variant="ghost" size="sm" onClick={() => setScreen({ name: "home" })}>
-            <ArrowLeft className="mr-1 h-3.5 w-3.5" />
-            All reconciliations
+          <Button size="sm" onClick={() => setNewSessionOpen(true)}>
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            New reconciliation
           </Button>
         }
-        scrollManaged
       >
-        <SessionHeader
-          session={session}
-          current="reconcile"
-          period={period}
-          statementName={statementName}
-          onNavigate={(step) => goToStep(step, screen.sessionId)}
+        <NewSessionDialog
+          open={newSessionOpen}
+          onOpenChange={setNewSessionOpen}
+          accounts={visibleAccounts.map((account) => ({ id: account.id, name: account.name }))}
+          knownTags={[
+            ...new Set(
+              (sessionsQuery.data ?? [])
+                .map((session) => session.tag)
+                .filter((tag): tag is string => Boolean(tag))
+            ),
+          ].sort()}
+          isCreating={mutations.createSession.isPending}
+          onStart={(id, tag) => {
+            setAccountId(id);
+            void startSession(id, tag);
+          }}
         />
-        {matchError && (
-          <p role="alert" className="px-4 pt-3 text-xs text-destructive">
-            {matchError}
-          </p>
-        )}
-        <Workbench
-          items={items}
-          statementRows={statementRowsById}
-          transactions={transactionsById}
-          coverage={coverage}
-          matchConfig={matchConfig}
-          matchPreset={matchPreset}
-          isMatching={isMatching}
-          canRematch={canRematch}
-          rematchBlockedReason={rematchBlockedReason}
-          payees={payeeOptions}
-          categories={categoryOptions}
-          onDisposition={handleDisposition}
-          onUseCandidate={handleUseCandidate}
-          onCorrectAmount={handleCorrectAmount}
-          onStage={handleStage}
-          onUnstage={handleUnstage}
-          onBulkDisposition={handleBulkDisposition}
-          onBulkCorrectAmount={handleBulkCorrectAmount}
-          transformContextFor={transformContextFor}
-          onTransform={handleTransform}
-          changeCount={applyPlan.operations.length}
-          onViewResult={
-            applyResult
-              ? () => setScreen({ name: "result", sessionId: screen.sessionId })
-              : undefined
+
+        <SessionList
+            sessions={sessionsQuery.data ?? []}
+            onOpen={(session) => {
+              // Cleared rather than left for the effect to replace, so the
+              // previous session's rows are never briefly shown under this one.
+              if (loadedSessionId !== session.id) {
+                setParsedRows([]);
+                setItems([]);
+                setSnapshot([]);
+                setPeriod(null);
+                setStatementName(null);
+                setApplyResult(null);
+                setLoadedSessionId(null);
+              }
+              setScreen({ name: "workbench", sessionId: session.id });
+            }}
+            onDelete={(session) => {
+              // Deleting takes the statement rows and every decision staged
+              // against them with it, and there is no undo — one stray click on
+              // a trash icon should not be able to do that.
+              const decided = rowCountOf(session);
+              setConfirm({
+                title: "Delete this reconciliation?",
+                message: (
+                  <>
+                    {session.accountName ?? "This account"}
+                    {session.tag ? ` · ${session.tag}` : ""}
+                    {decided !== null ? ` · ${decided} statement rows` : ""}. The statement and every
+                    decision staged against it are removed. Nothing in your budget changes, and
+                    anything already applied stays applied.
+                  </>
+                ),
+                onConfirm: () => void mutations.deleteSession.mutateAsync(session.id),
+              });
+            }}
+          onRetag={(session, tag) =>
+            void mutations.updateSession.mutateAsync({ id: session.id, payload: { tag } })
           }
-          onReview={() => setScreen({ name: "review", sessionId: screen.sessionId })}
-          onMatchConfigChange={(preset, config) => {
-            setMatchPreset(preset);
-            setMatchConfig(config);
-          }}
-          onRematch={() => {
-            if (!session || !period) return;
-            void runMatch({
-              sessionId: session.id,
-              accountId: session.accountId,
-              statementRows: parsedRows,
-              statementPeriod: period,
-              config: matchConfig,
-            });
-          }}
+          onNew={() => setNewSessionOpen(true)}
         />
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout
-      title="Bank Reconciliation"
-      count={
-        sessionsQuery.data?.length
-          ? `${sessionsQuery.data.length} session${sessionsQuery.data.length === 1 ? "" : "s"}`
-          : undefined
-      }
-      isLoading={sessionsQuery.isLoading}
-      isError={sessionsQuery.isError}
-      error={sessionsQuery.error}
-      onRetry={() => void sessionsQuery.refetch()}
-      scrollManaged
-      actions={
-        <Button size="sm" onClick={() => setNewSessionOpen(true)}>
-          <Plus className="mr-1 h-3.5 w-3.5" />
-          New reconciliation
-        </Button>
-      }
-    >
-      <NewSessionDialog
-        open={newSessionOpen}
-        onOpenChange={setNewSessionOpen}
-        accounts={visibleAccounts.map((account) => ({ id: account.id, name: account.name }))}
-        knownTags={[
-          ...new Set(
-            (sessionsQuery.data ?? [])
-              .map((session) => session.tag)
-              .filter((tag): tag is string => Boolean(tag))
-          ),
-        ].sort()}
-        isCreating={mutations.createSession.isPending}
-        onStart={(id, tag) => {
-          setAccountId(id);
-          void startSession(id, tag);
-        }}
-      />
-
-      <SessionList
-          sessions={sessionsQuery.data ?? []}
-          onOpen={(session) => {
-            // Cleared rather than left for the effect to replace, so the
-            // previous session's rows are never briefly shown under this one.
-            if (loadedSessionId !== session.id) {
-              setParsedRows([]);
-              setItems([]);
-              setSnapshot([]);
-              setPeriod(null);
-              setStatementName(null);
-              setApplyResult(null);
-              setLoadedSessionId(null);
-            }
-            setScreen({ name: "workbench", sessionId: session.id });
-          }}
-          onDelete={(session) => {
-            // Deleting takes the statement rows and every decision staged
-            // against them with it, and there is no undo — one stray click on
-            // a trash icon should not be able to do that.
-            const decided = rowCountOf(session);
-            setConfirm({
-              title: "Delete this reconciliation?",
-              message: (
-                <>
-                  {session.accountName ?? "This account"}
-                  {session.tag ? ` · ${session.tag}` : ""}
-                  {decided !== null ? ` · ${decided} statement rows` : ""}. The statement and every
-                  decision staged against it are removed. Nothing in your budget changes, and
-                  anything already applied stays applied.
-                </>
-              ),
-              onConfirm: () => void mutations.deleteSession.mutateAsync(session.id),
-            });
-          }}
-        onRetag={(session, tag) =>
-          void mutations.updateSession.mutateAsync({ id: session.id, payload: { tag } })
-        }
-        onNew={() => setNewSessionOpen(true)}
-      />
-
+    <>
+      {renderScreen()}
       <ConfirmDialog
         open={confirm !== null}
-        onOpenChange={(open) => { if (!open) setConfirm(null); }}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
         state={confirm}
       />
-    </PageLayout>
+    </>
   );
 }
 

--- a/src/features/reconciliation/components/ReconciliationView.tsx
+++ b/src/features/reconciliation/components/ReconciliationView.tsx
@@ -483,11 +483,28 @@ export function ReconciliationView() {
       const account = visibleAccounts.find((entry) => entry.id === (chosenId ?? accountId));
       if (!account) return;
       setNewSessionOpen(false);
-      const { session } = await mutations.createSession.mutateAsync({
-        accountId: account.id,
-        accountName: account.name,
-        tag: tag ?? null,
-      });
+      setPendingStatement(null);
+      setMatchError(null);
+
+      // Caught here because the caller fires this and forgets it. Without it a
+      // failed write is an unhandled rejection: the dialog has already closed,
+      // so the user lands back on the list with no session and no explanation.
+      let session: ReconciliationSessionRecord;
+      try {
+        ({ session } = await mutations.createSession.mutateAsync({
+          accountId: account.id,
+          accountName: account.name,
+          tag: tag ?? null,
+        }));
+      } catch (error) {
+        setMatchError(
+          error instanceof Error
+            ? `Could not start the reconciliation: ${error.message}`
+            : "Could not start the reconciliation"
+        );
+        return;
+      }
+
       setParsedRows([]);
       setItems([]);
       setPeriod(null);
@@ -1446,6 +1463,15 @@ export function ReconciliationView() {
           </Button>
         }
       >
+        {/* Starting a session fails *here*, on the list, so the message has to
+            be here too — the other screens render it, but this is the one the
+            user is looking at when the write is refused. */}
+        {matchError && (
+          <p role="alert" className="px-4 pt-3 text-xs text-destructive">
+            {matchError}
+          </p>
+        )}
+
         <NewSessionDialog
           open={newSessionOpen}
           onOpenChange={setNewSessionOpen}

--- a/src/features/reconciliation/components/ReviewComparison.tsx
+++ b/src/features/reconciliation/components/ReviewComparison.tsx
@@ -309,16 +309,16 @@ export function ReviewComparison({
               return (
                 <tr key={row.item.id} className="border-b border-border/20">
                   <td className="whitespace-nowrap px-2 py-1 tabular-nums text-muted-foreground">
-                    {row.statementRow ? formatShortDate(row.statementRow.postedDate) : "—"}
+                    {row.statementRow ? formatShortDate(row.statementRow.postedDate) : "-"}
                   </td>
                   <td
                     className="max-w-0 truncate px-2 py-1"
                     title={row.statementRow?.description}
                   >
-                    {row.statementRow?.description ?? "—"}
+                    {row.statementRow?.description ?? "-"}
                   </td>
                   <td className="whitespace-nowrap px-2 py-1 text-right tabular-nums">
-                    {row.statementRow ? formatMinorUnits(row.statementRow.amount) : "—"}
+                    {row.statementRow ? formatMinorUnits(row.statementRow.amount) : "-"}
                   </td>
 
                   <td
@@ -339,7 +339,7 @@ export function ReviewComparison({
                     <>
                       <td className="whitespace-nowrap px-2 py-1 tabular-nums text-muted-foreground">
                         <Changed changed={row.changedFields.has("date")} was={row.transaction?.date}>
-                          {row.pending.date ? formatShortDate(row.pending.date) : "—"}
+                          {row.pending.date ? formatShortDate(row.pending.date) : "-"}
                         </Changed>
                       </td>
                       <td className="max-w-0 truncate px-2 py-1" title={payeeName ?? undefined}>
@@ -349,8 +349,8 @@ export function ReviewComparison({
                         >
                           {payeeName ??
                             (row.pending.isNew && applyConfig.descriptionTarget === "payee"
-                              ? row.statementRow?.description ?? "—"
-                              : "—")}
+                              ? row.statementRow?.description ?? "-"
+                              : "-")}
                         </Changed>
                       </td>
                       <td className="max-w-0 truncate px-2 py-1" title={row.pending.notes ?? undefined}>
@@ -358,7 +358,7 @@ export function ReviewComparison({
                           changed={row.changedFields.has("notes")}
                           was={row.transaction?.notes}
                         >
-                          {row.pending.notes ?? "—"}
+                          {row.pending.notes ?? "-"}
                         </Changed>
                       </td>
                       <td className="max-w-0 truncate px-2 py-1" title={categoryName ?? undefined}>
@@ -366,7 +366,7 @@ export function ReviewComparison({
                           changed={row.changedFields.has("categoryId")}
                           was={row.transaction?.categoryName}
                         >
-                          {categoryName ?? "—"}
+                          {categoryName ?? "-"}
                         </Changed>
                       </td>
                       <td className="whitespace-nowrap px-2 py-1 text-right tabular-nums">
@@ -376,7 +376,7 @@ export function ReviewComparison({
                             row.transaction ? formatMinorUnits(row.transaction.amount) : undefined
                           }
                         >
-                          {row.pending.amount !== null ? formatMinorUnits(row.pending.amount) : "—"}
+                          {row.pending.amount !== null ? formatMinorUnits(row.pending.amount) : "-"}
                         </Changed>
                       </td>
                       {/* Whether this row ends up cleared, since that is a
@@ -388,7 +388,7 @@ export function ReviewComparison({
                         ) : row.willBeCleared === "already" ? (
                           <span className="text-muted-foreground">Already</span>
                         ) : (
-                          <span className="text-muted-foreground">—</span>
+                          <span className="text-muted-foreground">-</span>
                         )}
                       </td>
                     </>
@@ -408,13 +408,13 @@ export function ReviewComparison({
 
       <div className="shrink-0 space-y-1 border-t border-border/60 px-3 py-1.5 text-[11px] text-muted-foreground">
         <p>
-          Values in amber are changing — hover one to see what it is now. Everything else is shown
+          Values in amber are changing - hover one to see what it is now. Everything else is shown
           as it already stands.
         </p>
         {unresolved > 0 && (
           <p>
             {unresolved} row{unresolved === 1 ? "" : "s"} still have no decision. They will be left
-            exactly as they are — you can come back to them.
+            exactly as they are - you can come back to them.
           </p>
         )}
       </div>

--- a/src/features/reconciliation/components/ReviewPanel.tsx
+++ b/src/features/reconciliation/components/ReviewPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { AlertTriangle, CheckCircle2, Loader2, Plus, Trash2, Pencil } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { AlertTriangle, CheckCircle2, Plus, Trash2, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   balanceImpact,
@@ -66,17 +65,10 @@ export type ReviewPanelProps = {
   transactions: Map<string, ActualTransactionSnapshot>;
   payees: Option[];
   categories: Option[];
-  isApplying: boolean;
-  /** The pre-flight re-read is in progress. */
-  isCheckingDrift: boolean;
   /** What moved in Actual since the session loaded, once checked. */
   drift: DriftReport | null;
-  /** How far a run in flight has got, so a long apply is legible. */
-  progress: { done: number; total: number } | null;
   applyConfig: ApplyConfig;
   onApplyConfigChange: (config: ApplyConfig) => void;
-  onBack: () => void;
-  onApply: () => void;
 };
 
 export function ReviewPanel({
@@ -86,14 +78,9 @@ export function ReviewPanel({
   transactions,
   payees,
   categories,
-  isApplying,
-  isCheckingDrift,
   drift,
-  progress,
   applyConfig,
   onApplyConfigChange,
-  onBack,
-  onApply,
 }: ReviewPanelProps) {
   const counts = planCounts(plan);
   const total = totalChanges(plan);
@@ -106,7 +93,6 @@ export function ReviewPanel({
   // that will actually happen rather than the work that was planned.
   const withheld = drift?.withheld.length ?? 0;
   const applicable = Math.max(total - withheld, 0);
-  const busy = isApplying || isCheckingDrift;
 
   const fieldCounts = new Map<string, number>();
   for (const operation of plan.operations) {
@@ -244,51 +230,22 @@ export function ReviewPanel({
         />
       )}
 
-      {/* The decision sits with the table it is about, at the top where it is
-          reachable without scrolling past two hundred rows first. */}
-      <div className="flex flex-wrap items-center gap-2 border-t border-border/50 pt-3">
-        {/* Which fields the updates touch, on the same line as the decision it
-            informs rather than in a panel of its own above it. */}
-        {fieldCounts.size > 0 && (
-          <div className="text-xs">
-            <p className="text-muted-foreground">The changes will include:</p>
-            <p className="flex flex-wrap items-baseline gap-x-3">
-              {[...fieldCounts].map(([field, count]) => (
-                <span key={field}>
-                  <span className="font-medium tabular-nums">{count}</span>{" "}
-                  {pluralFieldLabel(field, count)}
-                </span>
-              ))}
-            </p>
-          </div>
-        )}
-
-        {/* A spinner alone cannot distinguish slow from stuck. */}
-        {isApplying && progress && (
-          <span className="text-xs tabular-nums text-muted-foreground">
-            Writing {progress.done} of {progress.total}…
-          </span>
-        )}
-        {isCheckingDrift && (
-          <span className="text-xs text-muted-foreground">
-            Checking what has changed in Actual…
-          </span>
-        )}
-
-        <div className="ml-auto flex items-center gap-2">
-          <Button variant="ghost" onClick={onBack} disabled={busy}>
-            Cancel
-          </Button>
-          <Button onClick={onApply} disabled={busy || applicable === 0}>
-            {busy && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
-            {applicable === 0
-              ? "Nothing to apply"
-              : withheld > 0
-                ? `Apply the other ${applicable} change${applicable === 1 ? "" : "s"}`
-                : `Apply ${applicable} change${applicable === 1 ? "" : "s"}`}
-          </Button>
+      {/* Which fields the updates touch. The Apply and Cancel buttons that used
+          to sit here now live in the page toolbar, with the rest of the phase
+          navigation. */}
+      {fieldCounts.size > 0 && (
+        <div className="border-t border-border/50 pt-3 text-xs">
+          <p className="text-muted-foreground">The changes will include:</p>
+          <p className="flex flex-wrap items-baseline gap-x-3">
+            {[...fieldCounts].map(([field, count]) => (
+              <span key={field}>
+                <span className="font-medium tabular-nums">{count}</span>{" "}
+                {pluralFieldLabel(field, count)}
+              </span>
+            ))}
+          </p>
         </div>
-      </div>
+      )}
 
       <ReviewComparison
         plan={plan}

--- a/src/features/reconciliation/components/ReviewPanel.tsx
+++ b/src/features/reconciliation/components/ReviewPanel.tsx
@@ -192,7 +192,7 @@ export function ReviewPanel({
             {
               value: "reconciled",
               label: "Everything confirmed",
-              hint: "Also clears matched transactions that are not cleared yet — the point of reconciling, but it turns rows needing no change into writes. Rows already cleared or reconciled in Actual are left untouched.",
+              hint: "Also clears matched transactions that are not cleared yet - the point of reconciling, but it turns rows needing no change into writes. Rows already cleared or reconciled in Actual are left untouched.",
             },
           ]}
         />
@@ -213,7 +213,7 @@ export function ReviewPanel({
               {
                 value: "notes",
                 label: "The notes",
-                hint: "Keeps a curated payee list free of raw bank text — and gives your rules something to read.",
+                hint: "Keeps a curated payee list free of raw bank text - and gives your rules something to read.",
               },
             ]}
           />

--- a/src/features/reconciliation/components/SessionHeader.tsx
+++ b/src/features/reconciliation/components/SessionHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { AlertTriangle, Check } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { ReconciliationSessionRecord } from "../lib/reconciliationApi";
@@ -90,6 +91,15 @@ export type SessionHeaderProps = {
   /** Navigate to a step. Only offered for steps the session has already reached. */
   onNavigate?: (step: SessionStep) => void;
   /**
+   * Leave the feature entirely.
+   *
+   * Lives here rather than in the toolbar because it is the one action that
+   * means the same thing on every screen. With it in the phase buttons, "back"
+   * retreated one step on three screens and left the feature on the fourth, and
+   * finishing meant walking backwards through screens the user was done with.
+   */
+  onExit?: () => void;
+  /**
    * Steps that cannot be returned to, and why.
    *
    * Rendered as plain text with the reason on hover rather than as a button
@@ -106,6 +116,7 @@ export function SessionHeader({
   statementName,
   onNavigate,
   blockedSteps,
+  onExit,
 }: SessionHeaderProps) {
   const status = session?.status ?? "draft";
   const reached = reachedIndex(status);
@@ -117,6 +128,18 @@ export function SessionHeader({
 
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/50 px-4 py-2">
+      {onExit && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-ml-2 h-7 shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={onExit}
+        >
+          <ArrowLeft className="mr-1 h-3.5 w-3.5" />
+          All reconciliations
+        </Button>
+      )}
+
       <div className="flex flex-wrap items-baseline gap-x-2">
         <span className="text-sm font-semibold">{session?.accountName ?? "Reconciliation"}</span>
         {session?.tag && (

--- a/src/features/reconciliation/components/SessionHeader.tsx
+++ b/src/features/reconciliation/components/SessionHeader.tsx
@@ -89,6 +89,14 @@ export type SessionHeaderProps = {
   statementName?: string | null;
   /** Navigate to a step. Only offered for steps the session has already reached. */
   onNavigate?: (step: SessionStep) => void;
+  /**
+   * Steps that cannot be returned to, and why.
+   *
+   * Rendered as plain text with the reason on hover rather than as a button
+   * that quietly does nothing — a control that looks live and is not is worse
+   * than one that is plainly unavailable.
+   */
+  blockedSteps?: Partial<Record<SessionStep, string>>;
 };
 
 export function SessionHeader({
@@ -97,6 +105,7 @@ export function SessionHeader({
   period,
   statementName,
   onNavigate,
+  blockedSteps,
 }: SessionHeaderProps) {
   const status = session?.status ?? "draft";
   const reached = reachedIndex(status);
@@ -138,7 +147,8 @@ export function SessionHeader({
           const isCurrent = index === currentIndex;
           // Only somewhere the session has actually been. Offering Review on a
           // session with nothing decided would lead to an empty screen.
-          const reachable = Boolean(onNavigate) && index <= reached && !isCurrent;
+          const blocked = blockedSteps?.[step.id];
+          const reachable = Boolean(onNavigate) && index <= reached && !isCurrent && !blocked;
 
           const content = (
             <span
@@ -189,7 +199,13 @@ export function SessionHeader({
                   {content}
                 </button>
               ) : (
-                <span aria-current={isCurrent ? "step" : undefined}>{content}</span>
+                <span
+                  aria-current={isCurrent ? "step" : undefined}
+                  title={blocked ?? undefined}
+                  className={cn(blocked && "cursor-not-allowed opacity-60")}
+                >
+                  {content}
+                </span>
               )}
             </li>
           );

--- a/src/features/reconciliation/components/SessionHeader.tsx
+++ b/src/features/reconciliation/components/SessionHeader.tsx
@@ -228,6 +228,11 @@ export function SessionHeader({
                   className={cn(blocked && "cursor-not-allowed opacity-60")}
                 >
                   {content}
+                  {/* `title` reaches a mouse and nothing else. This step is not
+                      focusable, so without text in the flow a keyboard or
+                      screen-reader user is told the step exists and never why
+                      it cannot be returned to. */}
+                  {blocked && <span className="sr-only"> - {blocked}</span>}
                 </span>
               )}
             </li>

--- a/src/features/reconciliation/components/SessionList.tsx
+++ b/src/features/reconciliation/components/SessionList.tsx
@@ -122,7 +122,7 @@ function formatTimestamp(iso: string): string {
 }
 
 function periodOf(session: ReconciliationSessionRecord): string {
-  if (!session.statementStart || !session.statementEnd) return "—";
+  if (!session.statementStart || !session.statementEnd) return "-";
   return `${session.statementStart} → ${session.statementEnd}`;
 }
 
@@ -478,12 +478,12 @@ export function SessionList({ sessions, onOpen, onDelete, onRetag, onNew }: Sess
                   )}
                 </td>
                 <td className="max-w-0 truncate px-3 py-1.5 text-muted-foreground">
-                  {session.statementName ?? "—"}
+                  {session.statementName ?? "-"}
                 </td>
                 <td className="whitespace-nowrap px-3 py-1.5 tabular-nums text-muted-foreground">
                   {periodOf(session)}
                 </td>
-                <td className="px-3 py-1.5 tabular-nums">{rowCountOf(session) ?? "—"}</td>
+                <td className="px-3 py-1.5 tabular-nums">{rowCountOf(session) ?? "-"}</td>
                 <td className="px-3 py-1.5">
                   <Badge variant="outline" className={cn("text-[11px]", statusTone(session.status))}>
                     {STATUS_LABELS[session.status] ?? session.status}

--- a/src/features/reconciliation/components/ShortcutsHelp.tsx
+++ b/src/features/reconciliation/components/ShortcutsHelp.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * What the keyboard can do here.
+ *
+ * The workbench has had row navigation since it was built, and almost nobody
+ * would have found it: the only hint was a single badge on one button. Deciding
+ * a few hundred rows without touching the mouse is the difference between this
+ * screen being pleasant and being a chore, so the bindings need somewhere to be
+ * announced.
+ */
+
+const GROUPS: { title: string; rows: { keys: string[]; label: string }[] }[] = [
+  {
+    title: "Moving",
+    rows: [
+      { keys: ["j", "↓"], label: "Next row" },
+      { keys: ["k", "↑"], label: "Previous row" },
+      { keys: ["n"], label: "Next row still undecided" },
+      { keys: ["Esc"], label: "Close the details panel" },
+    ],
+  },
+  {
+    title: "Deciding",
+    rows: [
+      { keys: ["Enter"], label: "Accept what this row is for - confirm, create, or keep" },
+      { keys: ["c"], label: "Create in Actual" },
+      { keys: ["d"], label: "Delete from Actual" },
+      { keys: ["i"], label: "Ignore this row" },
+      { keys: ["u"], label: "Undo the decision" },
+    ],
+  },
+];
+
+export type ShortcutsHelpProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function ShortcutsHelp({ open, onOpenChange }: ShortcutsHelpProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Deciding advances to the next undecided row, so a clean statement can be worked through
+            without leaving the keyboard.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {GROUPS.map((group) => (
+            <section key={group.title}>
+              <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {group.title}
+              </h3>
+              <dl className="space-y-1.5">
+                {group.rows.map((row) => (
+                  <div key={row.label} className="flex items-baseline gap-2">
+                    <dt className="flex shrink-0 gap-1">
+                      {row.keys.map((key) => (
+                        <kbd
+                          key={key}
+                          className="rounded border border-border bg-muted/50 px-1.5 py-0.5 text-[11px] font-medium"
+                        >
+                          {key}
+                        </kbd>
+                      ))}
+                    </dt>
+                    <dd className="text-xs text-muted-foreground">{row.label}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+
+        <p className="text-[11px] text-muted-foreground">
+          Keys are ignored while you are typing in a search box or a field, and a decision a row
+          does not offer - deleting a transfer, say - is refused here exactly as its button is.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/reconciliation/components/StagedFields.tsx
+++ b/src/features/reconciliation/components/StagedFields.tsx
@@ -134,12 +134,20 @@ export function StagedFields({
         what posted. It is displayed so the user can see what the transaction
         already carries and know it is being left alone.
       */}
-      <div className="flex flex-col gap-1">
+      {/* Laid out as a fact rather than as a field: label beside value on one
+          line, so it reads as something being reported rather than a control
+          the user is hunting for the edit affordance on. The qualifier stays
+          visible - that reconciliation never touches categories is a promise
+          worth seeing rather than discovering on hover. */}
+      <div
+        className="grid grid-cols-[5.5rem_1fr] items-baseline gap-2"
+        title="Categories are set in Actual, where the rules and the budget context are. A reconciliation never changes them."
+      >
         <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
           Category
         </span>
         <p className="text-xs">
-          {categories.find((option) => option.id === current.categoryId)?.name ?? "—"}
+          {categories.find((option) => option.id === current.categoryId)?.name ?? "-"}
           <span className="ml-1 text-muted-foreground">· set in Actual</span>
         </p>
       </div>

--- a/src/features/reconciliation/components/TransformDialog.tsx
+++ b/src/features/reconciliation/components/TransformDialog.tsx
@@ -68,6 +68,50 @@ const FIELD_LABELS: Record<string, string> = {
   date: "Date",
 };
 
+/**
+ * Which comparisons make sense for which field.
+ *
+ * The operator list was the same eleven entries whatever the field, so the form
+ * happily offered "Amount has tag" and "Notes is more than" - combinations that
+ * can only ever match nothing, and which the user has to discover are useless
+ * by trying them.
+ */
+const OPERATORS_BY_FIELD: Record<ConditionField, ConditionOperator[]> = {
+  // Tags live in the notes, so only notes can be asked about them.
+  notes: ["hasTag", "doesNotHaveTag", "contains", "notContains", "equals", "notEquals", "startsWith", "endsWith"],
+  statementDescription: ["contains", "notContains", "equals", "notEquals", "startsWith", "endsWith"],
+  payee: ["contains", "notContains", "equals", "notEquals", "startsWith", "endsWith"],
+  category: ["contains", "notContains", "equals", "notEquals", "startsWith", "endsWith"],
+  amount: ["equals", "notEquals", "greaterThan", "lessThan", "between"],
+  date: ["equals", "notEquals", "greaterThan", "lessThan", "between"],
+  // A decision is one of a fixed set, so it is only ever "is" or "is not".
+  matchStatus: ["equals", "notEquals"],
+};
+
+/** "Is more than" reads wrong for a date; everything else keeps its wording. */
+const DATE_OPERATOR_LABELS: Partial<Record<ConditionOperator, string>> = {
+  greaterThan: "is after",
+  lessThan: "is before",
+};
+
+function operatorLabel(field: ConditionField, operator: ConditionOperator): string {
+  if (field === "date" && DATE_OPERATOR_LABELS[operator]) {
+    return DATE_OPERATOR_LABELS[operator]!;
+  }
+  return OPERATORS.find((entry) => entry.id === operator)?.label ?? operator;
+}
+
+/** The decisions a row can be in, for the value dropdown when asking about one. */
+const DECISION_VALUES: { id: string; label: string }[] = [
+  { id: "unresolved", label: "Undecided" },
+  { id: "matched", label: "Matched" },
+  { id: "create", label: "Create in Actual" },
+  { id: "keep", label: "Keep" },
+  { id: "delete", label: "Delete from Actual" },
+  { id: "correct-amount", label: "Correct the amount" },
+  { id: "ignored", label: "Ignored" },
+];
+
 type ActionKind = TransformAction["kind"];
 
 const ACTIONS: { id: ActionKind; label: string }[] = [
@@ -150,13 +194,13 @@ export function TransformDialog({
     const byId = new Map(items.map((item) => [item.id, item]));
     return (itemId: string): string => {
       const item = byId.get(itemId);
-      if (!item) return "—";
+      if (!item) return "-";
       const context = contextFor(item);
       return (
         context.statementRow?.description ??
         context.transaction?.payeeName ??
         context.transaction?.notes ??
-        "—"
+        "-"
       );
     };
   }, [items, contextFor]);
@@ -194,7 +238,7 @@ export function TransformDialog({
             Change many rows at once
           </DialogTitle>
           <DialogDescription>
-            Nothing is written to your budget — this stages the changes, and you still review them
+            Nothing is written to your budget - this stages the changes, and you still review them
             before applying.
           </DialogDescription>
         </DialogHeader>
@@ -234,13 +278,23 @@ export function TransformDialog({
               className="h-8 rounded-md border border-input bg-background px-2 text-xs"
               value={condition.field}
               aria-label="Field"
-              onChange={(event) =>
+              onChange={(event) => {
+                const field = event.target.value as ConditionField;
                 setConditions((previous) =>
-                  previous.map((entry, i) =>
-                    i === index ? { ...entry, field: event.target.value as ConditionField } : entry
-                  )
-                )
-              }
+                  previous.map((entry, i) => {
+                    if (i !== index) return entry;
+                    const allowed = OPERATORS_BY_FIELD[field];
+                    return {
+                      ...entry,
+                      field,
+                      // Carry the operator over only if the new field can use
+                      // it; otherwise fall to that field's first sensible one.
+                      operator: allowed.includes(entry.operator) ? entry.operator : allowed[0],
+                      value: field === "matchStatus" ? DECISION_VALUES[0].id : entry.value,
+                    };
+                  })
+                );
+              }}
             >
               {FIELDS.map((field) => (
                 <option key={field.id} value={field.id}>
@@ -263,26 +317,50 @@ export function TransformDialog({
                 )
               }
             >
-              {OPERATORS.map((operator) => (
-                <option key={operator.id} value={operator.id}>
-                  {operator.label}
+              {OPERATORS_BY_FIELD[condition.field].map((operator) => (
+                <option key={operator} value={operator}>
+                  {operatorLabel(condition.field, operator)}
                 </option>
               ))}
             </select>
 
-            <input
-              className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
-              value={condition.value}
-              aria-label="Value"
-              placeholder={condition.operator.includes("Tag") ? "#API" : ""}
-              onChange={(event) =>
-                setConditions((previous) =>
-                  previous.map((entry, i) =>
-                    i === index ? { ...entry, value: event.target.value } : entry
+            {/* A decision is one of a fixed set, so it is chosen rather than
+                typed - spelling "correct-amount" by hand is not a thing to ask
+                of anyone. */}
+            {condition.field === "matchStatus" ? (
+              <select
+                className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
+                value={condition.value}
+                aria-label="Decision"
+                onChange={(event) =>
+                  setConditions((previous) =>
+                    previous.map((entry, i) =>
+                      i === index ? { ...entry, value: event.target.value } : entry
+                    )
                   )
-                )
-              }
-            />
+                }
+              >
+                {DECISION_VALUES.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.label}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
+                value={condition.value}
+                aria-label="Value"
+                placeholder={condition.operator.includes("Tag") ? "#API" : ""}
+                onChange={(event) =>
+                  setConditions((previous) =>
+                    previous.map((entry, i) =>
+                      i === index ? { ...entry, value: event.target.value } : entry
+                    )
+                  )
+                }
+              />
+            )}
 
             {condition.operator === "between" && (
               <input
@@ -578,10 +656,10 @@ export function TransformDialog({
                           {FIELD_LABELS[change.field] ?? change.field}
                         </td>
                         <td className="px-3 py-1 align-top text-muted-foreground">
-                          {change.before ?? "—"}
+                          {change.before ?? "-"}
                         </td>
                         <td className="px-3 py-1 align-top text-amber-600 dark:text-amber-400">
-                          {change.after ?? "—"}
+                          {change.after ?? "-"}
                         </td>
                       </tr>
                     ))

--- a/src/features/reconciliation/components/Workbench.tsx
+++ b/src/features/reconciliation/components/Workbench.tsx
@@ -38,7 +38,7 @@ import { WorkbenchRow } from "./WorkbenchRow";
  * with the apply pipeline, so nothing here can change the budget.
  */
 
-type FilterId =
+export type FilterId =
   | "all"
   | "needs-review"
   | "ambiguous"
@@ -226,36 +226,49 @@ function matchesAttributes(
   return true;
 }
 
-function matchesFilter(item: ReconciliationItem, filter: FilterId): boolean {
+/**
+ * Every reason a row lands in review.
+ *
+ * Declared once so the parent filter cannot drift from the children that break
+ * it down — which is exactly how the two came to disagree.
+ */
+const REVIEW_REASON_CODES: string[] = [
+  REASON.ambiguousMatch,
+  REASON.belowConfidenceFloor,
+  REASON.amountMismatch,
+  REASON.sameMerchantDate,
+  REASON.merchantCluster,
+  REASON.likelyDuplicate,
+];
+
+/** A row still waiting on the user, for one of the given reasons. */
+function isUndecidedReview(item: ReconciliationItem, reasons: string[]): boolean {
+  return item.disposition === "unresolved" && reasons.includes(item.reasonCode ?? "");
+}
+
+export function matchesFilter(item: ReconciliationItem, filter: FilterId): boolean {
   switch (filter) {
     case "matched":
       return item.disposition === "matched";
+    // "Needs review" and the four reasons beneath it are one question asked at
+    // two levels, so they share the same test. They did not: the parent counted
+    // only rows still undecided while the children counted by reason alone, so
+    // deciding a row removed it from the parent and left it in the child —
+    // "Needs review 0" above "Amount differs 14".
+    //
+    // Both now mean "still to review". They shrink together as the work is done,
+    // and the parent is exactly the union of its children. Revisiting rows
+    // already settled is what the Progress axis is for.
     case "needs-review":
-      return (
-        item.disposition === "unresolved" &&
-        (item.reasonCode === REASON.ambiguousMatch ||
-          item.reasonCode === REASON.belowConfidenceFloor ||
-          item.reasonCode === REASON.amountMismatch ||
-          item.reasonCode === REASON.sameMerchantDate ||
-          item.reasonCode === REASON.merchantCluster ||
-          item.reasonCode === REASON.likelyDuplicate)
-      );
+      return isUndecidedReview(item, REVIEW_REASON_CODES);
     case "ambiguous":
-      return (
-        item.reasonCode === REASON.ambiguousMatch ||
-        item.reasonCode === REASON.belowConfidenceFloor
-      );
+      return isUndecidedReview(item, [REASON.ambiguousMatch, REASON.belowConfidenceFloor]);
     case "amount-mismatch":
-      return item.reasonCode === REASON.amountMismatch;
+      return isUndecidedReview(item, [REASON.amountMismatch]);
     case "wrong-amount":
-      return (
-        item.reasonCode === REASON.sameMerchantDate ||
-        item.reasonCode === REASON.merchantCluster
-      );
+      return isUndecidedReview(item, [REASON.sameMerchantDate, REASON.merchantCluster]);
     case "duplicates":
-      // A matched row can carry the duplicate flag; it belongs under Matched,
-      // not under the work still to do.
-      return item.disposition !== "matched" && item.reasonCode === REASON.likelyDuplicate;
+      return isUndecidedReview(item, [REASON.likelyDuplicate]);
     case "create":
       return item.reasonCode === REASON.noActualCandidate;
     case "actual-only":

--- a/src/features/reconciliation/components/Workbench.tsx
+++ b/src/features/reconciliation/components/Workbench.tsx
@@ -219,10 +219,8 @@ export type WorkbenchProps = {
     entries: { itemId: string; transactionId: string; amount: number }[]
   ) => void;
   /** Writes the plan would make, named on the button rather than a row count. */
-  changeCount: number;
   /** Set when this session has already been applied, so its outcome is reachable. */
   onViewResult?: () => void;
-  onReview: () => void;
   transformContextFor: (item: ReconciliationItem) => TransformContext;
   onTransform: (changes: { itemId: string; patch: StagedPatch | undefined }[]) => void;
 };
@@ -280,9 +278,7 @@ export function Workbench({
   onUnstage,
   onBulkDisposition,
   onBulkCorrectAmount,
-  changeCount,
   onViewResult,
-  onReview,
   transformContextFor,
   onTransform,
 }: WorkbenchProps) {
@@ -532,11 +528,6 @@ export function Workbench({
           {/* Named in changes, not rows: most of a reconciliation needs no
               write, and offering to "apply 248" when 12 will change is how a
               user stops trusting the numbers. */}
-          <Button size="sm" disabled={changeCount === 0} onClick={onReview}>
-            {changeCount === 0
-              ? "Nothing to review"
-              : `Review ${changeCount} change${changeCount === 1 ? "" : "s"}`}
-          </Button>
         </div>
       </div>
 

--- a/src/features/reconciliation/components/Workbench.tsx
+++ b/src/features/reconciliation/components/Workbench.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FileCheck, RefreshCw, Search, SlidersHorizontal, Wand2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MultiPillGroup, PillGroup } from "@/components/ui/pill-group";
 import { cn } from "@/lib/utils";
 import { REASON } from "@/lib/reconciliation/session/build";
+import { canStageDelete } from "@/lib/reconciliation/session/staging";
 import type { ReconciliationCoverage } from "@/lib/reconciliation/session/build";
 import type {
   ActualTransactionSnapshot,
@@ -22,9 +23,10 @@ import type { TransformContext } from "@/lib/reconciliation/transform/rules";
 import type { StagedPatch } from "@/lib/reconciliation/types";
 import { useTableSelection } from "@/hooks/useTableSelection";
 import { BulkDecisionBar } from "./BulkDecisionBar";
-import { CoverageSummary } from "./CoverageSummary";
+import { CoverageSummary, DecisionProgressMeter } from "./CoverageSummary";
 import { Inspector } from "./Inspector";
 import { MatchOptions } from "./MatchOptions";
+import { ShortcutsHelp } from "./ShortcutsHelp";
 import { TransformDialog } from "./TransformDialog";
 import { WorkbenchRow } from "./WorkbenchRow";
 
@@ -55,6 +57,14 @@ type FilterDef = {
   dot: string;
   /** Indented under the filter it refines. */
   child?: boolean;
+  /**
+   * What this filter actually means, on hover.
+   *
+   * The labels are necessarily terse, and several of them ("Amount differs" vs
+   * "Amount looks wrong") only make sense once you know the matcher's rules —
+   * which the user should not have to.
+   */
+  hint: string;
 };
 
 /**
@@ -65,14 +75,53 @@ type FilterDef = {
  * one of the rows needing review.
  */
 const STATEMENT_FILTERS: FilterDef[] = [
-  { id: "all", label: "All", dot: "bg-muted-foreground/40" },
-  { id: "needs-review", label: "Needs review", dot: "bg-amber-500/70" },
-  { id: "ambiguous", label: "Several candidates", dot: "bg-amber-500/40", child: true },
-  { id: "amount-mismatch", label: "Amount differs", dot: "bg-amber-500/40", child: true },
-  { id: "wrong-amount", label: "Amount looks wrong", dot: "bg-amber-500/40", child: true },
-  { id: "duplicates", label: "Duplicates", dot: "bg-amber-500/40", child: true },
-  { id: "create", label: "Not in Actual", dot: "bg-sky-500/60" },
-  { id: "matched", label: "Matched", dot: "bg-emerald-500/70" },
+  { id: "all", label: "All", dot: "bg-muted-foreground/40", hint: "Every row on this statement." },
+  {
+    id: "needs-review",
+    label: "Needs review",
+    dot: "bg-amber-500/70",
+    hint: "Rows the matcher would not decide on its own. Select this to break them down by reason.",
+  },
+  {
+    id: "ambiguous",
+    label: "Several candidates",
+    dot: "bg-amber-500/40",
+    child: true,
+    hint: "More than one transaction in Actual fits this row, and none is clearly the right one.",
+  },
+  {
+    id: "amount-mismatch",
+    label: "Amount differs",
+    dot: "bg-amber-500/40",
+    child: true,
+    hint: "The text matches a transaction plainly, but the amounts do not agree.",
+  },
+  {
+    id: "wrong-amount",
+    label: "Amount looks wrong",
+    dot: "bg-amber-500/40",
+    child: true,
+    hint: "Same merchant and date as the only transaction left, but the amount is far off - often a conversion done wrong before it reached the budget.",
+  },
+  {
+    id: "duplicates",
+    label: "Duplicates",
+    dot: "bg-amber-500/40",
+    child: true,
+    hint: "One statement row, but more than one transaction in Actual recording it.",
+  },
+  {
+    id: "create",
+    label: "Not in Actual",
+    dot: "bg-sky-500/60",
+    hint: "On the statement with nothing in Actual to match - these become new transactions if you create them.",
+  },
+  {
+    id: "matched",
+    label: "Matched",
+    dot: "bg-emerald-500/70",
+    hint: "Paired with a transaction in Actual. Nothing is written unless you have staged a change.",
+  },
 ];
 
 /**
@@ -80,10 +129,37 @@ const STATEMENT_FILTERS: FilterDef[] = [
  * of the statement's total: nothing here counts towards how much of the
  * statement is covered.
  */
+/** The reasons a row lands in review — children of `needs-review`. */
+const REVIEW_REASON_FILTERS = STATEMENT_FILTERS.filter((entry) => entry.child);
+
 const ACTUAL_ONLY_FILTERS: FilterDef[] = [
-  { id: "actual-only", label: "Actual only", dot: "bg-violet-500/60" },
-  { id: "outside-period", label: "Outside period", dot: "bg-muted-foreground/40" },
+  {
+    id: "actual-only",
+    // Named as the coverage bar names it: one thing, one word for it.
+    label: "Not on statement",
+    dot: "bg-violet-500/60",
+    hint: "In Actual within the statement's dates, but the statement does not mention them. Not counted against the statement's coverage.",
+  },
+  {
+    id: "outside-period",
+    label: "Outside period",
+    dot: "bg-muted-foreground/40",
+    hint: "Loaded to help matching near the edges of the period, but dated outside it. The statement makes no claim about these.",
+  },
 ];
+
+/**
+ * Single-key decisions.
+ *
+ * The loop this screen exists for is "look at a row, decide, move on", a few
+ * hundred times. Moving was already on the keyboard; deciding was not, so every
+ * row meant reaching for the mouse and coming back. These are the whole closed
+ * set of dispositions, one key each.
+ *
+ * `Enter` is deliberately the contextual one — accept whatever this row is
+ * plainly for — because most rows only ever need that.
+ */
+const DECISION_KEYS = new Set(["Enter", "c", "d", "i", "u"]);
 
 /**
  * A second axis: where the row stands in the user's own workflow, rather than
@@ -205,6 +281,14 @@ export type WorkbenchProps = {
    * button, because "why can I not do this" is the next question.
    */
   rematchBlockedReason?: string | null;
+  /**
+   * The session has been applied, so it is a record rather than a workspace.
+   *
+   * Staging more changes on it invites the user to build up work that cannot be
+   * re-matched and would need a second write against a budget that has already
+   * moved. Reading it stays useful; editing it does not.
+   */
+  readOnly?: boolean;
   payees: Option[];
   categories: Option[];
   onMatchConfigChange: (preset: TextTargetPreset, config: MatchConfig) => void;
@@ -241,9 +325,10 @@ function FilterButton({
       type="button"
       aria-pressed={active}
       onClick={onSelect}
+      title={entry.hint}
       className={cn(
         "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors",
-        entry.child && "ml-1 text-[11px]",
+        entry.child && "text-[11px]",
         active
           ? "bg-accent text-accent-foreground"
           : "text-muted-foreground hover:bg-accent/50",
@@ -267,6 +352,7 @@ export function Workbench({
   isMatching,
   canRematch,
   rematchBlockedReason,
+  readOnly = false,
   payees,
   categories,
   onMatchConfigChange,
@@ -286,6 +372,9 @@ export function Workbench({
   const [decisionFilter, setDecisionFilter] = useState<DecisionFilter>("any");
   const [attributeFilters, setAttributeFilters] = useState<Set<AttributeFilter>>(new Set());
   const [search, setSearch] = useState("");
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  /** The scroll container the grid lives in, for revealing the selected row. */
+  const gridRef = useRef<HTMLDivElement>(null);
   const { selectedIds, toggleSelect, toggleSelectAll, clearSelection } = useTableSelection();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [optionsOpen, setOptionsOpen] = useState(false);
@@ -365,6 +454,26 @@ export function Workbench({
   }, [sorted, filter, decisionFilter, attributeFilters, search, statementRows, transactions]);
 
   const visibleIds = useMemo(() => visible.map((item) => item.id), [visible]);
+
+  /*
+   * The reasons appear only once the user is actually in that branch.
+   *
+   * Opening them whenever a reason merely had rows meant they were expanded by
+   * default on most sessions, costing a whole row of width for a breakdown
+   * nobody had asked for. The parent's own count is the signal that there is
+   * something in there; clicking it is what reveals why.
+   */
+  const reviewBranchOpen =
+    filter === "needs-review" || REVIEW_REASON_FILTERS.some((entry) => filter === entry.id);
+
+  /*
+   * And only the reasons that have rows, plus whichever is selected — a
+   * breakdown of four where three are always zero is noise, and the width it
+   * costs is what pushes this row onto a second line.
+   */
+  const visibleReviewReasons = REVIEW_REASON_FILTERS.filter(
+    (entry) => counts[entry.id] > 0 || filter === entry.id
+  );
   const allVisibleSelected =
     visibleIds.length > 0 && visibleIds.every((id) => selectedIds.has(id));
   const selectedItems = useMemo(
@@ -384,14 +493,22 @@ export function Workbench({
    * sequential: look at a row, decide, move on. j/k and the arrow keys follow
    * the visible order, so the filter in force defines what "next" means.
    */
+  /** Brings a row into view after the keyboard moves the selection to it. */
+  const reveal = useCallback((itemId: string) => {
+    gridRef.current
+      ?.querySelector(`[data-item-id="${itemId}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, []);
+
   const step = useCallback(
     (delta: number) => {
       if (visible.length === 0) return;
       const index = visible.findIndex((item) => item.id === selectedId);
       const next = index === -1 ? 0 : Math.min(visible.length - 1, Math.max(0, index + delta));
       setSelectedId(visible[next].id);
+      reveal(visible[next].id);
     },
-    [visible, selectedId]
+    [visible, selectedId, reveal]
   );
 
   /** Jump to the next row still waiting on a decision. */
@@ -399,11 +516,79 @@ export function Workbench({
     const index = visible.findIndex((item) => item.id === selectedId);
     const after = visible.slice(index + 1).find((item) => item.disposition === "unresolved");
     const wrapped = after ?? visible.find((item) => item.disposition === "unresolved");
-    if (wrapped) setSelectedId(wrapped.id);
-  }, [visible, selectedId]);
+    if (wrapped) {
+      setSelectedId(wrapped.id);
+      reveal(wrapped.id);
+    }
+  }, [visible, selectedId, reveal]);
+
+  /**
+   * Apply a keyed decision to the selected row.
+   *
+   * Guards are checked here rather than assumed: the buttons refuse a delete on
+   * a transfer or a reconciled row, and a keystroke must refuse it for the same
+   * reason. Anything not offered for this row is simply ignored — a key that
+   * silently does the wrong thing is worse than one that does nothing.
+   */
+  const decideSelected = useCallback(
+    (key: string) => {
+      if (readOnly) return;
+      const item = visible.find((entry) => entry.id === selectedId);
+      if (!item) return;
+
+      const hasStatementRow = item.statementRowIds.length > 0;
+      const hasTransaction = item.actualTransactionIds.length > 0;
+
+      const advance = () => goToNextUndecided();
+
+      if (key === "u") {
+        if (item.disposition !== "unresolved") onDisposition(item.id, "unresolved");
+        return;
+      }
+
+      if (key === "i") {
+        onDisposition(item.id, "ignored");
+        advance();
+        return;
+      }
+
+      if (key === "c") {
+        // Creating only makes sense for a row the statement has and Actual does not.
+        if (hasStatementRow && !hasTransaction) {
+          onDisposition(item.id, "create");
+          advance();
+        }
+        return;
+      }
+
+      if (key === "d") {
+        if (!hasTransaction) return;
+        if (!canStageDelete(item).allowed) return;
+        onDisposition(item.id, "delete");
+        advance();
+        return;
+      }
+
+      if (key === "Enter") {
+        // Whatever this row is plainly for: confirm the pair, create what is
+        // missing, or keep what the statement does not mention.
+        if (hasStatementRow && hasTransaction) onDisposition(item.id, "matched");
+        else if (hasStatementRow) onDisposition(item.id, "create");
+        else if (hasTransaction) onDisposition(item.id, "keep");
+        else return;
+        advance();
+      }
+    },
+    [visible, selectedId, onDisposition, goToNextUndecided, readOnly]
+  );
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
+      // Never act behind a dialog. The listener is on the window, so without
+      // this an Enter meant for the transform dialog's button would also decide
+      // whichever row happens to be selected underneath it.
+      if (document.querySelector('[role="dialog"]')) return;
+
       // Never steal a key from someone typing in the search box or a note.
       const target = event.target as HTMLElement | null;
       if (
@@ -425,14 +610,20 @@ export function Workbench({
       } else if (event.key === "n") {
         event.preventDefault();
         goToNextUndecided();
+      } else if (event.key === "?") {
+        event.preventDefault();
+        setShortcutsOpen((open) => !open);
       } else if (event.key === "Escape") {
         setSelectedId(null);
+      } else if (DECISION_KEYS.has(event.key)) {
+        event.preventDefault();
+        decideSelected(event.key);
       }
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [step, goToNextUndecided]);
+  }, [step, goToNextUndecided, decideSelected]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -443,15 +634,37 @@ export function Workbench({
       </header>
 
       <div className="flex flex-wrap items-center gap-2 border-b border-border/50 px-4 py-2">
+        {/*
+          The four reasons a row needs review are children of "Needs review",
+          and rendered as a flat row they read as eight unrelated filters — five
+          of which are usually zero. They now appear only when that branch is in
+          play, bracketed and indented so the relationship is visible rather
+          than implied by a slightly smaller font.
+        */}
         <div role="group" aria-label="Filter statement rows" className="flex flex-wrap items-center gap-1">
-          {STATEMENT_FILTERS.map((entry) => (
-            <FilterButton
-              key={entry.id}
-              entry={entry}
-              active={filter === entry.id}
-              count={counts[entry.id]}
-              onSelect={() => setFilter(entry.id)}
-            />
+          {STATEMENT_FILTERS.filter((entry) => !entry.child).map((entry) => (
+            <span key={entry.id} className="flex items-center gap-1">
+              <FilterButton
+                entry={entry}
+                active={filter === entry.id}
+                count={counts[entry.id]}
+                onSelect={() => setFilter(entry.id)}
+              />
+
+              {entry.id === "needs-review" && reviewBranchOpen && (
+                <span className="flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/5 px-1 py-0.5">
+                  {visibleReviewReasons.map((child) => (
+                    <FilterButton
+                      key={child.id}
+                      entry={child}
+                      active={filter === child.id}
+                      count={counts[child.id]}
+                      onSelect={() => setFilter(child.id)}
+                    />
+                  ))}
+                </span>
+              )}
+            </span>
           ))}
         </div>
 
@@ -493,6 +706,8 @@ export function Workbench({
             variant="outline"
             size="sm"
             aria-expanded={transformOpen}
+            disabled={readOnly}
+            title={readOnly ? rematchBlockedReason ?? undefined : undefined}
             onClick={() => setTransformOpen((open) => !open)}
           >
             <Wand2 className="mr-1 h-3.5 w-3.5" />
@@ -502,6 +717,8 @@ export function Workbench({
             variant="outline"
             size="sm"
             aria-expanded={optionsOpen}
+            disabled={readOnly}
+            title={readOnly ? rematchBlockedReason ?? undefined : undefined}
             onClick={() => setOptionsOpen((open) => !open)}
           >
             <SlidersHorizontal className="mr-1 h-3.5 w-3.5" />
@@ -542,6 +759,8 @@ export function Workbench({
           onChange={setDecisionFilter}
         />
 
+        <DecisionProgressMeter coverage={coverage} />
+
         <span className="ml-2 text-muted-foreground">Show only</span>
         <MultiPillGroup
           options={ATTRIBUTE_FILTERS.map((entry) => ({ value: entry.id, label: entry.label }))}
@@ -553,13 +772,24 @@ export function Workbench({
         <div className="ml-auto flex items-center gap-2">
           <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={goToNextUndecided}>
             Next undecided
-            <kbd className="ml-1.5 rounded border border-border px-1 text-[10px]">n</kbd>
+            <kbd className="ml-1.5 rounded border border-border px-1 text-[11px]">n</kbd>
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 text-xs"
+            aria-label="Keyboard shortcuts"
+            onClick={() => setShortcutsOpen(true)}
+          >
+            <kbd className="rounded border border-border px-1 text-[11px]">?</kbd>
           </Button>
           <span className="tabular-nums text-muted-foreground">
             {visible.length} of {items.length} rows
           </span>
         </div>
       </div>
+
+      <ShortcutsHelp open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
 
       {transformOpen && (
         <TransformDialog
@@ -579,13 +809,13 @@ export function Workbench({
         <div className="border-b border-border/50 px-4 py-3">
           <MatchOptions config={matchConfig} preset={matchPreset} onChange={onMatchConfigChange} />
           <p className="mt-2 text-[11px] text-muted-foreground">
-            Changing these does not re-match on its own — choose Re-run when you are ready.
+            Changing these does not re-match on its own - choose Re-run when you are ready.
           </p>
         </div>
       )}
 
       <div className="flex min-h-0 flex-1">
-        <div className="min-h-0 flex-1 overflow-auto">
+        <div ref={gridRef} className="min-h-0 flex-1 overflow-auto">
           <table className="w-full border-collapse">
             <caption className="sr-only">
               Bank statement rows matched against Actual transactions
@@ -665,7 +895,7 @@ export function Workbench({
               </tr>
             </thead>
             <tbody>
-              {visible.map((item) => (
+              {!isMatching && visible.map((item) => (
                 <WorkbenchRow
                   key={item.id}
                   item={item}
@@ -684,7 +914,27 @@ export function Workbench({
             </tbody>
           </table>
 
-          {visible.length === 0 && (
+          {/* Re-running replaces every row, so the grid below is about to be
+              wrong. A skeleton says "this is being rebuilt" where stale rows
+              under a spinning button say nothing at all. */}
+          {isMatching && (
+            <div className="space-y-1 p-2" aria-busy="true" aria-label="Matching…">
+              {Array.from({ length: 10 }).map((_, index) => (
+                <div key={index} className="flex items-center gap-3 px-2 py-1.5">
+                  <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-muted" />
+                  <div
+                    className={cn(
+                      "h-3 animate-pulse rounded bg-muted",
+                      index % 3 === 0 ? "w-64" : index % 3 === 1 ? "w-48" : "w-56"
+                    )}
+                  />
+                  <div className="ml-auto h-3 w-20 shrink-0 animate-pulse rounded bg-muted" />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!isMatching && visible.length === 0 && (
             <p className="px-4 py-8 text-center text-xs text-muted-foreground">
               {items.length === 0
                 ? "No matching has run for this session yet. Choose Re-run to match it against Actual."
@@ -708,6 +958,7 @@ export function Workbench({
               .filter((t): t is ActualTransactionSnapshot => Boolean(t))}
             payees={payees}
             categories={categories}
+            readOnly={readOnly}
             onClose={() => setSelectedId(null)}
             onDisposition={(disposition) => onDisposition(selected.id, disposition)}
             onUseCandidate={(transactionId) => onUseCandidate(selected.id, transactionId)}
@@ -720,20 +971,22 @@ export function Workbench({
         )}
       </div>
 
-      <BulkDecisionBar
-        selected={selectedItems}
-        statementRows={statementRows}
-        transactions={transactions}
-        onClear={clearSelection}
-        onBulkDisposition={(itemIds, disposition) => {
-          onBulkDisposition(itemIds, disposition);
-          clearSelection();
-        }}
-        onBulkCorrectAmount={(entries) => {
-          onBulkCorrectAmount(entries);
-          clearSelection();
-        }}
-      />
+      {!readOnly && (
+        <BulkDecisionBar
+          selected={selectedItems}
+          statementRows={statementRows}
+          transactions={transactions}
+          onClear={clearSelection}
+          onBulkDisposition={(itemIds, disposition) => {
+            onBulkDisposition(itemIds, disposition);
+            clearSelection();
+          }}
+          onBulkCorrectAmount={(entries) => {
+            onBulkCorrectAmount(entries);
+            clearSelection();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/reconciliation/components/Workbench.tsx
+++ b/src/features/reconciliation/components/Workbench.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MultiPillGroup, PillGroup } from "@/components/ui/pill-group";
 import { cn } from "@/lib/utils";
-import { REASON } from "@/lib/reconciliation/session/build";
+import { REASON, REVIEW_REASONS } from "@/lib/reconciliation/session/build";
 import { canStageDelete } from "@/lib/reconciliation/session/staging";
 import type { ReconciliationCoverage } from "@/lib/reconciliation/session/build";
 import type {
@@ -227,48 +227,39 @@ function matchesAttributes(
 }
 
 /**
- * Every reason a row lands in review.
+ * A row the matcher would not settle, for one of the given reasons.
  *
- * Declared once so the parent filter cannot drift from the children that break
- * it down — which is exactly how the two came to disagree.
+ * Deliberately the same test the coverage bar uses, and deliberately *not*
+ * keyed on whether the user has decided it. "Needs review" says what kind of
+ * row this is, and deciding one does not change what kind of row it was - the
+ * count is meant to hold still while the statement is worked through. Picking a
+ * candidate is the exception: that turns an open question into a match, which
+ * is a change of kind rather than a decision about it.
+ *
+ * How much is left to do is the decision meter's job, and the progress filters
+ * compose with these to narrow by it.
  */
-const REVIEW_REASON_CODES: string[] = [
-  REASON.ambiguousMatch,
-  REASON.belowConfidenceFloor,
-  REASON.amountMismatch,
-  REASON.sameMerchantDate,
-  REASON.merchantCluster,
-  REASON.likelyDuplicate,
-];
-
-/** A row still waiting on the user, for one of the given reasons. */
-function isUndecidedReview(item: ReconciliationItem, reasons: string[]): boolean {
-  return item.disposition === "unresolved" && reasons.includes(item.reasonCode ?? "");
+function isReviewRow(item: ReconciliationItem, reasons: string[]): boolean {
+  return item.disposition !== "matched" && reasons.includes(item.reasonCode ?? "");
 }
 
 export function matchesFilter(item: ReconciliationItem, filter: FilterId): boolean {
   switch (filter) {
     case "matched":
       return item.disposition === "matched";
-    // "Needs review" and the four reasons beneath it are one question asked at
-    // two levels, so they share the same test. They did not: the parent counted
-    // only rows still undecided while the children counted by reason alone, so
-    // deciding a row removed it from the parent and left it in the child —
-    // "Needs review 0" above "Amount differs 14".
-    //
-    // Both now mean "still to review". They shrink together as the work is done,
-    // and the parent is exactly the union of its children. Revisiting rows
-    // already settled is what the Progress axis is for.
+    // One test for the parent and the reasons beneath it, and the same one the
+    // coverage bar uses - the three disagreed, so the bar could read
+    // "Needs review 20" above a filter reading 0.
     case "needs-review":
-      return isUndecidedReview(item, REVIEW_REASON_CODES);
+      return isReviewRow(item, [...REVIEW_REASONS]);
     case "ambiguous":
-      return isUndecidedReview(item, [REASON.ambiguousMatch, REASON.belowConfidenceFloor]);
+      return isReviewRow(item, [REASON.ambiguousMatch, REASON.belowConfidenceFloor]);
     case "amount-mismatch":
-      return isUndecidedReview(item, [REASON.amountMismatch]);
+      return isReviewRow(item, [REASON.amountMismatch]);
     case "wrong-amount":
-      return isUndecidedReview(item, [REASON.sameMerchantDate, REASON.merchantCluster]);
+      return isReviewRow(item, [REASON.sameMerchantDate, REASON.merchantCluster]);
     case "duplicates":
-      return isUndecidedReview(item, [REASON.likelyDuplicate]);
+      return isReviewRow(item, [REASON.likelyDuplicate]);
     case "create":
       return item.reasonCode === REASON.noActualCandidate;
     case "actual-only":

--- a/src/features/reconciliation/components/WorkbenchRow.tsx
+++ b/src/features/reconciliation/components/WorkbenchRow.tsx
@@ -155,7 +155,7 @@ function middleState(item: ReconciliationItem): MiddleState {
 
 const EMPTY = (
   <span className="text-muted-foreground/60" aria-hidden="true">
-    —
+    -
   </span>
 );
 
@@ -197,6 +197,9 @@ export function WorkbenchRow({
 
   return (
     <tr
+      // Addressable so keyboard movement can bring the selected row into view;
+      // moving the selection to a row nobody can see is worse than not moving.
+      data-item-id={item.id}
       aria-selected={selected}
       onClick={onSelect}
       className={cn(

--- a/src/features/reconciliation/components/workbenchFilters.test.ts
+++ b/src/features/reconciliation/components/workbenchFilters.test.ts
@@ -1,13 +1,17 @@
-import { REASON } from "@/lib/reconciliation/session/build";
+import { REASON, summarizeCoverage } from "@/lib/reconciliation/session/build";
 import type { ReconciliationItem } from "@/lib/reconciliation/types";
 import { matchesFilter, type FilterId } from "./Workbench";
 
 /**
- * "Needs review" and the four reasons beneath it are one question asked at two
- * levels, and they drifted: the parent counted only rows still undecided while
- * the children counted by reason alone. Deciding a row then removed it from the
- * parent and left it in the child, so the workbench showed "Needs review 0"
- * above "Amount differs 14".
+ * "Needs review", the reasons beneath it, and the coverage bar are one question
+ * asked in three places, and all three had drifted apart. The parent required a
+ * row to be undecided, the children counted by reason alone, and the bar used a
+ * third rule - so the workbench could show "Needs review 20" on the bar, 0 on
+ * the filter, and 14 on a reason beneath it, all at once.
+ *
+ * They now share one test: it says what kind of row this is, which deciding it
+ * does not change. Only pairing it does, because that turns an open question
+ * into a match. How much is left to do is the decision meter's job.
  */
 
 function item(over: Partial<ReconciliationItem> = {}): ReconciliationItem {
@@ -42,12 +46,21 @@ describe("the review filter and the reasons beneath it", () => {
     expect(matchesFilter(row, "needs-review")).toBe(true);
   });
 
-  it.each(REASON_FILTERS)("drops a decided %s row from parent and child alike", (child) => {
-    // The bug: this stayed in the child while leaving the parent, so the parent
-    // could read zero while its own breakdown showed twenty.
+  it.each(REASON_FILTERS)("keeps a decided %s row in parent and child alike", (child) => {
+    // Deciding does not change what kind of row it was, so the count holds
+    // still. The bug was that it held still in the child and not in the parent.
+    const row = item({ reasonCode: REASON_FOR[child], disposition: "ignored" });
+    expect(matchesFilter(row, child)).toBe(true);
+    expect(matchesFilter(row, "needs-review")).toBe(true);
+  });
+
+  it.each(REASON_FILTERS)("drops a %s row once it is paired", (child) => {
+    // Pairing is the one decision that changes the kind: the open question is
+    // answered, and the row is a match. The coverage bar counts it that way too.
     const row = item({ reasonCode: REASON_FOR[child], disposition: "matched" });
     expect(matchesFilter(row, child)).toBe(false);
     expect(matchesFilter(row, "needs-review")).toBe(false);
+    expect(matchesFilter(row, "matched")).toBe(true);
   });
 
   it("counts the parent as exactly the union of its children", () => {
@@ -58,8 +71,8 @@ describe("the review filter and the reasons beneath it", () => {
       item({ id: "d", reasonCode: REASON.sameMerchantDate }),
       item({ id: "e", reasonCode: REASON.merchantCluster }),
       item({ id: "f", reasonCode: REASON.likelyDuplicate }),
-      // Decided, and so in neither.
-      item({ id: "g", reasonCode: REASON.amountMismatch, disposition: "create" }),
+      // Decided but still the same kind of row, so still in both.
+      item({ id: "g", reasonCode: REASON.amountMismatch, disposition: "correct-amount" }),
       // Never a review row at all.
       item({ id: "h", reasonCode: REASON.noActualCandidate }),
     ];
@@ -69,8 +82,52 @@ describe("the review filter and the reasons beneath it", () => {
       REASON_FILTERS.some((child) => matchesFilter(row, child))
     );
 
-    expect(parent.map((row) => row.id)).toEqual(["a", "b", "c", "d", "e", "f"]);
+    expect(parent.map((row) => row.id)).toEqual(["a", "b", "c", "d", "e", "f", "g"]);
     expect(children.map((row) => row.id)).toEqual(parent.map((row) => row.id));
+  });
+
+  it("agrees with the coverage bar on every row", () => {
+    /*
+     * The whole point: the bar and the filter are two readings of one fact, and
+     * a user who sees them disagree has no way to know which to believe. This
+     * pins them together over every combination of reason and decision.
+     */
+    const reasons = [
+      REASON.ambiguousMatch,
+      REASON.belowConfidenceFloor,
+      REASON.amountMismatch,
+      REASON.sameMerchantDate,
+      REASON.merchantCluster,
+      REASON.likelyDuplicate,
+      REASON.noActualCandidate,
+      REASON.notOnStatement,
+    ];
+    const dispositions = [
+      "unresolved",
+      "matched",
+      "create",
+      "keep",
+      "delete",
+      "ignored",
+      "correct-amount",
+    ] as const;
+
+    for (const reasonCode of reasons) {
+      for (const disposition of dispositions) {
+        const rows = [item({ reasonCode, disposition })];
+        const onTheBar = summarizeCoverage(rows, {
+          statementRows: 1,
+          loadedTransactions: 1,
+        }).statement.needsReview;
+        const inTheFilter = rows.filter((row) => matchesFilter(row, "needs-review")).length;
+
+        expect({ reasonCode, disposition, onTheBar }).toEqual({
+          reasonCode,
+          disposition,
+          onTheBar: inTheFilter,
+        });
+      }
+    }
   });
 
   it("keeps rows that are not under review out of it", () => {

--- a/src/features/reconciliation/components/workbenchFilters.test.ts
+++ b/src/features/reconciliation/components/workbenchFilters.test.ts
@@ -1,0 +1,80 @@
+import { REASON } from "@/lib/reconciliation/session/build";
+import type { ReconciliationItem } from "@/lib/reconciliation/types";
+import { matchesFilter, type FilterId } from "./Workbench";
+
+/**
+ * "Needs review" and the four reasons beneath it are one question asked at two
+ * levels, and they drifted: the parent counted only rows still undecided while
+ * the children counted by reason alone. Deciding a row then removed it from the
+ * parent and left it in the child, so the workbench showed "Needs review 0"
+ * above "Amount differs 14".
+ */
+
+function item(over: Partial<ReconciliationItem> = {}): ReconciliationItem {
+  return {
+    id: "i1",
+    statementRowIds: ["s1"],
+    actualTransactionIds: ["t1"],
+    disposition: "unresolved",
+    guards: { protectedReconciled: false, splitParent: false, transfer: "no" },
+    ...over,
+  } as ReconciliationItem;
+}
+
+const REASON_FILTERS: FilterId[] = [
+  "ambiguous",
+  "amount-mismatch",
+  "wrong-amount",
+  "duplicates",
+];
+
+const REASON_FOR: Record<string, string> = {
+  ambiguous: REASON.ambiguousMatch,
+  "amount-mismatch": REASON.amountMismatch,
+  "wrong-amount": REASON.sameMerchantDate,
+  duplicates: REASON.likelyDuplicate,
+};
+
+describe("the review filter and the reasons beneath it", () => {
+  it.each(REASON_FILTERS)("counts an undecided %s row under its parent too", (child) => {
+    const row = item({ reasonCode: REASON_FOR[child] });
+    expect(matchesFilter(row, child)).toBe(true);
+    expect(matchesFilter(row, "needs-review")).toBe(true);
+  });
+
+  it.each(REASON_FILTERS)("drops a decided %s row from parent and child alike", (child) => {
+    // The bug: this stayed in the child while leaving the parent, so the parent
+    // could read zero while its own breakdown showed twenty.
+    const row = item({ reasonCode: REASON_FOR[child], disposition: "matched" });
+    expect(matchesFilter(row, child)).toBe(false);
+    expect(matchesFilter(row, "needs-review")).toBe(false);
+  });
+
+  it("counts the parent as exactly the union of its children", () => {
+    const rows = [
+      item({ id: "a", reasonCode: REASON.ambiguousMatch }),
+      item({ id: "b", reasonCode: REASON.belowConfidenceFloor }),
+      item({ id: "c", reasonCode: REASON.amountMismatch }),
+      item({ id: "d", reasonCode: REASON.sameMerchantDate }),
+      item({ id: "e", reasonCode: REASON.merchantCluster }),
+      item({ id: "f", reasonCode: REASON.likelyDuplicate }),
+      // Decided, and so in neither.
+      item({ id: "g", reasonCode: REASON.amountMismatch, disposition: "create" }),
+      // Never a review row at all.
+      item({ id: "h", reasonCode: REASON.noActualCandidate }),
+    ];
+
+    const parent = rows.filter((row) => matchesFilter(row, "needs-review"));
+    const children = rows.filter((row) =>
+      REASON_FILTERS.some((child) => matchesFilter(row, child))
+    );
+
+    expect(parent.map((row) => row.id)).toEqual(["a", "b", "c", "d", "e", "f"]);
+    expect(children.map((row) => row.id)).toEqual(parent.map((row) => row.id));
+  });
+
+  it("keeps rows that are not under review out of it", () => {
+    expect(matchesFilter(item({ reasonCode: REASON.noActualCandidate }), "needs-review")).toBe(false);
+    expect(matchesFilter(item({ reasonCode: REASON.notOnStatement }), "needs-review")).toBe(false);
+  });
+});

--- a/src/features/reconciliation/lib/format.ts
+++ b/src/features/reconciliation/lib/format.ts
@@ -112,7 +112,7 @@ export function describeReason(reason: MatchReason): string {
         `Amount differs by ${formatMinorUnits(difference)} ` +
         `(statement ${formatMinorUnits(Math.abs(reason.statementAmount))}, ` +
         `Actual ${formatMinorUnits(Math.abs(reason.actualAmount))}` +
-        (ratio ? ` — recorded ${ratio}× the statement` : "") +
+        (ratio ? ` - recorded ${ratio}× the statement` : "") +
         ")"
       );
     }

--- a/src/hooks/useEditableGrid.ts
+++ b/src/hooks/useEditableGrid.ts
@@ -126,6 +126,9 @@ export function useEditableGrid<Col extends string>({
   }
 
   function handleGridKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    // Synthetic keydowns (autofill, some password managers) arrive without a
+    // `key`, and the default branch below reads its length.
+    if (!e.key) return;
     if (!selectedCell) return;
     if (editingCell?.rowId === selectedCell.rowId && editingCell?.colId === selectedCell.colId) return;
     if (!rowIndexById.has(selectedCell.rowId)) return;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -29,6 +29,10 @@ export function useKeyboardShortcuts() {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const mod = e.ctrlKey || e.metaKey;
+      // `key` is absent on synthetic keydowns — browser autofill and some
+      // password managers dispatch them — and this handler is bound to the
+      // window on every page, so an unguarded read throws for the whole app.
+      if (!e.key) return;
       const key = e.key.toLowerCase();
 
       // Bare "N" — open quick-create only when no input/dialog is focused

--- a/src/lib/reconciliation/apply/drift.ts
+++ b/src/lib/reconciliation/apply/drift.ts
@@ -125,7 +125,7 @@ export function reconcilePlanWithDrift(input: DriftInput): {
         verdicts.push({
           operationId: operation.id,
           status: "vanished",
-          reason: "Already deleted in Actual — nothing left to do.",
+          reason: "Already deleted in Actual - nothing left to do.",
         });
         continue;
       }

--- a/src/lib/reconciliation/apply/verification.ts
+++ b/src/lib/reconciliation/apply/verification.ts
@@ -123,7 +123,7 @@ function verifyOne(
       issues.push({
         operationId: operation.id,
         kind: "duplicate-create",
-        detail: `This transaction appears ${count} times in the account — it was created more than once.`,
+        detail: `This transaction appears ${count} times in the account - it was created more than once.`,
       });
     }
     return issues;

--- a/src/lib/reconciliation/session/build.test.ts
+++ b/src/lib/reconciliation/session/build.test.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_MATCH_CONFIG } from "../match/config";
 import { match } from "../match/matcher";
-import type { ActualTransactionSnapshot, StatementRow } from "../types";
+import type {
+  ActualTransactionSnapshot,
+  ReconciliationItem,
+  StatementRow,
+} from "../types";
 import {
   REASON,
   buildReconciliationItems,
@@ -259,6 +263,52 @@ describe("summarizeCoverage", () => {
     expect(statement.matched).toBe(1);
     expect(statement.needsReview).toBe(1);
     expect(statement.unaccounted).toBe(1);
+  });
+
+  it("keeps counting a row as needing review after it is decided", () => {
+    /*
+     * "Needs review" says what kind of row this is - one the matcher would not
+     * settle on its own - and deciding it does not change that. The count is
+     * meant to hold still while the statement is worked through; how much is
+     * left to do is the decision meter's job.
+     */
+    const reviewItem: ReconciliationItem = {
+      id: "i1",
+      statementRowIds: ["s1"],
+      actualTransactionIds: ["t1"],
+      disposition: "unresolved",
+      reasonCode: REASON.amountMismatch,
+      guards: { protectedReconciled: false, splitParent: false, transfer: "no" },
+    };
+    const counted = { statementRows: 1, loadedTransactions: 1 };
+
+    expect(summarizeCoverage([reviewItem], counted).statement.needsReview).toBe(1);
+
+    for (const disposition of ["ignored", "create", "correct-amount", "delete"] as const) {
+      const decided = summarizeCoverage([{ ...reviewItem, disposition }], counted);
+      expect(decided.statement.needsReview).toBe(1);
+    }
+  });
+
+  it("moves a row out of review only when it is paired", () => {
+    // Picking a candidate is the one decision that changes what kind of row it
+    // is: it stops being an open question and becomes a match.
+    const paired = summarizeCoverage(
+      [
+        {
+          id: "i1",
+          statementRowIds: ["s1"],
+          actualTransactionIds: ["t1"],
+          disposition: "matched",
+          reasonCode: REASON.ambiguousMatch,
+          guards: { protectedReconciled: false, splitParent: false, transfer: "no" },
+        },
+      ],
+      { statementRows: 1, loadedTransactions: 1 }
+    );
+
+    expect(paired.statement.matched).toBe(1);
+    expect(paired.statement.needsReview).toBe(0);
   });
 
   it("breaks Actual into parts that sum to its total", () => {

--- a/src/lib/reconciliation/session/build.ts
+++ b/src/lib/reconciliation/session/build.ts
@@ -329,12 +329,21 @@ export type ReconciliationCoverage = {
   loadedAsHeadroom: number;
 };
 
-const REVIEW_REASONS = new Set<string>([
+/**
+ * Every reason a row is one the matcher would not settle on its own.
+ *
+ * Exported because the workbench filters read the same fact, and when each kept
+ * its own copy they drifted: the bar counted a likely duplicate as simply
+ * unaccounted for while the filter counted it as needing review, so the two
+ * disagreed about the same row.
+ */
+export const REVIEW_REASONS = new Set<string>([
   REASON.ambiguousMatch,
   REASON.belowConfidenceFloor,
   REASON.amountMismatch,
   REASON.sameMerchantDate,
   REASON.merchantCluster,
+  REASON.likelyDuplicate,
 ]);
 
 export function summarizeCoverage(
@@ -359,6 +368,13 @@ export function summarizeCoverage(
     statement.total += statementCount;
     actual.total += transactionIds.length;
 
+    /*
+     * Classified by *why* the matcher put the row here, not by what the user
+     * has since decided. "Needs review" describes the kind of row it is, and
+     * deciding one does not change what kind of row it was - the count is meant
+     * to hold still while it is worked through. How much is left to do is the
+     * decision meter's job, and it is the only figure here that moves.
+     */
     if (item.disposition === "matched") {
       statement.matched += statementCount;
       actual.matched += transactionIds.length;


### PR DESCRIPTION
Follow-up UI and UX work on the bank reconciliation workbench, plus one crash fix that affects the whole app.

## A synthetic keypress could take the app down

`e.key` is absent on keydown events the browser did not originate — autofill and some password managers dispatch them — and the global shortcut handler read it unguarded. That handler is bound to the window on every page, so one such event crashed the app wherever you were. The editable grid had the same hazard in the branch that reads the key's length.

## Finishing a reconciliation took two steps backwards

Once a run completed, the primary slot on the result screen stood empty, so leaving meant retreating through the workbench — a screen an applied session can no longer use — and then out again. There is now a **Done** action where the next step belongs; a partial run keeps *Retry what failed* as the primary with *Done* beside it.

Leaving moved to the session header, where it reads the same on every screen. That lets **Back** mean one thing throughout: retreat one phase. Previously it retreated a phase on three screens and left the feature on the fourth.

## The workbench loop is now keyboard-complete

Moving between rows was already bound; deciding was not, so every row meant reaching for the mouse and back — a few hundred times per statement.

- `Enter` accepts whatever a row is plainly for (confirm the pair, create what is missing, keep what the statement does not mention), with `c` / `d` / `i` / `u` for the explicit cases. Each advances to the next undecided row.
- Guards are enforced for a keystroke exactly as for a button: deleting a transfer leg or a reconciled row is refused either way.
- Keys are ignored in text fields **and behind dialogs**, so an `Enter` meant for a dialog button cannot also decide the row underneath it.
- The selected row is brought into view; it previously moved off-screen while the details panel described something invisible.
- A `?` sheet lists the bindings, which were previously announced by a single badge on one button.

## Saying what things mean

- **A count that never moved.** The statement bar reported rows "still needing a decision", but those segments are classified by *why* a row landed there, not by what the user has since decided — so the figure was frozen. Removed; how much is left to do is now a small meter beside the decision filters, the only figure here that climbs to 100%.
- **One thing, two names and two colours.** Rows only in Actual were *Not on statement* in the coverage bar and *Actual only* in the filters — and the bar drew them in the same colour as rows missing from Actual, which mean the opposite. Now one name, and a colour each matching the filter that selects it.
- **The review reasons looked like five unrelated filters**, mostly permanently zero. They now sit bracketed under their parent, appear when that branch is being worked, and list only reasons with rows in them. Every filter explains itself on hover; *Amount differs* and *Amount looks wrong* only made sense to someone who knew the matcher's rules.
- **Matching now reports which part is running.** Applying has always said "writing 12 of 200"; matching said only "Matching…" while it fetched a candidate window over the network and scored several hundred rows, with the grid still showing rows it was about to replace. That status is announced to screen readers, along with the apply and drift-check progress that was silent before.

## An applied reconciliation is a record, not a workspace

It no longer offers to transform, re-match, or decide anything. Staging more work on it would only build up changes that cannot be re-matched and would need a second write against a budget that has already moved.

## Transform conditions

Operators now match the field they ask about. The same eleven were offered whatever the field, so the builder accepted "amount has tag" and "notes is more than" — combinations that can only ever match nothing, and which you could only discover were useless by trying them. A decision is chosen from its own list rather than typed.

## Also

The overview's tool cards follow the sidebar's order and include bank reconciliation, with a test that keeps the two lists honest. The searchable dropdowns take arrow keys, with the listbox roles wired to the search field. Interface text uses hyphens rather than em dashes.

## Validation

`npm run lint` (0 errors), `npx tsc --noEmit`, `npm test` (2046 passing), and `npm run build`.
