### PR TITLE
Refocus the documentation site on end users

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -32,14 +32,65 @@ export default defineConfig({
 			editLink: {
 				baseUrl: 'https://github.com/x-rous/actual-bench/edit/main/docs-site/',
 			},
-			// Sidebar groups use autogenerate so an entry appears only once its page
-			// exists — no empty or "coming soon" links while the site is built out.
+			// Lead with the jobs readers came to do. Detailed entity and operator
+			// reference stays available without competing with the primary workflows.
 			sidebar: [
-				{ label: 'Getting Started', items: [{ autogenerate: { directory: 'getting-started' } }] },
-				{ label: 'User Guide', items: [{ autogenerate: { directory: 'user-guide' } }] },
-				{ label: 'Administration', items: [{ autogenerate: { directory: 'administration' } }] },
-				{ label: 'Help', items: [{ autogenerate: { directory: 'help' } }] },
-				{ label: 'Contributing', link: '/contributing/' },
+				{
+					label: 'Start Here',
+					items: [
+						{ label: 'What Actual Bench adds', link: '/getting-started/introduction/' },
+						{ label: 'Install Actual Bench', link: '/getting-started/installation/' },
+						{ label: 'Connect to a budget', link: '/getting-started/connecting/' },
+						{ label: 'Work safely', link: '/getting-started/core-concepts/' },
+					],
+				},
+				{
+					label: 'Common Workflows',
+					items: [
+						{ label: 'Plan a full year', link: '/user-guide/budget-management/' },
+						{ label: 'Set up & clean up data', link: '/user-guide/managing-your-data/' },
+						{ label: 'Build & audit rules', link: '/user-guide/rules/' },
+						{ label: 'Reconcile a bank statement', link: '/user-guide/bank-reconciliation/' },
+						{ label: 'Sync budget files', link: '/user-guide/budget-sync/' },
+						{ label: 'Explore & diagnose data', link: '/user-guide/budget-file-tools/' },
+					],
+				},
+				{
+					label: 'Feature Reference',
+					collapsed: true,
+					items: [
+						{ label: 'Budget Overview', link: '/getting-started/budget-overview/' },
+						{ label: 'Accounts', link: '/user-guide/accounts/' },
+						{ label: 'Payees', link: '/user-guide/payees/' },
+						{ label: 'Categories', link: '/user-guide/categories/' },
+						{ label: 'Schedules', link: '/user-guide/schedules/' },
+						{ label: 'Tags', link: '/user-guide/tags/' },
+						{ label: 'Rule Diagnostics', link: '/user-guide/rule-diagnostics/' },
+						{ label: 'ActualQL', link: '/user-guide/actualql/' },
+						{ label: 'FX Rates', link: '/user-guide/fx-rates/' },
+						{ label: 'Bundle Export / Import', link: '/user-guide/bundle-export-import/' },
+					],
+				},
+				{
+					label: 'For Self-hosters',
+					collapsed: true,
+					items: [
+						{ label: 'Deployment', link: '/administration/deployment/' },
+						{ label: 'Configuration', link: '/administration/configuration/' },
+						{ label: 'Upgrades & backups', link: '/administration/upgrading-and-backups/' },
+						{ label: 'App Health', link: '/administration/app-health/' },
+					],
+				},
+				{
+					label: 'Help',
+					collapsed: true,
+					items: [
+						{ label: 'Troubleshooting', link: '/help/troubleshooting/' },
+						{ label: 'Known limitations', link: '/help/known-limitations/' },
+						{ label: 'Glossary', link: '/help/glossary/' },
+						{ label: 'Contributing', link: '/contributing/' },
+					],
+				},
 			],
 		}),
 	],

--- a/docs-site/src/content/docs/administration/app-health.mdx
+++ b/docs-site/src/content/docs/administration/app-health.mdx
@@ -5,14 +5,14 @@ sidebar:
   order: 4
 ---
 
-App Health is a compact diagnostics page for **Actual Bench's own server-side metadata database** —
-not your budget. Use it to confirm the app can persist its workflow data (sync flows, run history, FX
-registry) across restarts. Open it from **App Health** under the **Tools** sidebar section.
+Use **App Health** when you operate Actual Bench and need to verify its own metadata database or
+unattended scheduler. It diagnoses Actual Bench, not the connected budget; normal end users can ignore
+it unless an administrator asks for these details.
 
 :::note[This is about Actual Bench, not your budget]
-The metadata database holds Actual Bench workflow data only. It is **not** a copy of your Actual Budget
-data and does **not** store Actual credentials, API keys, server passwords, or budget encryption
-passwords. See [Core Concepts](../../getting-started/core-concepts/#where-data-lives).
+The metadata database is not a copy of your Actual Budget. It holds workflow metadata and can hold the
+two explicit encrypted credential opt-ins: remembered servers and unattended sync. It never stores
+those credentials in plaintext. See [Work safely](../../getting-started/core-concepts/#where-data-lives).
 :::
 
 ## What it reports
@@ -22,7 +22,8 @@ passwords. See [Core Concepts](../../getting-started/core-concepts/#where-data-l
 - **Writable** — whether Actual Bench can write to the database. Should be **Yes**.
 - **Schema** — the current schema version, or `Not initialized` if the database hasn't been set up.
 - **Migration status** — whether migrations are up to date.
-- **Persistence** — a reminder that data is *Persistent when `/data` is mounted*.
+- **Persistence** — a reminder that `/data` must be mounted externally. Writable storage alone does
+  not prove it will survive container replacement.
 
 ## Verify a healthy install
 

--- a/docs-site/src/content/docs/administration/configuration.mdx
+++ b/docs-site/src/content/docs/administration/configuration.mdx
@@ -5,8 +5,9 @@ sidebar:
   order: 2
 ---
 
-Actual Bench needs **no environment variables for a basic setup**. This page documents the settings you
-can provide for specific features and deployments.
+This is operator reference. Someone who only uses Actual Bench does not need these settings. A basic
+self-hosted installation needs persistent `/data` storage and no mandatory environment variables;
+configure only the feature you intend to enable.
 
 ## How configuration is loaded
 
@@ -74,8 +75,8 @@ the user sets** — no environment variable is involved. Credentials are server-
 opens any of its budgets); budget encryption passwords are sealed separately, per budget. The passphrase
 and derived key are never stored (only the ciphertext and a salt), so the server cannot decrypt on its
 own; the user unlocks once per session. This is **separate** from the `SYNC_VAULT_KEY` unattended-sync
-vault below — the two never share ciphertext or a key. The feature is only offered when this database is
-durable, so it is inert on non-durable runtimes. Back up `/data` to preserve remembered servers; a lost
+vault below—the two never share ciphertext or a key. Back up and persist `/data` to preserve remembered
+servers across container replacement; a writable path by itself does not prove durability. A lost
 passphrase means the user resets the vault and re-saves.
 
 ## Unattended sync settings

--- a/docs-site/src/content/docs/administration/deployment.mdx
+++ b/docs-site/src/content/docs/administration/deployment.mdx
@@ -5,9 +5,12 @@ sidebar:
   order: 1
 ---
 
-This guide covers running Actual Bench in production. For a first install, start with
-[Installation](../../getting-started/installation/); this page adds architecture, networking, reverse
-proxy, and hardening detail.
+This guide is for the person operating Actual Bench, not someone who only uses the application. Start
+with [Installation](../../getting-started/installation/) for one working container; return here when
+you need production networking, HTTPS, or hardening.
+
+For most single-VPS installations, the goal is simple: one container, one persistent `/data` volume,
+one HTTPS endpoint, and a network path to the selected Actual connection mode.
 
 ## Deployment architecture
 

--- a/docs-site/src/content/docs/administration/upgrading-and-backups.mdx
+++ b/docs-site/src/content/docs/administration/upgrading-and-backups.mdx
@@ -5,9 +5,10 @@ sidebar:
   order: 3
 ---
 
-This guide helps administrators upgrade Actual Bench safely and protect its data. The most important
-idea: **the only server-side state Actual Bench owns is its metadata database under `/data`** — your
-budget data lives in Actual Budget, not here.
+This guide is for operators replacing an Actual Bench container or moving it to another host. The rule
+that matters most is: **reuse and back up the same `/data` storage**. Your budgets remain in Actual;
+Actual Bench's sessions, flows, saved queries, rates, and encrypted credential opt-ins live in its own
+metadata database.
 
 ## What needs to be backed up
 
@@ -17,10 +18,11 @@ budget data lives in Actual Budget, not here.
 | Actual Bench metadata | `/data` volume (SQLite) | **Yes** |
 | Configuration | Your Compose file / environment | Yes |
 | `SYNC_VAULT_KEY` | Your secret manager | Yes — **store it separately and safely** |
-| Browser session state | The browser | No (transient; re-enter secrets on reconnect) |
+| Remembered-server passphrase | Known by the user | Yes, separately—the database cannot recover it |
+| Browser session state | The browser | No (transient; unlock or reconnect after restart) |
 
-The metadata database holds sync flows, run history, and (if enabled) **encrypted** unattended-sync
-credentials. It does not contain your budget data or plaintext Actual credentials.
+The metadata database does not contain your budget data or plaintext credentials. It can contain the
+two explicit encrypted opt-ins: remembered-server secrets and unattended-sync credentials.
 
 ## Before upgrading
 
@@ -29,7 +31,8 @@ credentials. It does not contain your budget data or plaintext Actual credential
 3. **Back up `/data`** (see [Backup](#back-up-the-metadata-database)).
 4. Back up your Compose file and environment configuration.
 5. Ensure `SYNC_VAULT_KEY` is safely retained (needed to keep unattended credentials usable).
-6. Prefer upgrading to a **pinned `:<version>`** rather than a moving tag, for a controlled change.
+6. If you use remembered servers, confirm the user still knows the vault passphrase.
+7. Prefer upgrading to a **pinned `:<version>`** rather than a moving tag, for a controlled change.
 
 ## Upgrade procedures
 
@@ -74,7 +77,8 @@ container. Keep the same `/data` volume so your metadata carries over.
 1. The app loads and shows the new version in the sidebar footer.
 2. App Health: **Writable = Yes**, **Schema** current, **Persistence** as expected.
 3. Your sync flows and run history are present.
-4. If you use unattended sync, its scheduler section on App Health looks healthy.
+4. Remembered servers are still listed; the vault is expected to be locked until a user unlocks it.
+5. If you use unattended sync, its scheduler section on App Health looks healthy.
 
 ## Rollback
 

--- a/docs-site/src/content/docs/contributing.mdx
+++ b/docs-site/src/content/docs/contributing.mdx
@@ -64,7 +64,9 @@ npm run build
 When writing docs:
 
 - Treat the **current implementation and UI** as the source of truth; use exact in-app labels.
-- Keep each page substantial and task-oriented — smaller workflows are sections, not new pages.
+- Lead feature pages with the user's situation, problem, value over Actual Budget, and write model.
+- Put the shortest useful workflow before exhaustive options and technical reference.
+- Keep pages task-oriented; smaller workflows are sections, not new pages.
 - Put images under `docs-site/src/assets/screenshots/` and reference them relatively.
 - Never include real secrets, credentials, private hostnames, or personal budget data.
 - Use base-safe links (relative, or prefixed with `/actual-bench/`).

--- a/docs-site/src/content/docs/getting-started/budget-overview.mdx
+++ b/docs-site/src/content/docs/getting-started/budget-overview.mdx
@@ -5,9 +5,12 @@ sidebar:
   order: 5
 ---
 
-After you connect to a budget, Actual Bench takes you to the **Budget Overview** (`/overview`) — your
-home base for that budget. It's a lightweight snapshot and navigation hub, not an editing surface, so
-it loads fast and always reflects current **saved** server state.
+After you connect, **Budget Overview** is the quickest place to confirm that you opened the intended
+budget and choose your next job. It is useful for orientation, whole-structure export/import, and
+jumping to another workspace; it is not an editing surface.
+
+**Write model:** read-only, except for the explicit Bundle Import workflow it opens. Counts reflect
+saved server state, not unsaved drafts.
 
 ## What the Overview shows
 

--- a/docs-site/src/content/docs/getting-started/connecting.mdx
+++ b/docs-site/src/content/docs/getting-started/connecting.mdx
@@ -1,188 +1,98 @@
 ---
-title: Connect to Actual Budget
-description: Choose Direct Actual Server mode or HTTP API Server mode, enter your server details, and open a budget in Actual Bench.
+title: Connect to a budget
+description: Choose the connection method your installation supports, load a server's budgets, and understand what is remembered.
 sidebar:
   order: 3
 ---
 
-Actual Bench uses a two-step connection flow: first **Choose a server**, then **Choose a budget**. This
-page explains the two connection modes and how to complete each step.
+You need a connection only to open an existing Actual budget. Most users should choose **Direct Actual
+Server**, enter the same server URL and password they use for Actual, and then pick a budget. Use
+**HTTP API Server** when your installation already provides `actual-http-api`.
 
-## Choose a connection mode
-
-At the top of the connection screen you pick one of two modes:
-
-- **Direct Actual Server** — Actual Bench connects to your Actual Server and runs Actual's engine
-  directly in your browser. This is the target architecture for new browser-based workflows.
-- **HTTP API Server** — Actual Bench connects through a separate
-  [actual-http-api](https://github.com/jhonderson/actual-http-api) server. This path remains fully
-  supported for deployments and integrations that prefer or require it.
-
-:::note
-If only **HTTP API Server** is shown, Direct mode has been disabled for this deployment with
-`DIRECT_BROWSER_API=0` or `NEXT_PUBLIC_DIRECT_BROWSER_API=0`. Remove that setting and restart to show
-both modes.
+:::tip[If someone else runs Actual Bench]
+Ask the administrator which mode and URL to use. You do not need to understand the networking details
+to use the rest of Actual Bench.
 :::
 
-### Mode comparison
+## Choose a mode
 
-| Topic | Direct Actual Server mode | HTTP API Server mode |
+| | Direct Actual Server | HTTP API Server |
 |---|---|---|
-| Connects to | Your Actual Server | An `actual-http-api` server |
-| Where Actual runs | In your browser (a worker) | On the API server |
-| Credential entered | **Server password** | **API Key** (`ACTUAL_API_KEY`) |
-| Reachability required | Browser → Actual Server | Actual Bench container → `actual-http-api` |
-| Special requirements | CORS and cross-origin isolation | API key and network path to the API |
-| Unattended server-side sync | Not supported | Supported when configured |
+| Best fit | Most new installations | Existing `actual-http-api` deployments and unattended sync |
+| You enter | Actual Server URL and server password | HTTP API URL and API key |
+| Actual runs | In your browser | On the API server |
+| Network path | Your browser must reach Actual Server | Actual Bench must reach `actual-http-api` |
+| Unattended server sync | No | Yes, when configured |
 
-Both modes support opening multiple budgets, encrypted budgets, and the core workspaces. Some
-capabilities differ by mode — those differences are called out in the relevant feature guides.
+Both modes support encrypted budgets and the core workspaces. A feature guide calls out any meaningful
+mode difference.
 
-## Connect using Direct Actual Server mode
+## Connect
 
-1. On the connection screen, under **Choose a server**, select **Direct Actual Server**.
-2. In **Actual Server URL**, enter your Actual Server base URL (for example
-   `https://actual.example.com`).
-3. In **Server password**, enter the password your Actual Server browser clients use.
-4. Select **Load Budgets**. Actual Bench opens the Actual engine in your browser and lists the
-   available budgets.
-5. Continue to [Select a budget](#select-a-budget).
+1. Choose **Direct Actual Server** or **HTTP API Server**.
+2. Enter the server URL and the requested credential.
+3. Select **Load Budgets**.
+4. Choose a budget. If it is end-to-end encrypted, enter its separate **Encryption password**.
+5. Select **Connect**.
 
-:::caution[Direct mode needs a reachable, isolated origin]
-Your browser must be able to reach the Actual Server URL, and the response must satisfy CORS and
-cross-origin isolation requirements. In practice this usually means serving both Actual Bench and
-Actual Server over HTTPS, with CORS allowed or a same-origin reverse proxy. If budgets fail to load in
-Direct mode, this is the first thing to check — see [Troubleshooting](#troubleshooting).
+Actual Bench opens the [Budget Overview](../budget-overview/).
+
+## Reconnect later
+
+Two kinds of convenience are available:
+
+- **Recent connection details** remember only non-secret labels and URLs for the current browser tab.
+  You re-enter credentials after the tab closes.
+- **Remember this server** is an optional encrypted vault. It keeps the server credential in the
+  Actual Bench metadata database and protects it with a passphrase you choose.
+
+### Remember a server
+
+1. On the budget step, select **Remember this server**.
+2. Create or unlock the shared vault passphrase.
+3. Connect. The server credential is encrypted and saved; an encrypted budget's password is saved
+   separately for that budget.
+
+Saved servers appear in the **Connections** list. Unlock once after an Actual Bench restart, then open
+any remembered budget without re-entering its credentials. A server is remembered once even when it
+contains several budgets.
+
+:::caution[The passphrase cannot be recovered]
+The passphrase and derived key are not stored. If you forget it, **Reset vault** removes the encrypted
+saved servers so you can start again. It does not remove or change your Actual budgets.
 :::
 
-## Connect using HTTP API Server mode
+Remembered servers survive only when the administrator persists Actual Bench's `/data` storage. See
+[Upgrades and backups](../../administration/upgrading-and-backups/) if you run the installation.
 
-1. Under **Choose a server**, select **HTTP API Server**.
-2. In **HTTP API Server URL**, enter your `actual-http-api` base URL (for example
-   `https://budgetapi.example.com`).
-3. In **API Key**, enter the `ACTUAL_API_KEY` configured on that server. It is kept in memory only.
-4. Select **Load Budgets** to validate the server and list budgets.
-5. Continue to [Select a budget](#select-a-budget).
+## Switch between open budgets
 
-## Select a budget
+Open budgets appear in the top-bar connection switcher. Each connection has its own staged edits and
+query cache. Switching never mixes drafts between budgets, but always confirm the active budget before
+you Save or Apply.
 
-After **Load Budgets** succeeds, the **Choose a budget** step appears:
+## How credentials are handled
 
-1. Pick a budget from the list.
-2. If the budget is end-to-end encrypted, enter its **Encryption password**. Leave it blank if the
-   budget is not encrypted.
-3. Select **Connect**.
+- By default, server passwords, API keys, and encryption passwords stay in browser memory only.
+- Recent connection details contain no secrets.
+- Remembered-server credentials are an explicit passphrase-encrypted opt-in.
+- Unattended-sync credentials are a separate operator-controlled encrypted opt-in.
 
-Actual Bench opens the budget and takes you to the [Budget Overview](../budget-overview/).
+See [Work safely](../core-concepts/#where-data-lives) for the storage summary.
 
-## Encrypted budgets
+## If budgets do not load
 
-For end-to-end encrypted budgets, the **Encryption password** is required to open the budget and is
-kept in memory only. It is separate from your Actual Server password or API key.
+### Direct mode
 
-## Saved presets and reconnecting
+- Confirm the Actual Server URL works from the same browser.
+- Use HTTPS outside localhost.
+- The administrator may need to configure CORS or a same-origin reverse proxy.
 
-Previously used connections appear on the connection screen so you can reconnect in a single step
-during the current browser session.
+### HTTP API mode
 
-- Only **non-secret** connection details (such as the server URL and label) are saved, in the browser's
-  session storage.
-- Secrets — the Server password, API Key, and Encryption password — are **not** saved by default. You
-  re-enter them when reconnecting, unless you opt in to remembering the connection (below).
-- Because presets live in session storage, they are cleared when the browser tab is closed.
+- Confirm the API URL and `ACTUAL_API_KEY`.
+- If both applications run in containers, `localhost` points back to Actual Bench; use a shared-network
+  service name or another reachable address.
 
-## Remember a server (optional)
-
-To avoid re-typing credentials every session, you can **remember a server**. Credentials are
-**server-scoped**: one saved server (its mode + URL, with its API key or password) opens **any** of its
-budgets. The secret is stored **encrypted on the server**, protected by a passphrase you choose, and
-after unlocking once you open any budget on that server without re-entering anything.
-
-:::note[Off by default]
-Remembering is opt-in. If you do nothing, secrets stay in memory only and you re-enter them each
-session. The option is hidden where storage isn't durable (for example the public demo).
-:::
-
-### Remember it while connecting
-
-1. On the **Choose a budget** step, tick **Remember this server**.
-2. The first time, you're asked to **create a passphrase** (at least 8 characters). This passphrase
-   protects every saved server; if a passphrase already exists, unlock it instead.
-3. Select **Connect**. The server's secret is sealed in the metadata database. If the budget is
-   encrypted, its **encryption password** is remembered separately, tied to that budget.
-
-### Reconnect from the Connections list
-
-On the connect screen, the **Connections** list shows everything you can open, grouped by server. Each
-budget appears once with small state chips:
-
-- **open** — loaded in this browser session. Click to switch to it **instantly** — no passphrase needed,
-  since its credentials are still in memory.
-- **saved** — kept in the vault. Click to reconnect after unlocking once; the server credential and the
-  budget's encryption password (if any) are used automatically, with no re-typing.
-
-A budget that is both shows both chips and opens instantly.
-
-1. If the vault is locked, enter your **passphrase** once to unlock the **saved** budgets. (Budgets that
-   are already **open** this session stay clickable without unlocking.)
-2. Select a **budget** to open it.
-3. To open a budget you haven't opened here yet, use **Open another budget** under a saved server: the
-   full budget list loads (still without re-entering credentials) so you can pick one.
-4. Use the **✕** next to a budget to forget just that budget, or the **trash** icon on a server to
-   forget the whole server (and its remembered budget passwords).
-
-:::note[Your saved credentials stay protected]
-Saved credentials are encrypted at rest and unlocked only with your passphrase. Reconnecting simply
-signs you in with them, just as if you'd typed them yourself — nothing is shared anywhere new. In Direct
-mode that happens in your browser (where Actual runs); in HTTP API mode they're used like any other API
-connection.
-:::
-
-### About the passphrase
-
-- It protects the stored secrets and is entered **once per session** to unlock them. It is **not** a
-  login for Actual Bench — the app still has no built-in authentication (see the security note above).
-- The passphrase and its derived key are **never stored** on the server — only the encrypted secrets
-  and a salt. Changing the passphrase re-encrypts everything.
-- If you **forget the passphrase**, saved secrets can't be recovered. Use **Forgot passphrase?** on the
-  unlock panel to **reset the vault** — this removes all saved servers and clears the passphrase so you
-  can set a new one. Your budgets and their data are untouched.
-
-See [Core Concepts](../core-concepts/#where-data-lives) for where remembered secrets live, and the
-**Administration** guides for backup implications.
-
-## Switch between connections
-
-You can add several connections and switch between them from the top bar. Each connection has its own
-staged edits and query cache, so switching budgets never mixes local state between them.
-
-:::tip[Check the active connection before you Save]
-Staged changes belong to the connection they were made in. Confirm the active connection in the top bar
-before saving, so changes land in the intended budget.
-:::
-
-## Credential handling
-
-- Server passwords, API keys, and encryption passwords are held **in memory only**. Refreshing or
-  reopening the tab requires reconnecting.
-- Saved presets contain non-secret details only.
-- Actual Bench's server-side metadata database does not store Actual credentials.
-
-See [Core Concepts](../core-concepts/) for the full picture of where data lives.
-
-## Troubleshooting
-
-- **Budgets won't load in Direct mode** — verify the browser can reach the Actual Server URL over HTTPS
-  and that CORS / cross-origin isolation are satisfied (or use a same-origin reverse proxy).
-- **Budgets won't load in HTTP API mode** — verify the **HTTP API Server URL** is correct, the **API
-  Key** matches `ACTUAL_API_KEY`, and the Actual Bench container can reach the API server. If the API
-  runs in another container, remember that `localhost` refers to the Actual Bench container itself.
-- **Only HTTP API Server mode is shown** — Direct mode is disabled via `DIRECT_BROWSER_API=0` /
-  `NEXT_PUBLIC_DIRECT_BROWSER_API=0`.
-- **Budget won't open** — for encrypted budgets, confirm the **Encryption password**.
-
-The **Help → Troubleshooting** guide covers connection problems in more depth.
-
-## Next step
-
-Read [Core Concepts](../core-concepts/) before making larger changes.
+If only HTTP API mode is visible, Direct mode was disabled by the administrator. See
+[Troubleshooting](../../help/troubleshooting/) for deeper deployment checks.

--- a/docs-site/src/content/docs/getting-started/core-concepts.mdx
+++ b/docs-site/src/content/docs/getting-started/core-concepts.mdx
@@ -1,117 +1,66 @@
 ---
-title: Core Concepts
-description: Staged edits and the Save model, immediate-save exceptions, connection scoping, safety patterns, and where Actual Bench keeps data.
+title: Work safely
+description: Know when Actual Bench stages, applies, immediately saves, or only reads before you make changes.
 sidebar:
   order: 4
 ---
 
-Actual Bench is built around reviewing changes before they reach your budget. Understanding a few core
-behaviors — especially the difference between *staged* and *saved* data — will help you work confidently
-before you make larger changes.
+Before using a feature, identify its write model. Actual Bench does not force every job into one kind
+of Save button: bulk editing, reconciliation, diagnostics, and small explicit actions need different
+safety controls.
 
-## Saved data versus staged data
+## The four models
 
-Most edits you make in Actual Bench are **staged** locally first. Nothing is written to your Actual
-Budget server until you explicitly **Save**.
+| Model | What happens | Used for |
+|---|---|---|
+| **Stage → review → Save** | Changes remain in the current browser session until you review and Save | Accounts, payees, categories, rules, schedules, tags, budget amounts, transfers, and holds |
+| **Review → Apply** | A session or preview shows the planned writes; only an explicit Apply writes them | Bank Reconciliation and Budget File Sync |
+| **Immediate explicit write** | The named action writes at once and is not part of the main staged Save | Notes and carryover toggles |
+| **Read-only** | The tool inspects data and never writes to the budget | ActualQL, Rule Diagnostics, Budget File Health, and Data Browser |
 
-- **Saved state** is what currently exists on the server.
-- **Staged state** is your local working set of pending creates, edits, and deletes.
-- Staged rows are visually marked — for example new, updated, or deleted — so you can see exactly what
-  will change.
-- The **Draft Changes** panel and the top bar summarize what is pending across the current workspace.
-- **Save** writes staged changes to the server; **Discard** reverts to the last saved state.
-- Refreshing, navigating away, or closing the tab with unsaved changes prompts for confirmation so you
-  don't lose work by accident.
+Each feature guide repeats the relevant model near the top so you do not need to remember the table.
 
-## Undo and redo
+## Staged work
 
-Undo and redo apply to staged edits within your session:
+New, edited, and deleted rows are visually marked. The **Draft Changes** panel and top bar summarize
+what is pending. **Save** writes the draft; **Discard** returns to saved server state. Undo and redo
+apply only to staged work and cannot reverse something already saved.
 
-- Use the top bar undo/redo controls, or `Ctrl/Cmd+Z` and `Ctrl/Cmd+Shift+Z` (or `Ctrl+Y`).
-- The Budget Management workspace keeps its own edit history for cell edits, holds, and transfers.
-
-Undo affects staged changes; it is not a way to reverse changes that have already been saved to the
-server.
+Staged work is scoped to the connected budget. When several budgets are open, confirm the active
+connection before saving.
 
 ## Immediate-save exceptions
 
-A few actions do **not** wait for the main **Save** button — they save immediately:
+- **Notes** save as soon as you confirm the note editor. Discarding other staged work does not undo them.
+- **Carryover** is toggled through an explicit Budget Management action and writes directly. It is not
+  part of the budget-cell draft.
 
-- **Notes** — editing a note on an account, category, category group, budget month, or budget cell
-  saves right away, independently of your other staged edits.
+These exceptions should feel like individual actions, not background saves.
 
-:::caution
-Because notes save immediately, editing a note is not undone by **Discard** and is not part of the
-staged **Save**. Treat note edits as taking effect at once.
-:::
+## Apply workflows
 
-## Connection scoping
-
-Each connected budget has its own local state:
-
-- Staged edits and the query cache are **scoped per connection**.
-- Switching connections from the top bar never mixes staged data or cached query results between
-  budgets.
-- Always confirm the **active connection** before you Save, so changes land in the budget you intend.
-
-## Safety patterns
-
-You will encounter a few distinct interaction patterns across Actual Bench. Recognizing which one
-applies helps you know when a change becomes permanent:
-
-1. **Staged edit → review → Save** — the default for most entity and budget edits.
-   *Example:* renaming a payee, or editing a budget cell.
-2. **Preview → select → Apply** — used by Budget File Sync. A dry-run preview classifies items, and
-   only the items you select are written.
-3. **Impact-aware confirmation** — destructive actions confirm first, showing impact such as
-   transaction counts, rule references, or a balance.
-   *Example:* deleting a category group shows how many child categories and transactions are affected.
-4. **Read-only inspection** — tools that never write back to your budget.
-   *Example:* Budget File Health and the Data Browser.
-5. **Immediate save** — specific fields that save at once, such as notes.
-
-## Credential handling
-
-Actual Bench is deliberately conservative with secrets:
-
-- Server passwords, API keys, and budget encryption passwords are held **in memory only** by default;
-  refreshing or reopening the tab requires reconnecting.
-- Saved connection presets in session storage contain **non-secret** details only.
-- **Remembered servers (opt-in):** if you choose to remember a server, its secret is sealed
-  **AES-256-GCM in the metadata database**, encrypted with a key derived from a **passphrase you set**.
-  Credentials are server-scoped, so one saved server opens any of its budgets; encryption passwords for
-  encrypted budgets are remembered separately, per budget. The passphrase and key are never stored, so
-  the server cannot decrypt on its own — you unlock once per session. The passphrase is **not** an app
-  login. See [Remember a server](../connecting/#remember-a-server-optional).
-- Credentials for unattended server-side sync are stored only after you explicitly enroll them, and are
-  kept **encrypted** in the metadata database (that key comes from the server environment,
-  `SYNC_VAULT_KEY`, never the database). This vault is separate from remembered-connection storage.
-- Beyond those explicit, encrypted opt-ins, the metadata database does not store Actual credentials.
+Budget File Sync previews and classifies potential items before Apply. Bank Reconciliation keeps your
+statement decisions in a persistent session, shows the planned result, and re-reads affected Actual
+transactions immediately before Apply. Both preserve item-level failures for review or retry.
 
 ## Where data lives
 
-| Data | Where it lives | Persistence | Contains secrets? |
-|---|---|---|---|
-| Actual budget data | Your Actual Server | Managed by Actual | Your budget content |
-| Staged edits & query cache | Browser (in memory) | Until refresh / tab close | No server credentials |
-| Saved connection preset | Browser session storage | Cleared when the tab closes | Non-secret details only |
-| Actual Bench metadata | `/data` SQLite on the server | Persistent (with `/data` mounted) | Workflow metadata only |
-| Remembered server secret (opt-in) | Metadata database, encrypted | Persistent | Encrypted; needs your passphrase |
-| Unattended sync credentials | Metadata database, encrypted | Persistent | Encrypted credentials |
-| Exported budget snapshot | Processed locally in your browser | Cached during the session | May contain budget data |
+| Information | Location | How long it lasts |
+|---|---|---|
+| Actual budget data | Your Actual Server | Managed by Actual |
+| Staged edits and active connections | Browser memory | Until refresh or tab close |
+| Non-secret recent connection details | Browser session storage | Until the tab closes |
+| Actual Bench workflow metadata | `/data/actual-bench.sqlite` | Across restarts when `/data` is persisted |
+| Remembered server secrets, when enabled | Metadata database, encrypted with your passphrase | Until you forget or reset them |
+| Unattended-sync credentials, when enabled | Metadata database, encrypted with `SYNC_VAULT_KEY` | Until withdrawn or the database is removed |
+| Exported budget snapshot | Browser memory; downloadable by you | Current session or your downloaded file |
 
-For where the metadata database lives and how to back it up, see the **Administration** guides.
+Remembering credentials is optional. By default, credentials are held in memory only. The two
+encrypted opt-ins are separate and use different keys.
 
-## Working with multiple budgets
+## Two habits prevent most mistakes
 
-You can keep several connections open and switch between them:
+1. Check the active budget before **Save** or **Apply**.
+2. Read the review or impact screen instead of treating it as a confirmation to click through.
 
-- Each budget keeps its own staged edits and query cache.
-- Nothing is shared between connections, so you can safely work across budgets in one session.
-- Verify the active connection before saving or applying changes.
-
-## Next steps
-
-- If you haven't yet, [install Actual Bench](../installation/) and
-  [connect to a budget](../connecting/).
-- Then explore the feature guides in the **User Guide** section.
+You can now go straight to the workflow that brought you here.

--- a/docs-site/src/content/docs/getting-started/installation.mdx
+++ b/docs-site/src/content/docs/getting-started/installation.mdx
@@ -5,8 +5,9 @@ sidebar:
   order: 2
 ---
 
-This page helps you get Actual Bench running with the simplest supported installation. Actual Bench is
-distributed as a Docker image, so Docker (with or without Compose) is the recommended way to run it.
+This page is for the person running Actual Bench. If someone else already hosts it, skip to
+[Connect to a budget](../connecting/). The supported installation is a Docker container; Compose is
+the shortest path for a persistent self-hosted instance.
 
 :::note[You still need Actual Budget]
 Actual Bench connects to an existing [Actual Budget](https://github.com/actualbudget/actual) server —
@@ -125,9 +126,8 @@ Actual Bench stores its own workflow metadata in a SQLite database at `/data/act
 across container recreation.
 
 :::note[What `/data` is — and isn't]
-The metadata database holds Actual Bench workflow data only (such as sync flows and run history). It is
-**not** a copy of your Actual Budget data and does **not** store Actual credentials, API keys, Actual
-Server passwords, or budget encryption passwords.
+The metadata database is not a copy of your Actual Budget. It holds Actual Bench workflow data and,
+only when explicitly enabled, encrypted remembered-server or unattended-sync credentials.
 :::
 
 ## Update the container

--- a/docs-site/src/content/docs/getting-started/introduction.mdx
+++ b/docs-site/src/content/docs/getting-started/introduction.mdx
@@ -1,102 +1,63 @@
 ---
-title: Introduction
-description: What Actual Bench is, who it is for, how it connects to Actual Budget, and the safety model to understand before you make changes.
+title: What Actual Bench adds
+description: Decide whether Actual Bench fits the work you do in Actual Budget and choose the first workflow worth trying.
 sidebar:
   order: 1
 ---
 
-This page explains what Actual Bench is, what it is not, and how to approach it. It is for anyone
-evaluating or getting started with Actual Bench, whether you are a budgeting power user or the person
-self-hosting it.
+Actual Bench is for the jobs around an Actual Budget file that become tedious or difficult to verify
+in the everyday budgeting interface. It complements Actual; it does not ask you to move your normal
+budgeting or transaction entry somewhere new.
 
-:::note[Independent companion app]
-Actual Bench is an independent companion application for [Actual Budget](https://actualbudget.org/).
-It is **not** the official Actual Budget application or official Actual Budget documentation.
-:::
+## Is it for you?
 
-## What is Actual Bench?
+Actual Bench is likely useful when at least one of these sounds familiar:
 
-Actual Bench is a companion app for Actual Budget. It provides a focused interface for the work that
-is cumbersome or unavailable in the native Actual Budget UI: bulk setup, master-data cleanup, advanced
-rule maintenance, full-year budget editing, diagnostics, ad-hoc ActualQL analysis, and cross-budget
-synchronization.
+- You manage enough accounts, payees, categories, schedules, tags, or rules that one-at-a-time
+  maintenance is getting painful.
+- You plan several months at once or prepare numbers in Excel or Google Sheets.
+- You have accumulated rules and want to find broken references, duplicates, or surprising overlaps.
+- You reconcile from downloaded bank statements and want a persistent, review-first workflow.
+- You keep separate budget files for people, businesses, purposes, or currencies.
+- You need to inspect or query details that are not exposed in Actual's normal screens.
 
-It is the workbench you open when you need to **inspect, repair, seed, audit, or reshape** your budget
-data with confidence — not a replacement for everyday budgeting.
+If you mainly enter transactions, check balances, and adjust the current month's budget, continue doing
+that in Actual Budget. Actual Bench is the occasional workbench for larger jobs.
 
-## Who should use it?
+## Choose the first workflow
 
-Actual Bench is aimed at power users and administrators, including people who:
-
-- Manage large or complex budget files.
-- Need to make bulk changes to accounts, payees, categories, schedules, tags, or rules.
-- Build advanced rules or want to lint existing ones.
-- Run ad-hoc queries against their budget data.
-- Consolidate several budget files, including budgets kept in different currencies.
-- Self-host and operate the deployment.
+| Your job | Start here |
+|---|---|
+| Plan or revise a whole year | [Budget Management](../../user-guide/budget-management/) |
+| Seed a new budget or clean up an established one | [Set up and clean up data](../../user-guide/managing-your-data/) |
+| Create complex automation or audit existing rules | [Rules](../../user-guide/rules/) |
+| Compare a downloaded statement with an account | [Bank Reconciliation](../../user-guide/bank-reconciliation/) |
+| Copy selected data between budget files | [Budget Sync](../../user-guide/budget-sync/) |
+| Investigate the contents or health of a budget | [Budget File Tools](../../user-guide/budget-file-tools/) |
+| Ask a custom question of saved budget data | [ActualQL](../../user-guide/actualql/) |
 
 ## What it does not replace
 
-Actual Bench supplements Actual Budget. It is **not** intended to replace:
+Actual Bench is not intended to replace:
 
-- Normal day-to-day transaction entry.
-- Reconciliation in Actual Budget.
-- Everyday mobile budgeting.
+- Everyday transaction entry and mobile budgeting in Actual.
+- Actual's normal budget views and reports.
+- Actual's own bank-sync and day-to-day reconciliation experience. Actual Bench adds a separate,
+  statement-driven workbench for cases where you want to import and audit a complete statement.
 - The official Actual Budget documentation.
 
-## Main workspaces
+## Why the workflows feel different
 
-At a glance, Actual Bench is organized into these areas (each has its own guide):
+The safest interaction depends on the job. Most maintenance work is staged until **Save**; sync and
+statement reconciliation use **Preview/Review → Apply**; diagnostic tools are read-only; notes and
+carryover toggles are explicit immediate writes. [Work safely](../core-concepts/) explains these
+patterns in a few minutes.
 
-- **Budget Overview** — the landing page and navigation hub for a connected budget.
-- **Budget Management** — a spreadsheet-grade 12-month budget editor.
-- **Accounts, Payees, Categories, and Tags** — dedicated master-data admin pages, each focused on what
-  Actual Bench adds over Actual Budget (bulk actions, CSV, usage visibility).
-- **Schedules** — recurring and one-time planned transactions.
-- **Rules** and **Rule Diagnostics** — build rules, and lint your rule set for problems.
-- **ActualQL** — a query console for advanced analysis.
-- **Budget File Health and Data Browser** — read-only inspection of exported budget snapshots.
-- **Budget Sync and FX Rates** — sync data between budgets and manage currency conversion.
-- **App Health** — diagnostics for Actual Bench's own metadata storage.
+## What you need
 
-## How it connects to Actual Budget
+- An existing Actual Server and a modern browser.
+- An Actual Bench installation, or the [live demo](https://actual-bench-demo.vercel.app) for evaluation.
+- `actual-http-api` only when your installation uses HTTP API Server mode.
 
-Actual Bench can connect to your budget in two ways:
-
-- **Direct Actual Server mode** — connects to your Actual Server and runs Actual's engine in your
-  browser. This is the target architecture for new browser-based workflows.
-- **HTTP API Server mode** — connects through a separate [actual-http-api](https://github.com/jhonderson/actual-http-api)
-  server. This remains fully supported for deployments and integrations that prefer or require it.
-
-The two modes differ in networking requirements and in a few capabilities. See
-[Connect to Actual Budget](../connecting/) for a full comparison and step-by-step setup.
-
-## Safety philosophy
-
-Actual Bench is built around reviewing changes before they reach your budget. You will encounter a few
-distinct patterns:
-
-- **Staged editing** — most changes stay local until you click **Save**.
-- **Immediate-save exceptions** — a few actions (such as editing notes) save right away.
-- **Preview and Apply** — Budget File Sync previews a run and writes only the items you select.
-- **Read-only inspection** — Budget File Health and the Data Browser never write to your budget.
-- **Confirmation dialogs** — destructive actions show their impact before you commit.
-
-[Core Concepts](../core-concepts/) explains each pattern in detail. It is worth reading before you make
-larger changes.
-
-## What you need before starting
-
-- A running [Actual Budget](https://github.com/actualbudget/actual) server.
-- A modern browser.
-- A supported way to run Actual Bench, such as Docker (see [Installation](../installation/)).
-- An [actual-http-api](https://github.com/jhonderson/actual-http-api) instance **only** if you plan to
-  use HTTP API Server mode.
-
-## Recommended learning path
-
-1. [Install Actual Bench](../installation/).
-2. [Connect to Actual Budget](../connecting/).
-3. Read [Core Concepts](../core-concepts/).
-4. Make a small edit and Save it.
-5. Explore the feature guides in the **User Guide** section.
+Ready to use your own budget? [Install Actual Bench](../installation/) and then
+[connect to a budget](../connecting/).

--- a/docs-site/src/content/docs/help/glossary.mdx
+++ b/docs-site/src/content/docs/help/glossary.mdx
@@ -71,8 +71,10 @@ included.
 - **Rate override** — a manually entered rate for a specific date.
 - **Locked rate** — a rate captured at first sync that won't silently change.
 - **Immutable rate snapshot** — the stored rate and amounts kept with a converted transaction.
-- **Vault** — the encrypted store for unattended-sync credentials.
-- **`SYNC_VAULT_KEY`** — the environment secret that enables and encrypts that vault.
+- **Remembered-server vault** — optional saved server credentials encrypted with a user passphrase.
+- **Unattended-sync vault** — optional HTTP API credentials encrypted for server-side scheduled sync.
+- **`SYNC_VAULT_KEY`** — the operator environment secret that enables and encrypts the unattended-sync
+  vault; it is unrelated to the remembered-server passphrase.
 - **Unattended sync** — safe-only server-side sync that runs with the app closed (HTTP API mode).
 - **Auto-pause** — a flow automatically pausing after repeated failed automated runs.
 

--- a/docs-site/src/content/docs/help/known-limitations.mdx
+++ b/docs-site/src/content/docs/help/known-limitations.mdx
@@ -12,8 +12,8 @@ a roadmap and includes no delivery promises.
 ## Product scope
 
 - **Actual Bench does not replace everyday budgeting.** It supplements Actual Budget for administration,
-  cleanup, diagnostics, queries, and cross-budget sync — not day-to-day transaction entry or
-  reconciliation.
+  cleanup, statement-driven reconciliation, diagnostics, queries, and cross-budget sync—not day-to-day
+  transaction entry, mobile budgeting, or Actual's normal bank-sync workflow.
 
 ## Connection modes
 
@@ -40,9 +40,9 @@ Server executions, not Direct mode.
 
 **Applies to:** the "Remember this server" option.
 
-Remembered secrets are stored in the server's metadata database, so the option is **only offered when
-that database is durable** (a mounted `/data` volume). On an ephemeral runtime such as the public demo,
-it is hidden.
+Remembered secrets are stored in the server's metadata database and survive only when `/data` is
+persistent. The public demo disables remembering. Self-hosters must verify their volume mount; a
+writable container directory is not enough to survive container replacement.
 
 ### A forgotten passphrase can't be recovered
 
@@ -108,7 +108,8 @@ Not currently in scope:
 
 - True Actual **transfer-linked** sync (same-budget flows use a plain copy).
 - **Automatic (non-review) target deletes** — deletion is always review-first.
-- **Category auto-create** during sync.
+- Transaction-flow **category auto-create**. Dedicated Category flows can create missing categories
+  under a placeable target group.
 - **Fuzzy duplicate auto-mapping** — only exact duplicates can be auto-mapped (opt-in); fuzzy duplicates
   always go to the review queue.
 

--- a/docs-site/src/content/docs/help/troubleshooting.mdx
+++ b/docs-site/src/content/docs/help/troubleshooting.mdx
@@ -63,9 +63,13 @@ Redact secrets before sharing any logs.
 
 ## Browser state
 
-- **Saved preset but must re-enter secrets** — expected: secrets are held in memory only and are never
-  saved.
-- **Refresh requires reconnecting** — expected, for the same reason.
+- **Recent connection but must re-enter secrets** — expected for non-secret recent connection details;
+  use the optional remembered-server vault if you want encrypted reconnect credentials.
+- **Remembered servers remain but the vault is locked** — expected after an Actual Bench restart;
+  unlock it with the vault passphrase.
+- **Remembered servers disappeared** — the metadata database or `/data` volume was replaced. Ask the
+  operator to verify the deployment and restore a backup if one exists.
+- **Refresh requires reconnecting** — expected for memory-only connections.
 - **Stale worker/cache in Direct mode** — as a last resort, clear this site's browser data. This removes
   saved presets and cached worker state and requires reconnecting.
 
@@ -75,6 +79,8 @@ Redact secrets before sharing any logs.
   error, with a retry option.
 - **A note "won't discard"** — notes save immediately and are not part of the staged Save. See
   [Core Concepts](../../getting-started/core-concepts/#immediate-save-exceptions).
+- **A carryover toggle is not in Draft Changes** — carryover is an explicit immediate write, not a
+  staged budget-cell edit.
 - **Wrong budget affected** — confirm the active connection before saving; staged data is scoped per
   connection.
 

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,85 +1,100 @@
 ---
 title: Actual Bench documentation
-description: Learn how to install, connect, use, and self-host Actual Bench — the advanced admin, budgeting, diagnostics, and ActualQL workbench for Actual Budget.
+description: Explore the main tools Actual Bench adds for advanced budgeting, administration, reconciliation, synchronization, and analysis.
 template: splash
 hero:
-  tagline: The advanced admin, budgeting, diagnostics, and query workbench for Actual Budget. Inspect, repair, seed, audit, and reshape your budget data — with every change staged until you Save.
+  tagline: Advanced tools for Actual Budget. See the full year clearly, manage budget data in bulk, audit rules, reconcile statements, sync budget files, and investigate the details.
   image:
     file: ../../assets/actual-bench-icon.png
     alt: Actual Bench
   actions:
-    - text: Get started
-      link: /actual-bench/getting-started/introduction/
+    - text: Explore the main functions
+      link: '#main-functions'
       icon: right-arrow
-    - text: View on GitHub
-      link: https://github.com/x-rous/actual-bench
+    - text: Try the live demo
+      link: https://actual-bench-demo.vercel.app
       icon: external
       variant: minimal
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+Actual Budget remains the place for everyday budgeting and transaction entry. **Actual Bench** is the
+independent companion you open when a larger job becomes slow, repetitive, difficult to inspect, or
+risky to do one item at a time.
+
 :::note[Independent companion app]
-Actual Bench is an independent companion application for [Actual Budget](https://actualbudget.org/). It is **not** the official Actual Budget application or official Actual Budget documentation, and it does not replace normal day-to-day transaction entry in Actual Budget.
+Actual Bench is not the official Actual Budget application or documentation. It connects to an
+existing Actual Server and adds focused administration, planning, audit, and data tools.
 :::
 
-## What Actual Bench helps you do
+## Main functions
 
 <CardGrid>
-	<Card title="Manage & clean up data" icon="list-format">
-		Bulk-edit accounts, payees, categories, schedules, tags, and rules with filters, inline editing, and impact-aware confirmations.
+	<Card title="Full-year Budget Workspace" icon="setting">
+		See 12 consecutive months in a focused Budget, Actuals, or Balance view. This gives Envelope and especially Tracking users a clearer throughout-the-year perspective, plus spreadsheet-style editing when needed.
+		[Explore the Budget Workspace →](/actual-bench/user-guide/budget-management/)
 	</Card>
-	<Card title="Edit a full-year budget" icon="setting">
-		A spreadsheet-grade 12-month budget workspace with multi-cell selection, copy/paste, fill actions, and a draft review panel.
+	<Card title="Data Management" icon="list-format">
+		Bulk-create, merge, reorganize, import, export, and audit accounts, payees, categories, schedules, tags, and rules—with staged review before Save.
+		[Manage budget data →](/actual-bench/user-guide/managing-your-data/)
 	</Card>
-	<Card title="Build & diagnose rules" icon="approve-check">
-		Create, merge, and lint Actual Budget rules with resolved entity names, templates, and formulas.
+	<Card title="Rules and Rule Diagnostics" icon="approve-check">
+		Build advanced rules with readable references, then audit the entire rule set for broken references, overlaps, broad matches, and duplicates.
+		[Build and audit rules →](/actual-bench/user-guide/rules/)
 	</Card>
-	<Card title="Query with ActualQL" icon="magnifier">
-		Run, explain, save, and export ActualQL queries with table, JSON, scalar, and tree result views.
+	<Card title="Bank Reconciliation" icon="check-circle">
+		Import a complete statement, match it conservatively against one account, decide the differences, and apply only the changes you reviewed.
+		[Explore Bank Reconciliation →](/actual-bench/user-guide/bank-reconciliation/)
 	</Card>
-	<Card title="Inspect budget files" icon="seti:db">
-		Open exported budget snapshots locally in the browser for read-only health checks and SQLite data browsing.
+	<Card title="Budget File Sync and FX Rates" icon="random">
+		Create saved, preview-first flows for transactions, payees, and categories, including controlled conversion between budgets kept in different currencies.
+		[Explore Budget File Sync →](/actual-bench/user-guide/budget-sync/)
 	</Card>
-	<Card title="Sync & convert currencies" icon="random">
-		Sync data between budget files as preview-first flows, including multi-currency conversion with managed FX rates.
+	<Card title="ActualQL and Budget File Tools" icon="magnifier">
+		Query saved budget data, inspect an exported file, run structural health checks, or browse its SQLite tables without writing anything back.
+		[Explore analysis and diagnostics →](/actual-bench/user-guide/budget-file-tools/)
 	</Card>
 </CardGrid>
 
-## Who Actual Bench is for
+## How it complements Actual Budget
 
-Actual Bench is aimed at **Actual Budget power users** and **self-hosting administrators**:
+| Area | What Actual Budget already does well | What Actual Bench adds |
+|---|---|---|
+| Budgeting | A compact working view with Budget, Spent, and Balance together for up to six months | A focused 12-month Budget, Actuals, or Balance view, annual context, and spreadsheet-style editing |
+| Budget structure | Everyday creation and maintenance inside the budgeting experience | Bulk actions, CSV, duplicate handling, dependency visibility, and staged review |
+| Rules | Executes automation as transactions arrive | Richer authoring plus a whole-rule-set diagnostics pass |
+| Reconciliation | Everyday importing, bank sync, and normal reconciliation | A persistent, statement-driven comparison and correction workflow |
+| Multiple budget files | Keeps each budget independent | Controlled one-way synchronization, mappings, history, review queues, and FX conversion |
+| Investigation | Reports and normal data views | ActualQL, exported-file diagnostics, and read-only SQLite inspection |
 
-- Users managing large or complex budget files.
-- Users who need bulk maintenance and cleanup.
-- Users building advanced rules or running ad-hoc queries.
-- Users consolidating multiple budget files, including across currencies.
-- Administrators running a self-hosted deployment.
+Actual Bench remains a companion, not a replacement. Continue using Actual Budget for everyday
+transaction entry, normal budgeting, reports, bank sync, and mobile use.
 
-## Choose your path
+## How changes reach your budget
+
+Actual Bench uses different safety models for different jobs:
+
+- **Stage → review → Save** for most entity and budget edits.
+- **Preview → select → Apply** for Budget File Sync and Bank Reconciliation.
+- **Read-only** for ActualQL, Rule Diagnostics, Budget File Health, and the Data Browser.
+- **Immediate explicit actions** for notes and carryover toggles.
+
+The relevant guide states its write model before its instructions. Read [Work safely](/actual-bench/getting-started/core-concepts/)
+for the complete model.
+
+## Start using it
 
 <CardGrid>
-	<LinkCard title="New here? Start with the Introduction" href="/actual-bench/getting-started/introduction/" description="What Actual Bench is, how it connects, and the safety model — then install and connect." />
-	<LinkCard title="Install Actual Bench" href="/actual-bench/getting-started/installation/" description="Run Actual Bench with Docker or Docker Compose." />
-	<LinkCard title="Connect to Actual Budget" href="/actual-bench/getting-started/connecting/" description="Choose Direct Actual Server mode or HTTP API Server mode and open a budget." />
-	<LinkCard title="Understand core concepts" href="/actual-bench/getting-started/core-concepts/" description="Staged edits, the Save model, connection scoping, and where data lives." />
+	<LinkCard title="See whether it fits" href="/actual-bench/getting-started/introduction/" description="A short guide to who benefits, what Actual Bench complements, and where it adds value." />
+	<LinkCard title="Try the demo" href="https://actual-bench-demo.vercel.app" description="Explore realistic Envelope and Tracking household budgets without connecting your own data." />
+	<LinkCard title="Install Actual Bench" href="/actual-bench/getting-started/installation/" description="Run the container and keep its metadata persistent." />
+	<LinkCard title="Connect a budget" href="/actual-bench/getting-started/connecting/" description="Choose the connection mode your installation supports and open a budget." />
 </CardGrid>
 
-## How Actual Bench keeps changes safe
-
-Most work in Actual Bench is deliberate and reversible before it reaches your budget:
-
-- **Staged changes** — most creates, edits, and deletes stay local until you click **Save**; a Draft Changes panel shows what is pending, with undo and redo.
-- **Preview before apply** — Budget File Sync produces a dry-run preview and only writes the items you select.
-- **Impact-aware confirmations** — destructive actions show transaction counts, rule references, and other impact before you commit.
-- **Read-only inspection** — Budget File Health and the Data Browser never write back to your budget.
-
-Some specific actions (such as editing notes) save immediately — see [Core Concepts](/actual-bench/getting-started/core-concepts/) for the full model.
-
-## Project & support links
+## Project and support
 
 - [GitHub repository](https://github.com/x-rous/actual-bench)
 - [Releases](https://github.com/x-rous/actual-bench/releases)
 - [Issue tracker](https://github.com/x-rous/actual-bench/issues)
-- [Live demo](https://actual-bench-demo.vercel.app) — shared `Live Demo - Envelope` and `Live Demo - Tracking` household budgets with 13 months of history that reset periodically
-- [Actual Budget](https://actualbudget.org/) · [actual-http-api](https://github.com/jhonderson/actual-http-api)
+- [Actual Budget](https://actualbudget.org/)

--- a/docs-site/src/content/docs/user-guide/accounts.mdx
+++ b/docs-site/src/content/docs/user-guide/accounts.mdx
@@ -5,11 +5,14 @@ sidebar:
   order: 3
 ---
 
-The Accounts page manages your accounts, their balances, and their budget type. It shares the
-[master-data editing model](../managing-your-data/) (inline edit, staged rows, bulk actions, CSV,
-Usage Inspector) — this page covers what's specific to accounts.
+Use **Accounts** when you are seeding several accounts, closing or reopening a group of old accounts,
+or checking balances and dependencies before removing one. Actual Bench adds bulk setup and an impact
+preview; normal transaction work still belongs in Actual.
 
-Open **Accounts** from the **Data Management** section of the sidebar.
+**Write model:** stage → review → **Save**. Account notes save immediately.
+
+It shares the [master-data editing model](../managing-your-data/). Open **Accounts** from **Data
+Management**.
 
 ## What you get beyond Actual Budget
 

--- a/docs-site/src/content/docs/user-guide/actualql.mdx
+++ b/docs-site/src/content/docs/user-guide/actualql.mdx
@@ -5,19 +5,26 @@ sidebar:
   order: 10
 ---
 
-The ActualQL workspace lets you run arbitrary ActualQL queries against the open budget for advanced
-analysis. Open it from **ActualQL Queries** under the **Tools** sidebar section (`/query`). It works in
-both Direct Actual Server mode and HTTP API Server mode.
+Use **ActualQL** when you have a precise question that Actual's normal reports do not answer—for
+example, a targeted transaction subset, an aggregate by month, or a cleanup check. It is best suited to
+people comfortable editing structured JSON; start from the built-in examples rather than a blank page.
+
+**Write model:** read-only. Queries see saved server state, not unsaved drafts.
+
+Open **ActualQL Queries** under **Tools**. It works in both connection modes.
+
+## Get an answer quickly
+
+1. Open **Examples** and choose the closest question.
+2. Adjust its table, fields, filters, or dates.
+3. Select **Explain** to check your intent without running it.
+4. Select **Run**, then choose Table, Raw JSON, Scalar, or Tree.
+5. Save a useful query or export the result.
 
 ## What ActualQL is
 
 ActualQL is Actual Budget's query language, expressed as **JSON** (not SQL). In Actual Bench this
 workspace is used for reading and analyzing data.
-
-:::note[Read-only from Actual Bench's side]
-Running a query does not stage or write anything. Results reflect **saved server state**, not your
-unsaved staged edits.
-:::
 
 ## Open the workspace and understand the editor
 

--- a/docs-site/src/content/docs/user-guide/bank-reconciliation.mdx
+++ b/docs-site/src/content/docs/user-guide/bank-reconciliation.mdx
@@ -1,25 +1,48 @@
 ---
 title: Bank Reconciliation
-description: Check a bank statement against an account in Actual — import CSV/TSV, OFX/QFX or QIF, match, decide, review, apply — with amount-exact matching, bank provenance kept apart from your curated payees and notes, and a drift check that protects edits made in Actual meanwhile.
+description: Import a bank statement, compare it with one Actual account, decide the differences, and apply only the changes you reviewed.
 sidebar:
   order: 15
 ---
 
-The **Bank Reconciliation** workbench checks a bank statement against one account in your budget and
-helps you settle the differences. Open it from **Bank Reconciliation** under the **Tools** sidebar
-section (`/reconciliation`).
+Use **Bank Reconciliation** when you have a complete downloaded statement and want to prove that one
+Actual account agrees with it—especially when bank sync is unavailable, a period needs auditing, or
+you expect missing, duplicate, or incorrect transactions.
 
-Sessions are persistent: import a statement today, work through it over several sittings, and apply
-when you are ready. **Nothing is written to your budget until you press Apply**, and the review screen
-names the work precisely: staged *changes* are counted separately from bank-detail writes that only
-record the statement's merchant text as an imported payee. A fully matched statement therefore does
-not present a screenful of provenance as unexplained edits to your payees or notes.
+Actual Bench adds persistent sessions, conservative amount-first matching, row-by-row decisions, a
+review of the exact writes, and a final drift check. It complements Actual's everyday import and
+reconciliation tools; it does not replace routine transaction entry.
+
+**Write model:** decide → review → **Apply**. Nothing is written before Apply. Categories are never
+read or written by this workflow.
+
+Open **Bank Reconciliation** under **Tools** (`/reconciliation`).
+
+## The workflow in five steps
+
+1. **Start** a session for one account and optionally give it a memorable tag.
+2. **Import** a CSV/TSV, OFX/QFX, or QIF statement and verify the parsed dates, amounts, payee text,
+   and notes.
+3. **Reconcile** each row: accept a match, choose another candidate, create a missing transaction,
+   correct an amount, delete a duplicate, or leave it undecided.
+4. **Review** the account-balance effect, clearing choice, bank-text writes, and every planned change.
+5. **Apply**. Actual Bench re-reads affected transactions first, writes what is still safe, and keeps
+   failures available for retry.
+
+Sessions survive browser sessions, so you can stop between steps. Once applied, the session becomes an
+audit record and does not offer the same writes again.
 
 :::note[Reconciliation does not touch categories]
 It never reads, stages, or writes a transaction's category. Categorisation belongs in Actual, where
 your rules and your own judgement live. A reconciliation that quietly blanked categories would undo
 work this tool has no business undoing.
 :::
+
+The rest of this page is detailed reference. For a first reconciliation, follow the five steps above
+and use the relevant section only when a choice needs explanation.
+
+<details>
+<summary>Sessions and detailed statement-import behavior</summary>
 
 ## Where a session is up to
 
@@ -190,6 +213,11 @@ Save how a statement is read — column mapping, date and amount conventions, pa
 the matching options for an account as a **profile**, and apply it next month in one click.
 Statements from the same bank rarely change shape.
 
+</details>
+
+<details>
+<summary>Matching evidence, safeguards, decisions, and note transformations</summary>
+
 ## 2. Matching
 
 Matching is deliberately conservative, and the reason is worth stating: **an exact signed amount is
@@ -276,6 +304,8 @@ A transformation can be applied to many rows at once and previewed before it is 
   `| dinner with Ahmad` both survive. Where no such run can be identified, the note is left alone and
   you are told why, rather than guessed at.
 
+</details>
+
 ## 4. Review
 
 The review screen shows, statement row by statement row, what each will look like in your budget
@@ -298,6 +328,9 @@ It also states:
   during Import are stated here rather than changed after transformations have already used them.
 - **Whether matched transactions gain the bank's merchant text** — **On new and matched rows** or
   **On new rows only** — see below.
+
+<details>
+<summary>Exact field behavior for imported payee, payee, and notes</summary>
 
 ### What actually gets written
 
@@ -345,7 +378,16 @@ Once Apply starts, **Record the bank's merchant text** and **Mark as cleared** a
 reopened applied or partially applied reconciliation, they show what was executed and cannot be
 changed.
 
+</details>
+
 ## 5. Apply
+
+Apply first re-reads every affected transaction. Safe rows are written, changed or conflicting rows
+are held back, partial successes are recorded honestly, and **Retry what failed** attempts only the
+unfinished work.
+
+<details>
+<summary>Drift handling, idempotent writes, rules, and post-write verification</summary>
 
 ### The drift check
 
@@ -392,6 +434,8 @@ Once the writes are done, the account is read back and compared against what you
 transactions are present and present *once*, updated fields hold the approved values, deleted rows are
 gone, split parents still add up, and nothing reconciled in Actual moved. A transport can report
 success for a field it quietly dropped, so this is confirmed rather than assumed.
+
+</details>
 
 ## What is stored, and where
 

--- a/docs-site/src/content/docs/user-guide/budget-file-tools.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-file-tools.mdx
@@ -5,11 +5,26 @@ sidebar:
   order: 11
 ---
 
-Budget File Tools are **read-only** diagnostics for the exported budget snapshot: **Budget File Health**
-(metadata and health checks) and the **Data Browser** (raw SQLite tables and rows). Both process the
-snapshot **locally in your browser** and never write anything back to your budget.
+Use **Budget File Tools** when you suspect a file-level problem, need evidence for a support issue, or
+want to inspect data that normal Actual screens do not expose. These are advanced investigation tools,
+not part of everyday budgeting.
+
+**Write model:** strictly read-only. Both tools inspect an exported snapshot locally in your browser
+and never write it back to Actual.
 
 Open **Budget File Health** and **Data Browser** from the **Tools** sidebar section.
+
+## Choose the right tool
+
+| Your question | Use |
+|---|---|
+| Is this exported file structurally healthy? | **Budget File Health** |
+| What does the snapshot contain and how large is it? | **Budget File Health → Overview** |
+| What rows and columns exist in a table? | **Data Browser** |
+| I need a reusable query against live saved data | [ActualQL](../actualql/) |
+
+Start with Budget File Health. Open the Data Browser only when a diagnostic or investigation requires
+table-level detail.
 
 :::caution[Snapshots contain your financial data]
 An exported snapshot can include personal financial information. Processing happens locally in your

--- a/docs-site/src/content/docs/user-guide/budget-management.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-management.mdx
@@ -1,21 +1,40 @@
 ---
 title: Budget Management
-description: Edit a full-year budget in Actual Bench's spreadsheet-grade workspace — cells, multi-cell selection, fill actions, envelope and tracking modes, notes, and CSV import/export.
+description: See and edit a full year in focused Budget, Actuals, or Balance views, with model-aware context and spreadsheet-grade tools.
 sidebar:
   order: 1
 ---
 
-Budget Management is a full-width, 12-month budget editor for both envelope and tracking budgets. It
-behaves like a spreadsheet: select ranges, paste from Excel or Google Sheets, fill values, and review
-everything in a draft panel before you **Save**.
+Use **Budget Management** when you need to understand the year as a whole, not only work inside a
+compact month-to-month budget view. Actual Budget can display up to six months and shows Budget,
+Spent, and Balance together. That is useful for everyday budgeting, but it can be difficult to scan
+one measure across an entire year.
+
+Actual Bench shows 12 consecutive months and lets the whole grid focus on **Budget**, **Actuals**, or
+**Balance**. The separation is especially valuable for Tracking budgets, where seeing the annual plan,
+actual activity, running balance, and model-specific variance in context matters more than envelope
+availability. Spreadsheet-style selection, paste, fill, and staged editing are available when you want
+to revise the plan—not just inspect it.
+
+**Write model:** budget amounts, holds, and transfers are staged until **Save**. Notes and carryover
+toggles are explicit immediate writes.
 
 Open it from the **Budget** item in the sidebar (under **Data Management**), or go to
 `/budget-management`.
 
-:::note[Staged like the rest of the app]
-Budget cell edits are staged locally and only written to your Actual Server when you **Save**. See
-[Core Concepts](../../getting-started/core-concepts/) for the staging model.
-:::
+## Get the full-year view
+
+1. Confirm the **Envelope** or **Tracking** badge matches your budget.
+2. Choose **Budget**, **Actuals**, or **Balance** to focus the entire 12-month grid on one measure.
+3. Scan category and group rows across the year; use the details panel for the selected period and the
+   KPIs that belong to your budget model.
+4. If you need to revise the plan, edit a cell, paste a range, or use a fill action.
+5. Review the pending changes and select **Save** when the staged draft is ready.
+
+Everything below is reference for working faster or using model-specific actions.
+
+<details>
+<summary>Understand the workspace, budget models, and cell views</summary>
 
 ## Understand the workspace
 
@@ -73,6 +92,11 @@ amber as you approach the limit, and adding a red segment when you go over. A ce
 funding shows a distinct red bar. The exact spent and balance numbers stay in the cell's hover tooltip and
 the details panel. Turn the bars off or on with the **Spending Bars** toggle in the toolbar (on by
 default); income rows never show a bar.
+
+</details>
+
+<details>
+<summary>Navigate, select, paste, fill, and use bulk actions</summary>
 
 ## Navigate months and years
 
@@ -138,8 +162,11 @@ Right-click a category budget cell for a context menu:
 - **Set Budget**: Copy previous month, Copy specific month…, Set to zero, Set to fixed amount…, Apply
   % change…, and 3-, 6-, or 12-month averages (averages use each prior month's **budgeted** amount).
 
-No-input actions run immediately as one undo step; actions that need input open a two-step
-(parameters → preview) dialog.
+Budget-setting actions stage as one undo step; actions that need input open a two-step
+(parameters → preview) dialog. Carryover is the exception: its explicit toggle writes directly and
+reports its result immediately.
+
+</details>
 
 ## Review staged changes and Save
 
@@ -151,6 +178,9 @@ No-input actions run immediately as one undo step; actions that need input open 
 - Partial failures are reported with a **Retry Failed** option; only changes the server accepted are
   cleared.
 - Undo/redo works across staged edits (`Ctrl/Cmd+Z`, `Ctrl/Cmd+Shift+Z` / `Ctrl+Y`), up to 50 steps.
+
+<details>
+<summary>Notes, Envelope and Tracking actions, import/export, and shortcuts</summary>
 
 ## Use notes
 
@@ -175,7 +205,8 @@ Holds and transfers are envelope-mode only.
 
 In tracking mode the workspace uses planning language rather than envelope balances. Past months show
 actual performance, the current month is marked partial, and future months show budgeted context
-instead of a zero-actual result. Rollover (carryover) is toggled per category from the right-click menu.
+instead of a zero-actual result. Rollover (carryover) is toggled per category from the right-click menu
+and writes immediately after the explicit action; it is not part of the staged cell draft.
 
 ## Import and export
 
@@ -197,10 +228,12 @@ Press `?` (or `F1`, `Ctrl/Cmd+/`, or the toolbar **Shortcuts** button) to open t
 generated from the app's keymap. Bare-letter shortcuts (`V`, `F`, `H`, `E`, `[`, `]`) don't fire while
 you're typing in a cell.
 
+</details>
+
 ## Safety and limitations
 
-- Rollover (carryover) is toggled via the right-click menu (tracking mode); it is shown but not directly
-  editable as a grid cell.
+- Rollover (carryover) is an immediate explicit write through the right-click menu (tracking mode); it
+  is not a staged grid-cell edit.
 - Category-to-pool transfers (omitting a source or destination category) are not supported.
 - The grid is not virtualized, so very large category lists may scroll more slowly.
 

--- a/docs-site/src/content/docs/user-guide/budget-sync.mdx
+++ b/docs-site/src/content/docs/user-guide/budget-sync.mdx
@@ -5,12 +5,29 @@ sidebar:
   order: 12
 ---
 
-Budget File Sync copies data between budget files as saved, one-way **flows**. One unified engine covers
-**transactions, payees, and categories**, so preview, apply, run history, the review queue, and the
-safe-only automation layer work the same way for each. It is **preview-first** and conservative by
-default (**create-only**), with opt-in advanced modes that never write silently.
+Use **Budget File Sync** when you deliberately keep separate budget files but need selected
+transactions, payees, or categories to move between them—for example household consolidation,
+business/personal separation, an archive, or budgets kept in different currencies.
+
+Actual Bench adds saved one-way **flows**, a dry-run preview, durable mappings, history, and a review
+queue. It does not try to make two Actual files behave like one live database.
+
+**Write model:** Preview never writes. Only an explicit **Apply**, or an opted-in safe-only automation
+policy, writes classified safe items. Uncertain rows remain for review.
 
 Open it from **Budget File Sync** under the **Tools** sidebar section (`/sync`).
+
+## Get the first flow working
+
+1. Create a flow and choose Transactions, Payees, or Categories.
+2. Pick one source and one target; choose accounts for a transaction flow.
+3. Keep the conservative create-only defaults for the first run.
+4. Select **Preview** and read the row classifications.
+5. Select only safe **New** rows and **Apply**.
+6. Preview again to confirm they now appear as **Already synced**.
+
+Add updates, deletion review, currency conversion, or automation only after that basic loop behaves as
+you expect.
 
 ## The safety model
 
@@ -45,6 +62,9 @@ A source and target on the same budget is allowed for transaction flows (between
 accounts); entity flows require two different budgets. A true self-sync (same account on both sides) is
 blocked.
 
+<details>
+<summary>Transaction filters, transforms, and entity-flow behavior</summary>
+
 ## Transaction flow settings
 
 ### Filters
@@ -73,6 +93,8 @@ blocked.
   review** unless you enable **create missing groups**. Income and expense categories stay distinct.
 - **No renames, deletes, or hides** — create-only. Mappings let reruns skip already-synced entities.
 
+</details>
+
 ## Preview a flow
 
 Select **Preview** to produce a dry-run. Each row is classified. The exact labels you'll see:
@@ -98,6 +120,9 @@ Select the safe **New** rows and **Apply**:
 - Only the selected safe items are written; each create is stamped with a durable target-side marker
   (`imported_id`), and an app-owned **mapping** is recorded immediately after each success.
 - Partial failures are reported and never lose earlier successes.
+
+<details>
+<summary>Mappings, updates, deletion review, retries, and flow portability</summary>
 
 ### Mappings and idempotency
 
@@ -139,6 +164,11 @@ retry, and act on changes.
   connections on import.
 - **Export a run's audit** to CSV.
 
+</details>
+
+<details>
+<summary>Automation, flow health, and target-rule behavior</summary>
+
 ## Automation (opt-in)
 
 Each flow has a **review policy**:
@@ -178,11 +208,15 @@ Because Actual Budget rules run when a transaction is created, an applied target
 from the preview (payee, category, notes, or cleared state). Actual Bench surfaces this as a **warning**,
 not an error.
 
+</details>
+
 ## Limitations
 
 Not in scope: true Actual transfer-linked sync (same-budget uses a plain copy), automatic (non-review)
-target deletes, category auto-create, fuzzy duplicate auto-mapping, unattended sync for **Direct**-mode
-flows, FX gain/loss accounting, and multi-currency within a single budget file. See
+target deletes, transaction-flow category auto-creation, fuzzy duplicate auto-mapping, unattended sync
+for **Direct**-mode flows, FX gain/loss accounting, and multi-currency within a single budget file. A
+dedicated **Category** flow can create missing categories under an existing, selected, or explicitly
+created group. See
 [Known Limitations](../../help/known-limitations/).
 
 ## Troubleshooting

--- a/docs-site/src/content/docs/user-guide/bundle-export-import.mdx
+++ b/docs-site/src/content/docs/user-guide/bundle-export-import.mdx
@@ -5,14 +5,16 @@ sidebar:
   order: 14
 ---
 
-Bundle Export / Import moves **all six master-data types at once** — Accounts, Payees, Categories &
-Groups, Tags, Schedules, and Rules — as a single ZIP. It's the fastest way to snapshot a whole budget's
-structure or seed a new budget from an existing one.
+Use **Bundle Export / Import** when you want a reusable budget template, need to seed a new budget from
+an existing structure, or want one portable snapshot of all master data before a large cleanup.
+
+It moves Accounts, Payees, Categories & Groups, Tags, Schedules, and Rules as one ZIP. **Export is
+read-only; Import stages everything for review and writes only when you Save.**
 
 Open it from the **Export** / **Import** buttons in the [Budget Overview](../../getting-started/budget-overview/)
 page header.
 
-## What you get beyond Actual Budget
+## Why use a bundle?
 
 Actual Budget has no single "export all my structure" action. Bundle Export / Import adds:
 

--- a/docs-site/src/content/docs/user-guide/categories.mdx
+++ b/docs-site/src/content/docs/user-guide/categories.mdx
@@ -5,11 +5,14 @@ sidebar:
   order: 5
 ---
 
-The Categories page manages income and expense category groups, the categories inside them,
-visibility, and hierarchy. It shares the [master-data editing model](../managing-your-data/) — this
-page covers what's specific to categories.
+Use **Categories** when you are designing a new category structure, importing one from a spreadsheet,
+changing visibility in bulk, or checking the cascade before deleting a group. Actual Bench makes the
+whole hierarchy visible and reviewable at once.
 
-Open **Categories** from the **Data Management** section of the sidebar.
+**Write model:** stage → review → **Save**. Category and group notes save immediately.
+
+It shares the [master-data editing model](../managing-your-data/). Open **Categories** from **Data
+Management**.
 
 ## What you get beyond Actual Budget
 

--- a/docs-site/src/content/docs/user-guide/fx-rates.mdx
+++ b/docs-site/src/content/docs/user-guide/fx-rates.mdx
@@ -5,15 +5,24 @@ sidebar:
   order: 13
 ---
 
-When you consolidate budgets kept in **different currencies**, Actual Bench converts transaction amounts
-during sync. The **FX Rates** page manages the exchange rates it uses. Open it from **FX Rates** under
-the **Tools** sidebar section (`/fx-rates`).
+Use **FX Rates** only when a transaction [Budget Sync](../budget-sync/) flow moves money between budget
+files kept in different currencies. It is not a general currency feature and does not add
+multi-currency accounts to one Actual budget.
 
-:::note[FX applies to cross-currency sync, not single-file multi-currency]
-Currency conversion is part of transaction [Budget Sync](../budget-sync/) between budgets configured
-with different currencies. Actual Bench does not add multi-currency accounts inside a single Actual
-budget file.
-:::
+Actual Bench adds date-specific rates, missing-rate coverage, manual overrides, and immutable audit
+snapshots so a later market-rate change cannot silently rewrite past conversions.
+
+**Write model:** changing the rate registry writes Actual Bench metadata. Actual transactions change
+only through a separately previewed and applied sync update.
+
+Open **FX Rates** under **Tools** after you have configured a converting flow.
+
+## Get a converting flow ready
+
+1. Enable **Convert currency** on a transaction flow and choose its source and target currencies.
+2. Open **FX Rates** and inspect coverage for that pair and date range.
+3. Fill gaps from Frankfurter, import rates, or set a deliberate override.
+4. Preview the flow and verify the original amount, rate, and converted amount before Apply.
 
 ## When currency conversion is used
 

--- a/docs-site/src/content/docs/user-guide/managing-your-data.mdx
+++ b/docs-site/src/content/docs/user-guide/managing-your-data.mdx
@@ -5,9 +5,14 @@ sidebar:
   order: 2
 ---
 
-Accounts, Payees, Categories, and Tags are Actual Bench's **master-data** pages, opened from the
-**Data Management** section of the sidebar. They share one editing model, so this page explains it
-once — each entity's own guide then focuses on what it adds over Actual Budget.
+Use these pages when you are setting up a budget, cleaning up years of imported names, reorganizing
+its structure, or auditing what depends on an entity before you change it. Actual Budget is excellent
+for everyday maintenance; Actual Bench adds the bulk and review tools for a larger cleanup pass.
+
+Accounts, Payees, Categories, and Tags share one editing model. This page is the shortest route to
+understanding it; the entity references cover only their special cases.
+
+**Write model:** stage → review → **Save**. Notes are the immediate-save exception.
 
 ## Why manage this data in Actual Bench?
 
@@ -25,6 +30,17 @@ doesn't offer:
 - **Staged review** — creates, edits, and deletes are collected as drafts and only written when you
   **Save**, so you can review a whole cleanup pass before it touches your budget.
 - **Duplicate detection** — name clashes are flagged as you work.
+
+## Start with one cleanup pass
+
+1. Open the entity page that contains the problem.
+2. Filter or search until the affected rows are visible.
+3. Inspect usage before deleting or merging anything important.
+4. Stage the edits or bulk action.
+5. Review **Draft Changes**, then **Save**.
+
+For moving an entire structure in or out, use [Bundle Export / Import](../bundle-export-import/)
+instead of repeating that flow page by page.
 
 ## The shared editing model
 

--- a/docs-site/src/content/docs/user-guide/payees.mdx
+++ b/docs-site/src/content/docs/user-guide/payees.mdx
@@ -5,10 +5,14 @@ sidebar:
   order: 4
 ---
 
-The Payees page manages regular payees and makes transfer payees explicit. It shares the
-[master-data editing model](../managing-your-data/) — this page covers what's specific to payees.
+Use **Payees** when imports have created duplicate names, you need to merge several payees safely, or
+you want to see transaction and rule impact before deleting one. Actual Bench turns that cleanup into
+one staged, reviewable pass instead of a sequence of immediate edits.
 
-Open **Payees** from the **Data Management** section of the sidebar.
+**Write model:** stage → review → **Save**.
+
+It shares the [master-data editing model](../managing-your-data/). Open **Payees** from **Data
+Management**.
 
 ## What you get beyond Actual Budget
 

--- a/docs-site/src/content/docs/user-guide/rule-diagnostics.mdx
+++ b/docs-site/src/content/docs/user-guide/rule-diagnostics.mdx
@@ -5,14 +5,17 @@ sidebar:
   order: 9
 ---
 
-Rule Diagnostics is a **read-only, advisory linter** for your rules — a capability Actual Budget has no
-equivalent for. It never modifies, creates, or deletes anything as a side effect, and it runs entirely
-in the browser against your current working set, **including unsaved staged edits**.
+Use **Rule Diagnostics** when a growing rule set has become hard to trust: references may point at
+deleted entities, broad rules may shadow specific ones, or duplicates may be doing the same work twice.
+Actual runs rules one transaction at a time; this workspace audits the set as a whole.
+
+**Write model:** read-only and advisory. It includes unsaved staged rules, but never modifies anything
+unless you follow a finding into the normal staged rule editor or confirm a merge.
 
 Open **Rule Diagnostics** from the **Tools** sidebar section, or the **Diagnostics** button on the
 Rules toolbar. The URL `/rules/diagnostics` is bookmarkable.
 
-## Why this doesn't exist in Actual Budget
+## What Actual Bench adds
 
 Actual Budget runs rules but gives you no way to audit them in aggregate. As a rule set grows, problems
 accumulate silently — a rule pointing at a deleted category, two rules that quietly shadow each other,

--- a/docs-site/src/content/docs/user-guide/rules.mdx
+++ b/docs-site/src/content/docs/user-guide/rules.mdx
@@ -5,14 +5,22 @@ sidebar:
   order: 8
 ---
 
-Rules automate changes to transactions in Actual Budget. Actual Bench gives you a full condition/action
-builder that shows resolved entity names instead of raw IDs, plus power tools — templates, formulas,
-duplicate merging, and CSV round-trip — that the native rule editor doesn't offer. To *find* problems
-across your rule set, use the separate [Rule Diagnostics](../rule-diagnostics/) linter.
+Use **Rules** when your automation has grown beyond a few simple categorization rules: you need
+readable entity references, advanced actions, bulk import/export, or a safe way to consolidate
+duplicates. Actual still executes the rules; Actual Bench makes the rule set easier to build and audit.
+
+**Write model:** stage → review → **Save**. [Rule Diagnostics](../rule-diagnostics/) is read-only until
+you explicitly open or merge a rule.
 
 Open **Rules** from the **Data Management** sidebar section.
 
-## What you get beyond Actual Budget
+## Start with the job you have
+
+- **Create or edit automation:** use the rule builder below.
+- **Find broken, overlapping, or duplicate rules:** run [Rule Diagnostics](../rule-diagnostics/).
+- **Move or bulk-edit a rule set:** export it to CSV, edit it, then import and review the staged result.
+
+## Why use Actual Bench for rules?
 
 - **Resolved entity names everywhere** — payees, categories, and accounts show as readable chips, and
   search matches them by name, so you never hunt through raw IDs.

--- a/docs-site/src/content/docs/user-guide/schedules.mdx
+++ b/docs-site/src/content/docs/user-guide/schedules.mdx
@@ -5,9 +5,11 @@ sidebar:
   order: 6
 ---
 
-A schedule describes a planned transaction — one-time or recurring — with an amount, timing, and
-optional payee and account. Schedules are staged and written on **Save**, like the rest of Actual
-Bench (see [Core Concepts](../../getting-started/core-concepts/)).
+Use **Schedules** when you need to create or revise several recurring plans, move them through CSV, or
+understand the linked rule and transaction impact before deleting one. Actual Bench adds bulk setup,
+richer recurrence summaries, and staged review around Actual's schedule model.
+
+**Write model:** stage → review → **Save**.
 
 Open **Schedules** from the **Data Management** section of the sidebar.
 

--- a/docs-site/src/content/docs/user-guide/tags.mdx
+++ b/docs-site/src/content/docs/user-guide/tags.mdx
@@ -5,11 +5,14 @@ sidebar:
   order: 7
 ---
 
-Tags are simple labels (with an optional color and description) attached to transactions, available in
-Actual Budget v26.3.0 and later. The Tags page shares the
-[master-data editing model](../managing-your-data/) — this page covers what's specific to tags.
+Use **Tags** when you want to seed or clean up a tag vocabulary rather than add labels transaction by
+transaction. Actual Bench adds bulk creation/deletion, CSV round-trip, color filtering, and visibility
+into rules that reference a tag.
 
-Open **Tags** from the **Data Management** section of the sidebar.
+Tags require Actual Budget v26.3.0 or later. **Write model:** stage → review → **Save**.
+
+The page shares the [master-data editing model](../managing-your-data/). Open **Tags** from **Data
+Management**.
 
 ## What you get beyond Actual Budget
 


### PR DESCRIPTION
## Summary

- reorganize the docs around the main Actual Bench functions and end-user value
- add audience, problem, value, and write-model context to every feature guide
- shorten flagship workflows while keeping advanced reference available through progressive disclosure
- separate end-user guidance from self-hosting reference
- correct stale claims about staging, reconciliation, credential persistence, and sync behavior

## User impact

Actual Budget users can understand what Actual Bench adds, identify its major capabilities, and reach the shortest useful guidance without reading the full technical reference.

## Validation

- `npm --prefix docs-site ci`
- `npm --prefix docs-site run build`
- generated internal page and heading-anchor link check
- `git diff --check`

The docs build generated all 30 pages successfully.