### PR TITLE
Recognize connected budgets in sync flow list

### DIFF
--- a/src/features/sync/components/FlowList.tsx
+++ b/src/features/sync/components/FlowList.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { Plus, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { connectionFingerprint } from "@/lib/sync/connectionRef";
+import { connectionFingerprint, connectionMatchesBudget } from "@/lib/sync/connectionRef";
 import { decodeFlowPlanConfig } from "@/lib/sync/flowConfig";
 import { latestRunLabel, runNeedsAttention, runQueuedCount } from "../lib/runsView";
 import { computeUnattendedStatus, nextRunPhrase } from "../lib/unattendedStatus";
@@ -22,9 +22,15 @@ type FlowListProps = {
   onCreate: () => void;
 };
 
-function connectionAvailable(fingerprint: string, connections: ConnectionInstance[]): boolean {
-  if (!fingerprint) return false;
-  return connections.some((c) => connectionFingerprint(c) === fingerprint);
+function connectionAvailable(
+  fingerprint: string,
+  budgetSyncId: string,
+  connections: ConnectionInstance[]
+): boolean {
+  const exactMatch = fingerprint
+    ? connections.some((connection) => connectionFingerprint(connection) === fingerprint)
+    : false;
+  return exactMatch || connections.some((connection) => connectionMatchesBudget(connection, budgetSyncId));
 }
 
 function isHttpFingerprint(fingerprint: string, connections: ConnectionInstance[]): boolean {
@@ -92,8 +98,16 @@ export function FlowList({
               const selected = flow.id === selectedFlowId;
               const config = decodeFlowPlanConfig(flow);
               const connected =
-                connectionAvailable(config.sourceConnectionFingerprint, connections) &&
-                connectionAvailable(config.targetConnectionFingerprint, connections);
+                connectionAvailable(
+                  config.sourceConnectionFingerprint,
+                  config.sourceBudgetId,
+                  connections
+                ) &&
+                connectionAvailable(
+                  config.targetConnectionFingerprint,
+                  config.targetBudgetId,
+                  connections
+                );
               const latestRun = latestRuns.get(flow.id);
               const autoPaused = !flow.enabled && !!config.autoPausedAt;
               const lastRunMs = latestRun ? new Date(latestRun.finishedAt ?? latestRun.startedAt).getTime() : null;

--- a/src/features/sync/components/SyncView.test.tsx
+++ b/src/features/sync/components/SyncView.test.tsx
@@ -102,6 +102,24 @@ describe("SyncView", () => {
     expect(screen.queryByText(/needs a connection/i)).not.toBeInTheDocument();
   });
 
+  it("recognizes open flow budgets when the live connection details changed", () => {
+    const httpSource: ConnectionInstance = { id: "http-src", label: "Home", mode: "http-api", baseUrl: "https://api.example.com", apiKey: "k", budgetSyncId: "b-src" };
+    const httpTarget: ConnectionInstance = { id: "http-tgt", label: "Family", mode: "http-api", baseUrl: "https://api.example.com", apiKey: "k", budgetSyncId: "b-tgt" };
+    setup([httpSource, httpTarget]);
+
+    render(<SyncView />);
+
+    expect(screen.queryByText("Needs connection")).not.toBeInTheDocument();
+  });
+
+  it("still flags a flow when one of its budgets is not open", () => {
+    setup([conn1]);
+
+    render(<SyncView />);
+
+    expect(screen.getByText("Needs connection")).toBeInTheDocument();
+  });
+
   it("opens the editor dialog with default transform (same sign, create payee)", async () => {
     setup([conn1, conn2]);
     render(<SyncView />);


### PR DESCRIPTION
## Summary

- make the Sync Flows list resolve open connections by exact fingerprint first, then by the budget's stable sync ID
- keep showing **Needs connection** when either the source or target budget is genuinely unavailable
- add regression coverage for changed connection mode/server details and a missing target budget

## Why

The flow editor and sync execution paths already fall back to stable budget identity, but the list badge only compared the saved connection fingerprint. Because a fingerprint also includes connection mode and server URL, a valid open connection to the same budget could be reported as unavailable.

## User impact

Saved flows now show their normal run status whenever both budget files are open, even if they are reached through a different transport or server URL than when the flow was saved.

## Validation

- `npx eslint src/features/sync/components/FlowList.tsx src/features/sync/components/SyncView.test.tsx` — passed
- `npm test -- --runInBand src/features/sync/components/SyncView.test.tsx` — 11 tests passed
- `npx tsc --noEmit` — passed
- `git diff --check` — passed
- full test suite and production build not run