### PR TITLE
fix(connect): stop the post-connect redirect from bouncing users back to overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ specs/
 .specify/
 # Local app metadata database for dev/self-hosted mounts
 .actual-bench-data/
+.agents/
+skills-lock.json

--- a/src/components/connect/ConnectForm.tsx
+++ b/src/components/connect/ConnectForm.tsx
@@ -119,6 +119,11 @@ export function ConnectForm({ directBrowserApiEnabled }: ConnectFormProps) {
   // calm CTA so the saved list stays the focus).
   const [addingServer, setAddingServer] = useState(false);
 
+  // Single owner of the post-connect redirect. Connect/reconnect handlers must
+  // NOT navigate themselves: an imperative `router.push` in an async handler
+  // outlives this component and fires wherever the user has since navigated.
+  // That produced a bounce back to /overview in Direct mode, where the busy
+  // main thread left the stale navigation pending for seconds.
   useEffect(() => {
     if (hydrated && connectedInstance) {
       router.replace("/overview");

--- a/src/components/connect/useConnectForm.test.tsx
+++ b/src/components/connect/useConnectForm.test.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useConnectForm } from "./useConnectForm";
-import { useConnectionStore, type ConnectionInstance } from "@/store/connection";
+import {
+  useConnectionStore,
+  type ConnectionInstance,
+  type ConnectionMode,
+} from "@/store/connection";
 import { useSavedServersStore } from "@/store/savedServers";
 import { useStagedStore } from "@/store/staged";
 
@@ -79,6 +83,22 @@ function expectNoNavigation() {
   expect(mockReplace).not.toHaveBeenCalled();
 }
 
+/**
+ * Waits for the connection the test selected — not merely "some" connection — to
+ * become active. Identity matters here: the redirect ConnectForm performs is
+ * driven off the active instance, so activating the wrong budget or mode would
+ * still redirect and still look green under a truthiness check.
+ */
+async function expectActiveInstance(expected: { budgetSyncId: string; mode: ConnectionMode }) {
+  await waitFor(
+    () => {
+      const { instances, activeInstanceId } = useConnectionStore.getState();
+      expect(instances.find((i) => i.id === activeInstanceId)).toMatchObject(expected);
+    },
+    { timeout: 2_000 }
+  );
+}
+
 describe("useConnectForm connection activation", () => {
   beforeEach(() => {
     mockPush.mockReset();
@@ -141,9 +161,7 @@ describe("useConnectForm connection activation", () => {
       result.current.handleConnect();
     });
 
-    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBeTruthy(), {
-      timeout: 2_000,
-    });
+    await expectActiveInstance({ budgetSyncId: "budget-1", mode: "browser-api" });
     expectNoNavigation();
     const [savedServer] = useSavedServersStore.getState().servers;
     expect(savedServer).toEqual(
@@ -270,9 +288,7 @@ describe("useConnectForm connection activation", () => {
       result.current.handleConnect();
     });
 
-    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBeTruthy(), {
-      timeout: 2_000,
-    });
+    await expectActiveInstance({ budgetSyncId: "local-budget-1", mode: "browser-api" });
     expectNoNavigation();
     expect(mockEnsureTransportReady).toHaveBeenCalledWith(
       expect.objectContaining({ budgetSyncId: "local-budget-1" })
@@ -324,9 +340,7 @@ describe("useConnectForm connection activation", () => {
       );
     });
 
-    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBeTruthy(), {
-      timeout: 2_000,
-    });
+    await expectActiveInstance({ budgetSyncId: "b1", mode: "http-api" });
     expectNoNavigation();
     // Revealed with the budget id so an encrypted budget's password comes along.
     expect(mockRevealServerSecret).toHaveBeenCalledWith("fp", "b1");

--- a/src/components/connect/useConnectForm.test.tsx
+++ b/src/components/connect/useConnectForm.test.tsx
@@ -68,7 +68,18 @@ function resetStores() {
   useStagedStore.getState().discardAll();
 }
 
-describe("useConnectForm Direct redirects", () => {
+/**
+ * The hook must never navigate. Redirecting to /overview belongs to ConnectForm's
+ * effect: an imperative push from an async connect handler outlives the component
+ * and lands wherever the user has since navigated, which bounced Direct-mode users
+ * back to /overview seconds after they left it.
+ */
+function expectNoNavigation() {
+  expect(mockPush).not.toHaveBeenCalled();
+  expect(mockReplace).not.toHaveBeenCalled();
+}
+
+describe("useConnectForm connection activation", () => {
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
@@ -102,7 +113,7 @@ describe("useConnectForm Direct redirects", () => {
     });
   });
 
-  it("redirects a successful Direct budget connection to overview", async () => {
+  it("activates a successful Direct budget connection without navigating", async () => {
     mockLoadBrowserApiBudgetList.mockResolvedValue({
       budgets: [{ groupId: "budget-1", name: "Budget One" }],
       serverVersion: "25.1.0",
@@ -130,8 +141,10 @@ describe("useConnectForm Direct redirects", () => {
       result.current.handleConnect();
     });
 
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
-    expect(mockPush).not.toHaveBeenCalledWith("/accounts");
+    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBeTruthy(), {
+      timeout: 2_000,
+    });
+    expectNoNavigation();
     const [savedServer] = useSavedServersStore.getState().servers;
     expect(savedServer).toEqual(
       expect.objectContaining({
@@ -257,7 +270,10 @@ describe("useConnectForm Direct redirects", () => {
       result.current.handleConnect();
     });
 
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
+    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBeTruthy(), {
+      timeout: 2_000,
+    });
+    expectNoNavigation();
     expect(mockEnsureTransportReady).toHaveBeenCalledWith(
       expect.objectContaining({ budgetSyncId: "local-budget-1" })
     );
@@ -290,7 +306,7 @@ describe("useConnectForm Direct redirects", () => {
     expect(mockRevealServerSecret).toHaveBeenCalledWith(expect.any(String), "budget-1");
   });
 
-  it("opens a remembered budget in one click, straight to overview", async () => {
+  it("opens a remembered budget in one click", async () => {
     mockRevealServerSecret.mockResolvedValue({
       mode: "http-api",
       baseUrl: "https://api.example.com",
@@ -308,7 +324,10 @@ describe("useConnectForm Direct redirects", () => {
       );
     });
 
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
+    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBeTruthy(), {
+      timeout: 2_000,
+    });
+    expectNoNavigation();
     // Revealed with the budget id so an encrypted budget's password comes along.
     expect(mockRevealServerSecret).toHaveBeenCalledWith("fp", "b1");
     // No budget picker was involved — the instance went straight in.
@@ -360,7 +379,7 @@ describe("useConnectForm Direct redirects", () => {
     expect(mockPush).not.toHaveBeenCalledWith("/overview");
   });
 
-  it("redirects a successful Direct reconnect to overview", async () => {
+  it("activates a successful Direct reconnect without navigating", async () => {
     const instance: ConnectionInstance = {
       id: "direct-1",
       mode: "browser-api",
@@ -380,7 +399,9 @@ describe("useConnectForm Direct redirects", () => {
       result.current.handleReconnect(instance);
     });
 
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/overview"), { timeout: 2_000 });
-    expect(mockPush).not.toHaveBeenCalledWith("/accounts");
+    await waitFor(() => expect(useConnectionStore.getState().activeInstanceId).toBe("direct-1"), {
+      timeout: 2_000,
+    });
+    expectNoNavigation();
   });
 });

--- a/src/components/connect/useConnectForm.ts
+++ b/src/components/connect/useConnectForm.ts
@@ -1,5 +1,4 @@
 import { useState, useMemo, useRef } from "react";
-import { useRouter } from "next/navigation";
 import type { ConfirmState } from "@/components/ui/confirm-dialog";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -66,7 +65,6 @@ export type SavedBudgetRef = {
 };
 
 export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudgetRef[] } = {}) {
-  const router = useRouter();
   const queryClient = useQueryClient();
   const addInstance = useConnectionStore((s) => s.addInstance);
   const removeInstance = useConnectionStore((s) => s.removeInstance);
@@ -251,9 +249,7 @@ export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudg
         discardAll();
         queryClient.clear();
         setActiveInstance(instance.id);
-        toast.success("Direct connection opened. Redirecting…");
-        await new Promise((r) => setTimeout(r, 600));
-        router.push("/overview");
+        toast.success("Direct connection opened.");
       } finally {
         setReconnectBusyId(null);
       }
@@ -282,9 +278,7 @@ export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudg
       discardAll();
       queryClient.clear();
       setActiveInstance(instance.id);
-      toast.success("Connected! Redirecting…");
-      await new Promise((r) => setTimeout(r, 600));
-      router.push("/overview");
+      toast.success("Connected!");
     } finally {
       setReconnectBusyId(null);
     }
@@ -592,9 +586,7 @@ export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudg
         setActiveInstance(directConnection.id);
         await maybeRemember(directConnection);
         setConnectStatus({ kind: "success" });
-        toast.success("Direct connection opened. Redirecting…");
-        await new Promise((r) => setTimeout(r, 800));
-        router.push("/overview");
+        toast.success("Direct connection opened.");
       } catch (err) {
         setConnectStatus({ kind: "error", message: parseApiError(err) });
       }
@@ -674,9 +666,7 @@ export function useConnectForm({ savedBudgets = [] }: { savedBudgets?: SavedBudg
       setActiveInstance(finalInstance.id);
       await maybeRemember(finalInstance);
       setConnectStatus({ kind: "success" });
-      toast.success("Connected! Redirecting…");
-      await new Promise((r) => setTimeout(r, 800));
-      router.push("/overview");
+      toast.success("Connected!");
     } catch (err) {
       const status =
         err && typeof err === "object" && "status" in err


### PR DESCRIPTION
## The bug

In Direct mode, connecting lands you on Overview — then if you navigate to another page within the next couple of seconds, you get yanked back to Overview. Waiting a few seconds first avoids it. HTTP API mode is unaffected.

## Cause

Connecting navigated to `/overview` **twice**:

1. `ConnectForm.tsx` — an effect redirects as soon as `setActiveInstance()` makes the connection active. This is the navigation that actually lands you on Overview.
2. `useConnectForm.ts` — the connect/reconnect handlers then slept 600–800ms and issued a second `router.push("/overview")`.

That second push is a plain async continuation. It outlives the unmounted connect page, never checks where the user currently is, and cannot be cancelled — so it fires unconditionally.

**Why Direct mode only:** the push is issued ~800ms after landing, but doesn't *commit* until Next finishes the route transition. In Direct mode the main thread is saturated by worker init, `sql-wasm`, and budget download/decode, so the transition stayed pending for seconds and committed after the user had already navigated away. In HTTP mode the `/overview` payload is warm from the first navigation and the CPU is idle, so the duplicate committed instantly as an invisible no-op. Same bug, different timing.

A visible symptom confirmed the diagnosis: the "Redirecting…" toast was displayed *on the Overview page*, meaning the first navigation had already committed while the redirect it announced was still pending. The Toaster lives in the root layout, so it survives the route change.

## Fix

Removed the sleep and `router.push` from all four call sites (2 connect paths, 2 reconnect paths), leaving `ConnectForm`'s effect as the single owner of the redirect. It fires on exactly the right condition and, being declarative, cannot outlive its component. `useRouter` is no longer needed in the hook, so the handlers now structurally cannot navigate.

Toasts state what happened (`"Direct connection opened."`) instead of promising a redirect that had already occurred.

**Behaviour change:** the redirect is now immediate rather than delayed by 600–800ms, so connecting feels snappier and you land on Overview while the toast is still up.

## Testing

Four existing tests asserted the duplicate `router.push`, i.e. they were pinning the buggy behaviour. They now assert the hook's real contract — the connection becomes active — plus a shared `expectNoNavigation()` guard that the hook performs no navigation at all.

- `tsc --noEmit` clean
- `npm test` — 2072 passing
- `npm run lint` — 0 errors
- **Manually verified in Direct mode by the reporter:** navigating away immediately after connecting no longer bounces back.

Also ignores local `ui-ux-pro-max` skill files.
