### PR TITLE
chore(deps): upgrade @actual-app/api to 26.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actual-bench",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actual-bench",
-      "version": "1.2.6",
+      "version": "1.2.8",
       "hasInstallScript": true,
       "dependencies": {
-        "@actual-app/api": "^26.8.0",
+        "@actual-app/api": "26.8.1",
         "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@sqlite.org/sqlite-wasm": "^3.41.2",
@@ -51,12 +51,12 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.8.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.0.tgz",
-      "integrity": "sha512-hFtepJjD9pmWo7eY53mvZ4AACEENUYCW4v0EYmYS/BhxTVMY5MjzcsW7GXwOE2iO9tJLJmSBkORWTB6rDNte2Q==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
+      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.8.0",
+        "@actual-app/core": "26.8.1",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.8.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.0.tgz",
-      "integrity": "sha512-TP3Bw86JVshli5lccr/RqOaLIh2KLGE+Rtz4iTJnML7hFsSF1261db6QqntrSwvmxyTYqbxQR/2EQua2Uc20VQ==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
+      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -7757,9 +7757,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf .next .next-build tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@actual-app/api": "26.8.0",
+    "@actual-app/api": "26.8.1",
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@sqlite.org/sqlite-wasm": "^3.41.2",

--- a/src/features/query/lib/queryValidation.test.ts
+++ b/src/features/query/lib/queryValidation.test.ts
@@ -1,0 +1,84 @@
+import { lintQuery } from "./queryValidation";
+import type { ActualQLQuery } from "../types";
+
+const ids = (query: ActualQLQuery) => lintQuery(query).map((w) => w.id);
+
+describe("lintQuery - empty $or / $and", () => {
+  it("warns on a top-level empty $or", () => {
+    expect(
+      ids({ table: "transactions", filter: { $or: [] } } as ActualQLQuery),
+    ).toContain("empty-compound");
+  });
+
+  it("warns on a top-level empty $and", () => {
+    expect(
+      ids({ table: "transactions", filter: { $and: [] } } as ActualQLQuery),
+    ).toContain("empty-compound");
+  });
+
+  it("warns on an empty compound nested inside a populated one", () => {
+    expect(
+      ids({
+        table: "transactions",
+        filter: { $and: [{ payee: "p-1" }, { $or: [] }] },
+      } as ActualQLQuery),
+    ).toContain("empty-compound");
+  });
+
+  it("warns on an empty compound nested under a field's sub-object", () => {
+    expect(
+      ids({
+        table: "transactions",
+        filter: { account: { $and: [] } },
+      } as ActualQLQuery),
+    ).toContain("empty-compound");
+  });
+
+  it("does not warn when every compound is populated", () => {
+    expect(
+      ids({
+        table: "transactions",
+        filter: { $or: [{ payee: "p-1" }, { $and: [{ amount: { $gt: 0 } }] }] },
+      } as ActualQLQuery),
+    ).not.toContain("empty-compound");
+  });
+
+  it("does not warn on a plain filter with no compound operators", () => {
+    expect(
+      ids({
+        table: "transactions",
+        filter: { date: { $gte: "2026-01-01" } },
+      } as ActualQLQuery),
+    ).not.toContain("empty-compound");
+  });
+
+  it("is reported independently of the empty-$oneof warning", () => {
+    // Opposite failure modes: $oneof:[] matches nothing, $or:[] matches everything.
+    const warnings = ids({
+      table: "transactions",
+      filter: { $or: [], account: { $oneof: [] } },
+    } as ActualQLQuery);
+    expect(warnings).toContain("empty-compound");
+    expect(warnings).toContain("empty-oneof");
+  });
+
+  it("still finds an empty $oneof sitting beside a compound operator", () => {
+    expect(
+      ids({
+        table: "transactions",
+        filter: { $or: [{ payee: "p-1" }], account: { $oneof: [] } },
+      } as ActualQLQuery),
+    ).toContain("empty-oneof");
+  });
+
+  it("catches the case the unbounded-scan warning misses", () => {
+    // `{ $or: [] }` is a non-empty object, so the query counts as "filtered"
+    // and unbounded-transactions stays silent - this warning is the only signal.
+    const warnings = ids({
+      table: "transactions",
+      filter: { $or: [] },
+    } as ActualQLQuery);
+    expect(warnings).not.toContain("unbounded-transactions");
+    expect(warnings).toContain("empty-compound");
+  });
+});

--- a/src/features/query/lib/queryValidation.ts
+++ b/src/features/query/lib/queryValidation.ts
@@ -102,6 +102,17 @@ export function lintQuery(query: ActualQLQuery): LintWarning[] {
     });
   }
 
+  // Empty $or / $and — compiles away to no constraint at all, so the filter
+  // silently widens instead of narrowing. Reported separately from $oneof
+  // because the failure mode is the opposite: too many rows, not zero.
+  if (query.filter && hasEmptyCompound(query.filter)) {
+    warnings.push({
+      id: "empty-compound",
+      message:
+        'Empty "$or"/"$and" array - this applies no constraint at all, so the query scans every row instead of narrowing. Remove the operator or populate it.',
+    });
+  }
+
   // groupBy without an aggregate in select — every group will return its
   // raw rows, which is rarely what the user intends
   if (
@@ -145,17 +156,43 @@ function hasQueryValue(value: unknown): boolean {
   return value !== undefined && value !== null;
 }
 
+function hasEmptyCompound(filter: unknown): boolean {
+  if (Array.isArray(filter)) return filter.some((item) => hasEmptyCompound(item));
+  if (!filter || typeof filter !== "object") return false;
+  const obj = filter as Record<string, unknown>;
+
+  for (const key of ["$and", "$or"] as const) {
+    if (key in obj && Array.isArray(obj[key])) {
+      const clauses = obj[key] as unknown[];
+      if (clauses.length === 0) return true;
+      if (clauses.some((clause) => hasEmptyCompound(clause))) return true;
+    }
+  }
+
+  // Recurse into nested filter objects (e.g. dotted-path sub-objects)
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === "$and" || key === "$or") continue;
+    if (typeof val === "object" && val !== null && hasEmptyCompound(val)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function hasEmptyOneof(filter: unknown): boolean {
   if (Array.isArray(filter)) return filter.some((item) => hasEmptyOneof(item));
   if (!filter || typeof filter !== "object") return false;
   const obj = filter as Record<string, unknown>;
 
-  // Handle $and / $or compound operators at this level
-  if ("$and" in obj && Array.isArray(obj["$and"])) {
-    return (obj["$and"] as unknown[]).some((clause) => hasEmptyOneof(clause));
-  }
-  if ("$or" in obj && Array.isArray(obj["$or"])) {
-    return (obj["$or"] as unknown[]).some((clause) => hasEmptyOneof(clause));
+  // Handle $and / $or compound operators at this level. These are checked
+  // alongside sibling fields, not instead of them — a filter may mix
+  // `{ $or: [...] }` with plain field constraints at the same level.
+  for (const key of ["$and", "$or"] as const) {
+    if (key in obj && Array.isArray(obj[key])) {
+      const clauses = obj[key] as unknown[];
+      if (clauses.some((clause) => hasEmptyOneof(clause))) return true;
+    }
   }
 
   // Check each field's operator object for an empty $oneof


### PR DESCRIPTION
## Summary

Upgrades `@actual-app/api` from 26.8.0 to 26.8.1, plus one small ActualQL linter fix that came out of reviewing the release.

## Dependency upgrade

26.8.1 is a patch release — five upstream PRs, all bugfix/maintenance, **no new API surface**. Four are `desktop-client`-only and cannot reach us. The single change that lands inside `@actual-app/api` is an internal `loot-core` query fix (`getHasTransactionsQuery`) that we do not call.

Diffed `node_modules/@actual-app/api/dist/` against 26.8.0, since a previous release silently reshaped the browser build:

- File layout identical apart from a content-hashed sourcemap filename.
- **No `.d.ts` changed** — the public type surface is byte-identical, so a green typecheck is not meaningful evidence here.
- Browser worker bootstrap unchanged (still the self-contained inline-worker form), so `src/lib/actual/browser/setup.ts` needs no changes.

Also pulls `@actual-app/core` 26.8.1 and, transitively, `hyperformula` 3.4.0 (`^3.3.0` range under core). The lockfile additionally absorbs pre-existing drift unrelated to this bump: the root `version` field, and the exact api pin `package.json` has always declared.

## ActualQL linter: empty `$or` / `$and`

Upstream's fix was for an empty `$or` compiling away to no constraint at all (`WHERE 1`) — a filter that silently *widens* into a full scan. Our own schedules query is immune by construction, but the footgun is reachable through the `/query` workspace, and our linter did not catch it:

- New `empty-compound` warning. It was previously invisible in two directions — the `unbounded-transactions` check treats any non-empty `filter` object as "scoped", and `{ "$or": [] }` is a non-empty object.
- **Pre-existing bug fixed**: `hasEmptyOneof()` early-returned on the first `$and`/`$or` key it found, so sibling field constraints at that level were never inspected — `{ $or: [...], account: { $oneof: [] } }` reported nothing. Surfaced by a test written for the new rule.

## Testing

- `tsc --noEmit` clean
- `npm test` — 2072 passing (was 2063; +9 new cases in `queryValidation.test.ts`)
- `npm run build` succeeds
- `npm run lint` — 0 errors (12 pre-existing warnings, none in touched files)

**Not yet done:** manual Direct + HTTP smoke test against a live budget. Worth doing before merge, given the typecheck signal is weak for this bump.
