### PR TITLE
Make dialog form controls more compact

### DIFF
--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -2,15 +2,18 @@
 
 import { useState } from "react";
 import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 export function TagInput({
   values,
   onChange,
   placeholder = "Type and press Enter…",
+  compact = false,
 }: {
   values: string[];
   onChange: (v: string[]) => void;
   placeholder?: string;
+  compact?: boolean;
 }) {
   const [input, setInput] = useState("");
 
@@ -27,7 +30,12 @@ export function TagInput({
   }
 
   return (
-    <div className="flex flex-1 flex-wrap items-center gap-1 rounded-md border border-input bg-background px-2 py-1 min-h-8">
+    <div
+      className={cn(
+        "flex min-h-8 flex-1 flex-wrap items-center gap-1 rounded-md border border-input bg-background px-2 py-1",
+        compact && "min-h-7 py-0.5"
+      )}
+    >
       {values.map((v, i) => (
         <span
           key={i}

--- a/src/features/budget-management/components/BudgetExportDialog.tsx
+++ b/src/features/budget-management/components/BudgetExportDialog.tsx
@@ -294,7 +294,7 @@ export function BudgetExportDialog({
               <select
                 value={rangeFrom}
                 onChange={(e) => handleRangeFromChange(e.target.value)}
-                className="w-full text-xs border border-border rounded px-2 py-1.5 bg-background font-mono"
+                className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs font-mono"
                 aria-label="Range start month"
               >
                 {availableMonths.map((m) => (
@@ -308,7 +308,7 @@ export function BudgetExportDialog({
               <select
                 value={rangeTo}
                 onChange={(e) => handleRangeToChange(e.target.value)}
-                className="w-full text-xs border border-border rounded px-2 py-1.5 bg-background font-mono"
+                className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs font-mono"
                 aria-label="Range end month"
               >
                 {availableMonths.map((m) => (
@@ -330,6 +330,7 @@ export function BudgetExportDialog({
               values={selectMonths}
               onChange={setSelectMonths}
               placeholder="Search and select months…"
+              triggerClassName="h-7"
             />
           </div>
         )}
@@ -359,7 +360,7 @@ export function BudgetExportDialog({
         <fieldset className="mb-4 space-y-2">
           <legend className="text-sm font-medium mb-2">Options</legend>
 
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <label className="flex items-center gap-2 text-xs cursor-pointer">
             <input
               type="checkbox"
               checked={includeHidden}
@@ -369,7 +370,7 @@ export function BudgetExportDialog({
             Include hidden categories
           </label>
 
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <label className="flex items-center gap-2 text-xs cursor-pointer">
             <input
               type="checkbox"
               checked={includeIncome}
@@ -380,7 +381,7 @@ export function BudgetExportDialog({
           </label>
 
           {stagedEdits && Object.keys(stagedEdits).length > 0 && (
-            <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <label className="flex items-center gap-2 text-xs cursor-pointer">
               <input
                 type="checkbox"
                 checked={includeStagedView}

--- a/src/features/budget-management/components/BulkActionDialog.tsx
+++ b/src/features/budget-management/components/BulkActionDialog.tsx
@@ -123,14 +123,14 @@ export function BulkActionDialog({
             <div className="space-y-3 mb-4">
               {!initialAction && (
                 <div>
-                  <label htmlFor="bulk-action-type" className="block text-sm font-medium mb-1">
+                  <label htmlFor="bulk-action-type" className="block text-xs font-medium mb-1">
                     Action
                   </label>
                   <select
                     id="bulk-action-type"
                     value={action}
                     onChange={(e) => setAction(e.target.value as BulkActionType)}
-                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background"
+                    className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs"
                   >
                     {(Object.keys(ACTION_LABELS) as BulkActionType[]).map((a) => (
                       <option key={a} value={a}>
@@ -143,7 +143,7 @@ export function BulkActionDialog({
 
               {needsFixed && (
                 <div>
-                  <label htmlFor="bulk-fixed-amount" className="block text-sm font-medium mb-1">
+                  <label htmlFor="bulk-fixed-amount" className="block text-xs font-medium mb-1">
                     Amount ($)
                   </label>
                   <input
@@ -154,7 +154,7 @@ export function BulkActionDialog({
                     value={fixedAmount}
                     onChange={(e) => setFixedAmount(e.target.value)}
                     placeholder="0.00"
-                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+                    className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs font-mono"
                     aria-label="Fixed amount in dollars"
                   />
                 </div>
@@ -162,14 +162,14 @@ export function BulkActionDialog({
 
               {needsSourceMonth && (
                 <div>
-                  <label htmlFor="bulk-source-month" className="block text-sm font-medium mb-1">
+                  <label htmlFor="bulk-source-month" className="block text-xs font-medium mb-1">
                     Source month
                   </label>
                   <select
                     id="bulk-source-month"
                     value={sourceMonth}
                     onChange={(e) => setSourceMonth(e.target.value)}
-                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background"
+                    className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs"
                   >
                     {activeMonths.map((m) => (
                       <option key={m} value={m}>{m}</option>
@@ -180,7 +180,7 @@ export function BulkActionDialog({
 
               {needsPercentage && (
                 <div>
-                  <label htmlFor="bulk-percentage" className="block text-sm font-medium mb-1">
+                  <label htmlFor="bulk-percentage" className="block text-xs font-medium mb-1">
                     New value as % of current (e.g. 110 = 10% increase)
                   </label>
                   <input
@@ -190,7 +190,7 @@ export function BulkActionDialog({
                     step="1"
                     value={percentage}
                     onChange={(e) => setPercentage(e.target.value)}
-                    className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+                    className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs font-mono"
                     aria-label="Percentage of current value"
                   />
                 </div>

--- a/src/features/budget-management/components/CategoryBalanceCombobox.tsx
+++ b/src/features/budget-management/components/CategoryBalanceCombobox.tsx
@@ -118,7 +118,7 @@ export function CategoryBalanceCombobox({
         autoComplete="off"
         value={displayValue}
         placeholder={placeholder}
-        className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+        className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
         onFocus={() => setOpen(true)}
         onClick={() => setOpen(true)}
         onChange={(e) => {

--- a/src/features/budget-management/components/NextMonthHoldDialog.tsx
+++ b/src/features/budget-management/components/NextMonthHoldDialog.tsx
@@ -80,7 +80,7 @@ export function NextMonthHoldDialog({
         </h2>
 
         <div className="mb-4">
-          <label htmlFor="hold-amount" className="block text-sm font-medium mb-1">
+          <label htmlFor="hold-amount" className="block text-xs font-medium mb-1">
             Amount to hold
           </label>
           <input
@@ -93,7 +93,7 @@ export function NextMonthHoldDialog({
             onChange={(e) => setAmountStr(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter" && amountStr !== "") handleSet(); }}
             placeholder="0.00"
-            className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono"
+            className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs font-mono"
             aria-label="Hold amount in dollars"
           />
         </div>

--- a/src/features/budget-management/components/StagedCategoryTransferDialog.tsx
+++ b/src/features/budget-management/components/StagedCategoryTransferDialog.tsx
@@ -228,7 +228,7 @@ export function StagedCategoryTransferDialog({
                 setValidationError(null);
               }}
               placeholder="0.00"
-              className="w-full text-sm border border-border rounded px-2 py-1.5 bg-background font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+              className="h-7 w-full rounded border border-border bg-background px-2 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-ring"
               aria-label="Transfer amount in dollars"
             />
             <div className="text-[10px] text-muted-foreground mt-0.5">

--- a/src/features/reconciliation/components/TransformDialog.tsx
+++ b/src/features/reconciliation/components/TransformDialog.tsx
@@ -278,7 +278,7 @@ export function TransformDialog({
         {conditions.map((condition, index) => (
           <div key={index} className="flex flex-wrap items-center gap-1.5">
             <select
-              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+              className="h-7 rounded-md border border-input bg-background px-2 text-xs"
               value={condition.field}
               aria-label="Field"
               onChange={(event) => {
@@ -307,7 +307,7 @@ export function TransformDialog({
             </select>
 
             <select
-              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+              className="h-7 rounded-md border border-input bg-background px-2 text-xs"
               value={condition.operator}
               aria-label="Comparison"
               onChange={(event) =>
@@ -332,7 +332,7 @@ export function TransformDialog({
                 of anyone. */}
             {condition.field === "matchStatus" ? (
               <select
-                className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 w-40 rounded-md border border-input bg-background px-2 text-xs"
                 value={condition.value}
                 aria-label="Decision"
                 onChange={(event) =>
@@ -351,7 +351,7 @@ export function TransformDialog({
               </select>
             ) : (
               <input
-                className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 w-40 rounded-md border border-input bg-background px-2 text-xs"
                 value={condition.value}
                 aria-label="Value"
                 placeholder={condition.operator.includes("Tag") ? "#API" : ""}
@@ -367,7 +367,7 @@ export function TransformDialog({
 
             {condition.operator === "between" && (
               <input
-                className="h-8 w-28 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 w-28 rounded-md border border-input bg-background px-2 text-xs"
                 value={condition.value2 ?? ""}
                 aria-label="Upper bound"
                 onChange={(event) =>
@@ -412,7 +412,7 @@ export function TransformDialog({
         {actions.map((action, index) => (
           <div key={index} className="flex flex-wrap items-center gap-1.5">
             <select
-              className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+              className="h-7 rounded-md border border-input bg-background px-2 text-xs"
               value={action.kind}
               aria-label="Action"
               onChange={(event) =>
@@ -433,7 +433,7 @@ export function TransformDialog({
             {action.kind === "replaceTag" && (
               <>
                 <input
-                  className="h-8 w-32 rounded-md border border-input bg-background px-2 text-xs"
+                  className="h-7 w-32 rounded-md border border-input bg-background px-2 text-xs"
                   value={action.from}
                   placeholder="#API"
                   aria-label="Tag to replace"
@@ -449,7 +449,7 @@ export function TransformDialog({
                 />
                 <span className="text-xs text-muted-foreground">with</span>
                 <input
-                  className="h-8 w-32 rounded-md border border-input bg-background px-2 text-xs"
+                  className="h-7 w-32 rounded-md border border-input bg-background px-2 text-xs"
                   value={action.to}
                   placeholder="#2026-07"
                   aria-label="Replacement tag"
@@ -468,7 +468,7 @@ export function TransformDialog({
 
             {action.kind === "addTag" && (
               <select
-                className="h-8 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 rounded-md border border-input bg-background px-2 text-xs"
                 aria-label="Where the tag goes"
                 value={action.position ?? "end"}
                 onChange={(event) =>
@@ -488,7 +488,7 @@ export function TransformDialog({
 
             {(action.kind === "addTag" || action.kind === "removeTag") && (
               <input
-                className="h-8 w-32 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 w-32 rounded-md border border-input bg-background px-2 text-xs"
                 value={action.tag}
                 placeholder="#2026-07"
                 aria-label="Tag"
@@ -506,7 +506,7 @@ export function TransformDialog({
 
             {(action.kind === "appendNote" || action.kind === "prependNote") && (
               <input
-                className="h-8 w-64 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 w-64 rounded-md border border-input bg-background px-2 text-xs"
                 value={action.text}
                 placeholder="Checked against statement"
                 aria-label="Text to append"
@@ -530,7 +530,7 @@ export function TransformDialog({
 
             {action.kind === "setPayee" && (
               <select
-                className="h-8 w-52 rounded-md border border-input bg-background px-2 text-xs"
+                className="h-7 w-52 rounded-md border border-input bg-background px-2 text-xs"
                 aria-label="Payee"
                 value={action.payeeId ?? ""}
                 onChange={(event) =>

--- a/src/features/rules/components/ActionRow.tsx
+++ b/src/features/rules/components/ActionRow.tsx
@@ -22,12 +22,14 @@ export function ActionRow({
   error,
   onChange,
   onDelete,
+  compact = false,
 }: {
   action: ConditionOrAction;
   entityOptions: RuleEntityOptionsMap;
   error?: string;
   onChange: (a: ConditionOrAction) => void;
   onDelete: () => void;
+  compact?: boolean;
 }) {
   const op = action.op ?? "set";
   const field = action.field ?? "";
@@ -117,7 +119,7 @@ export function ActionRow({
       <div className="space-y-1">
         <div className="flex items-start gap-1.5">
           <select
-            className={cn(selectCls, "w-48 shrink-0")}
+            className={cn(selectCls, compact && "h-7", "w-48 shrink-0")}
             value={op}
             onChange={(e) => handleOpChange(e.target.value)}
           >
@@ -147,7 +149,7 @@ export function ActionRow({
       <div className="space-y-1">
         <div className="flex items-start gap-1.5">
           <select
-            className={cn(selectCls, "w-48 shrink-0")}
+            className={cn(selectCls, compact && "h-7", "w-48 shrink-0")}
             value={op}
             onChange={(e) => handleOpChange(e.target.value)}
           >
@@ -156,7 +158,7 @@ export function ActionRow({
             ))}
           </select>
           <input
-            className={inputCls}
+            className={cn(inputCls, compact && "h-7")}
             value={valueToString(action.value)}
             onChange={(e) => onChange({ ...action, value: e.target.value })}
             placeholder="text to prepend/append…"
@@ -181,7 +183,7 @@ export function ActionRow({
     <div className="space-y-1">
       <div className="flex items-start gap-1.5">
         <select
-          className={cn(selectCls, "w-32 shrink-0")}
+          className={cn(selectCls, compact && "h-7", "w-32 shrink-0")}
           value={op}
           onChange={(e) => handleOpChange(e.target.value)}
         >
@@ -191,7 +193,7 @@ export function ActionRow({
         </select>
 
         <select
-          className={cn(fieldSelectCls, "w-32 shrink-0")}
+          className={cn(fieldSelectCls, compact && "h-7", "w-32 shrink-0")}
           value={field}
           onChange={(e) => handleFieldChange(e.target.value)}
         >
@@ -205,7 +207,7 @@ export function ActionRow({
         {isFormula ? (
           <div className="flex flex-1 flex-col gap-0.5">
             <input
-              className={inputCls}
+              className={cn(inputCls, compact && "h-7")}
               value={action.options?.formula ?? ""}
               onChange={(e) => onChange({ ...action, options: { formula: e.target.value } })}
               placeholder="=IF(ISBLANK(notes), …)"
@@ -217,7 +219,7 @@ export function ActionRow({
         ) : isTemplate ? (
           <div className="flex flex-1 flex-col gap-0.5">
             <input
-              className={inputCls}
+              className={cn(inputCls, compact && "h-7")}
               value={action.options?.template ?? ""}
               onChange={(e) => onChange({ ...action, options: { template: e.target.value } })}
               placeholder="{{handlebars expression…}}"
@@ -227,7 +229,7 @@ export function ActionRow({
             </span>
           </div>
         ) : fieldDef?.type === "boolean" ? (
-          <div className="flex h-8 flex-1 items-center gap-2">
+          <div className={cn("flex h-8 flex-1 items-center gap-2", compact && "h-7")}>
             <input
               type="checkbox"
               checked={action.value === true || action.value === "true"}
@@ -241,7 +243,7 @@ export function ActionRow({
         ) : fieldDef?.type === "number" ? (
           <input
             type="number"
-            className={inputCls}
+            className={cn(inputCls, compact && "h-7")}
             value={typeof action.value === "number" ? action.value : typeof action.value === "string" ? action.value : ""}
             onChange={(e) => onChange({ ...action, value: e.target.value === "" ? "" : Number(e.target.value) })}
             placeholder="0.00"
@@ -250,7 +252,7 @@ export function ActionRow({
         ) : fieldDef?.type === "date" ? (
           <input
             type="date"
-            className={inputCls}
+            className={cn(inputCls, compact && "h-7")}
             value={valueToString(action.value)}
             onChange={(e) => onChange({ ...action, value: e.target.value })}
           />
@@ -261,10 +263,11 @@ export function ActionRow({
             value={valueToString(action.value)}
             onChange={(v) => onChange({ ...action, value: v })}
             onQuickCreate={(name) => openQuickCreate(fieldDef.entity as QuickCreateEntityType, name)}
+            compact={compact}
           />
         ) : (
           <input
-            className={inputCls}
+            className={cn(inputCls, compact && "h-7")}
             value={valueToString(action.value)}
             onChange={(e) => onChange({ ...action, value: e.target.value })}
             placeholder="value…"

--- a/src/features/rules/components/ConditionRow.tsx
+++ b/src/features/rules/components/ConditionRow.tsx
@@ -35,11 +35,13 @@ function ConditionValueInput({
   entityOptions,
   onChange,
   onQuickCreate,
+  compact = false,
 }: {
   condition: ConditionOrAction;
   entityOptions: RuleEntityOptionsMap;
   onChange: (c: ConditionOrAction) => void;
   onQuickCreate: (entity: QuickCreateEntityType, name: string) => void;
+  compact?: boolean;
 }) {
   const fieldDef = CONDITION_FIELDS[condition.field ?? ""];
   const ops = getConditionOps(condition.field ?? "");
@@ -60,7 +62,7 @@ function ConditionValueInput({
       <div className="flex flex-1 items-center gap-1">
         <input
           type="number"
-          className={inputCls}
+          className={cn(inputCls, compact && "h-7")}
           value={range.num1}
           onChange={(e) =>
             onChange({ ...condition, value: { ...range, num1: Number(e.target.value) } })
@@ -70,7 +72,7 @@ function ConditionValueInput({
         <span className="text-xs text-muted-foreground shrink-0">–</span>
         <input
           type="number"
-          className={inputCls}
+          className={cn(inputCls, compact && "h-7")}
           value={range.num2}
           onChange={(e) =>
             onChange({ ...condition, value: { ...range, num2: Number(e.target.value) } })
@@ -93,6 +95,7 @@ function ConditionValueInput({
         options={entityOptions[fieldDef.entity]}
         values={arr}
         onChange={(v) => onChange({ ...condition, value: v })}
+        compact={compact}
       />
     );
   }
@@ -108,6 +111,7 @@ function ConditionValueInput({
         values={arr}
         onChange={(v) => onChange({ ...condition, value: v })}
         placeholder="Type and press Enter…"
+        compact={compact}
       />
     );
   }
@@ -125,6 +129,7 @@ function ConditionValueInput({
         value={scalar}
         onChange={(v) => onChange({ ...condition, value: v })}
         onQuickCreate={quickCreateEntity ? (name) => onQuickCreate(quickCreateEntity, name) : undefined}
+        compact={compact}
       />
     );
   }
@@ -133,7 +138,7 @@ function ConditionValueInput({
     return (
       <input
         type="number"
-        className={inputCls}
+        className={cn(inputCls, compact && "h-7")}
         value={valueToString(condition.value)}
         onChange={(e) =>
           onChange({
@@ -151,7 +156,7 @@ function ConditionValueInput({
   return isRegex ? (
     <div className="flex flex-1 flex-col gap-0.5">
       <input
-        className={inputCls}
+        className={cn(inputCls, compact && "h-7")}
         value={valueToString(condition.value)}
         onChange={(e) => onChange({ ...condition, value: e.target.value })}
         placeholder="regex pattern…"
@@ -162,7 +167,7 @@ function ConditionValueInput({
     </div>
   ) : (
     <input
-      className={inputCls}
+      className={cn(inputCls, compact && "h-7")}
       value={valueToString(condition.value)}
       onChange={(e) => onChange({ ...condition, value: e.target.value })}
       placeholder="value…"
@@ -179,6 +184,7 @@ export function ConditionRow({
   error,
   onChange,
   onDelete,
+  compact = false,
 }: {
   condition: ConditionOrAction;
   scheduleLinked?: boolean;
@@ -186,6 +192,7 @@ export function ConditionRow({
   error?: string;
   onChange: (c: ConditionOrAction) => void;
   onDelete: () => void;
+  compact?: boolean;
 }) {
   const openQuickCreate = useQuickCreateStore((s) => s.open);
   const field = condition.field ?? "";
@@ -258,6 +265,7 @@ export function ConditionRow({
           <div
             className={cn(
               selectCls,
+              compact && "h-7",
               "flex w-32 shrink-0 items-center bg-muted/30 text-muted-foreground"
             )}
           >
@@ -267,6 +275,7 @@ export function ConditionRow({
           <div
             className={cn(
               selectCls,
+              compact && "h-7",
               "flex w-32 shrink-0 items-center bg-muted/30 text-muted-foreground"
             )}
           >
@@ -274,7 +283,7 @@ export function ConditionRow({
           </div>
 
           <div className="flex-1">
-            <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} onQuickCreate={openQuickCreate} />
+            <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} onQuickCreate={openQuickCreate} compact={compact} />
           </div>
 
           <span className="mt-2 shrink-0 text-[10px] italic text-muted-foreground/60">
@@ -290,7 +299,7 @@ export function ConditionRow({
     <div className="space-y-1">
       <div className="flex items-start gap-1.5">
         <select
-          className={cn(conditionFieldSelectCls, "w-32 shrink-0")}
+          className={cn(conditionFieldSelectCls, compact && "h-7", "w-32 shrink-0")}
           value={field ?? ""}
           onChange={(e) => setField(e.target.value)}
         >
@@ -302,7 +311,7 @@ export function ConditionRow({
         </select>
 
         <select
-          className={cn(selectCls, "w-32 shrink-0")}
+          className={cn(selectCls, compact && "h-7", "w-32 shrink-0")}
           value={condition.op ?? ""}
           onChange={(e) => handleOpChange(e.target.value)}
         >
@@ -313,7 +322,7 @@ export function ConditionRow({
           ))}
         </select>
 
-        <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} onQuickCreate={openQuickCreate} />
+        <ConditionValueInput condition={condition} entityOptions={entityOptions} onChange={onChange} onQuickCreate={openQuickCreate} compact={compact} />
 
         <Button
           variant="ghost"

--- a/src/features/rules/components/EntityCombobox.tsx
+++ b/src/features/rules/components/EntityCombobox.tsx
@@ -2,6 +2,7 @@
 
 import { Plus } from "lucide-react";
 import { SearchableCombobox, MultiSearchableCombobox } from "@/components/ui/combobox";
+import { cn } from "@/lib/utils";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import type { RuleEntityType } from "../lib/ruleEditor";
 
@@ -11,12 +12,14 @@ export function EntityCombobox({
   value,
   onChange,
   onQuickCreate,
+  compact = false,
 }: {
   entity: RuleEntityType;
   options: ComboboxOption[];
   value: string;
   onChange: (v: string) => void;
   onQuickCreate?: (name: string) => void;
+  compact?: boolean;
 }) {
   const placeholder =
     entity === "payee"
@@ -36,7 +39,10 @@ export function EntityCombobox({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
-      triggerClassName="bg-sky-50 border-sky-200 dark:bg-sky-950/20 dark:border-sky-800"
+      triggerClassName={cn(
+        "border-sky-200 bg-sky-50 dark:border-sky-800 dark:bg-sky-950/20",
+        compact && "h-7"
+      )}
       footer={
         canQuickCreate
           ? (search) =>
@@ -61,11 +67,13 @@ export function MultiEntityCombobox({
   options,
   values,
   onChange,
+  compact = false,
 }: {
   entity: RuleEntityType;
   options: ComboboxOption[];
   values: string[];
   onChange: (v: string[]) => void;
+  compact?: boolean;
 }) {
   const placeholder =
     entity === "payee"
@@ -81,7 +89,10 @@ export function MultiEntityCombobox({
       values={values}
       onChange={onChange}
       placeholder={placeholder}
-      triggerClassName="bg-sky-50 border-sky-200 dark:bg-sky-950/20 dark:border-sky-800"
+      triggerClassName={cn(
+        "border-sky-200 bg-sky-50 dark:border-sky-800 dark:bg-sky-950/20",
+        compact && "h-7"
+      )}
     />
   );
 }

--- a/src/features/rules/components/MergeRulesDialog.tsx
+++ b/src/features/rules/components/MergeRulesDialog.tsx
@@ -252,6 +252,7 @@ export function MergeRulesDialog({
           showValidation={saveAttempted}
           touchedConditionIds={touchedConditionIds}
           touchedActionIds={touchedActionIds}
+          compact
           onStageChange={setStage}
           onConditionsOpChange={setConditionsOp}
           onAddCondition={addCondition}
@@ -274,7 +275,7 @@ export function MergeRulesDialog({
               />
               <label
                 htmlFor="merge-delete-originals"
-                className="cursor-pointer select-none text-sm font-medium"
+                className="cursor-pointer select-none text-xs font-medium"
               >
                 Delete original {ruleCount} rule{ruleCount !== 1 ? "s" : ""} after merging
               </label>

--- a/src/features/rules/components/RuleEditorFields.tsx
+++ b/src/features/rules/components/RuleEditorFields.tsx
@@ -32,6 +32,7 @@ type Props = {
   onActionDelete: (clientId: string) => void;
   onActionTouched: (clientId: string) => void;
   children?: ReactNode;
+  compact?: boolean;
 };
 
 export function RuleEditorFields({
@@ -56,6 +57,7 @@ export function RuleEditorFields({
   onActionDelete,
   onActionTouched,
   children,
+  compact = false,
 }: Props) {
   const visibleFormErrors = showValidation ? validation.formErrors : [];
 
@@ -173,6 +175,7 @@ export function RuleEditorFields({
                   scheduleLinked={scheduleLinked}
                   entityOptions={entityOptions}
                   error={rowErrors[0]}
+                  compact={compact}
                   onChange={(updated) => {
                     onConditionTouched(entry.clientId);
                     onConditionChange(entry.clientId, updated);
@@ -214,6 +217,7 @@ export function RuleEditorFields({
                   action={entry.part}
                   entityOptions={entityOptions}
                   error={rowErrors[0]}
+                  compact={compact}
                   onChange={(updated) => {
                     onActionTouched(entry.clientId);
                     onActionChange(entry.clientId, updated);

--- a/src/features/sync/components/FlowEditDialog.tsx
+++ b/src/features/sync/components/FlowEditDialog.tsx
@@ -36,7 +36,8 @@ type FlowEditDialogProps = {
   onRan?: () => void;
 };
 
-const selectClass = "rounded-md border border-border bg-background px-2 py-1.5 text-sm min-w-0";
+const compactInputClass = "h-7 rounded-md px-2 py-1 text-xs md:text-xs";
+const selectClass = "h-7 min-w-0 rounded-md border border-input bg-background px-2 py-1 text-xs";
 
 /** A tooltip-bearing info dot, for inline field/option explanations. */
 function InfoDot({ text }: { text: string }) {
@@ -218,12 +219,12 @@ export function FlowEditDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="w-[92vw] sm:max-w-[1080px]">
+      <DialogContent className="h-[88vh] max-h-[800px] w-[92vw] grid-rows-[auto_minmax(0,1fr)_auto] sm:max-w-[1080px]">
         <DialogHeader>
           <DialogTitle>{isNew ? "New sync flow" : "Edit sync flow"}</DialogTitle>
         </DialogHeader>
 
-        <div className="flex max-h-[72vh] flex-col gap-4 overflow-y-auto pr-1">
+        <div className="flex min-h-0 flex-col gap-4 overflow-y-auto pr-1">
           {/* Type + name on one line — the type reshapes the rest of the form */}
           <div className="flex flex-wrap items-end gap-x-4 gap-y-3">
             <div className="flex flex-col gap-1.5">
@@ -247,7 +248,7 @@ export function FlowEditDialog({
             </div>
             <div className="flex min-w-[16rem] flex-1 flex-col gap-1.5">
               <span className="text-[11px] font-semibold uppercase text-muted-foreground">Name</span>
-              <Input aria-label="Flow name" value={form.name} onChange={(e) => set({ name: e.target.value })} placeholder={entityMode ? "e.g. Shared payees" : "e.g. Joint card → Personal"} />
+              <Input className={compactInputClass} aria-label="Flow name" value={form.name} onChange={(e) => set({ name: e.target.value })} placeholder={entityMode ? "e.g. Shared payees" : "e.g. Joint card → Personal"} />
             </div>
           </div>
 
@@ -295,6 +296,7 @@ export function FlowEditDialog({
                   <label className="flex flex-col gap-1 text-xs text-muted-foreground">
                     Run every (minutes)
                     <Input
+                      className={compactInputClass}
                       type="number"
                       min={15}
                       step={5}
@@ -324,7 +326,7 @@ export function FlowEditDialog({
                 <div className="flex flex-col gap-2">
                   <span className="text-[11px] font-semibold uppercase text-muted-foreground">What a sync may do</span>
                   {syncToggles.map((t) => (
-                    <label key={t.key} className="flex items-start gap-2 text-sm">
+                    <label key={t.key} className="flex items-start gap-2 text-xs">
                       <input
                         type="checkbox"
                         className="mt-0.5"
@@ -352,13 +354,14 @@ export function FlowEditDialog({
                   <label className="flex max-w-xs flex-col gap-1 text-xs text-muted-foreground">
                     Default group
                     <Input
+                      className={compactInputClass}
                       aria-label="Default target group"
                       value={form.entity.defaultGroupName}
                       onChange={(e) => setEntity({ defaultGroupName: e.target.value })}
                       placeholder="e.g. Uncategorized"
                     />
                   </label>
-                  <label className="flex items-center gap-2 text-sm" title="Create the source group on the target when it doesn't exist there.">
+                  <label className="flex items-center gap-2 text-xs" title="Create the source group on the target when it doesn't exist there.">
                     <input
                       type="checkbox"
                       aria-label="Create missing groups"
@@ -396,13 +399,14 @@ export function FlowEditDialog({
                   </select>
                 </label>
               </div>
-              <label className="flex items-center gap-2 text-sm">
+              <label className="flex items-center gap-2 text-xs">
                 <input type="checkbox" aria-label="Add notes marker" checked={form.transform.notesMarkerEnabled} onChange={(e) => setTransform({ notesMarkerEnabled: e.target.checked })} />
                 Add a note to synced transactions
               </label>
               {form.transform.notesMarkerEnabled && (
                 <div className="flex flex-col gap-1 pl-6">
                   <Input
+                    className={compactInputClass}
                     aria-label="Notes marker text"
                     value={form.transform.notesMarker}
                     onChange={(e) => setTransform({ notesMarker: e.target.value })}
@@ -411,7 +415,7 @@ export function FlowEditDialog({
                   <span className="text-[11px] text-muted-foreground">Leave blank to use the default.</span>
                 </div>
               )}
-              <label className="flex items-center gap-2 text-sm" title="Copy the source transaction's own notes onto the target, before the marker.">
+              <label className="flex items-center gap-2 text-xs" title="Copy the source transaction's own notes onto the target, before the marker.">
                 <input type="checkbox" aria-label="Copy source notes" checked={form.transform.copySourceNotes} onChange={(e) => setTransform({ copySourceNotes: e.target.checked })} />
                 Also copy the source transaction&apos;s notes
               </label>
@@ -419,16 +423,16 @@ export function FlowEditDialog({
 
               {!entityMode && (
                 <div className="flex flex-col gap-2 border-t border-border/60 pt-3">
-                  <label className="flex items-center gap-2 text-sm" title="Convert amounts into a master currency using the FX rate for each transaction's date (RD-056). Missing rates go to review.">
+                  <label className="flex items-center gap-2 text-xs" title="Convert amounts into a master currency using the FX rate for each transaction's date (RD-056). Missing rates go to review.">
                     <input type="checkbox" aria-label="Convert currency" checked={form.transform.fxEnabled} onChange={(e) => setTransform({ fxEnabled: e.target.checked })} />
                     Convert currency (multi-currency consolidation)
                   </label>
                   {form.transform.fxEnabled && (
                     <div className="flex flex-col gap-2 pl-6">
                       <div className="flex flex-wrap items-center gap-2">
-                        <Input aria-label="Source currency" className="w-16 uppercase" maxLength={3} placeholder="AED" value={form.transform.fxSourceCurrency} onChange={(e) => setTransform({ fxSourceCurrency: e.target.value.toUpperCase() })} />
+                        <Input aria-label="Source currency" className={cn(compactInputClass, "w-16 uppercase")} maxLength={3} placeholder="AED" value={form.transform.fxSourceCurrency} onChange={(e) => setTransform({ fxSourceCurrency: e.target.value.toUpperCase() })} />
                         <span className="text-muted-foreground">→</span>
-                        <Input aria-label="Target currency" className="w-16 uppercase" maxLength={3} placeholder="AUD" value={form.transform.fxTargetCurrency} onChange={(e) => setTransform({ fxTargetCurrency: e.target.value.toUpperCase() })} />
+                        <Input aria-label="Target currency" className={cn(compactInputClass, "w-16 uppercase")} maxLength={3} placeholder="AUD" value={form.transform.fxTargetCurrency} onChange={(e) => setTransform({ fxTargetCurrency: e.target.value.toUpperCase() })} />
                         <span className="text-[11px] text-muted-foreground">ISO 4217 codes — target is your master currency</span>
                       </div>
                       <label className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -459,8 +463,8 @@ export function FlowEditDialog({
                 )}
               </div>
               <div className="grid gap-3 sm:grid-cols-2">
-                <label className={cn("flex flex-col gap-1 text-xs", filterActive.startDate ? "text-foreground" : "text-muted-foreground")}>Start date<Input type="date" aria-label="Start date" className={cn(filterActive.startDate && activeRing)} value={form.filter.startDate} onChange={(e) => setFilter({ startDate: e.target.value })} /></label>
-                <label className={cn("flex flex-col gap-1 text-xs", filterActive.endDate ? "text-foreground" : "text-muted-foreground")}>End date<Input type="date" aria-label="End date" className={cn(filterActive.endDate && activeRing)} value={form.filter.endDate} onChange={(e) => setFilter({ endDate: e.target.value })} /></label>
+                <label className={cn("flex flex-col gap-1 text-xs", filterActive.startDate ? "text-foreground" : "text-muted-foreground")}>Start date<Input type="date" aria-label="Start date" className={cn(compactInputClass, filterActive.startDate && activeRing)} value={form.filter.startDate} onChange={(e) => setFilter({ startDate: e.target.value })} /></label>
+                <label className={cn("flex flex-col gap-1 text-xs", filterActive.endDate ? "text-foreground" : "text-muted-foreground")}>End date<Input type="date" aria-label="End date" className={cn(compactInputClass, filterActive.endDate && activeRing)} value={form.filter.endDate} onChange={(e) => setFilter({ endDate: e.target.value })} /></label>
                 <label className={cn("flex flex-col gap-1 text-xs", filterActive.amountSign ? "text-foreground" : "text-muted-foreground")}>Amount sign
                   <select aria-label="Amount sign" className={cn(selectClass, filterActive.amountSign && activeRing)} value={form.filter.amountSign} onChange={(e) => setFilter({ amountSign: e.target.value as "any" | "inflow" | "outflow" })}>
                     <option value="any">Both</option><option value="inflow">Inflow only</option><option value="outflow">Outflow only</option>
@@ -471,9 +475,9 @@ export function FlowEditDialog({
                     <option value="any">Any</option><option value="cleared">Cleared</option><option value="uncleared">Uncleared</option>
                   </select>
                 </label>
-                <label className={cn("flex flex-col gap-1 text-xs", filterActive.payeeInclude ? "text-foreground" : "text-muted-foreground")}>Payee include<Input aria-label="Payee include" className={cn(filterActive.payeeInclude && activeRing)} value={form.filter.payeeInclude} onChange={(e) => setFilter({ payeeInclude: e.target.value })} placeholder="comma-separated" /></label>
-                <label className={cn("flex flex-col gap-1 text-xs", filterActive.categoryInclude ? "text-foreground" : "text-muted-foreground")}>Category include<Input aria-label="Category include" className={cn(filterActive.categoryInclude && activeRing)} value={form.filter.categoryInclude} onChange={(e) => setFilter({ categoryInclude: e.target.value })} placeholder="comma-separated" /></label>
-                <label className={cn("flex flex-col gap-1 text-xs sm:col-span-2", filterActive.notesContains ? "text-foreground" : "text-muted-foreground")}>Notes contains<Input aria-label="Notes contains" className={cn(filterActive.notesContains && activeRing)} value={form.filter.notesContains} onChange={(e) => setFilter({ notesContains: e.target.value })} /></label>
+                <label className={cn("flex flex-col gap-1 text-xs", filterActive.payeeInclude ? "text-foreground" : "text-muted-foreground")}>Payee include<Input aria-label="Payee include" className={cn(compactInputClass, filterActive.payeeInclude && activeRing)} value={form.filter.payeeInclude} onChange={(e) => setFilter({ payeeInclude: e.target.value })} placeholder="comma-separated" /></label>
+                <label className={cn("flex flex-col gap-1 text-xs", filterActive.categoryInclude ? "text-foreground" : "text-muted-foreground")}>Category include<Input aria-label="Category include" className={cn(compactInputClass, filterActive.categoryInclude && activeRing)} value={form.filter.categoryInclude} onChange={(e) => setFilter({ categoryInclude: e.target.value })} placeholder="comma-separated" /></label>
+                <label className={cn("flex flex-col gap-1 text-xs sm:col-span-2", filterActive.notesContains ? "text-foreground" : "text-muted-foreground")}>Notes contains<Input aria-label="Notes contains" className={cn(compactInputClass, filterActive.notesContains && activeRing)} value={form.filter.notesContains} onChange={(e) => setFilter({ notesContains: e.target.value })} /></label>
               </div>
               <p className="text-xs text-muted-foreground">Sync-generated transactions are always excluded to prevent loops.</p>
             </section>


### PR DESCRIPTION
## Summary

- compact text fields and dropdowns in the Sync Flow, reconciliation transform, budget action, budget export, and rule merge dialogs
- reduce related checkbox and field-label typography where dense forms need more room
- keep dialog dimensions, copy, buttons, and behavior unchanged
- leave the Payees Merge dialog unchanged

## Why

Several dense dialogs mixed default-sized and legacy form controls, consuming vertical space and making related fields look inconsistent. This scopes compact styling to the affected dialogs without shrinking shared controls throughout the application.

## User impact

Dense workflows fit more cleanly within their existing dialogs, with better alignment and less unnecessary scrolling. Optional content in the Sync Flow dialog has more room while the dialog retains its larger fixed height.

## Validation

- `npm run lint` — passed with 0 errors and 11 existing warnings
- `npx tsc --noEmit` — passed
- `npm test -- --runInBand` — 209 suites and 2,233 tests passed
- `git diff --check` — passed
- build not run, per the requested local-development workflow