### PR TITLE
Payee Cleanup: consolidate duplicate payees created by bank imports

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -268,6 +268,45 @@ A standalone page (own navigation item) for browsing the active budget's exporte
 - Every delete action (single and bulk) always confirms, showing the payee's transaction count and rule reference count — previously single deletes with no rule references skipped the confirmation entirely; transfer payees are excluded from bulk delete and counted separately in the dialog
 - Info button on each regular payee row opens the Usage Inspector drawer (see below)
 
+## Payee Cleanup
+
+Finds payees that are really the same merchant under different bank spellings, and helps you
+consolidate them safely. Nothing is written until you save.
+
+- **Finds the variants for you.** Bank text carries dates, times, card numbers, reference numbers,
+  store numbers, exchange rates and web addresses; cleanup removes them by *shape*, so it works the
+  same for any bank in any country without knowing yours.
+- **Learns your bank's own boilerplate.** Wrapping that no pattern can identify — a channel prefix, a
+  trailing city and country — is recognised because it repeats across many otherwise unrelated
+  payees. Anything learned this way is treated as a guess and lands in Needs review.
+- **Decides on one screen.** Each suggestion is a single card in three columns — the result and the
+  payees behind it, what changes, and future imports — with no dialog to open. Struck-through text
+  shows exactly what each name lost, and *Reasoning* expands the detector's own account.
+- **Shows the blast radius before you decide** — transactions that will move, regular rules, active
+  and completed schedule-linked rules counted separately, and any disagreement over Favorite or
+  Category learning.
+- **You correct it.** Drop a member, add one the scan missed, choose which payee survives, edit the
+  final name, or mark a group as *not duplicates* — which is remembered, per budget, and reversible
+  from the Dismissed tab. *Undo my changes* restores the detector's original proposal.
+- **Accepts the unambiguous ones in bulk.** *Accept n safe* takes only the structural matches with no
+  settings conflict, no rule reaching beyond the group and counts already loaded — not simply
+  everything above a score.
+- **Will not create the duplicate you were removing.** Two accepted groups heading for the same payee
+  name block the stage and are offered as one combined group instead.
+- **Keyboard triage** — `A` accept, `R` reasoning, `N` not duplicates on the focused card.
+- **Unused payees** — those with no transactions and no rules — are listed separately for deletion.
+- **Optional rule to stop it recurring.** Where cleanup alone will not fix future imports, cleanup
+  proposes a rule that catches the merchant, backtested against your own history so you can see what
+  it would and would not have matched. The matched text and the field it matches on are editable.
+- **Merging uses Actual's own operation.** Transactions follow automatically; rules keep pointing at
+  the old payee and Actual resolves them afterwards. Actual Bench never rewrites transactions or
+  rules itself.
+
+Known limits: `Favorite` and `Category learning` cannot be changed from outside Actual, so the payee
+you keep decides them. Saved payee locations cannot be read through Actual's API, so cleanup does not
+report or move them. The unused-payee check is slightly stricter than Actual's own, because it also
+counts rules that *set* a payee.
+
 ## Categories
 
 - Create and manage category groups (income or expense type)

--- a/docs-site/src/content/docs/user-guide/payee-cleanup.mdx
+++ b/docs-site/src/content/docs/user-guide/payee-cleanup.mdx
@@ -1,0 +1,126 @@
+---
+title: Payee Cleanup
+description: Find payees that are really the same merchant under different bank spellings, see exactly what merging would change, and stop the duplicates coming back.
+sidebar:
+  order: 5
+---
+
+Bank imports create a payee per distinct piece of text. One shop becomes many payees, because the
+text carries a date, a card number, a store number or a location that changes every transaction:
+
+```text
+MARKET BOYS PTY LTD Melbourne VI AUS Card xx4534 Value Date: 12/03/2024
+MARKET BOYS PTY LTD Melbourne VI AUS Card xx9166 Value Date: 24/12/2024
+MARKET BOYS PTY LTD Sydney Value Date: 10/11/2025
+```
+
+**Payee Cleanup** finds those groups, shows what merging them would change, and lets you fix the
+budget in one reviewed pass. Open it from **Tools → Payee Cleanup**.
+
+**Write model:** scan → review → accept → **Stage cleanup** → **Save**. Staging hands the merges,
+renames, deletions and new rules to the normal staged-changes flow; nothing reaches your budget until
+you save on the Payees page.
+
+## How it finds duplicates
+
+Two layers, and the difference matters when you are deciding whether to trust a suggestion.
+
+**Shape rules** remove text that identifies itself by its structure: dates in any common layout,
+times, card numbers, long reference and authorization numbers, `Label: value` metadata, exchange
+rates, trailing store numbers and web addresses. These work the same for any bank in any country —
+nothing here knows about yours.
+
+**Learned boilerplate** covers what no pattern can identify. If `DUBAI UAE` closes forty otherwise
+unrelated payees, or `NFC - (AP-PAY)-` opens sixty of them, it is wrapping rather than a name. This
+is worked out from your own payees, so a French `CARTE … RETRAIT DAB` is found by the same rule.
+
+Anything learned this way is treated as a **guess**. It lowers the confidence and puts the suggestion
+in **Needs review**, because repetition proves a fragment is shared — not that removing it is safe.
+`TRANSFER FROM` also opens many payees, and it means something.
+
+## Working through the suggestions
+
+A toolbar across the top carries the search box, the **Suggestions / Unused / Dismissed** tabs, the
+confidence filters, **Re-scan** and **Stage cleanup**. Under it, three boxes count what the scan
+found and a fourth — **Pending changes** — counts what you are about to do, and reminds you that none
+of it is written until you save.
+
+**Accept _n_ safe** accepts, in one click, only the suggestions that need no judgement. It is
+deliberately stricter than "everything above 90%": the match must be structural rather than inferred,
+the payees must agree on Favorite and Category learning, transaction counts must have finished
+loading, and no rule — proposed or existing — may reach beyond the group. Everything else stays for
+you.
+
+## Reading a suggestion
+
+Everything a decision needs is on the card itself; there is no dialog to open. The header names the
+result, its confidence, and how many payees collapse into one. Below it, three columns:
+
+- **Result** — the payee that survives and the name it takes, both editable, with every member listed
+  and its transaction count. The text each name loses is struck through, so you can see what was
+  removed. Drop a member, add one the scan missed, or pick a different survivor here.
+- **What changes** — transactions that move; rules, split into regular rules, active schedule-linked
+  rules and completed schedule-linked ones (a schedule reaches its payee *through* its rule, so
+  counting them separately would report the same relationship twice); and whether the payees disagree
+  on Favorite or Category learning. **Reasoning** expands the detector's own account of the grouping.
+- **Future imports** — the optional rule, described below.
+
+Confidence bands: **High** and **Likely** are structural matches. **Needs review** means an
+interpreted step was involved, or nothing but spelling similarity connects the payees.
+
+With a card focused, <kbd>A</kbd> accepts, <kbd>R</kbd> toggles the reasoning and <kbd>N</kbd> marks
+it *not duplicates* — ignored while you are typing in one of its fields.
+
+## Correcting a suggestion
+
+Nothing is fixed. Every change you make is remembered against that group, and **Undo my changes**
+appears once there is something to undo, restoring the detector's original proposal.
+
+If two groups you accepted would end up with the same payee name, cleanup blocks the stage rather
+than quietly creating a second payee with that name — and offers to **combine them into one group**,
+since naming them alike is how you said they are the same merchant.
+
+**Not duplicates** dismisses a group for good. It is remembered per budget and reversible from the
+**Dismissed** tab — including learned boilerplate you disagreed with, so a wrong inference stops
+being applied everywhere rather than needing rejection on every card.
+
+## Stopping the duplicates coming back
+
+Cleaning up today does not stop the next import recreating the mess — but often no rule is needed.
+Actual matches an imported name that exactly equals an existing payee, so the merge alone fixes
+future imports, and an existing rule may already do the job. Cleanup checks both before proposing
+anything.
+
+Where a rule *is* worth it, cleanup builds one and backtests it against your own import history:
+
+> Also create a rule: when imported payee starts with "WOOLWORTHS", set the payee.
+> Matches 92 past transactions of this payee and nothing else.
+
+It is never pre-selected if it would also catch another payee's transactions — you are told which
+ones. The **matched text** and the **field it matches on** (imported payee or notes) are both
+editable, and changing either re-runs the backtest.
+
+## Unused payees
+
+The **Unused** tab lists payees with no transactions and no rules pointing at them, ready to stage for
+deletion. Actual Bench applies its own check here and is slightly more cautious than Actual's: it
+also counts rules that *set* a payee, so a payee some rule writes to is never offered for deletion.
+
+## What merging actually does
+
+Merging uses Actual's own operation. Transactions follow automatically — Actual resolves them to the
+payee you kept. **Rules are not rewritten**: they keep pointing at the old payee, and Actual resolves
+them afterwards. Actual Bench never rewrites transactions or rules itself.
+
+## Known limits
+
+- **Favorite and Category learning cannot be changed** from outside Actual. The payee you keep
+  decides them, which is why cleanup shows the difference and lets you choose the survivor rather
+  than offering an editor.
+- **Saved payee locations cannot be read** through Actual's API, and merging does not move them.
+  Cleanup neither reports them nor promises anything about them.
+- **Transfer payees are never touched.** Actual manages them with their accounts, and its merge
+  silently does nothing when one is involved.
+- Statements that concatenate every field with no separators, or that put the date before the
+  merchant, reduce to their transaction *type* rather than a merchant name. That still groups them
+  usefully, but it is not a merchant.

--- a/docs-site/src/content/docs/user-guide/payees.mdx
+++ b/docs-site/src/content/docs/user-guide/payees.mdx
@@ -14,6 +14,11 @@ one staged, reviewable pass instead of a sequence of immediate edits.
 It shares the [master-data editing model](../managing-your-data/). Open **Payees** from **Data
 Management**.
 
+:::tip[Merging a lot of import duplicates?]
+[Payee Cleanup](../payee-cleanup/) finds the groups for you, shows what each merge would change, and
+can add a rule so the duplicates stop coming back.
+:::
+
 ## What you get beyond Actual Budget
 
 - **Bulk-merge duplicate payees** — collapse several payees into one, staged and undoable, before it

--- a/src/app/(app)/payees/cleanup/page.tsx
+++ b/src/app/(app)/payees/cleanup/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { PayeeCleanupView } from "@/features/payee-cleanup/components/PayeeCleanupView";
+
+export const metadata: Metadata = {
+  title: "Payee Cleanup - Actual Bench",
+};
+
+export default function PayeeCleanupPage() {
+  return <PayeeCleanupView />;
+}

--- a/src/app/api/payee-cleanup-suppressions/[id]/route.ts
+++ b/src/app/api/payee-cleanup-suppressions/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { deletePayeeCleanupSuppression } from "@/lib/app-db/payeeCleanupSuppressionRepository";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/** Undoing one decision, so a mistaken rejection is recoverable. */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const removed = deletePayeeCleanupSuppression(getAppDb(), id);
+    if (!removed) {
+      return NextResponse.json({ error: "Suppression not found" }, { status: 404 });
+    }
+    return NextResponse.json({ removed: true });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/payee-cleanup-suppressions/[id]/route.ts
+++ b/src/app/api/payee-cleanup-suppressions/[id]/route.ts
@@ -8,12 +8,18 @@ export const runtime = "nodejs";
 
 /** Undoing one decision, so a mistaken rejection is recoverable. */
 export async function DELETE(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { id } = await params;
-    const removed = deletePayeeCleanupSuppression(getAppDb(), id);
+    // Budget-scoped like every other operation on this table: an id on its own
+    // would let one budget delete another budget's decision.
+    const budgetSyncId = new URL(request.url).searchParams.get("budgetSyncId");
+    if (!budgetSyncId) {
+      return NextResponse.json({ error: "budgetSyncId is required" }, { status: 400 });
+    }
+    const removed = deletePayeeCleanupSuppression(getAppDb(), id, budgetSyncId);
     if (!removed) {
       return NextResponse.json({ error: "Suppression not found" }, { status: 404 });
     }

--- a/src/app/api/payee-cleanup-suppressions/route.ts
+++ b/src/app/api/payee-cleanup-suppressions/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  clearPayeeCleanupSuppressions,
+  createPayeeCleanupSuppression,
+  listPayeeCleanupSuppressions,
+} from "@/lib/app-db/payeeCleanupSuppressionRepository";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Payee Cleanup suppressions are always budget-scoped: payee ids and names
+ * belong to one budget file, so a decision made in one must never silence a
+ * suggestion in another.
+ */
+function budgetSyncId(request: Request): string | null {
+  const value = new URL(request.url).searchParams.get("budgetSyncId");
+  return value && value.trim() ? value.trim() : null;
+}
+
+export function GET(request: Request) {
+  try {
+    const budget = budgetSyncId(request);
+    if (!budget) {
+      return NextResponse.json(
+        { error: "budgetSyncId is required" },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({
+      suppressions: listPayeeCleanupSuppressions(getAppDb(), budget),
+    });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await readJsonBody(request);
+    const suppression = createPayeeCleanupSuppression(getAppDb(), body);
+    return NextResponse.json({ suppression }, { status: 201 });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+/** "Start over": clears every decision for one budget. */
+export function DELETE(request: Request) {
+  try {
+    const budget = budgetSyncId(request);
+    if (!budget) {
+      return NextResponse.json(
+        { error: "budgetSyncId is required" },
+        { status: 400 }
+      );
+    }
+    const removed = clearPayeeCleanupSuppressions(getAppDb(), budget);
+    return NextResponse.json({ removed });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -35,6 +35,7 @@ import {
   Keyboard,
   Settings,
   ClipboardCheck,
+  Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -109,6 +110,7 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
       label: "Tools",
       items: [
         { id: "rule-diagnostics", label: "Rule Diagnostics", href: "/rules/diagnostics", icon: ShieldCheck },
+        { id: "payee-cleanup", label: "Payee Cleanup", href: "/payees/cleanup", icon: Sparkles },
         {
           id: "reconciliation",
           label: "Bank Reconciliation",

--- a/src/features/overview/lib/overviewCards.test.ts
+++ b/src/features/overview/lib/overviewCards.test.ts
@@ -47,11 +47,19 @@ describe("overview cards follow the sidebar", () => {
     expect(TOOL_CARDS.some((card) => card.href === "/reconciliation")).toBe(true);
   });
 
-  it("places bank reconciliation immediately after rule diagnostics", () => {
-    const expectedPair = ["/rules/diagnostics", "/reconciliation"];
+  it("keeps the sidebar and the cards in the same order position for position", () => {
+    // The original form of this test pinned one specific adjacent pair, so it
+    // failed the first time a tool was inserted between them even though both
+    // lists stayed consistent. What actually matters is that the cards, in
+    // order, are the nav order with any card-less entries removed.
+    const cards = TOOL_CARDS.map((card) => card.href);
+    const navForCards = navHrefs("Tools").filter((href) => cards.includes(href));
 
-    expect(navHrefs("Tools").slice(0, 2)).toEqual(expectedPair);
-    expect(TOOL_CARDS.slice(0, 2).map((card) => card.href)).toEqual(expectedPair);
+    expect(cards).toEqual(navForCards);
+  });
+
+  it("offers a card for payee cleanup", () => {
+    expect(TOOL_CARDS.some((card) => card.href === "/payees/cleanup")).toBe(true);
   });
 
   it("leaves FX Rates to the sidebar", () => {

--- a/src/features/overview/lib/overviewCards.ts
+++ b/src/features/overview/lib/overviewCards.ts
@@ -8,6 +8,7 @@ import {
   LayoutList,
   ScrollText,
   ShieldCheck,
+  Sparkles,
   Tag,
   Terminal,
   Users,
@@ -109,6 +110,15 @@ export const TOOL_CARDS: OverviewActionCard[] = [
     icon: ShieldCheck,
     tone: "tool",
     href: "/rules/diagnostics",
+  },
+  {
+    id: "payee-cleanup",
+    label: "Payee Cleanup",
+    description:
+      "Find payees that are really the same merchant under different bank spellings, with the evidence behind every suggestion.",
+    icon: Sparkles,
+    tone: "tool",
+    href: "/payees/cleanup",
   },
   {
     id: "reconciliation",

--- a/src/features/payee-cleanup/components/CleanupFilterBar.tsx
+++ b/src/features/payee-cleanup/components/CleanupFilterBar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { PillGroup } from "@/components/ui/pill-group";
+import type { ConfidenceBand } from "../lib/confidence";
+
+export type CleanupTab = "suggestions" | "unused" | "dismissed";
+export type BandFilter = "all" | ConfidenceBand;
+
+const BAND_FILTERS: { value: BandFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "high", label: "High" },
+  { value: "strong", label: "Likely" },
+  { value: "review", label: "Needs review" },
+  { value: "hidden", label: "Low" },
+];
+
+type Props = {
+  tab: CleanupTab;
+  onTabChange: (tab: CleanupTab) => void;
+  band: BandFilter;
+  onBandChange: (band: BandFilter) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+  counts: { suggestions: number; unused: number; dismissed: number };
+};
+
+/**
+ * Search and filters in one row (F-096 follow-up).
+ *
+ * Deliberately the same shape as Rule Diagnostics' filter bar: same position,
+ * same search affordance, same pill groups. Two tools that do the same kind of
+ * job should not need to be learned twice.
+ */
+export function CleanupFilterBar({
+  tab,
+  onTabChange,
+  band,
+  onBandChange,
+  search,
+  onSearchChange,
+  counts,
+}: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border/40 bg-muted/10 px-4 py-2">
+      <div className="relative flex items-center">
+        <Search className="absolute left-1.5 h-3.5 w-3.5 text-muted-foreground" />
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search payees…"
+          aria-label="Search payees"
+          className="h-7 w-56 rounded border border-border bg-background pl-6 pr-6 text-xs outline-none focus:ring-1 focus:ring-ring"
+        />
+        {search ? (
+          <button
+            type="button"
+            onClick={() => onSearchChange("")}
+            aria-label="Clear search"
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        ) : null}
+      </div>
+
+      <PillGroup
+        options={[
+          { value: "suggestions" as const, label: `Suggestions ${counts.suggestions}` },
+          { value: "unused" as const, label: `Unused ${counts.unused}` },
+          { value: "dismissed" as const, label: `Dismissed ${counts.dismissed}` },
+        ]}
+        value={tab}
+        onChange={onTabChange}
+      />
+
+      {tab === "suggestions" ? (
+        <>
+          <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Confidence
+          </span>
+          <PillGroup options={BAND_FILTERS} value={band} onChange={onBandChange} />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/components/CleanupSummaryCards.tsx
+++ b/src/features/payee-cleanup/components/CleanupSummaryCards.tsx
@@ -1,0 +1,121 @@
+import type { CleanupScanResult } from "../lib/scan";
+import type { CleanupPlan } from "../lib/plan";
+
+type Props = {
+  result: CleanupScanResult;
+  plan: CleanupPlan;
+};
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
+ * The scan totals (RD-078 §11).
+ *
+ * No "payees analyzed" box: the toolbar already states it, and repeating a
+ * number two inches below itself is space that could hold a suggestion.
+ *
+ * The fourth box is what the user is about to do, rather than another way of
+ * describing what the scan found. It carries its own "not written until you
+ * save" caption, so the safety model sits with the pending changes instead of
+ * needing a strip of its own.
+ */
+export function CleanupSummaryCards({ result, plan }: Props) {
+  const pendingParts = [
+    plan.merges.length > 0
+      ? `${plan.merges.length} ${plan.merges.length === 1 ? "merge" : "merges"}`
+      : null,
+    plan.renames.length > 0
+      ? `${plan.renames.length} ${plan.renames.length === 1 ? "rename" : "renames"}`
+      : null,
+    plan.rules.length > 0
+      ? `${plan.rules.length} ${plan.rules.length === 1 ? "rule" : "rules"}`
+      : null,
+    plan.deletions.length > 0 ? `${plan.deletions.length} deleted` : null,
+  ].filter(Boolean);
+
+  const mergedPayeeCount = plan.merges.reduce((n, m) => n + m.mergeIds.length, 0);
+
+  const scanCards = [
+    {
+      id: "suggestions",
+      label: "Cleanup suggestions",
+      value: formatCount(
+        result.counts.high + result.counts.strong + result.counts.review
+      ),
+      tone: "neutral" as const,
+    },
+    {
+      id: "high",
+      label: "High confidence",
+      value: formatCount(result.counts.high),
+      tone: "neutral" as const,
+    },
+    {
+      id: "review",
+      label: "Need review",
+      value: formatCount(result.counts.review),
+      tone: "caution" as const,
+    },
+  ];
+
+  const pendingActive = pendingParts.length > 0;
+
+  return (
+    // Two groups, not four equal boxes: three describe what the scan found,
+    // one describes what the user is about to do. The rule between them says
+    // that without a heading.
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-stretch">
+      <div className="grid flex-1 gap-3 sm:grid-cols-3">
+        {scanCards.map((card) => (
+          <div
+            key={card.id}
+            className="rounded-md border border-border/70 bg-muted/12 p-3"
+          >
+            <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              {card.label}
+            </div>
+            <div
+              className={
+                "mt-2 text-2xl font-semibold tracking-tight " +
+                (card.tone === "caution" && result.counts.review > 0
+                  ? "text-amber-700 dark:text-amber-400"
+                  : "text-foreground")
+              }
+            >
+              {card.value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="hidden w-px shrink-0 self-stretch bg-border/70 lg:block"
+        aria-hidden="true"
+      />
+
+      <div
+        className={
+          "rounded-md border p-3 lg:w-72 lg:shrink-0 " +
+          (pendingActive
+            ? "border-emerald-600/40 bg-emerald-500/5"
+            : "border-border/70 bg-muted/12")
+        }
+      >
+        <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          Pending changes
+        </div>
+        <div className="mt-2 text-sm font-semibold tracking-tight text-foreground">
+          {pendingActive ? pendingParts.join(" · ") : "None yet"}
+        </div>
+        {pendingActive ? (
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            {mergedPayeeCount} {mergedPayeeCount === 1 ? "payee stops" : "payees stop"}{" "}
+            existing · not written until you save
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/components/ClusterImpactPanel.tsx
+++ b/src/features/payee-cleanup/components/ClusterImpactPanel.tsx
@@ -1,0 +1,123 @@
+import { Star } from "lucide-react";
+import type { ClusterImpact } from "../lib/impact";
+
+type Props = {
+  impact: ClusterImpact;
+  targetName: string;
+};
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
+ * The blast radius of one merge (RD-078 §10).
+ *
+ * Every number here is something the user is about to change, so each is stated
+ * in Actual's own terms — and where Actual's behaviour is surprising, the panel
+ * says so rather than leaving the user to infer it.
+ *
+ * No per-payee list: the payee list on the card already carries each member's
+ * transaction count, and showing the same rows twice on one screen was pure
+ * noise.
+ */
+export function ClusterImpactPanel({ impact, targetName }: Props) {
+  const { rules, behavior } = impact;
+  const totalRules = rules.regular + rules.activeSchedule;
+
+  return (
+    <div className="space-y-3 text-xs">
+      <section>
+        <h4 className="font-medium text-foreground">Transactions</h4>
+        <p className="text-muted-foreground">
+          {impact.transactionsLoading || impact.transactionTotal === undefined ? (
+            "Counting…"
+          ) : (
+            <>
+              {formatCount(impact.transactionTotal)}{" "}
+              {impact.transactionTotal === 1 ? "transaction" : "transactions"} will
+              show <span className="font-medium text-foreground">{targetName}</span>{" "}
+              as their payee.
+            </>
+          )}
+        </p>
+      </section>
+
+      <section>
+        <h4 className="font-medium text-foreground">Rules</h4>
+        {totalRules === 0 && rules.completedSchedule === 0 ? (
+          <p className="text-muted-foreground">No rules reference these payees.</p>
+        ) : (
+          <ul className="space-y-0.5 text-muted-foreground">
+            {rules.regular > 0 ? (
+              <li>
+                {formatCount(rules.regular)} regular{" "}
+                {rules.regular === 1 ? "rule" : "rules"}
+              </li>
+            ) : null}
+            {rules.activeSchedule > 0 ? (
+              <li>
+                {formatCount(rules.activeSchedule)} active schedule
+                {rules.activeSchedule === 1 ? "" : "s"} (through{" "}
+                {rules.activeSchedule === 1 ? "its rule" : "their rules"})
+              </li>
+            ) : null}
+            {rules.completedSchedule > 0 ? (
+              <li>
+                {formatCount(rules.completedSchedule)} completed schedule
+                {rules.completedSchedule === 1 ? "" : "s"} — not counted as active
+              </li>
+            ) : null}
+          </ul>
+        )}
+        {totalRules > 0 ? (
+          // The single most surprising thing about Actual's merge, and the user
+          // is about to rely on it.
+          <p className="mt-1 text-muted-foreground">
+            Merging does not rewrite these rules. They keep pointing at the old
+            payee, and Actual resolves them to{" "}
+            <span className="font-medium text-foreground">{targetName}</span>{" "}
+            afterwards.
+          </p>
+        ) : null}
+      </section>
+
+      <section>
+        <h4 className="font-medium text-foreground">Payee settings</h4>
+        {behavior.favoriteDiffers || behavior.learnCategoriesDiffers ? (
+          <p className="text-muted-foreground">
+            These payees disagree on{" "}
+            {[
+              behavior.favoriteDiffers ? "Favorite" : null,
+              behavior.learnCategoriesDiffers ? "Category learning" : null,
+            ]
+              .filter(Boolean)
+              .join(" and ")}
+            . The payee you keep decides the outcome — Actual&apos;s API does not
+            let Actual Bench change either setting.
+          </p>
+        ) : (
+          <p className="text-muted-foreground">
+            All of these payees agree on Favorite and Category learning.
+          </p>
+        )}
+        <p className="mt-1 flex items-center gap-1.5 text-muted-foreground">
+          <span>After merging:</span>
+          {behavior.survivingFavorite ? (
+            <span className="inline-flex items-center gap-1 font-medium text-foreground">
+              <Star className="size-3" aria-hidden="true" />
+              Favorite
+            </span>
+          ) : (
+            <span className="font-medium text-foreground">Not a favorite</span>
+          )}
+          <span aria-hidden="true">·</span>
+          <span className="font-medium text-foreground">
+            Category learning {behavior.survivingLearnCategories ? "on" : "off"}
+          </span>
+        </p>
+      </section>
+
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/components/CombineGroupsBanner.tsx
+++ b/src/features/payee-cleanup/components/CombineGroupsBanner.tsx
@@ -1,0 +1,57 @@
+import { AlertTriangle, Merge } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { NameCollision } from "../lib/triage";
+
+type Props = {
+  collisions: NameCollision[];
+  onCombine: (collision: NameCollision) => void;
+};
+
+/**
+ * Offers to fold groups that would end up with the same name (RD-078 §13).
+ *
+ * Naming two groups the same thing is the user saying those payees are one
+ * merchant — the scan could not see it because the names reduce to different
+ * stems. Blocking alone would be technically correct and practically useless:
+ * it leaves them to reconcile by hand the thing they already decided.
+ *
+ * The banner states exactly what combining does before they click, which is the
+ * confirmation. No modal: the action is staged-only and every group it touches
+ * can be undone individually.
+ */
+export function CombineGroupsBanner({ collisions, onCombine }: Props) {
+  if (collisions.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {collisions.map((collision) => {
+        const payeeCount = collision.suggestions.reduce(
+          (total, suggestion) => total + suggestion.cluster.members.length,
+          0
+        );
+
+        return (
+          <div
+            key={collision.finalName}
+            className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-600/40 bg-amber-500/5 p-3"
+          >
+            <p className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+              <span>
+                {collision.suggestions.length} groups are all named{" "}
+                <span className="font-medium">“{collision.finalName}”</span>. Saving
+                them separately would leave {collision.suggestions.length} payees with
+                that name.
+              </span>
+            </p>
+
+            <Button size="sm" variant="outline" onClick={() => onCombine(collision)}>
+              <Merge className="size-3.5" aria-hidden="true" />
+              Combine into one group ({payeeCount} payees → 1)
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/components/FutureRulePanel.tsx
+++ b/src/features/payee-cleanup/components/FutureRulePanel.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { FutureResolution, SourceField } from "../lib/ruleCandidates";
+
+type Props = {
+  resolution: FutureResolution;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  /** Replaces the generated pattern; clearing the text restores it. */
+  onPatternChange: (pattern: { field: SourceField; text: string } | undefined) => void;
+};
+
+const SKIP_COPY: Record<NonNullable<FutureResolution["skipReason"]>, string> = {
+  "already-resolved-by-name":
+    "No rule needed — after cleanup, Actual will match these imports to the payee by name on its own.",
+  "existing-rule-covers-it":
+    "No rule needed — one of your existing rules already sets the payee for this text.",
+  "no-safe-pattern":
+    "No rule offered — no pattern catches this payee without also catching other payees' transactions.",
+  "no-matching-pattern":
+    "No rule offered — no pattern built from this name matches the imported text on record.",
+};
+
+/**
+ * The "stop this happening again" step (RD-078 §15–§17).
+ *
+ * Most of this panel's job is *not* proposing a rule. Actual already resolves an
+ * imported name that exactly matches an existing payee, and an existing rule may
+ * already do the work — so cleanup often fixes future imports with no rule at
+ * all, and adding one anyway is the rule sprawl this feature exists to undo.
+ */
+export function FutureRulePanel({
+  resolution,
+  enabled,
+  onToggle,
+  onPatternChange,
+}: Props) {
+  const { recommended, skipReason, exactName, relatedRules, candidates } = resolution;
+  const [draft, setDraft] = useState<string | null>(null);
+  const field: SourceField = recommended?.candidate.field ?? "imported_payee";
+
+  return (
+    <section className="mt-3 border-t border-border/60 pt-3 text-xs">
+      <h4 className="font-medium text-foreground">Future imports</h4>
+
+      {exactName.covered > 0 ? (
+        <p className="mt-1 text-muted-foreground">
+          {exactName.covered} past import{exactName.covered === 1 ? "" : "s"}{" "}
+          already match the name you are keeping, so {exactName.covered === 1 ? "it" : "they"} will
+          resolve without a rule.
+        </p>
+      ) : null}
+
+      {relatedRules.length > 0 ? (
+        <p className="mt-1 text-muted-foreground">
+          {relatedRules.length} existing rule{relatedRules.length === 1 ? "" : "s"} already
+          touch{relatedRules.length === 1 ? "es" : ""} these payees
+          {relatedRules.some((r) => r.interaction === "potential-conflict")
+            ? " — at least one could conflict with a new rule."
+            : "."}
+        </p>
+      ) : null}
+
+      {skipReason ? (
+        <p className="mt-1 text-muted-foreground">{SKIP_COPY[skipReason]}</p>
+      ) : null}
+
+      {recommended ? (
+        <div className="mt-2 space-y-1">
+          <label className="flex items-start gap-2">
+            <Checkbox
+              checked={enabled}
+              onCheckedChange={(value) => onToggle(value === true)}
+              aria-label="Also create a rule so future imports match this payee"
+            />
+            <span>
+              <span className="text-foreground">
+                Also create a rule: when{" "}
+                {recommended.candidate.field === "notes" ? "notes" : "imported payee"}{" "}
+                {recommended.candidate.description}, set the payee.
+              </span>
+              <span className="ml-1 block text-muted-foreground">
+                Matches {recommended.expectedMatches} past transaction
+                {recommended.expectedMatches === 1 ? "" : "s"} of this payee
+                {recommended.unexpectedMatches === 0
+                  ? " and nothing else."
+                  : ` — and ${recommended.unexpectedMatches} belonging to other payees.`}
+              </span>
+            </span>
+          </label>
+
+          {recommended.unexpectedMatches > 0 ? (
+            <p className="ml-6 text-amber-700 dark:text-amber-400">
+              Not selected for you, because it would also catch{" "}
+              {recommended.unexpectedExamples
+                .map((e) => (e.payeeName ? `"${e.text}" (${e.payeeName})` : `"${e.text}"`))
+                .join(", ")}
+            </p>
+          ) : null}
+
+          <div className="ml-6 space-y-1">
+            <label className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground">Match on</span>
+              <select
+                value={field}
+                onChange={(e) =>
+                  onPatternChange({
+                    field: e.target.value as SourceField,
+                    text: draft ?? resolution.matchText,
+                  })
+                }
+                className="h-7 rounded-md border border-border bg-background px-1 text-xs"
+                aria-label="Which field the rule matches on"
+              >
+                <option value="imported_payee">imported payee</option>
+                <option value="notes">notes</option>
+              </select>
+              <span className="text-muted-foreground">text</span>
+              <input
+                type="text"
+                value={draft ?? resolution.matchText}
+                onChange={(e) => setDraft(e.target.value)}
+                onBlur={() => {
+                  if (draft !== null && draft !== resolution.matchText) {
+                    onPatternChange(draft.trim() ? { field, text: draft } : undefined);
+                  }
+                  setDraft(null);
+                }}
+                className="h-7 min-w-[12rem] rounded-md border border-border bg-background px-2 text-xs"
+                aria-label="Text the rule should match"
+              />
+            </label>
+
+            <code className="inline-block rounded bg-muted px-1 py-0.5 font-mono text-[11px] break-all">
+              {recommended.candidate.field} {recommended.candidate.op}{" "}
+              {recommended.candidate.value}
+            </code>
+
+            {candidates.length > 1 ? (
+              <p className="text-muted-foreground">
+                {candidates.length - 1} other pattern
+                {candidates.length === 2 ? "" : "s"} considered
+                {recommended.unexpectedMatches === 0
+                  ? "; this one caught the most of this payee's history without catching anything else."
+                  : "; none caught this payee without also catching others — edit the text above to narrow it."}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/payee-cleanup/components/FutureRulePanel.tsx
+++ b/src/features/payee-cleanup/components/FutureRulePanel.tsx
@@ -99,12 +99,7 @@ export function FutureRulePanel({
             </span>
           </label>
 
-          ) : (
-            <p className="text-amber-700 dark:text-amber-400">
-              No pattern on this field matches your import history. Change the
-              field or the text below, or leave the rule off.
-            </p>
-          )}
+          ) : null}
 
           {recommended && recommended.unexpectedMatches > 0 ? (
             <p className="ml-6 text-amber-700 dark:text-amber-400">

--- a/src/features/payee-cleanup/components/FutureRulePanel.tsx
+++ b/src/features/payee-cleanup/components/FutureRulePanel.tsx
@@ -18,7 +18,7 @@ const SKIP_COPY: Record<NonNullable<FutureResolution["skipReason"]>, string> = {
   "no-safe-pattern":
     "No rule offered — no pattern catches this payee without also catching other payees' transactions.",
   "no-matching-pattern":
-    "No rule offered — no pattern built from this name matches the imported text on record.",
+    "No rule offered — nothing in the imported text on record matches this pattern.",
 };
 
 /**

--- a/src/features/payee-cleanup/components/FutureRulePanel.tsx
+++ b/src/features/payee-cleanup/components/FutureRulePanel.tsx
@@ -37,7 +37,12 @@ export function FutureRulePanel({
 }: Props) {
   const { recommended, skipReason, exactName, relatedRules, candidates } = resolution;
   const [draft, setDraft] = useState<string | null>(null);
-  const field: SourceField = recommended?.candidate.field ?? "imported_payee";
+  // Edit state, not a view of the detected field: a field whose pattern the
+  // backtest cannot recommend produced no candidate, so the select snapped back
+  // to `imported_payee` and the next blur committed that over the user's choice.
+  const [fieldOverride, setFieldOverride] = useState<SourceField | null>(null);
+  const field: SourceField =
+    fieldOverride ?? recommended?.candidate.field ?? "imported_payee";
 
   return (
     <section className="mt-3 border-t border-border/60 pt-3 text-xs">
@@ -99,16 +104,25 @@ export function FutureRulePanel({
           ) : null}
 
           <div className="ml-6 space-y-1">
-            <label className="flex flex-wrap items-center gap-2">
+            {/* A group, not a label: one <label> can only name one control, and
+                this row holds a select and an input. Both carry their own
+                aria-label. */}
+            <div
+              role="group"
+              aria-label="Rule pattern"
+              className="flex flex-wrap items-center gap-2"
+            >
               <span className="text-muted-foreground">Match on</span>
               <select
                 value={field}
-                onChange={(e) =>
+                onChange={(e) => {
+                  const next = e.target.value as SourceField;
+                  setFieldOverride(next);
                   onPatternChange({
-                    field: e.target.value as SourceField,
+                    field: next,
                     text: draft ?? resolution.matchText,
-                  })
-                }
+                  });
+                }}
                 className="h-7 rounded-md border border-border bg-background px-1 text-xs"
                 aria-label="Which field the rule matches on"
               >
@@ -129,7 +143,7 @@ export function FutureRulePanel({
                 className="h-7 min-w-[12rem] rounded-md border border-border bg-background px-2 text-xs"
                 aria-label="Text the rule should match"
               />
-            </label>
+            </div>
 
             <code className="inline-block rounded bg-muted px-1 py-0.5 font-mono text-[11px] break-all">
               {recommended.candidate.field} {recommended.candidate.op}{" "}

--- a/src/features/payee-cleanup/components/FutureRulePanel.tsx
+++ b/src/features/payee-cleanup/components/FutureRulePanel.tsx
@@ -70,8 +70,13 @@ export function FutureRulePanel({
         <p className="mt-1 text-muted-foreground">{SKIP_COPY[skipReason]}</p>
       ) : null}
 
-      {recommended ? (
+      {/* The editor survives an override that finds nothing. Hiding it whenever
+          there is no recommendation trapped the user: choosing a field with no
+          historical matches removed the very controls needed to choose another
+          one, or to type text that would match. */}
+      {recommended || fieldOverride !== null ? (
         <div className="mt-2 space-y-1">
+          {recommended ? (
           <label className="flex items-start gap-2">
             <Checkbox
               checked={enabled}
@@ -94,7 +99,14 @@ export function FutureRulePanel({
             </span>
           </label>
 
-          {recommended.unexpectedMatches > 0 ? (
+          ) : (
+            <p className="text-amber-700 dark:text-amber-400">
+              No pattern on this field matches your import history. Change the
+              field or the text below, or leave the rule off.
+            </p>
+          )}
+
+          {recommended && recommended.unexpectedMatches > 0 ? (
             <p className="ml-6 text-amber-700 dark:text-amber-400">
               Not selected for you, because it would also catch{" "}
               {recommended.unexpectedExamples
@@ -145,12 +157,14 @@ export function FutureRulePanel({
               />
             </div>
 
-            <code className="inline-block rounded bg-muted px-1 py-0.5 font-mono text-[11px] break-all">
-              {recommended.candidate.field} {recommended.candidate.op}{" "}
-              {recommended.candidate.value}
-            </code>
+            {recommended ? (
+              <code className="inline-block rounded bg-muted px-1 py-0.5 font-mono text-[11px] break-all">
+                {recommended.candidate.field} {recommended.candidate.op}{" "}
+                {recommended.candidate.value}
+              </code>
+            ) : null}
 
-            {candidates.length > 1 ? (
+            {recommended && candidates.length > 1 ? (
               <p className="text-muted-foreground">
                 {candidates.length - 1} other pattern
                 {candidates.length === 2 ? "" : "s"} considered

--- a/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
@@ -510,6 +510,11 @@ describe("PayeeCleanupView", () => {
     );
     expect(screen.getByLabelText(/text the rule should match/i)).toBeInTheDocument();
 
+    // And the explanation names the real reason rather than a generic one.
+    expect(
+      screen.getByText(/no pattern built from this name matches the imported text/i)
+    ).toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText(/which field the rule matches on/i), {
       target: { value: "imported_payee" },
     });

--- a/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
@@ -512,7 +512,7 @@ describe("PayeeCleanupView", () => {
 
     // And the explanation names the real reason rather than a generic one.
     expect(
-      screen.getByText(/no pattern built from this name matches the imported text/i)
+      screen.getByText(/nothing in the imported text on record matches this pattern/i)
     ).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/which field the rule matches on/i), {

--- a/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
@@ -71,9 +71,13 @@ jest.mock("../hooks/useSuppressions", () => ({
 // The staged store is real in these tests: staging has to actually remove the
 // payees it staged from the candidate set.
 let pendingPayeeMerges: { targetId: string; mergeIds: string[] }[] = [];
+let stagedPayeeEntries: Record<
+  string,
+  { isNew: boolean; isUpdated: boolean; isDeleted: boolean }
+> = {};
 jest.mock("../../../store/staged", () => ({
   useStagedStore: (selector: (s: unknown) => unknown) =>
-    selector({ pendingPayeeMerges, payees: {}, rules: {} }),
+    selector({ pendingPayeeMerges, payees: stagedPayeeEntries, rules: {} }),
 }));
 
 jest.mock("../hooks/usePayeeCleanupCandidates", () => ({
@@ -95,6 +99,7 @@ beforeEach(() => {
   transactionsLoading = false;
   rejectCluster.mockClear();
   pendingPayeeMerges = [];
+  stagedPayeeEntries = {};
   toastSuccess.mockClear();
   stageMock.mockReset();
   stageMock.mockResolvedValue({ status: "staged", operations: 1 });
@@ -736,6 +741,34 @@ describe("PayeeCleanupView", () => {
     rerender(<PayeeCleanupView />);
 
     expect(screen.queryByRole("article")).not.toBeInTheDocument();
+  });
+
+  it("does not call an untouched working set staged changes", () => {
+    // The staged store holds every loaded payee, not only the edited ones, so
+    // counting its keys announced "441 changes are staged" on a page where
+    // nothing had been touched.
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+    stagedPayeeEntries = {
+      "p-WOOLWORTHS 0183": { isNew: false, isUpdated: false, isDeleted: false },
+      "p-WOOLWORTHS 0291": { isNew: false, isUpdated: false, isDeleted: false },
+    };
+
+    render(<PayeeCleanupView />);
+
+    expect(screen.queryByText(/staged and\s+waiting/i)).not.toBeInTheDocument();
+  });
+
+  it("counts a staged rename, which produces no merge at all", () => {
+    // A rename-only plan was reported as nothing pending — the one case this
+    // reminder exists for.
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+    stagedPayeeEntries = {
+      "p-WOOLWORTHS 0183": { isNew: false, isUpdated: true, isDeleted: false },
+    };
+
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByText(/1 change is staged and waiting/i)).toBeInTheDocument();
   });
 
   it("keeps unstaged work when only some groups are staged", () => {

--- a/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
@@ -1,0 +1,730 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { PayeeCleanupView } from "./PayeeCleanupView";
+import { partitionByEligibility } from "../lib/eligibility";
+import { getPayeeCleanupCapabilities } from "../lib/capabilities";
+import type { PayeeCleanupCandidate } from "../types";
+
+function payee(
+  name: string,
+  overrides: Partial<PayeeCleanupCandidate["metadata"]> = {}
+): PayeeCleanupCandidate {
+  const id = `p-${name}`;
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+      ...overrides,
+    },
+  };
+}
+
+let candidates: PayeeCleanupCandidate[] = [];
+let stagedRules: Record<string, unknown> = {};
+let transactionCounts: Map<string, number> | undefined = new Map();
+let transactionsLoading = false;
+let mode: "http-api" | "browser-api" = "http-api";
+let isLoading = false;
+
+// The impact hook owns the TanStack queries (rules, schedules, transaction
+// counts); this suite is about what the view renders, so it supplies the loaded
+// shape directly rather than standing up a QueryClientProvider.
+jest.mock("../hooks/usePayeeCleanupImpact", () => ({
+  usePayeeCleanupImpact: () => ({
+    stagedRules,
+    schedules: [],
+    transactionCounts,
+    transactionsLoading,
+  }),
+}));
+
+// Suppression persistence is exercised in its own suites (the repository and
+// lib/suppressions); here the view just needs the calls recorded.
+let importedText: { field: "imported_payee" | "notes"; text: string; payeeId: string | null; transactionCount: number }[] = [];
+jest.mock("../hooks/useImportedTextIndex", () => ({
+  useImportedTextIndex: () => ({ rows: importedText, isLoading: false }),
+}));
+
+const toastSuccess = jest.fn();
+jest.mock("sonner", () => ({ toast: { success: (m: string) => toastSuccess(m) } }));
+
+const rejectCluster = jest.fn();
+const stageMock = jest.fn();
+jest.mock("../hooks/usePayeeCleanupPlan", () => ({
+  usePayeeCleanupPlan: () => ({ stage: stageMock, isStaging: false }),
+}));
+jest.mock("../hooks/useSuppressions", () => ({
+  useSuppressions: () => ({
+    suppressions: [],
+    rejectCluster,
+    rejectAffix: jest.fn(),
+    undo: jest.fn(),
+    clearAll: jest.fn(),
+    isSaving: false,
+  }),
+}));
+
+// The staged store is real in these tests: staging has to actually remove the
+// payees it staged from the candidate set.
+let pendingPayeeMerges: { targetId: string; mergeIds: string[] }[] = [];
+jest.mock("../../../store/staged", () => ({
+  useStagedStore: (selector: (s: unknown) => unknown) =>
+    selector({ pendingPayeeMerges, payees: {} }),
+}));
+
+jest.mock("../hooks/usePayeeCleanupCandidates", () => ({
+  usePayeeCleanupCandidates: () => ({
+    partition: partitionByEligibility(candidates),
+    capabilities: getPayeeCleanupCapabilities({ mode }),
+    isLoading,
+    error: null,
+    refetch: jest.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  candidates = [];
+  mode = "http-api";
+  isLoading = false;
+  stagedRules = {};
+  transactionCounts = new Map();
+  transactionsLoading = false;
+  rejectCluster.mockClear();
+  pendingPayeeMerges = [];
+  toastSuccess.mockClear();
+  stageMock.mockReset();
+  stageMock.mockResolvedValue({ status: "staged", operations: 1 });
+  importedText = [];
+});
+
+/** Deep reasoning is behind an inline toggle; everything else is on the card. */
+function openReasoning() {
+  fireEvent.click(screen.getAllByRole("button", { name: /^reasoning$/i })[0]);
+}
+
+describe("PayeeCleanupView", () => {
+  it("shows a suggestion with its members, evidence and target", () => {
+    candidates = [
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("WOOLWORTHS 8442"),
+      payee("Woolworths"),
+    ];
+
+    render(<PayeeCleanupView />);
+
+    // Everything a decision needs is on one screen: the result, the payees it
+    // comes from with their counts, and what was detected.
+    const card = screen.getByRole("article");
+    expect(within(card).getByLabelText(/final payee name/i)).toHaveValue("Woolworths");
+    expect(within(card).getByText(/4 payees/)).toBeInTheDocument();
+    // The name renders as spans with the detected noise dimmed, so match the
+    // row rather than a contiguous text node.
+    expect(within(card).getByTitle("WOOLWORTHS 0183")).toBeInTheDocument();
+    expect(within(card).getByLabelText(/^keep Woolworths$/i)).toBeChecked();
+    expect(within(card).getByText(/store or terminal number/i)).toBeInTheDocument();
+  });
+
+  it("reports how many payees were analyzed and excluded", () => {
+    candidates = [
+      payee("AMAZON"),
+      payee("Amazon"),
+      payee("Transfer: Savings", { transferAccountId: "acct-1" }),
+    ];
+
+    render(<PayeeCleanupView />);
+
+    // Both live on the toolbar line now — the analyzed count had its own box
+    // two inches below itself, and the exclusion note a full sentence.
+    expect(
+      screen.getByText(/2 payees analyzed · 1 transfer excluded/)
+    ).toBeInTheDocument();
+  });
+
+  it("puts search, filters and the primary action where Rule Diagnostics does", () => {
+    // Two tools doing the same kind of job should not need learning twice.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByLabelText(/search payees/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /suggestions 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^scan again$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /stage cleanup/i })).toBeInTheDocument();
+  });
+
+  it("keeps the filters, totals and pending changes out of the scrolling list", () => {
+    // Triaging fifty groups means scrolling constantly; losing the counts and
+    // the Stage button on the first scroll makes the page feel unanchored.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    const scroller = document.querySelector(".overflow-auto");
+    expect(scroller).not.toBeNull();
+
+    // The card is inside the scroll area; the filters and totals are not.
+    expect(scroller?.contains(screen.getByRole("article"))).toBe(true);
+    expect(scroller?.contains(screen.getByLabelText(/search payees/i))).toBe(false);
+    // The summary boxes, matched exactly so the toolbar's own count does not
+    // also match.
+    expect(scroller?.contains(screen.getByText("Cleanup suggestions"))).toBe(false);
+  });
+
+  it("shows what is pending in its own box rather than a panel", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByText("None yet")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^accept$/i }));
+
+    expect(screen.getByText("Pending changes")).toBeInTheDocument();
+    expect(screen.getByText(/1 merge/)).toBeInTheDocument();
+    // The safety line travels with the changes it describes.
+    expect(
+      screen.getByText(/1 payee stops existing · not written until you save/i)
+    ).toBeInTheDocument();
+  });
+
+  it("hides the confidence filter on tabs it cannot filter", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByRole("button", { name: /needs review/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /unused/i }));
+    expect(
+      screen.queryByRole("button", { name: /needs review/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers no control that writes to the budget", () => {
+    // Accepting marks a proposal for the staged plan; it must not merge, save,
+    // apply or delete anything. Those arrive in 041e behind an explicit Save.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+
+    render(<PayeeCleanupView />);
+
+    for (const button of screen.getAllByRole("button")) {
+      expect(button.textContent ?? "").not.toMatch(/merge now|^save|apply|delete/i);
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: /^accept$/i }));
+    expect(screen.getByText(/not written until you save/i)).toBeInTheDocument();
+  });
+
+  it("records a rejection so it survives the next scan", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /not duplicates/i }));
+    expect(rejectCluster).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the user drop a member from a proposal", () => {
+    candidates = [payee("AMAZON"), payee("Amazon"), payee("amazon")];
+    render(<PayeeCleanupView />);
+    const card = screen.getByRole("article");
+
+    fireEvent.click(
+      within(card).getAllByRole("button", { name: /remove .* from this group/i })[0]
+    );
+
+
+    // Dropping to two members keeps it a proposal; the removed payee is gone.
+    expect(
+      within(screen.getByRole("article")).getAllByRole("button", {
+        name: /remove .* from this group/i,
+      })
+    ).toHaveLength(1);
+  });
+
+  it("lets the user choose which payee survives", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+
+    const radios = screen.getAllByRole("radio");
+    fireEvent.click(radios[radios.length - 1]);
+    expect(radios[radios.length - 1]).toBeChecked();
+  });
+
+  it("lets the user add a payee the scan missed", () => {
+    // The one correction exclusion cannot emulate.
+    candidates = [payee("AMAZON"), payee("Amazon"), payee("Amazon Web Services")];
+    render(<PayeeCleanupView />);
+    const card = screen.getByRole("article");
+
+    const input = within(card).getByLabelText(/add a payee the scan missed/i);
+    fireEvent.change(input, { target: { value: "Amazon Web Services" } });
+
+    // It is now a member of the proposal, which the per-member remove control
+    // proves — the name alone also appears in the picker's option list.
+    expect(
+      within(screen.getByRole("article")).getAllByRole("button", {
+        name: /remove .* from this group/i,
+      })
+    ).toHaveLength(2);
+  });
+
+  it("lets the user edit the final name", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+    const card = screen.getByRole("article");
+
+    const input = within(card).getByLabelText(/final payee name/i);
+    fireEvent.change(input, { target: { value: "Amazon Marketplace" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByText("Amazon Marketplace")).toBeInTheDocument();
+  });
+
+  it("states the Favorite / Category-learning outcome on the group it affects", () => {
+    // This used to be a page-wide banner that also claimed the feature was
+    // read-only. It belongs on the group whose settings actually differ.
+    candidates = [payee("AMAZON", { favorite: true }), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(
+      screen.getByText(/Favorite \/ Category learning differ/i)
+    ).toBeInTheDocument();
+  });
+
+  it("discloses the stricter unused-payee check where it applies", () => {
+    // On the Unused tab, next to the list it describes — not in a page-wide
+    // banner over suggestions it has nothing to do with.
+    candidates = [payee("Old Test Payee"), payee("AMAZON"), payee("Amazon")];
+    transactionCounts = new Map([["p-AMAZON", 4]]);
+
+    render(<PayeeCleanupView />);
+    expect(screen.queryByText(/more cautious than Actual/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /unused/i }));
+    expect(screen.getByText(/more cautious than Actual/i)).toBeInTheDocument();
+  });
+
+  it("does not convey confidence by colour alone", () => {
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+    render(<PayeeCleanupView />);
+
+    // The band is words, not a colour — and not a percentage either, which
+    // would read as a calibrated probability it is not.
+    expect(
+      screen.getAllByText(/^(High confidence|Likely|Needs review|Ambiguous)$/).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("tells the user plainly when there is nothing to clean up", () => {
+    candidates = [payee("Woolworths"), payee("Tesco")];
+    render(<PayeeCleanupView />);
+
+    expect(
+      screen.getByText(/No duplicate or variant payees found/i)
+    ).toBeInTheDocument();
+  });
+
+  it("says plainly that merging does not rewrite rules", () => {
+    // The most surprising thing about Actual's merge, and the user is about to
+    // rely on it.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    stagedRules = {
+      r1: {
+        entity: {
+          id: "r1",
+          stage: "default",
+          conditionsOp: "and",
+          conditions: [{ field: "payee", op: "is", value: "p-AMAZON" }],
+          actions: [],
+        },
+        original: null,
+        isNew: false,
+        isUpdated: false,
+        isDeleted: false,
+        validationErrors: {},
+      },
+    };
+
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByText(/merging does not rewrite them/i)).toBeInTheDocument();
+  });
+
+  it("shows counting rather than zero while transactions load", () => {
+    // Rendering 0 during load reads as "unused", the opposite of the truth.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    transactionCounts = undefined;
+    transactionsLoading = true;
+
+    render(<PayeeCleanupView />);
+
+    expect(screen.getAllByText(/counting/i).length).toBeGreaterThan(0);
+  });
+
+  it("lists unused payees on their own tab, with the stricter-check note", () => {
+    candidates = [payee("Old Test Payee"), payee("AMAZON"), payee("Amazon")];
+    transactionCounts = new Map([["p-AMAZON", 4]]);
+
+    render(<PayeeCleanupView />);
+    fireEvent.click(screen.getByRole("button", { name: /unused/i }));
+
+    expect(screen.getByText("Old Test Payee")).toBeInTheDocument();
+    expect(screen.getByText(/more cautious than Actual/i)).toBeInTheDocument();
+  });
+
+  it("keeps the toolbar's Stage button disabled until something is accepted", () => {
+    // The summary strip stays silent too: an empty "nothing accepted yet" panel
+    // above every scan is noise.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByRole("button", { name: /stage cleanup/i })).toBeDisabled();
+    expect(screen.queryByText(/nothing accepted yet/i)).not.toBeInTheDocument();
+  });
+
+  it("stages an accepted proposal and says nothing was written", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^accept$/i }));
+
+    expect(screen.getByText(/1 payee stops existing/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /stage cleanup/i }));
+    expect(stageMock).toHaveBeenCalledTimes(1);
+
+    // The confirmation is a moment, not a state — it goes to a toast rather
+    // than parking a panel on the page.
+    return Promise.resolve().then(() => {
+      expect(toastSuccess).toHaveBeenCalledWith(
+        expect.stringMatching(/staged — save on the Payees page/)
+      );
+      expect(screen.queryByText(/1 change staged\./)).not.toBeInTheDocument();
+    });
+  });
+
+  it("counts the payees that will stop existing, not just the operations", () => {
+    // "12 changes" tells a user nothing about whether a payee disappears.
+    candidates = [payee("AMAZON"), payee("Amazon"), payee("amazon")];
+    render(<PayeeCleanupView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^accept$/i }));
+    expect(screen.getByText(/2 payees stop existing/i)).toBeInTheDocument();
+  });
+
+  it("offers a rule that catches the payee, unchecked until the user opts in", () => {
+    candidates = [payee("AMAZON 1234"), payee("AMAZON 5678")];
+    importedText = [
+      { field: "imported_payee", text: "AMAZON 1234", payeeId: "p-AMAZON 1234", transactionCount: 12 },
+      { field: "imported_payee", text: "AMAZON 5678", payeeId: "p-AMAZON 5678", transactionCount: 8 },
+      { field: "imported_payee", text: "TESCO 9", payeeId: "p-other", transactionCount: 3 },
+    ];
+
+    render(<PayeeCleanupView />);
+
+
+    const toggle = screen.getByRole("checkbox", {
+      name: /create a rule so future imports match this payee/i,
+    });
+    expect(toggle).not.toBeChecked();
+    expect(screen.getByRole("article").textContent).toMatch(
+      /Matches 20 of this group's past transactions and nothing else/
+    );
+  });
+
+  it("says no rule is needed when the kept name already resolves the imports", () => {
+    // Actual matches an imported name to an existing payee by name, so cleanup
+    // alone often fixes future imports — proposing a rule anyway is sprawl.
+    candidates = [payee("Amazon"), payee("AMAZON")];
+    importedText = [
+      { field: "imported_payee", text: "Amazon", payeeId: "p-Amazon", transactionCount: 30 },
+      { field: "imported_payee", text: "AMAZON", payeeId: "p-AMAZON", transactionCount: 2 },
+    ];
+
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByText(/Actual will match these imports by name/i)).toBeInTheDocument();
+  });
+
+  it("lets the user narrow the rule's matched text", () => {
+    // The generated pattern anchors on the reduced stem, which can be narrower
+    // than the merchant: a rule for "HUNGRY JACKS MELBOURNE" misses every other
+    // suburb.
+    candidates = [payee("HUNGRY JACKS 0183"), payee("HUNGRY JACKS 0291")];
+    importedText = [
+      {
+        field: "imported_payee",
+        text: "HUNGRY JACKS 0183",
+        payeeId: "p-HUNGRY JACKS 0183",
+        transactionCount: 4,
+      },
+      {
+        field: "imported_payee",
+        text: "HUNGRY JACKS 0291",
+        payeeId: "p-HUNGRY JACKS 0291",
+        transactionCount: 6,
+      },
+    ];
+
+    render(<PayeeCleanupView />);
+
+
+    const input = screen.getByLabelText(/text the rule should match/i);
+    fireEvent.change(input, { target: { value: "HUNGRY" } });
+    fireEvent.blur(input);
+
+    // The pattern is rebuilt and re-scored from what the user typed.
+    expect(screen.getByLabelText(/text the rule should match/i)).toHaveValue("HUNGRY");
+    expect(screen.getByText(/\^HUNGRY/)).toBeInTheDocument();
+  });
+
+  it("keeps the deep reasoning behind an inline toggle, not a dialog", () => {
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+    render(<PayeeCleanupView />);
+
+    // The score lives here, next to the reasoning that produced it — not on the
+    // card, where a heuristic reads as a calibrated probability.
+    expect(screen.queryByText(/^\d+% —/)).not.toBeInTheDocument();
+    openReasoning();
+    expect(screen.getByText(/^\d+% —/)).toBeInTheDocument();
+    // No modal: the card stays in the accessibility tree.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("article")).toBeInTheDocument();
+  });
+
+  it("keeps the collapsed card to what a decision needs (F-096)", () => {
+    // The complaint was density: correct information, badly rationed. The
+    // reasoning, the impact breakdown and every editing control belong behind
+    // the toggle; the decision itself does not.
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByRole("button", { name: /^accept$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /not duplicates/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^reasoning$/i })).toBeInTheDocument();
+
+    // In the drawer, not on the card.
+    // The payee list appears exactly once — it carries the survivor choice and
+    // the counts together, rather than being printed again as a breakdown.
+    expect(screen.queryByText(/per payee/i)).not.toBeInTheDocument();
+    // Deep reasoning stays behind the toggle.
+    expect(screen.queryByText(/keeping this payee/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the safety copy with whatever is pending", () => {
+    // The line moved from under every card into the summary strip, which
+    // appears as soon as there is something to save. A disclosure repeated
+    // fifty times is wallpaper; one that never appears is worse.
+    candidates = [payee("AMAZON", { favorite: true }), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    // The settings warning belongs to the group it affects, so it is on the card.
+    expect(screen.getByText(/Favorite \/ Category learning differ/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not written until you save/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^accept$/i }));
+
+    expect(
+      screen.getByText(/1 payee stops existing · not written until you save/i)
+    ).toBeInTheDocument();
+  });
+
+  it("uses the page width instead of one tall column", () => {
+    // Three sections side by side — result, what changes, future imports — so a
+    // suggestion is one glance rather than a scroll.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    const card = screen.getByRole("article");
+    expect(within(card).getByText("Result")).toBeInTheDocument();
+    expect(within(card).getByText("What changes")).toBeInTheDocument();
+    expect(within(card).getByText("Future imports")).toBeInTheDocument();
+  });
+
+  it("groups Undo with the other whole-suggestion actions, only once there is something to undo", () => {
+    // It used to sit at the bottom of the Future imports column, which has
+    // nothing to do with undoing an edit.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(
+      screen.queryByRole("button", { name: /undo my changes/i })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^accept$/i }));
+
+    const header = screen.getByRole("article").querySelector("header");
+    expect(
+      within(header as HTMLElement).getByRole("button", { name: /undo my changes/i })
+    ).toBeInTheDocument();
+  });
+
+  it("restores the detector's proposal when undo is used", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    const name = screen.getByLabelText(/final payee name/i);
+    fireEvent.change(name, { target: { value: "Something Else" } });
+    fireEvent.blur(name);
+    expect(screen.getByDisplayValue("Something Else")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /undo my changes/i }));
+    expect(screen.queryByDisplayValue("Something Else")).not.toBeInTheDocument();
+  });
+
+  it("triages from the keyboard on the focused card", () => {
+    // A/R/N are scoped to the card, so they cannot fire while the user is
+    // typing in the search box or a drawer field.
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    const card = screen.getByRole("article");
+    card.focus();
+    fireEvent.keyDown(card, { key: "a" });
+
+    expect(screen.getByRole("button", { name: /accepted/i })).toBeInTheDocument();
+  });
+
+  it("does not fire triage keys while the user is typing in the card", () => {
+    // The card is full of inputs now — a rename field, a rule pattern, an
+    // add-payee box. Window-level shortcuts would reject a suggestion the
+    // moment someone typed an "n".
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    const nameField = screen.getByLabelText(/final payee name/i);
+    fireEvent.keyDown(nameField, { key: "n" });
+    fireEvent.keyDown(nameField, { key: "a" });
+
+    expect(rejectCluster).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /accepted/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("accepts the confident suggestions in one action, never the uncertain ones", () => {
+    // Forty cards each needing a click is the same complaint in another form.
+    candidates = [
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("WOOLWORTHS 8442"),
+      payee("TESCO 0001"),
+      payee("TESCO 0002"),
+      payee("TESCO 0003"),
+      // A fuzzy-only pair lands in "needs review" and must be left alone.
+      payee("Carrefour Market"),
+      payee("Carrefour Markt"),
+    ];
+    render(<PayeeCleanupView />);
+
+    fireEvent.click(screen.getByRole("button", { name: /accept 2 safe/i }));
+    expect(screen.getAllByRole("button", { name: /accepted/i })).toHaveLength(2);
+  });
+
+  it("offers to combine groups the user has given the same name", () => {
+    // Naming two groups the same thing is the user saying those payees are one
+    // merchant — the scan could not see it because the names reduce to
+    // different stems. Blocking alone leaves them to reconcile it by hand.
+    candidates = [
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("TESCO 0001"),
+      payee("TESCO 0002"),
+    ];
+    render(<PayeeCleanupView />);
+
+    const cards = screen.getAllByRole("article");
+    expect(cards).toHaveLength(2);
+
+    // Accept both, then name them the same thing.
+    for (const card of cards) {
+      fireEvent.click(within(card).getByRole("button", { name: /^accept$/i }));
+      const name = within(card).getByLabelText(/final payee name/i);
+      fireEvent.change(name, { target: { value: "Groceries Shop" } });
+      fireEvent.blur(name);
+    }
+
+    expect(
+      screen.getByText(/2 groups are all named/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /combine into one group/i }));
+
+    // One group now holds all four payees, and the collision is gone.
+    expect(screen.getAllByRole("article")).toHaveLength(1);
+    expect(screen.queryByText(/groups are all named/i)).not.toBeInTheDocument();
+    expect(
+      within(screen.getByRole("article")).getByText(/4 payees/)
+    ).toBeInTheDocument();
+  });
+
+  it("says what a risky rule catches as well as what it over-catches", () => {
+    // "Also catches 1 transaction of X" alone gives no sense of whether the
+    // rule is otherwise doing its job.
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+    importedText = [
+      { field: "imported_payee", text: "WOOLWORTHS 0183", payeeId: "p-WOOLWORTHS 0183", transactionCount: 4 },
+      { field: "imported_payee", text: "WOOLWORTHS 0291", payeeId: "p-WOOLWORTHS 0291", transactionCount: 2 },
+      { field: "imported_payee", text: "WOOLWORTHS MOBILE", payeeId: "p-other", transactionCount: 1 },
+    ];
+
+    render(<PayeeCleanupView />);
+
+    // The sentence is built from several nodes, so read the card's text.
+    const text = screen.getByRole("article").textContent ?? "";
+    expect(text).toMatch(/Matches 6 ?of this group's past transactions/);
+    expect(text).toMatch(/and 1 transaction of/);
+    expect(text).toMatch(/Narrow the text, or add that payee to this group/);
+  });
+
+  it("drops a group from the list once its payees are staged", () => {
+    // The candidate list comes from a fresh read that knows nothing about the
+    // staged store. Without this, staging left every suggestion on screen and
+    // the same merge could be staged twice.
+    candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
+
+    const { rerender } = render(<PayeeCleanupView />);
+    expect(screen.getAllByRole("article")).toHaveLength(1);
+
+    pendingPayeeMerges = [
+      { targetId: "p-WOOLWORTHS 0183", mergeIds: ["p-WOOLWORTHS 0291"] },
+    ];
+    rerender(<PayeeCleanupView />);
+
+    expect(screen.queryByRole("article")).not.toBeInTheDocument();
+  });
+
+  it("keeps unstaged work when only some groups are staged", () => {
+    // Clearing every correction after a stage threw away renames, target
+    // choices and combined groups the user was still working on — which looked
+    // exactly like the work had been lost.
+    candidates = [
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("TESCO 0001"),
+      payee("TESCO 0002"),
+    ];
+    render(<PayeeCleanupView />);
+
+    const [first, second] = screen.getAllByRole("article");
+    fireEvent.click(within(first).getByRole("button", { name: /^accept$/i }));
+
+    // The second group is mid-edit and not accepted.
+    const name = within(second).getByLabelText(/final payee name/i);
+    fireEvent.change(name, { target: { value: "Still Editing" } });
+    fireEvent.blur(name);
+
+    fireEvent.click(screen.getByRole("button", { name: /stage cleanup/i }));
+
+    return Promise.resolve().then(() => {
+      expect(screen.getByDisplayValue("Still Editing")).toBeInTheDocument();
+    });
+  });
+
+  it("labels the search field for screen readers", () => {
+    candidates = [payee("AMAZON"), payee("Amazon")];
+    render(<PayeeCleanupView />);
+
+    expect(screen.getByRole("searchbox", { name: /search payees/i })).toBeInTheDocument();
+  });
+});

--- a/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
@@ -478,6 +478,45 @@ describe("PayeeCleanupView", () => {
     expect(screen.getByText(/\^HUNGRY/)).toBeInTheDocument();
   });
 
+  it("keeps the pattern editor reachable after choosing a field with no matches", () => {
+    // Selecting a field the history cannot match leaves no recommendation. If
+    // that also removed the editor, the user could not choose another field or
+    // type text that would match — a one-way trip out of the rule.
+    candidates = [payee("HUNGRY JACKS 0183"), payee("HUNGRY JACKS 0291")];
+    importedText = [
+      {
+        field: "imported_payee",
+        text: "HUNGRY JACKS 0183",
+        payeeId: "p-HUNGRY JACKS 0183",
+        transactionCount: 4,
+      },
+      {
+        field: "imported_payee",
+        text: "HUNGRY JACKS 0291",
+        payeeId: "p-HUNGRY JACKS 0291",
+        transactionCount: 6,
+      },
+    ];
+
+    render(<PayeeCleanupView />);
+
+    const field = screen.getByLabelText(/which field the rule matches on/i);
+    fireEvent.change(field, { target: { value: "notes" } });
+
+    // Nothing in the history is a note, so there is no recommendation — but the
+    // controls are still there, and they still show the user's choice.
+    expect(screen.getByLabelText(/which field the rule matches on/i)).toHaveValue(
+      "notes"
+    );
+    expect(screen.getByLabelText(/text the rule should match/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/which field the rule matches on/i), {
+      target: { value: "imported_payee" },
+    });
+    // Back on a field the history can match, the recommendation returns.
+    expect(screen.getByText(/\^HUNGRY/)).toBeInTheDocument();
+  });
+
   it("keeps the deep reasoning behind an inline toggle, not a dialog", () => {
     candidates = [payee("WOOLWORTHS 0183"), payee("WOOLWORTHS 0291")];
     render(<PayeeCleanupView />);

--- a/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.test.tsx
@@ -73,7 +73,7 @@ jest.mock("../hooks/useSuppressions", () => ({
 let pendingPayeeMerges: { targetId: string; mergeIds: string[] }[] = [];
 jest.mock("../../../store/staged", () => ({
   useStagedStore: (selector: (s: unknown) => unknown) =>
-    selector({ pendingPayeeMerges, payees: {} }),
+    selector({ pendingPayeeMerges, payees: {}, rules: {} }),
 }));
 
 jest.mock("../hooks/usePayeeCleanupCandidates", () => ({

--- a/src/features/payee-cleanup/components/PayeeCleanupView.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.tsx
@@ -62,16 +62,19 @@ export function PayeeCleanupView() {
    *
    * A rename-only or rule-only plan produces no merge, so counting
    * `pendingPayeeMerges` reported "nothing pending" while real work sat unsaved
-   * — the one situation this reminder exists for. Staged payee and rule edits
-   * made elsewhere are counted too, and that is correct: they also need Save.
+   * — the one situation this reminder exists for.
+   *
+   * Counts *changed* entries only. The staged store holds the whole working set,
+   * so its key count is every payee in the budget, which read as hundreds of
+   * changes waiting on a page where nothing had been touched.
    */
-  const stagedCount = useMemo(
-    () =>
-      pendingMerges.length +
-      Object.keys(stagedPayees).length +
-      Object.keys(stagedRules).length,
-    [pendingMerges, stagedPayees, stagedRules]
-  );
+  const stagedCount = useMemo(() => {
+    const changed = (
+      map: Record<string, { isNew: boolean; isUpdated: boolean; isDeleted: boolean }>
+    ) => Object.values(map).filter((e) => e.isNew || e.isUpdated || e.isDeleted).length;
+
+    return pendingMerges.length + changed(stagedPayees) + changed(stagedRules);
+  }, [pendingMerges, stagedPayees, stagedRules]);
 
   const stagedAwayIds = useMemo(() => {
     const ids = new Set(pendingMerges.flatMap((m) => m.mergeIds));

--- a/src/features/payee-cleanup/components/PayeeCleanupView.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { useStagedStore } from "@/store/staged";
+import { usePayeeCleanupCandidates } from "../hooks/usePayeeCleanupCandidates";
+import { usePayeeCleanupImpact } from "../hooks/usePayeeCleanupImpact";
+import { useSuppressions } from "../hooks/useSuppressions";
+import {
+  addMember,
+  excludeMember,
+  resetCluster,
+  setCanonicalName,
+  setDecision,
+  combineGroups,
+  setCreateRule,
+  setRulePattern,
+  setTarget,
+  type CorrectionMap,
+} from "../lib/corrections";
+import { useImportedTextIndex } from "../hooks/useImportedTextIndex";
+import { scanForCleanup } from "../lib/scan";
+import { CleanupSummaryCards } from "./CleanupSummaryCards";
+import { SuggestionCard } from "./SuggestionCard";
+import { findNameCollisions, isSafeForBulkAccept } from "../lib/triage";
+import { CombineGroupsBanner } from "./CombineGroupsBanner";
+import { CleanupFilterBar, type BandFilter, type CleanupTab } from "./CleanupFilterBar";
+import { UnusedPayeeList } from "./UnusedPayeeList";
+import { SuppressionList } from "./SuppressionList";
+import { ReviewCleanupBar } from "./ReviewCleanupBar";
+import { usePayeeCleanupPlan, type StageOutcome } from "../hooks/usePayeeCleanupPlan";
+import { buildPlan, planOperationCount } from "../lib/plan";
+
+/**
+ * Payee Cleanup workspace — read-only (RD-078 Milestone 1).
+ *
+ * This slice can find and explain variants; it cannot change anything. There is
+ * deliberately no accept, merge or save control until the correction (041d) and
+ * staging (041e) slices land, so there is no path from here to a write.
+ */
+export function PayeeCleanupView() {
+  const { partition: scanned, isLoading, error, refetch } =
+    usePayeeCleanupCandidates({ enabled: true });
+
+  // Payees already staged for a merge or deletion are no longer candidates.
+  //
+  // The candidate list comes from a fresh `getPayees()`, which knows nothing
+  // about the staged store — so without this, staging left every suggestion on
+  // screen exactly as before, and the same merge could be staged twice.
+  const pendingMerges = useStagedStore((s) => s.pendingPayeeMerges);
+  const stagedPayees = useStagedStore((s) => s.payees);
+
+  const stagedAwayIds = useMemo(() => {
+    const ids = new Set(pendingMerges.flatMap((m) => m.mergeIds));
+    for (const [id, entry] of Object.entries(stagedPayees)) {
+      if (entry.isDeleted) ids.add(id);
+    }
+    return ids;
+  }, [pendingMerges, stagedPayees]);
+
+  const partition = useMemo(
+    () =>
+      stagedAwayIds.size === 0
+        ? scanned
+        : {
+            ...scanned,
+            eligible: scanned.eligible.filter((p) => !stagedAwayIds.has(p.id)),
+          },
+    [scanned, stagedAwayIds]
+  );
+
+  const [tab, setTab] = useState<CleanupTab>("suggestions");
+  const [band, setBand] = useState<BandFilter>("all");
+  const [search, setSearch] = useState("");
+
+  const [corrections, setCorrections] = useState<CorrectionMap>({});
+  const impact = usePayeeCleanupImpact(partition.eligible, { enabled: true });
+  const { suppressions, rejectCluster, undo, clearAll } = useSuppressions({
+    enabled: true,
+  });
+
+  const { rows: importedText, truncated: importedTextTruncated } =
+    useImportedTextIndex({ enabled: true });
+  const rules = useMemo(
+    () =>
+      Object.values(impact.stagedRules)
+        .filter((r) => !r.isDeleted)
+        .map((r) => r.entity),
+    [impact.stagedRules]
+  );
+
+  const result = useMemo(
+    () =>
+      scanForCleanup(partition, {
+        impactSources: impact,
+        suppressions,
+        corrections,
+        importedText,
+        importedTextTruncated,
+        rules,
+      }),
+    [
+      partition,
+      impact,
+      suppressions,
+      corrections,
+      importedText,
+      importedTextTruncated,
+      rules,
+    ]
+  );
+
+  const { stage, isStaging } = usePayeeCleanupPlan();
+  const [stageOutcome, setStageOutcome] = useState<StageOutcome | null>(null);
+  const clearOutcome = () => setStageOutcome(null);
+
+  const plan = useMemo(() => buildPlan(result.suggestions), [result.suggestions]);
+
+  // Deliberately stricter than "the score is high" — see `isSafeForBulkAccept`.
+  // A bulk action meaning "accept everything above 90%" would sweep up exactly
+  // the cases this feature exists to catch.
+  // Surfaced as soon as two accepted groups share a name, rather than waiting
+  // for a failed staging attempt to explain it.
+  const collisions = useMemo(
+    () => findNameCollisions(result.suggestions),
+    [result.suggestions]
+  );
+
+  const safeToAccept = useMemo(
+    () => result.suggestions.filter(isSafeForBulkAccept),
+    [result.suggestions]
+  );
+
+  function stageAccepted() {
+    const stagedClusterIds = result.suggestions
+      .filter((s) => s.correction.decision === "accepted")
+      .map((s) => s.cluster.id);
+
+    void stage(plan).then((outcome) => {
+      setStageOutcome(outcome);
+      if (outcome.status !== "staged") return;
+
+      // A confirmation is a moment, not a state: it says the click worked and
+      // then gets out of the way. The standing "staged and waiting" reminder in
+      // the strip is what persists.
+      toast.success(
+        `${outcome.operations} ${
+          outcome.operations === 1 ? "change" : "changes"
+        } staged — save on the Payees page to apply.`
+      );
+
+      // Clear only what was staged. Wiping every correction threw away renames,
+      // target choices and combined groups the user was still working on — and
+      // looked like the work had been lost.
+      setCorrections((c) => {
+        const next = { ...c };
+        for (const id of stagedClusterIds) delete next[id];
+        return next;
+      });
+    });
+  }
+
+  const candidateById = useMemo(
+    () => new Map(partition.eligible.map((c) => [c.id, c])),
+    [partition.eligible]
+  );
+
+  const visible = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return result.suggestions.filter((suggestion) => {
+      // Low-confidence proposals are computed but hidden by default, so the
+      // list stays trustworthy while a curious user can still widen it.
+      if (band === "all" ? suggestion.confidence.band === "hidden" : suggestion.confidence.band !== band) {
+        return false;
+      }
+      if (!query) return true;
+      return suggestion.cluster.members.some((m) =>
+        m.name.toLowerCase().includes(query)
+      );
+    });
+  }, [result.suggestions, band, search]);
+
+  return (
+    <PageLayout
+      title="Payee Cleanup"
+      count={
+        isLoading
+          ? undefined
+          : [
+              `${result.analyzedCount.toLocaleString("en-US")} payees analyzed`,
+              result.excludedTransferCount > 0
+                ? `${result.excludedTransferCount} transfer excluded`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")
+      }
+      actions={
+        <div className="flex items-center gap-2">
+          {safeToAccept.length > 0 ? (
+            <Button
+              variant="outline"
+              size="sm"
+              title="Structural matches with no rule, settings or future-rule conflicts. Still staged — nothing is written until you save."
+              onClick={() =>
+                setCorrections((c) => {
+                  let next = c;
+                  for (const suggestion of safeToAccept) {
+                    next = setDecision(next, suggestion.cluster.id, "accepted");
+                  }
+                  return next;
+                })
+              }
+            >
+              Accept {safeToAccept.length} safe
+            </Button>
+          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isLoading}
+          >
+            <RefreshCw className="size-3.5" aria-hidden="true" />
+            Scan again
+          </Button>
+          <Button
+            size="sm"
+            onClick={stageAccepted}
+            disabled={isStaging || planOperationCount(plan) === 0}
+          >
+            <Check className="size-3.5" aria-hidden="true" />
+            {isStaging
+              ? "Checking…"
+              : `Stage cleanup${
+                  planOperationCount(plan) > 0 ? ` (${planOperationCount(plan)})` : ""
+                }`}
+          </Button>
+        </div>
+      }
+      isLoading={isLoading}
+      isError={Boolean(error)}
+      error={error}
+      onRetry={() => refetch()}
+      emptyState={
+        result.analyzedCount === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            No payees to analyze yet.
+          </div>
+        ) : undefined
+      }
+      // The filters, the totals and the pending-changes strip stay put while
+      // the suggestion list scrolls under them. Triaging fifty groups means
+      // scrolling constantly, and losing the counts and the Stage button at the
+      // first scroll makes the page feel unanchored.
+      scrollManaged
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <CleanupFilterBar
+        tab={tab}
+        onTabChange={setTab}
+        band={band}
+        onBandChange={setBand}
+        search={search}
+        onSearchChange={setSearch}
+        counts={{
+          suggestions: result.suggestions.length,
+          unused: result.orphans.length,
+          dismissed: suppressions.length,
+        }}
+      />
+
+      <div className="shrink-0 px-4 pt-3">
+        <CleanupSummaryCards result={result} plan={plan} />
+      </div>
+
+      <ReviewCleanupBar
+        stagedCount={pendingMerges.length}
+        outcome={stageOutcome}
+      />
+
+      {collisions.length > 0 ? (
+      <div className="shrink-0 px-4 pt-3">
+        <CombineGroupsBanner
+          collisions={collisions}
+          onCombine={(collision) => {
+            // The group with the most payees survives, so the fewest members
+            // have to move.
+            const [survivor, ...absorbed] = [...collision.suggestions].sort(
+              (a, b) => b.cluster.members.length - a.cluster.members.length
+            );
+            setCorrections((c) =>
+              combineGroups(
+                c,
+                { clusterId: survivor.cluster.id, finalName: collision.finalName },
+                absorbed.map((s) => ({
+                  clusterId: s.cluster.id,
+                  memberIds: s.cluster.members.map((m) => m.id),
+                }))
+              )
+            );
+          }}
+        />
+      </div>
+      ) : null}
+
+      {/* The gap belongs to the rule, not to whatever happens to sit above it.
+          Putting it on the totals meant the pending strip and the combine
+          banner — which appear between the two — butted straight against the
+          line. */}
+      <div className="mt-4 min-h-0 flex-1 space-y-4 overflow-auto border-t border-border/40 p-4">
+        {tab === "dismissed" ? (
+          <SuppressionList
+            suppressions={suppressions}
+            onUndo={undo}
+            onClearAll={clearAll}
+          />
+        ) : tab === "unused" ? (
+          <UnusedPayeeList orphans={result.orphans} />
+        ) : (
+        <>
+        {visible.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border/70 p-8 text-center text-sm text-muted-foreground">
+            {result.suggestions.length === 0
+              ? "No duplicate or variant payees found. Nothing to clean up."
+              : "No suggestions match this filter."}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {visible.map((suggestion) => {
+              const clusterId = suggestion.cluster.id;
+              return (
+                <SuggestionCard
+                  key={clusterId}
+                  suggestion={suggestion}
+                  addablePayees={partition.eligible.filter(
+                    (p) => !suggestion.cluster.members.some((m) => m.id === p.id)
+                  )}
+                  onAccept={() => {
+                    clearOutcome();
+                    setCorrections((c) => setDecision(c, clusterId, "accepted"));
+                  }}
+                  onReject={() => {
+                    // Persisted immediately: a decision the user has to repeat
+                    // on every scan is not a decision.
+                    rejectCluster(suggestion.cluster);
+                    setCorrections((c) => setDecision(c, clusterId, "rejected"));
+                  }}
+                  onExcludeMember={(payeeId) =>
+                    setCorrections((c) => excludeMember(c, clusterId, payeeId))
+                  }
+                  onSetTarget={(payeeId) =>
+                    setCorrections((c) => {
+                      const candidate = candidateById.get(payeeId);
+                      if (!candidate) return c;
+                      const next = setTarget(c, clusterId, candidate);
+                      // A refusal comes back as a reason string; the eligibility
+                      // boundary already excludes those payees.
+                      return typeof next === "string" ? c : next;
+                    })
+                  }
+                  onAddMember={(payeeId) =>
+                    setCorrections((c) => {
+                      const candidate = candidateById.get(payeeId);
+                      if (!candidate) return c;
+                      const next = addMember(c, clusterId, candidate);
+                      return typeof next === "string" ? c : next;
+                    })
+                  }
+                  onRenameTo={(name) =>
+                    setCorrections((c) => setCanonicalName(c, clusterId, name))
+                  }
+                  onToggleRule={(enabled) =>
+                    setCorrections((c) => setCreateRule(c, clusterId, enabled))
+                  }
+                  onRulePatternChange={(pattern) =>
+                    setCorrections((c) => setRulePattern(c, clusterId, pattern))
+                  }
+                  onReset={() => setCorrections((c) => resetCluster(c, clusterId))}
+                />
+              );
+            })}
+          </div>
+        )}
+        </>
+        )}
+      </div>
+
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/features/payee-cleanup/components/PayeeCleanupView.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.tsx
@@ -35,11 +35,13 @@ import { usePayeeCleanupPlan, type StageOutcome } from "../hooks/usePayeeCleanup
 import { buildPlan, planOperationCount } from "../lib/plan";
 
 /**
- * Payee Cleanup workspace — read-only (RD-078 Milestone 1).
+ * The Payee Cleanup workspace: scan, review, correct, accept, stage.
  *
- * This slice can find and explain variants; it cannot change anything. There is
- * deliberately no accept, merge or save control until the correction (041d) and
- * staging (041e) slices land, so there is no path from here to a write.
+ * Every write leaves through `stage(plan)` and lands in the shared staged store,
+ * so this screen never touches the budget directly — the Payees page's Save is
+ * still the only thing that writes. The scan itself is derived state: it re-runs
+ * from the candidates, the impact sources and the user's corrections, which is
+ * why both hooks feeding it memoize their results.
  */
 export function PayeeCleanupView() {
   const { partition: scanned, isLoading, error, refetch } =
@@ -139,33 +141,49 @@ export function PayeeCleanupView() {
       .filter((s) => s.correction.decision === "accepted")
       .map((s) => s.cluster.id);
 
-    void stage(plan).then((outcome) => {
-      setStageOutcome(outcome);
-      if (outcome.status !== "staged") return;
+    void stage(plan).then(
+      (outcome) => {
+        setStageOutcome(outcome);
+        if (outcome.status !== "staged") return;
 
-      // A confirmation is a moment, not a state: it says the click worked and
-      // then gets out of the way. The standing "staged and waiting" reminder in
-      // the strip is what persists.
-      toast.success(
-        `${outcome.operations} ${
-          outcome.operations === 1 ? "change" : "changes"
-        } staged — save on the Payees page to apply.`
-      );
+        // A confirmation is a moment, not a state: it says the click worked and
+        // then gets out of the way. The standing "staged and waiting" reminder
+        // in the strip is what persists.
+        toast.success(
+          `${outcome.operations} ${
+            outcome.operations === 1 ? "change" : "changes"
+          } staged — save on the Payees page to apply.`
+        );
 
-      // Clear only what was staged. Wiping every correction threw away renames,
-      // target choices and combined groups the user was still working on — and
-      // looked like the work had been lost.
-      setCorrections((c) => {
-        const next = { ...c };
-        for (const id of stagedClusterIds) delete next[id];
-        return next;
-      });
-    });
+        // Clear only what was staged. Wiping every correction threw away
+        // renames, target choices and combined groups the user was still
+        // working on — and looked like the work had been lost.
+        setCorrections((c) => {
+          const next = { ...c };
+          for (const id of stagedClusterIds) delete next[id];
+          return next;
+        });
+      },
+      // A rejected promise used to be dropped: the click looked like it worked
+      // while nothing was staged. The corrections are deliberately left intact
+      // so the user can simply try again.
+      (error: Error) =>
+        toast.error(
+          error.message || "Could not stage this cleanup. Nothing was changed."
+        )
+    );
   }
 
   const candidateById = useMemo(
     () => new Map(partition.eligible.map((c) => [c.id, c])),
     [partition.eligible]
+  );
+
+  // The tab pill counts what the tab would show, ignoring the search box: a
+  // count that fell as you typed would read like suggestions disappearing.
+  const visibleBandCount = useMemo(
+    () => result.suggestions.filter((s) => s.confidence.band !== "hidden").length,
+    [result.suggestions]
   );
 
   const visible = useMemo(() => {
@@ -267,7 +285,9 @@ export function PayeeCleanupView() {
         search={search}
         onSearchChange={setSearch}
         counts={{
-          suggestions: result.suggestions.length,
+          // The same set the tab renders. Counting every suggestion included
+          // the hidden band, so the pill could read 12 above a list of 8.
+          suggestions: visibleBandCount,
           unused: result.orphans.length,
           dismissed: suppressions.length,
         }}

--- a/src/features/payee-cleanup/components/PayeeCleanupView.tsx
+++ b/src/features/payee-cleanup/components/PayeeCleanupView.tsx
@@ -55,6 +55,24 @@ export function PayeeCleanupView() {
   const pendingMerges = useStagedStore((s) => s.pendingPayeeMerges);
   const stagedPayees = useStagedStore((s) => s.payees);
 
+  const stagedRules = useStagedStore((s) => s.rules);
+
+  /**
+   * Everything staged and waiting for Save, not merges alone.
+   *
+   * A rename-only or rule-only plan produces no merge, so counting
+   * `pendingPayeeMerges` reported "nothing pending" while real work sat unsaved
+   * — the one situation this reminder exists for. Staged payee and rule edits
+   * made elsewhere are counted too, and that is correct: they also need Save.
+   */
+  const stagedCount = useMemo(
+    () =>
+      pendingMerges.length +
+      Object.keys(stagedPayees).length +
+      Object.keys(stagedRules).length,
+    [pendingMerges, stagedPayees, stagedRules]
+  );
+
   const stagedAwayIds = useMemo(() => {
     const ids = new Set(pendingMerges.flatMap((m) => m.mergeIds));
     for (const [id, entry] of Object.entries(stagedPayees)) {
@@ -298,7 +316,7 @@ export function PayeeCleanupView() {
       </div>
 
       <ReviewCleanupBar
-        stagedCount={pendingMerges.length}
+        stagedCount={stagedCount}
         outcome={stageOutcome}
       />
 

--- a/src/features/payee-cleanup/components/ReviewCleanupBar.tsx
+++ b/src/features/payee-cleanup/components/ReviewCleanupBar.tsx
@@ -37,7 +37,7 @@ export function ReviewCleanupBar({ stagedCount, outcome }: Props) {
         // gone. Without this, a user could stage twenty merges, see an empty
         // list, and close the tab believing they were done.
         <p className="rounded border border-emerald-600/40 bg-emerald-500/5 p-2 text-xs font-medium text-emerald-700 dark:text-emerald-400">
-          {stagedCount} {stagedCount === 1 ? "cleanup is" : "cleanups are"} staged and
+          {stagedCount} {stagedCount === 1 ? "change is" : "changes are"} staged and
           waiting — open the Payees page and save to apply them.
         </p>
       ) : null}

--- a/src/features/payee-cleanup/components/ReviewCleanupBar.tsx
+++ b/src/features/payee-cleanup/components/ReviewCleanupBar.tsx
@@ -1,0 +1,72 @@
+import { AlertTriangle } from "lucide-react";
+import type { PlanProblem } from "../lib/plan";
+import type { StageOutcome } from "../hooks/usePayeeCleanupPlan";
+
+type Props = {
+  /** Merges already staged and waiting to be saved on the Payees page. */
+  stagedCount: number;
+  outcome: StageOutcome | null;
+};
+
+/**
+ * Only what needs attention (RD-078 §22, M6).
+ *
+ * The routine "what will be staged" counts live in the Pending changes box,
+ * alongside the safety line, so this renders nothing at all on a normal pass.
+ * What remains is the three things a user must not miss: work already staged
+ * and waiting to be saved, a plan that cannot be staged, and a plan built on
+ * payees that have since changed.
+ *
+ * The "N changes staged" confirmation is deliberately *not* here — it is a
+ * moment, not a state, so it goes to a toast and leaves. The standing reminder
+ * that staged work is still unsaved is the part that has to persist.
+ */
+export function ReviewCleanupBar({ stagedCount, outcome }: Props) {
+  const blocking = outcome?.status === "blocked" ? outcome.problems : [];
+  const hasSomethingToSay =
+    stagedCount > 0 || blocking.length > 0 || outcome?.status === "stale";
+
+  // Routine counts moved into the Pending changes box. What is left is only
+  // what needs attention, so on a normal pass this renders nothing at all.
+  if (!hasSomethingToSay) return null;
+
+  return (
+    <div className="mx-4 mt-3 space-y-2">
+      {stagedCount > 0 ? (
+        // Staged work is invisible from this page once its suggestions are
+        // gone. Without this, a user could stage twenty merges, see an empty
+        // list, and close the tab believing they were done.
+        <p className="rounded border border-emerald-600/40 bg-emerald-500/5 p-2 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+          {stagedCount} {stagedCount === 1 ? "cleanup is" : "cleanups are"} staged and
+          waiting — open the Payees page and save to apply them.
+        </p>
+      ) : null}
+
+      {outcome?.status === "stale" ? (
+        <p className="flex items-start gap-2 rounded border border-amber-600/40 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          <span>
+            {outcome.changedCount}{" "}
+            {outcome.changedCount === 1 ? "payee has" : "payees have"} changed since
+            this cleanup was prepared. Scan again so you are deciding on what the
+            budget holds now.
+          </span>
+        </p>
+      ) : null}
+
+      {blocking.length > 0 ? (
+        <div className="rounded border border-destructive/40 bg-destructive/5 p-2">
+          <p className="flex items-center gap-2 text-xs font-medium text-destructive">
+            <AlertTriangle className="size-3.5" aria-hidden="true" />
+            This cleanup cannot be staged yet
+          </p>
+          <ul className="mt-1 space-y-0.5 text-xs text-destructive">
+            {blocking.map((problem: PlanProblem, index) => (
+              <li key={`${problem.payeeIds.join()}-${index}`}>{problem.message}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -40,6 +40,21 @@ const BAND_LABEL: Record<ConfidenceBand, string> = {
   hidden: "Ambiguous",
 };
 
+/** Why no rule is being offered. One place, because two branches show it. */
+const SKIP_COPY: Record<
+  NonNullable<CleanupSuggestion["futureResolution"]>["skipReason"] & string,
+  string
+> = {
+  "already-resolved-by-name":
+    "No rule needed — after cleanup Actual will match these imports by name.",
+  "existing-rule-covers-it":
+    "No rule needed — an existing rule already sets the payee for this text.",
+  "no-safe-pattern":
+    "No rule offered — no pattern catches this payee without catching others.",
+  "no-matching-pattern":
+    "No rule offered — no pattern built from this name matches the imported text on record.",
+};
+
 const BAND_CLASS: Record<ConfidenceBand, string> = {
   high: "border-emerald-600/40 text-emerald-700 dark:text-emerald-400",
   strong: "border-sky-600/40 text-sky-700 dark:text-sky-400",
@@ -400,9 +415,13 @@ export function SuggestionCard({
                   </span>
                 </label>
               ) : (
-                <p className="mt-1 text-amber-700 dark:text-amber-400">
-                  No pattern on this field matches your import history. Change the
-                  field or the text, or leave the rule off.
+                // `recommended` is null exactly when a skip reason is set, and
+                // that reason is the accurate explanation: "an existing rule
+                // already covers this" is not "nothing matches".
+                <p className="mt-1 text-muted-foreground">
+                  {future.skipReason
+                    ? SKIP_COPY[future.skipReason]
+                    : "Checking your import history…"}
                 </p>
               )}
 
@@ -489,15 +508,9 @@ export function SuggestionCard({
             </>
           ) : (
             <p className="mt-1 text-muted-foreground">
-              {future?.skipReason === "already-resolved-by-name"
-                ? "No rule needed — after cleanup Actual will match these imports by name."
-                : future?.skipReason === "existing-rule-covers-it"
-                  ? "No rule needed — an existing rule already sets the payee for this text."
-                  : future?.skipReason === "no-safe-pattern"
-                    ? "No rule offered — no pattern catches this payee without catching others."
-                    : future?.skipReason === "no-matching-pattern"
-                      ? "No rule offered — no pattern built from this name matches the imported text on record."
-                      : "Checking your import history…"}
+              {future?.skipReason
+                ? SKIP_COPY[future.skipReason]
+                : "Checking your import history…"}
             </p>
           )}
 

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -202,7 +202,18 @@ export function SuggestionCard({
             appears, so Accept and Not duplicates never move under the cursor. */}
         <div className="flex items-center gap-2">
           {hasEdits ? (
-            <Button size="sm" variant="ghost" onClick={onReset}>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                // Local editor state too. Leaving `fieldOverride` set meant the
+                // next text edit rebuilt a rule override on the field the user
+                // had just undone.
+                setFieldOverride(null);
+                setPatternDraft(null);
+                onReset();
+              }}
+            >
               <Undo2 className="size-3.5" aria-hidden="true" />
               Undo my changes
             </Button>

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -1,0 +1,455 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Star,
+  Undo2,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
+import { annotateNoise, detectionSummary } from "../lib/triage";
+import type { CleanupSuggestion } from "../lib/scan";
+import type { ConfidenceBand } from "../lib/confidence";
+import type { PayeeCleanupCandidate } from "../types";
+
+type Props = {
+  suggestion: CleanupSuggestion;
+  addablePayees: PayeeCleanupCandidate[];
+  onAccept: () => void;
+  onReject: () => void;
+  onExcludeMember: (payeeId: string) => void;
+  onSetTarget: (payeeId: string) => void;
+  onAddMember: (payeeId: string) => void;
+  onRenameTo: (name: string) => void;
+  onToggleRule: (enabled: boolean) => void;
+  onRulePatternChange: (
+    pattern: { field: "imported_payee" | "notes"; text: string } | undefined
+  ) => void;
+  onReset: () => void;
+};
+
+const BAND_LABEL: Record<ConfidenceBand, string> = {
+  high: "High confidence",
+  strong: "Likely",
+  review: "Needs review",
+  hidden: "Ambiguous",
+};
+
+const BAND_CLASS: Record<ConfidenceBand, string> = {
+  high: "border-emerald-600/40 text-emerald-700 dark:text-emerald-400",
+  strong: "border-sky-600/40 text-sky-700 dark:text-sky-400",
+  review: "border-amber-600/40 text-amber-700 dark:text-amber-400",
+  hidden: "border-border text-muted-foreground",
+};
+
+/**
+ * One cleanup suggestion, on one screen (RD-078 §11–§13; F-096).
+ *
+ * Three columns across the page width rather than a tall single column, so the
+ * result, what changes, and the future-import rule are all readable at once and
+ * the controls the user reaches for most — the final name, which payee survives,
+ * and the rule's matched text — are editable in place. An earlier version put
+ * these behind a modal drawer; opening a dialog per suggestion is worse than
+ * scrolling, and it hid exactly the fields people adjust most often.
+ *
+ * **One payee list.** It carries the survivor choice, the per-payee transaction
+ * counts and the remove control together. A separate "per payee" breakdown
+ * elsewhere on the card was the same rows printed twice.
+ *
+ * Rarely-needed diagnostics — the confidence breakdown, related rules, the
+ * pattern — sit behind an inline *reasoning* toggle, not a dialog.
+ */
+export function SuggestionCard({
+  suggestion,
+  addablePayees,
+  onAccept,
+  onReject,
+  onExcludeMember,
+  onSetTarget,
+  onAddMember,
+  onRenameTo,
+  onToggleRule,
+  onRulePatternChange,
+  onReset,
+}: Props) {
+  const [showReasoning, setShowReasoning] = useState(false);
+  const [patternDraft, setPatternDraft] = useState<string | null>(null);
+  // Fifty cards each rendering 200 <option> elements is 10,000 nodes nobody is
+  // looking at, so the list is built when the picker is first focused.
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const { cluster, confidence, target, canonicalName, correction, impact } = suggestion;
+  const future = suggestion.futureResolution;
+  const accepted = correction.decision === "accepted";
+  const removals = cluster.evidence.map((e) => e.detail);
+  const pattern = cluster.evidence.find((e) => e.pattern)?.pattern;
+
+  const hasEdits =
+    correction.excludedIds.length > 0 ||
+    correction.addedIds.length > 0 ||
+    correction.targetId !== undefined ||
+    correction.canonicalName !== undefined ||
+    correction.rulePattern !== undefined ||
+    correction.decision !== "undecided";
+
+  const settingsDiffer =
+    impact?.behavior.favoriteDiffers === true ||
+    impact?.behavior.learnCategoriesDiffers === true;
+  const activeRules = impact ? impact.rules.regular + impact.rules.activeSchedule : 0;
+  const countFor = (id: string) =>
+    impact?.members.find((m) => m.payeeId === id)?.transactionCount;
+
+  /** A accept · R reasoning · N not duplicates, only when the card itself has focus. */
+  function onKeyDown(event: React.KeyboardEvent<HTMLElement>) {
+    if (event.target !== event.currentTarget) return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    const key = event.key.toLowerCase();
+    if (key === "a") {
+      event.preventDefault();
+      onAccept();
+    } else if (key === "r") {
+      event.preventDefault();
+      setShowReasoning((open) => !open);
+    } else if (key === "n") {
+      event.preventDefault();
+      onReject();
+    }
+  }
+
+  return (
+    <article
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      aria-label={`${canonicalName} — ${BAND_LABEL[confidence.band]}`}
+      className={cn(
+        "rounded-md border p-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+        accepted ? "border-emerald-600/50 bg-emerald-500/5" : "border-border/70"
+      )}
+    >
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-sm font-semibold">{canonicalName}</h3>
+          <span
+            className={cn(
+              "rounded-full border px-2 py-0.5 text-[11px] font-medium",
+              BAND_CLASS[confidence.band]
+            )}
+          >
+            {BAND_LABEL[confidence.band]}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {cluster.members.length} payees
+            <ArrowRight className="mx-1 inline size-3" aria-hidden="true" />1
+          </span>
+        </div>
+
+        {/* Right-aligned, and Undo goes first: the group grows leftward when it
+            appears, so Accept and Not duplicates never move under the cursor. */}
+        <div className="flex items-center gap-2">
+          {hasEdits ? (
+            <Button size="sm" variant="ghost" onClick={onReset}>
+              <Undo2 className="size-3.5" aria-hidden="true" />
+              Undo my changes
+            </Button>
+          ) : null}
+          <Button size="sm" variant={accepted ? "default" : "outline"} onClick={onAccept}>
+            <Check className="size-3.5" aria-hidden="true" />
+            {accepted ? "Accepted" : "Accept"}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onReject}>
+            Not duplicates
+          </Button>
+        </div>
+      </header>
+
+      <div className="mt-3 grid gap-4 text-xs lg:grid-cols-3">
+        {/* ── Result and the payees it comes from ───────────────────────── */}
+        <section className="min-w-0">
+          <h4 className="font-medium text-foreground">Result</h4>
+          <input
+            type="text"
+            defaultValue={canonicalName}
+            key={canonicalName}
+            onBlur={(e) => {
+              if (e.target.value !== canonicalName) onRenameTo(e.target.value);
+            }}
+            aria-label="Final payee name"
+            className="mt-1 h-7 w-full rounded-md border border-border bg-background px-2 text-sm"
+          />
+
+          <ul className="mt-2 space-y-1" aria-label="Payees in this group">
+            {cluster.members.map((member) => {
+              const isTarget = member.id === target.targetId;
+              return (
+                <li key={member.id} className="flex items-center gap-1.5">
+                  <input
+                    type="radio"
+                    name={`keep-${cluster.id}`}
+                    checked={isTarget}
+                    onChange={() => onSetTarget(member.id)}
+                    aria-label={`Keep ${member.name}`}
+                    className="shrink-0"
+                  />
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate",
+                      isTarget ? "text-foreground" : "text-muted-foreground"
+                    )}
+                    title={member.name}
+                  >
+                    {annotateNoise(member.name, removals).map((part, index) => (
+                      <span
+                        key={index}
+                        className={part.noise ? "text-muted-foreground/40" : undefined}
+                      >
+                        {part.text}
+                      </span>
+                    ))}
+                  </span>
+                  {member.metadata.favorite ? (
+                    <Star
+                      className="size-3 shrink-0 text-amber-600 dark:text-amber-400"
+                      aria-label="Favorite payee"
+                    />
+                  ) : null}
+                  {/* Real budgets hold payees with identical names — the count
+                      is what tells them apart. */}
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {countFor(member.id) ?? "—"} tx
+                  </span>
+                  {isTarget ? null : (
+                    <button
+                      type="button"
+                      onClick={() => onExcludeMember(member.id)}
+                      aria-label={`Remove ${member.name} from this group`}
+                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                    >
+                      <X className="size-3" aria-hidden="true" />
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          <input
+            type="text"
+            list={`add-payee-${cluster.id}`}
+            placeholder="Add a payee the scan missed…"
+            aria-label="Add a payee the scan missed"
+            className="mt-1.5 h-7 w-full rounded-md border border-dashed border-border bg-background px-2 text-xs"
+            onFocus={() => setPickerOpen(true)}
+            onChange={(e) => {
+              const match = addablePayees.find((p) => p.name === e.target.value);
+              if (match) {
+                onAddMember(match.id);
+                e.target.value = "";
+              }
+            }}
+          />
+          <datalist id={`add-payee-${cluster.id}`}>
+            {pickerOpen
+              ? addablePayees.slice(0, 200).map((p) => (
+                  <option key={p.id} value={p.name} />
+                ))
+              : null}
+          </datalist>
+        </section>
+
+        {/* ── What changes ──────────────────────────────────────────────── */}
+        <section className="min-w-0">
+          <h4 className="font-medium text-foreground">What changes</h4>
+          <ul className="mt-1 space-y-0.5 text-muted-foreground">
+            <li>
+              {impact?.transactionTotal === undefined
+                ? "Counting transactions…"
+                : `${impact.transactionTotal.toLocaleString("en-US")} ${
+                    impact.transactionTotal === 1 ? "transaction moves" : "transactions move"
+                  } to the payee you keep`}
+            </li>
+            <li>
+              {activeRules === 0
+                ? "No rules reference these payees"
+                : `${activeRules} ${activeRules === 1 ? "rule references" : "rules reference"} these payees — merging does not rewrite them`}
+            </li>
+            {impact && impact.rules.completedSchedule > 0 ? (
+              <li>
+                {impact.rules.completedSchedule} completed schedule
+                {impact.rules.completedSchedule === 1 ? "" : "s"} — not counted as active
+              </li>
+            ) : null}
+            <li
+              className={
+                settingsDiffer ? "text-amber-700 dark:text-amber-400" : undefined
+              }
+            >
+              {settingsDiffer ? (
+                <>
+                  <AlertTriangle className="mr-1 inline size-3" aria-hidden="true" />
+                  Favorite / Category learning differ — the payee you keep decides
+                </>
+              ) : (
+                "Favorite and Category learning match"
+              )}
+            </li>
+          </ul>
+
+          <p className="mt-2 text-muted-foreground">{detectionSummary(suggestion)}</p>
+
+          <button
+            type="button"
+            onClick={() => setShowReasoning((open) => !open)}
+            aria-expanded={showReasoning}
+            className="mt-1 inline-flex items-center gap-1 rounded border border-border/70 px-1.5 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            {showReasoning ? (
+              <ChevronDown className="size-3" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="size-3" aria-hidden="true" />
+            )}
+            {showReasoning ? "Hide reasoning" : "Reasoning"}
+          </button>
+
+          {showReasoning ? (
+            <div className="mt-1 space-y-1 text-muted-foreground">
+              <p>{confidence.score}% — {confidence.reasons.map((r) => r.reason).join(" · ")}</p>
+              <p>
+                {target.reasons.length > 0
+                  ? `Keeping this payee: ${target.reasons.join(" · ")}`
+                  : "No clear signal favours any member — a stable default was chosen."}
+              </p>
+              {pattern ? (
+                <code className="inline-block rounded bg-muted px-1 py-0.5 font-mono text-[11px] break-all">
+                  {pattern}
+                </code>
+              ) : null}
+              {future && future.relatedRules.length > 0 ? (
+                <p>
+                  {future.relatedRules.length} existing rule
+                  {future.relatedRules.length === 1 ? "" : "s"} touch these payees
+                  {future.relatedRules.some((r) => r.interaction === "potential-conflict")
+                    ? " — at least one could conflict"
+                    : ""}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </section>
+
+        {/* ── Future imports ────────────────────────────────────────────── */}
+        <section className="min-w-0">
+          <h4 className="font-medium text-foreground">Future imports</h4>
+
+          {future?.recommended ? (
+            <>
+              <label className="mt-1 flex items-start gap-2">
+                <Checkbox
+                  checked={correction.createRule === true}
+                  onCheckedChange={(value) => onToggleRule(value === true)}
+                  aria-label="Create a rule so future imports match this payee"
+                />
+                <span className="text-foreground">Create a rule to prevent this recurring</span>
+              </label>
+
+              <div className="mt-1.5 flex items-center gap-1.5">
+                <select
+                  value={future.recommended.candidate.field}
+                  onChange={(e) =>
+                    onRulePatternChange({
+                      field: e.target.value as "imported_payee" | "notes",
+                      text: patternDraft ?? future.matchText,
+                    })
+                  }
+                  aria-label="Which field the rule matches on"
+                  className="h-7 rounded-md border border-border bg-background px-1"
+                >
+                  <option value="imported_payee">imported payee</option>
+                  <option value="notes">notes</option>
+                </select>
+                <input
+                  type="text"
+                  value={patternDraft ?? future.matchText}
+                  onChange={(e) => setPatternDraft(e.target.value)}
+                  onBlur={() => {
+                    if (patternDraft !== null && patternDraft !== future.matchText) {
+                      onRulePatternChange(
+                        patternDraft.trim()
+                          ? {
+                              field: future.recommended!.candidate.field,
+                              text: patternDraft,
+                            }
+                          : undefined
+                      );
+                    }
+                    setPatternDraft(null);
+                  }}
+                  aria-label="Text the rule should match"
+                  className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2"
+                />
+              </div>
+
+              {/* What will actually be created — one line, because "starts with
+                  X" and a regex are not the same promise. */}
+              <code className="mt-1 block truncate rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
+                {future.recommended.candidate.field} {future.recommended.candidate.op}{" "}
+                {future.recommended.candidate.value}
+              </code>
+
+              <p
+                className={cn(
+                  "mt-1",
+                  future.recommended.unexpectedMatches > 0
+                    ? "text-amber-700 dark:text-amber-400"
+                    : "text-muted-foreground"
+                )}
+              >
+                {future.recommended.unexpectedMatches === 0 ? (
+                  `Matches ${future.recommended.expectedMatches} of this group's past ${
+                    future.recommended.expectedMatches === 1 ? "transaction" : "transactions"
+                  }${
+                    future.historyTruncated
+                      ? " and nothing else in the history checked (only the most recent records were read)"
+                      : " and nothing else"
+                  }`
+                ) : (
+                  <>
+                    <AlertTriangle className="mr-1 inline size-3" aria-hidden="true" />
+                    {/* Both numbers, always: "also catches 1" alone gives no
+                        sense of whether the rule is otherwise doing its job. */}
+                    Matches {future.recommended.expectedMatches} of this group&apos;s past{" "}
+                    {future.recommended.expectedMatches === 1 ? "transaction" : "transactions"},
+                    and {future.recommended.unexpectedMatches}{" "}
+                    {future.recommended.unexpectedMatches === 1 ? "transaction" : "transactions"} of{" "}
+                    {future.recommended.unexpectedExamples
+                      .map((e) => e.payeeName ?? e.text)
+                      .slice(0, 2)
+                      .join(", ")}
+                    . Narrow the text, or add that payee to this group.
+                  </>
+                )}
+              </p>
+            </>
+          ) : (
+            <p className="mt-1 text-muted-foreground">
+              {future?.skipReason === "already-resolved-by-name"
+                ? "No rule needed — after cleanup Actual will match these imports by name."
+                : future?.skipReason === "existing-rule-covers-it"
+                  ? "No rule needed — an existing rule already sets the payee for this text."
+                  : future?.skipReason === "no-safe-pattern"
+                    ? "No rule offered — no pattern catches this payee without catching others."
+                    : future?.skipReason === "no-matching-pattern"
+                      ? "No rule offered — no pattern built from this name matches the imported text on record."
+                      : "Checking your import history…"}
+            </p>
+          )}
+
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -52,7 +52,7 @@ const SKIP_COPY: Record<
   "no-safe-pattern":
     "No rule offered — no pattern catches this payee without catching others.",
   "no-matching-pattern":
-    "No rule offered — no pattern built from this name matches the imported text on record.",
+    "No rule offered — nothing in the imported text on record matches this pattern.",
 };
 
 const BAND_CLASS: Record<ConfidenceBand, string> = {

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -79,6 +79,14 @@ export function SuggestionCard({
 }: Props) {
   const [showReasoning, setShowReasoning] = useState(false);
   const [patternDraft, setPatternDraft] = useState<string | null>(null);
+  // The chosen field is edit state, not a view of the detected one. Deriving it
+  // from the recommended candidate meant a field the backtest could not
+  // recommend — because the new pattern matched nothing — snapped back to
+  // `imported_payee`, and the next blur committed that instead of the user's
+  // choice.
+  const [fieldOverride, setFieldOverride] = useState<
+    "imported_payee" | "notes" | null
+  >(null);
   // Fifty cards each rendering 200 <option> elements is 10,000 nodes nobody is
   // looking at, so the list is built when the picker is first focused.
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -121,6 +129,12 @@ export function SuggestionCard({
           : payee.name,
     }));
   }, [addablePayees]);
+
+  const ruleField =
+    fieldOverride ??
+    suggestion.correction.rulePattern?.field ??
+    suggestion.futureResolution?.recommended?.candidate.field ??
+    "imported_payee";
 
   const countFor = (id: string) =>
     impact?.members.find((m) => m.payeeId === id)?.transactionCount;
@@ -381,13 +395,15 @@ export function SuggestionCard({
 
               <div className="mt-1.5 flex items-center gap-1.5">
                 <select
-                  value={future.recommended.candidate.field}
-                  onChange={(e) =>
+                  value={ruleField}
+                  onChange={(e) => {
+                    const field = e.target.value as "imported_payee" | "notes";
+                    setFieldOverride(field);
                     onRulePatternChange({
-                      field: e.target.value as "imported_payee" | "notes",
+                      field,
                       text: patternDraft ?? future.matchText,
-                    })
-                  }
+                    });
+                  }}
                   aria-label="Which field the rule matches on"
                   className="h-7 rounded-md border border-border bg-background px-1"
                 >
@@ -402,10 +418,7 @@ export function SuggestionCard({
                     if (patternDraft !== null && patternDraft !== future.matchText) {
                       onRulePatternChange(
                         patternDraft.trim()
-                          ? {
-                              field: future.recommended!.candidate.field,
-                              text: patternDraft,
-                            }
+                          ? { field: ruleField, text: patternDraft }
                           : undefined
                       );
                     }

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   AlertTriangle,
   ArrowRight,
@@ -101,6 +101,27 @@ export function SuggestionCard({
     impact?.behavior.favoriteDiffers === true ||
     impact?.behavior.learnCategoriesDiffers === true;
   const activeRules = impact ? impact.rules.regular + impact.rules.activeSchedule : 0;
+  /**
+   * The picker resolves the typed text back to a payee, so every option has to
+   * be unique. Real budgets hold payees with identical names — the browser then
+   * showed two identical rows and the lookup always returned the first, quietly
+   * adding the wrong payee to the merge. Only the duplicated names carry the
+   * disambiguating id, so the common case stays clean.
+   */
+  const addableOptions = useMemo(() => {
+    const nameCounts = new Map<string, number>();
+    for (const payee of addablePayees) {
+      nameCounts.set(payee.name, (nameCounts.get(payee.name) ?? 0) + 1);
+    }
+    return addablePayees.map((payee) => ({
+      id: payee.id,
+      label:
+        (nameCounts.get(payee.name) ?? 0) > 1
+          ? `${payee.name} · ${payee.id.slice(0, 6)}`
+          : payee.name,
+    }));
+  }, [addablePayees]);
+
   const countFor = (id: string) =>
     impact?.members.find((m) => m.payeeId === id)?.transactionCount;
 
@@ -245,7 +266,9 @@ export function SuggestionCard({
             className="mt-1.5 h-7 w-full rounded-md border border-dashed border-border bg-background px-2 text-xs"
             onFocus={() => setPickerOpen(true)}
             onChange={(e) => {
-              const match = addablePayees.find((p) => p.name === e.target.value);
+              const match = addableOptions.find(
+                (o) => o.label === e.target.value
+              );
               if (match) {
                 onAddMember(match.id);
                 e.target.value = "";
@@ -254,8 +277,8 @@ export function SuggestionCard({
           />
           <datalist id={`add-payee-${cluster.id}`}>
             {pickerOpen
-              ? addablePayees.slice(0, 200).map((p) => (
-                  <option key={p.id} value={p.name} />
+              ? addableOptions.slice(0, 200).map((o) => (
+                  <option key={o.id} value={o.label} />
                 ))
               : null}
           </datalist>

--- a/src/features/payee-cleanup/components/SuggestionCard.tsx
+++ b/src/features/payee-cleanup/components/SuggestionCard.tsx
@@ -382,16 +382,29 @@ export function SuggestionCard({
         <section className="min-w-0">
           <h4 className="font-medium text-foreground">Future imports</h4>
 
-          {future?.recommended ? (
+          {/* The editor stays once the user has overridden the field. Hiding it
+              whenever there is no recommendation trapped them: picking a field
+              with no historical matches removed the controls needed to pick
+              another one, or to type text that would match. */}
+          {future && (future.recommended || fieldOverride !== null) ? (
             <>
-              <label className="mt-1 flex items-start gap-2">
-                <Checkbox
-                  checked={correction.createRule === true}
-                  onCheckedChange={(value) => onToggleRule(value === true)}
-                  aria-label="Create a rule so future imports match this payee"
-                />
-                <span className="text-foreground">Create a rule to prevent this recurring</span>
-              </label>
+              {future.recommended ? (
+                <label className="mt-1 flex items-start gap-2">
+                  <Checkbox
+                    checked={correction.createRule === true}
+                    onCheckedChange={(value) => onToggleRule(value === true)}
+                    aria-label="Create a rule so future imports match this payee"
+                  />
+                  <span className="text-foreground">
+                    Create a rule to prevent this recurring
+                  </span>
+                </label>
+              ) : (
+                <p className="mt-1 text-amber-700 dark:text-amber-400">
+                  No pattern on this field matches your import history. Change the
+                  field or the text, or leave the rule off.
+                </p>
+              )}
 
               <div className="mt-1.5 flex items-center gap-1.5">
                 <select
@@ -431,6 +444,8 @@ export function SuggestionCard({
 
               {/* What will actually be created — one line, because "starts with
                   X" and a regex are not the same promise. */}
+              {future.recommended ? (
+              <>
               <code className="mt-1 block truncate rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
                 {future.recommended.candidate.field} {future.recommended.candidate.op}{" "}
                 {future.recommended.candidate.value}
@@ -469,6 +484,8 @@ export function SuggestionCard({
                   </>
                 )}
               </p>
+              </>
+              ) : null}
             </>
           ) : (
             <p className="mt-1 text-muted-foreground">

--- a/src/features/payee-cleanup/components/SuppressionList.tsx
+++ b/src/features/payee-cleanup/components/SuppressionList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Undo2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
@@ -16,6 +17,11 @@ type Props = {
  * every future scan and there is no way to find out why.
  */
 export function SuppressionList({ suppressions, onUndo, onClearAll }: Props) {
+  // Two-step rather than one click. Undoing a single row is reversible; clearing
+  // the list discards every decision the user has made about this budget and
+  // cannot be recovered from anywhere.
+  const [confirming, setConfirming] = useState(false);
+
   if (suppressions.length === 0) {
     return (
       <p className="rounded-md border border-dashed border-border/70 p-8 text-center text-sm text-muted-foreground">
@@ -30,9 +36,30 @@ export function SuppressionList({ suppressions, onUndo, onClearAll }: Props) {
         <p className="text-xs text-muted-foreground">
           These are hidden from your suggestions. Undo one to see it again.
         </p>
-        <Button size="sm" variant="ghost" onClick={onClearAll}>
-          Clear all
-        </Button>
+        {confirming ? (
+          <span className="flex shrink-0 items-center gap-1">
+            <span className="text-xs text-muted-foreground">
+              Clear all {suppressions.length}?
+            </span>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => {
+                setConfirming(false);
+                onClearAll();
+              }}
+            >
+              Clear all
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+          </span>
+        ) : (
+          <Button size="sm" variant="ghost" onClick={() => setConfirming(true)}>
+            Clear all
+          </Button>
+        )}
       </div>
       <ul className="divide-y divide-border/40 rounded-md border border-border/70">
         {suppressions.map((suppression) => (

--- a/src/features/payee-cleanup/components/SuppressionList.tsx
+++ b/src/features/payee-cleanup/components/SuppressionList.tsx
@@ -1,0 +1,67 @@
+import { Undo2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
+
+type Props = {
+  suppressions: PayeeCleanupSuppressionRecord[];
+  onUndo: (id: string) => void;
+  onClearAll: () => void;
+};
+
+/**
+ * The decisions the user has already made (RD-078 §14, M7).
+ *
+ * A suppression hides a suggestion permanently, so it needs to be visible and
+ * reversible — otherwise a mis-click quietly removes a real duplicate from
+ * every future scan and there is no way to find out why.
+ */
+export function SuppressionList({ suppressions, onUndo, onClearAll }: Props) {
+  if (suppressions.length === 0) {
+    return (
+      <p className="rounded-md border border-dashed border-border/70 p-8 text-center text-sm text-muted-foreground">
+        You haven&apos;t dismissed any suggestions yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          These are hidden from your suggestions. Undo one to see it again.
+        </p>
+        <Button size="sm" variant="ghost" onClick={onClearAll}>
+          Clear all
+        </Button>
+      </div>
+      <ul className="divide-y divide-border/40 rounded-md border border-border/70">
+        {suppressions.map((suppression) => (
+          <li
+            key={suppression.id}
+            className="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+          >
+            <span className="min-w-0">
+              <span className="break-words">
+                {suppression.normalizedNames.join("  ·  ")}
+              </span>
+              <span className="ml-2 text-xs text-muted-foreground">
+                {suppression.kind === "rejected-affix"
+                  ? "kept as part of the name"
+                  : "not duplicates"}
+              </span>
+            </span>
+            <Button
+              size="sm"
+              variant="ghost"
+              aria-label={`Undo: ${suppression.normalizedNames.join(", ")}`}
+              onClick={() => onUndo(suppression.id)}
+            >
+              <Undo2 className="size-3.5" aria-hidden="true" />
+              Undo
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/components/UnusedPayeeList.tsx
+++ b/src/features/payee-cleanup/components/UnusedPayeeList.tsx
@@ -1,0 +1,44 @@
+import type { OrphanPayee } from "../lib/orphans";
+
+type Props = {
+  orphans: OrphanPayee[];
+};
+
+/**
+ * Payees with nothing pointing at them (RD-078 §19).
+ *
+ * Read-only in this slice — staging the deletion is 041e's job. The copy states
+ * plainly that Actual Bench applies its own check and that the check is stricter
+ * than Actual's, because a user comparing this list against Actual's own
+ * "unused" view deserves to know why they might differ.
+ */
+export function UnusedPayeeList({ orphans }: Props) {
+  if (orphans.length === 0) {
+    return (
+      <p className="rounded-md border border-dashed border-border/70 p-8 text-center text-sm text-muted-foreground">
+        No unused payees. Everything is referenced by a transaction or a rule.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        These payees have no transactions and no rules pointing at them. Actual
+        Bench checks a payee&apos;s rule actions as well as its conditions, so
+        this list is slightly more cautious than Actual&apos;s own.
+      </p>
+      <ul className="divide-y divide-border/40 rounded-md border border-border/70">
+        {orphans.map(({ payee, reason }) => (
+          <li
+            key={payee.id}
+            className="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+          >
+            <span>{payee.name}</span>
+            <span className="text-xs text-muted-foreground">{reason}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/payee-cleanup/hooks/useImportedTextIndex.ts
+++ b/src/features/payee-cleanup/hooks/useImportedTextIndex.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { getImportedTextIndex } from "../lib/importedTextIndex";
+import type { ImportedTextRow } from "../lib/ruleCandidates";
+
+/**
+ * Historical import text, for backtesting proposed rules.
+ *
+ * Loaded lazily and cached for the session: it is a whole-budget read, and the
+ * answer does not change while the user works through a cleanup.
+ */
+const EMPTY_ROWS: ImportedTextRow[] = [];
+
+export function useImportedTextIndex(options: { enabled: boolean }): {
+  rows: ImportedTextRow[];
+  truncated: boolean;
+  isLoading: boolean;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["payeeCleanupImportedText", connection?.id],
+    queryFn: () => {
+      if (!connection) throw new Error("No active connection");
+      return getImportedTextIndex(connection);
+    },
+    enabled: options.enabled && !!connection,
+  });
+
+  // A fresh `[]` on every render would change the scan's dependencies and
+  // re-run the whole pipeline while the history is still loading.
+  const rows = useMemo(() => data?.rows ?? EMPTY_ROWS, [data]);
+  return { rows, truncated: data?.truncated ?? false, isLoading };
+}

--- a/src/features/payee-cleanup/hooks/usePayeeCleanupCandidates.ts
+++ b/src/features/payee-cleanup/hooks/usePayeeCleanupCandidates.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getTransport } from "@/lib/actual";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { getPayeeCleanupMetadata, fallbackMetadata } from "../lib/payeeMetadata";
+import { partitionByEligibility } from "../lib/eligibility";
+import { getPayeeCleanupCapabilities } from "../lib/capabilities";
+import type { EligibilityPartition } from "../lib/eligibility";
+import type { PayeeCleanupCandidate } from "../types";
+import type { PayeeCleanupCapabilityReport } from "../lib/capabilities";
+
+/**
+ * Loads the cleanup candidate set: payees joined with the ActualQL-only
+ * analysis metadata, already partitioned at the eligibility boundary.
+ *
+ * Two reads because no single supported call returns both — `getPayees()`
+ * carries the name, the AQL `payees` query carries favorite/learn_categories/
+ * tombstone/transfer_acct.
+ *
+ * Lazy by design: cleanup is a workspace the user opens, not something that
+ * should scan on app start. `enabled` stays false until the workspace mounts.
+ */
+export function usePayeeCleanupCandidates(options: { enabled: boolean }): {
+  partition: EligibilityPartition;
+  capabilities: PayeeCleanupCapabilityReport | null;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+} {
+  const connection = useConnectionStore(selectActiveInstance);
+
+  const query = useQuery({
+    queryKey: ["payeeCleanupCandidates", connection?.id],
+    queryFn: async (): Promise<PayeeCleanupCandidate[]> => {
+      if (!connection) throw new Error("No active connection");
+
+      // Sequential rather than Promise.all: the Direct runtime serializes work
+      // against one budget anyway, and a metadata failure should not be masked
+      // by a payee-list failure.
+      const payees = await getTransport(connection).getPayees();
+      const metadata = await getPayeeCleanupMetadata(connection);
+
+      return payees.map((payee) => ({
+        ...payee,
+        metadata:
+          metadata.get(payee.id) ??
+          fallbackMetadata(payee.id, payee.transferAccountId ?? null),
+      }));
+    },
+    enabled: options.enabled && !!connection,
+  });
+
+  const partition = useMemo(
+    () => partitionByEligibility(query.data ?? []),
+    [query.data]
+  );
+
+  const capabilities = useMemo(
+    () => (connection ? getPayeeCleanupCapabilities(connection) : null),
+    [connection]
+  );
+
+  return {
+    partition,
+    capabilities,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: () => void query.refetch(),
+  };
+}

--- a/src/features/payee-cleanup/hooks/usePayeeCleanupImpact.ts
+++ b/src/features/payee-cleanup/hooks/usePayeeCleanupImpact.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+import { useStagedStore } from "@/store/staged";
+import { useRules } from "@/features/rules/hooks/useRules";
+import { useSchedules } from "@/features/schedules/hooks/useSchedules";
+import { useTransactionCountsForIds } from "@/hooks/useTransactionCountsForIds";
+import type { ImpactSources } from "../lib/impact";
+import type { PayeeCleanupCandidate } from "../types";
+
+/**
+ * Loads everything the impact model needs: transaction counts per payee, the
+ * rule set, and the schedules that tell schedule-linked rules from regular ones.
+ *
+ * Rules and schedules come from the shared staged store, so cleanup sees the
+ * same working set as the rest of the app — including edits the user has staged
+ * but not saved, which is exactly what should inform a merge decision.
+ *
+ * The transaction query is one `$oneof`-filtered ActualQL call for every
+ * eligible payee, which works identically in both transports.
+ */
+export function usePayeeCleanupImpact(
+  candidates: PayeeCleanupCandidate[],
+  options: { enabled: boolean }
+): ImpactSources {
+  useRules({ enabled: options.enabled });
+  useSchedules({ enabled: options.enabled });
+
+  const stagedRules = useStagedStore((s) => s.rules);
+  const stagedSchedules = useStagedStore((s) => s.schedules);
+
+  const payeeIds = useMemo(() => candidates.map((c) => c.id), [candidates]);
+
+  const { data: transactionCounts, isLoading } = useTransactionCountsForIds(
+    "payee",
+    payeeIds,
+    { enabled: options.enabled && payeeIds.length > 0 }
+  );
+
+  const schedules = useMemo(
+    () =>
+      Object.values(stagedSchedules)
+        .filter((s) => !s.isDeleted)
+        .map((s) => s.entity),
+    [stagedSchedules]
+  );
+
+  // Memoized because the scan keys off this object. Returning a fresh literal
+  // re-ran detection, corpus learning, clustering and scoring on every render —
+  // including every keystroke in the search box.
+  return useMemo(
+    () => ({
+      stagedRules,
+      schedules,
+      transactionCounts,
+      transactionsLoading: isLoading,
+    }),
+    [stagedRules, schedules, transactionCounts, isLoading]
+  );
+}

--- a/src/features/payee-cleanup/hooks/usePayeeCleanupPlan.ts
+++ b/src/features/payee-cleanup/hooks/usePayeeCleanupPlan.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { getTransport } from "@/lib/actual";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import { useStagedStore } from "@/store/staged";
+import { getPayeeCleanupMetadata, fallbackMetadata } from "../lib/payeeMetadata";
+import { generateId } from "@/lib/uuid";
+import { buildNormalizationRule } from "../lib/ruleCandidates";
+import { validatePlan, type CleanupPlan, type PlanProblem } from "../lib/plan";
+import type { PayeeCleanupCandidate } from "../types";
+
+export type StageOutcome =
+  | { status: "staged"; operations: number }
+  | { status: "blocked"; problems: PlanProblem[] }
+  | { status: "stale"; changedCount: number };
+
+/**
+ * Stages a validated cleanup plan (RD-078 §21–§23).
+ *
+ * Nothing here writes to Actual. It puts operations into the shared staged
+ * store, where they join anything else the user has pending and are written by
+ * the existing payee save pipeline on an explicit Save — same as every other
+ * entity edit in the app.
+ *
+ * The one thing this hook insists on is a **fresh read immediately before
+ * staging**. A scan can be minutes old; in that time a sync, another tab, or the
+ * user's own edits elsewhere can rename, merge or delete the very payees the
+ * plan names. Applying a stale plan would merge into a payee that no longer
+ * exists, or silently no-op against one Actual has since made a transfer payee.
+ */
+export function usePayeeCleanupPlan() {
+  const connection = useConnectionStore(selectActiveInstance);
+  // `stagePayeeMerge` also marks the source payees deleted in the staged view,
+  // so the payees page stops showing rows that are about to be merged away.
+  const stagePayeeMerge = useStagedStore((s) => s.stagePayeeMerge);
+  const stageUpdate = useStagedStore((s) => s.stageUpdate);
+  const stageDelete = useStagedStore((s) => s.stageDelete);
+  const stageNew = useStagedStore((s) => s.stageNew);
+  const pushUndo = useStagedStore((s) => s.pushUndo);
+
+  const [isStaging, setIsStaging] = useState(false);
+
+  const stage = useCallback(
+    async (plan: CleanupPlan): Promise<StageOutcome> => {
+      if (!connection) throw new Error("No active connection");
+      setIsStaging(true);
+
+      try {
+        // ── Re-read, then re-validate against what is true *now* ────────────
+        const transport = getTransport(connection);
+        const payees = await transport.getPayees();
+        const metadata = await getPayeeCleanupMetadata(connection);
+
+        const byId = new Map<string, PayeeCleanupCandidate>(
+          payees.map((payee) => [
+            payee.id,
+            {
+              ...payee,
+              metadata:
+                metadata.get(payee.id) ??
+                fallbackMetadata(payee.id, payee.transferAccountId ?? null),
+            },
+          ])
+        );
+
+        const problems = validatePlan(plan, { byId });
+        const blocking = problems.filter((p) => p.severity === "blocking");
+        if (blocking.length > 0) {
+          // Report every problem, not just the first: a user fixing them one at
+          // a time through repeated re-validation is a bad afternoon.
+          return { status: "blocked", problems };
+        }
+
+        // A payee named by the plan whose *name* changed under us means the
+        // review screen showed something that is no longer true, even when the
+        // plan still validates. Surface it rather than quietly proceeding.
+        const changed = [
+          ...plan.merges.flatMap((m) => [
+            { id: m.targetId, name: m.targetName },
+            ...m.mergeIds.map((id, i) => ({ id, name: m.memberNames[i] })),
+          ]),
+          ...plan.renames.map((r) => ({ id: r.payeeId, name: r.from })),
+          ...plan.deletions.map((d) => ({ id: d.payeeId, name: d.name })),
+        ].filter(({ id, name }) => {
+          const live = byId.get(id);
+          return live !== undefined && live.name !== name;
+        });
+
+        if (changed.length > 0) {
+          return { status: "stale", changedCount: changed.length };
+        }
+
+        // ── Stage ───────────────────────────────────────────────────────────
+        // One undo entry for the whole plan: the user made one decision, so
+        // undo should reverse one decision rather than peel operations off.
+        pushUndo();
+
+        for (const rename of plan.renames) {
+          stageUpdate("payees", rename.payeeId, { name: rename.to });
+        }
+        for (const merge of plan.merges) {
+          stagePayeeMerge(merge.targetId, merge.mergeIds);
+        }
+        for (const deletion of plan.deletions) {
+          stageDelete("payees", deletion.payeeId);
+        }
+        for (const rule of plan.rules) {
+          // Staged through the normal rules pipeline, so it appears on the Rules
+          // page for review and is written by the same Save as everything else.
+          stageNew(
+            "rules",
+            buildNormalizationRule(
+              { field: rule.field, op: rule.op, value: rule.value, description: rule.description },
+              rule.targetPayeeId,
+              generateId()
+            )
+          );
+        }
+
+        return {
+          status: "staged",
+          operations:
+            plan.merges.length +
+            plan.renames.length +
+            plan.deletions.length +
+            plan.rules.length,
+        };
+      } finally {
+        setIsStaging(false);
+      }
+    },
+    [connection, pushUndo, stageDelete, stageNew, stagePayeeMerge, stageUpdate]
+  );
+
+  return { stage, isStaging };
+}

--- a/src/features/payee-cleanup/hooks/useSuppressions.ts
+++ b/src/features/payee-cleanup/hooks/useSuppressions.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useConnectionStore, selectActiveInstance } from "@/store/connection";
+import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
+import type { PayeeCluster } from "../lib/clusterResolver";
+import type { CorpusAffix } from "../lib/corpusAffixes";
+import { buildAffixSuppression, buildClusterSuppression } from "../lib/suppressions";
+
+/**
+ * The user's "not duplicates" decisions, persisted per budget.
+ *
+ * Suppressions live in the app database rather than browser storage because a
+ * decision about a budget's payees should survive a different browser, a
+ * different machine, and clearing site data — the same reasoning that moved
+ * saved queries out of `localStorage` in RD-064.
+ */
+export function useSuppressions(options: { enabled: boolean }) {
+  const connection = useConnectionStore(selectActiveInstance);
+  const budgetSyncId = connection?.budgetSyncId ?? null;
+  const queryClient = useQueryClient();
+
+  const queryKey = useMemo(
+    () => ["payeeCleanupSuppressions", budgetSyncId],
+    [budgetSyncId]
+  );
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<PayeeCleanupSuppressionRecord[]> => {
+      const response = await fetch(
+        `/api/payee-cleanup-suppressions?budgetSyncId=${encodeURIComponent(budgetSyncId ?? "")}`
+      );
+      if (!response.ok) throw new Error("Could not load cleanup decisions");
+      const body = (await response.json()) as {
+        suppressions: PayeeCleanupSuppressionRecord[];
+      };
+      return body.suppressions;
+    },
+    enabled: options.enabled && Boolean(budgetSyncId),
+  });
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey });
+    // The scan reads suppressions, so it has to re-run for the change to show.
+  }, [queryClient, queryKey]);
+
+  const create = useMutation({
+    mutationFn: async (payload: object) => {
+      const response = await fetch("/api/payee-cleanup-suppressions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error("Could not save that decision");
+    },
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: async (id: string) => {
+      const response = await fetch(`/api/payee-cleanup-suppressions/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error("Could not undo that decision");
+    },
+    onSuccess: invalidate,
+  });
+
+  const clearAll = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(
+        `/api/payee-cleanup-suppressions?budgetSyncId=${encodeURIComponent(budgetSyncId ?? "")}`,
+        { method: "DELETE" }
+      );
+      if (!response.ok) throw new Error("Could not clear your decisions");
+    },
+    onSuccess: invalidate,
+  });
+
+  return {
+    suppressions: data ?? [],
+    /** Records the whole grouping, not the individual payees (see lib/suppressions). */
+    rejectCluster: (cluster: PayeeCluster) => {
+      if (!budgetSyncId) return;
+      create.mutate(buildClusterSuppression(budgetSyncId, cluster));
+    },
+    /** Stops a learned fragment being treated as boilerplate anywhere. */
+    rejectAffix: (affix: CorpusAffix) => {
+      if (!budgetSyncId) return;
+      create.mutate(buildAffixSuppression(budgetSyncId, affix));
+    },
+    undo: (id: string) => remove.mutate(id),
+    clearAll: () => clearAll.mutate(),
+    isSaving: create.isPending || remove.isPending || clearAll.isPending,
+  };
+}

--- a/src/features/payee-cleanup/hooks/useSuppressions.ts
+++ b/src/features/payee-cleanup/hooks/useSuppressions.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useConnectionStore, selectActiveInstance } from "@/store/connection";
 import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
 import type { PayeeCluster } from "../lib/clusterResolver";
@@ -56,6 +57,11 @@ export function useSuppressions(options: { enabled: boolean }) {
       if (!response.ok) throw new Error("Could not save that decision");
     },
     onSuccess: invalidate,
+    // Reported rather than swallowed: the card disappears locally either way,
+    // so a silent failure would look like a saved decision until the next scan
+    // brought the group back with no explanation.
+    onError: (error: Error) =>
+      toast.error(`${error.message} — it will reappear on the next scan.`),
   });
 
   const remove = useMutation({
@@ -66,6 +72,7 @@ export function useSuppressions(options: { enabled: boolean }) {
       if (!response.ok) throw new Error("Could not undo that decision");
     },
     onSuccess: invalidate,
+    onError: (error: Error) => toast.error(error.message),
   });
 
   const clearAll = useMutation({
@@ -77,6 +84,7 @@ export function useSuppressions(options: { enabled: boolean }) {
       if (!response.ok) throw new Error("Could not clear your decisions");
     },
     onSuccess: invalidate,
+    onError: (error: Error) => toast.error(error.message),
   });
 
   return {
@@ -92,7 +100,12 @@ export function useSuppressions(options: { enabled: boolean }) {
       create.mutate(buildAffixSuppression(budgetSyncId, affix));
     },
     undo: (id: string) => remove.mutate(id),
-    clearAll: () => clearAll.mutate(),
+    // Guarded like the others. Without a budget id this sent an unscoped DELETE
+    // — a destructive request with nothing to scope it to.
+    clearAll: () => {
+      if (!budgetSyncId) return;
+      clearAll.mutate();
+    },
     isSaving: create.isPending || remove.isPending || clearAll.isPending,
   };
 }

--- a/src/features/payee-cleanup/hooks/useSuppressions.ts
+++ b/src/features/payee-cleanup/hooks/useSuppressions.ts
@@ -66,9 +66,12 @@ export function useSuppressions(options: { enabled: boolean }) {
 
   const remove = useMutation({
     mutationFn: async (id: string) => {
-      const response = await fetch(`/api/payee-cleanup-suppressions/${id}`, {
-        method: "DELETE",
-      });
+      const response = await fetch(
+        `/api/payee-cleanup-suppressions/${id}?budgetSyncId=${encodeURIComponent(
+          budgetSyncId ?? ""
+        )}`,
+        { method: "DELETE" }
+      );
       if (!response.ok) throw new Error("Could not undo that decision");
     },
     onSuccess: invalidate,
@@ -99,7 +102,10 @@ export function useSuppressions(options: { enabled: boolean }) {
       if (!budgetSyncId) return;
       create.mutate(buildAffixSuppression(budgetSyncId, affix));
     },
-    undo: (id: string) => remove.mutate(id),
+    undo: (id: string) => {
+      if (!budgetSyncId) return;
+      remove.mutate(id);
+    },
     // Guarded like the others. Without a budget id this sent an unscoped DELETE
     // — a destructive request with nothing to scope it to.
     clearAll: () => {

--- a/src/features/payee-cleanup/lib/capabilities.test.ts
+++ b/src/features/payee-cleanup/lib/capabilities.test.ts
@@ -1,0 +1,112 @@
+import {
+  explainMissingCapability,
+  getPayeeCleanupCapabilities,
+} from "./capabilities";
+
+describe("getPayeeCleanupCapabilities", () => {
+  it("supports cleanup in both transports", () => {
+    expect(getPayeeCleanupCapabilities({ mode: "http-api" }).supported).toBe(true);
+    expect(getPayeeCleanupCapabilities({ mode: "browser-api" }).supported).toBe(
+      true
+    );
+  });
+
+  it("reports the same core read/write set in both transports", () => {
+    const http = getPayeeCleanupCapabilities({ mode: "http-api" }).capabilities;
+    const direct = getPayeeCleanupCapabilities({ mode: "browser-api" }).capabilities;
+
+    for (const key of [
+      "listPayees",
+      "readPayeeAnalysisMetadata",
+      "renamePayee",
+      "mergePayees",
+      "deletePayee",
+      "readTransactionCountsByPayee",
+      "readImportedPayeeHistory",
+      "createRules",
+    ] as const) {
+      expect(http[key]).toBe(true);
+      expect(direct[key]).toBe(true);
+    }
+  });
+
+  it("declares favorite/learn_categories unwritable in BOTH transports", () => {
+    // APIPayeeEntity is Pick<PayeeEntity,'id'|'name'|'transfer_acct'> and
+    // actual-http-api's Payee schema matches — see nativeSemantics.test.ts.
+    expect(
+      getPayeeCleanupCapabilities({ mode: "http-api" }).capabilities
+        .writePayeeBehaviorFields
+    ).toBe(false);
+    expect(
+      getPayeeCleanupCapabilities({ mode: "browser-api" }).capabilities
+        .writePayeeBehaviorFields
+    ).toBe(false);
+  });
+
+  it("declares payee locations unreadable in BOTH transports", () => {
+    expect(
+      getPayeeCleanupCapabilities({ mode: "http-api" }).capabilities
+        .readPayeeLocations
+    ).toBe(false);
+    expect(
+      getPayeeCleanupCapabilities({ mode: "browser-api" }).capabilities
+        .readPayeeLocations
+    ).toBe(false);
+  });
+
+  it("exposes the native orphan handler in Direct mode only", () => {
+    // Direct reaches it through the runtime's `send`; actual-http-api has no
+    // route for it. Used to parity-check Bench's predicate, never as a second
+    // code path.
+    expect(
+      getPayeeCleanupCapabilities({ mode: "browser-api" }).capabilities
+        .nativeOrphanHandler
+    ).toBe(true);
+    expect(
+      getPayeeCleanupCapabilities({ mode: "http-api" }).capabilities
+        .nativeOrphanHandler
+    ).toBe(false);
+  });
+
+  it("returns an independent capability object per call", () => {
+    const first = getPayeeCleanupCapabilities({ mode: "http-api" });
+    first.capabilities.mergePayees = false;
+    expect(
+      getPayeeCleanupCapabilities({ mode: "http-api" }).capabilities.mergePayees
+    ).toBe(true);
+  });
+});
+
+describe("explainMissingCapability", () => {
+  it("explains every capability that is false somewhere, in user language", () => {
+    for (const key of [
+      "writePayeeBehaviorFields",
+      "readPayeeLocations",
+      "nativeOrphanHandler",
+    ] as const) {
+      const explanation = explainMissingCapability(key);
+      expect(explanation).toBeTruthy();
+      expect(explanation).not.toMatch(/APIPayeeEntity|payee_mapping|send\(/);
+    }
+  });
+
+  it("says the surviving payee keeps its own behavior settings", () => {
+    expect(explainMissingCapability("writePayeeBehaviorFields")).toContain(
+      "keeps its own settings"
+    );
+  });
+
+  it("says merging does not move saved locations", () => {
+    expect(explainMissingCapability("readPayeeLocations")).toContain(
+      "does not move"
+    );
+  });
+
+  it("discloses that Bench's unused-payee check is stricter than Actual's", () => {
+    expect(explainMissingCapability("nativeOrphanHandler")).toContain("stricter");
+  });
+
+  it("has no explanation for capabilities that are always available", () => {
+    expect(explainMissingCapability("mergePayees")).toBeNull();
+  });
+});

--- a/src/features/payee-cleanup/lib/capabilities.ts
+++ b/src/features/payee-cleanup/lib/capabilities.ts
@@ -1,0 +1,139 @@
+/**
+ * Payee Cleanup capability report (RD-078 §26).
+ *
+ * Mirrors `src/lib/sync/capabilities.ts`: a mode-keyed set with a reason, so
+ * the UI can gate a control instead of letting it fail at Save.
+ *
+ * Every `false` below is a *verified* gap, not a placeholder. The rule the
+ * whole feature depends on: never silently degrade a destructive operation
+ * because a capability is missing — disable it and say why.
+ */
+
+import type { ConnectionInstance, ConnectionMode } from "@/store/connection";
+
+export type PayeeCleanupCapabilitySet = {
+  /** Enumerate payees. `getPayees()` in Direct, `GET /payees` in HTTP. */
+  listPayees: boolean;
+  /**
+   * Read `favorite` / `learn_categories` / `tombstone`.
+   * Via the AQL `payees` schema — not `getPayees()`, which cannot carry them.
+   */
+  readPayeeAnalysisMetadata: boolean;
+  /**
+   * Write `favorite` / `learn_categories`.
+   *
+   * **False in both transports.** `updatePayee` takes `Partial<APIPayeeEntity>`
+   * (`id`/`name`/`transfer_acct` only) and actual-http-api's `Payee` schema
+   * matches. Only the internal `payees-batch-change` send handler can write
+   * them, and it has no HTTP equivalent. Cleanup therefore shows these fields
+   * as read-only differences and lets the user resolve them by choosing which
+   * payee survives.
+   */
+  writePayeeBehaviorFields: boolean;
+  /** Rename the surviving payee. `updatePayee({name})`, supported everywhere. */
+  renamePayee: boolean;
+  /** Native merge. `mergePayees(targetId, mergeIds)` in both transports. */
+  mergePayees: boolean;
+  /** Delete a validated orphan payee. */
+  deletePayee: boolean;
+  /** Count transactions per payee (ActualQL group-by). */
+  readTransactionCountsByPayee: boolean;
+  /** Read historical `imported_payee` for rule backtesting (041f). */
+  readImportedPayeeHistory: boolean;
+  /** Create the optional normalization rule (041f). */
+  createRules: boolean;
+  /**
+   * Actual's own orphan handlers (`payees-get-orphaned` /
+   * `payees-check-orphaned`).
+   *
+   * **False in HTTP mode** — they are internal `send` handlers with no
+   * actual-http-api route. Bench reimplements the predicate so both transports
+   * behave identically; where this is `true` (Direct) it is used to parity-check
+   * that reimplementation, never as a second code path.
+   */
+  nativeOrphanHandler: boolean;
+  /**
+   * Read payee locations (`payee-locations-get`).
+   *
+   * **False in both transports** — internal send handlers, no public API method
+   * and no HTTP route. `db.mergePayees` does not reassign locations, so a
+   * source's locations are left attached to a tombstoned payee. Cleanup does not
+   * surface or promise anything about them; documented as a known limitation.
+   */
+  readPayeeLocations: boolean;
+};
+
+/**
+ * Capabilities common to both transports. Everything here is exercised by
+ * existing shipped code (entity CRUD, `mergePayees`, ActualQL) rather than
+ * assumed from a schema.
+ */
+const SHARED_CAPABILITIES: PayeeCleanupCapabilitySet = {
+  listPayees: true,
+  readPayeeAnalysisMetadata: true,
+  writePayeeBehaviorFields: false,
+  renamePayee: true,
+  mergePayees: true,
+  deletePayee: true,
+  readTransactionCountsByPayee: true,
+  readImportedPayeeHistory: true,
+  createRules: true,
+  nativeOrphanHandler: false,
+  readPayeeLocations: false,
+};
+
+const DIRECT_CAPABILITIES: PayeeCleanupCapabilitySet = {
+  ...SHARED_CAPABILITIES,
+  // The browser runtime exposes Actual's `send`, so the orphan handlers are
+  // reachable here — used only to parity-check Bench's own predicate.
+  nativeOrphanHandler: true,
+};
+
+const HTTP_CAPABILITIES: PayeeCleanupCapabilitySet = {
+  ...SHARED_CAPABILITIES,
+};
+
+export type PayeeCleanupCapabilityKey = keyof PayeeCleanupCapabilitySet;
+
+export type PayeeCleanupCapabilityReport = {
+  mode: ConnectionMode;
+  /** False only when cleanup cannot run at all in this mode. */
+  supported: boolean;
+  reason: string | null;
+  capabilities: PayeeCleanupCapabilitySet;
+};
+
+export function getPayeeCleanupCapabilities(
+  connection: Pick<ConnectionInstance, "mode"> | { mode: ConnectionMode }
+): PayeeCleanupCapabilityReport {
+  const capabilities =
+    connection.mode === "http-api"
+      ? { ...HTTP_CAPABILITIES }
+      : { ...DIRECT_CAPABILITIES };
+
+  return {
+    mode: connection.mode,
+    supported: true,
+    reason: null,
+    capabilities,
+  };
+}
+
+/**
+ * User-facing explanation for a capability the current mode does not have.
+ * Used by the UI to disable a control *with a reason* (RD-078 §26).
+ */
+export function explainMissingCapability(
+  key: PayeeCleanupCapabilityKey
+): string | null {
+  switch (key) {
+    case "writePayeeBehaviorFields":
+      return "Actual's API does not allow changing Favorite or Category learning from outside Actual. The payee you keep as the merge target keeps its own settings.";
+    case "readPayeeLocations":
+      return "Saved payee locations cannot be read through Actual's API, so cleanup does not report them. Merging does not move a payee's saved locations to the payee you keep.";
+    case "nativeOrphanHandler":
+      return "Actual's built-in unused-payee check is not available over the HTTP API, so Actual Bench applies the same rules itself — and checks a payee's rule actions as well as its conditions, which is slightly stricter.";
+    default:
+      return null;
+  }
+}

--- a/src/features/payee-cleanup/lib/clusterResolver.test.ts
+++ b/src/features/payee-cleanup/lib/clusterResolver.test.ts
@@ -154,8 +154,12 @@ describe("fuzzy clustering is never transitive", () => {
       true
     );
 
-    for (const c of clusters) {
-      if (c.fuzzyOnly) expect(c.members).toHaveLength(2);
+    // Asserted up front: with no fuzzy cluster at all, the loop and the size
+    // bound below both pass while the behaviour they guard has disappeared.
+    const fuzzy = clusters.filter((c) => c.fuzzyOnly);
+    expect(fuzzy).toHaveLength(1);
+    for (const c of fuzzy) {
+      expect(c.members).toHaveLength(2);
     }
     const clusteredIds = clusters.flatMap((c) => c.members.map((m) => m.id));
     expect(new Set(clusteredIds).size).toBeLessThanOrEqual(2);
@@ -177,6 +181,9 @@ describe("fuzzy clustering is never transitive", () => {
       true
     );
 
+    // Two structural clusters, TESCO and TESC0, and neither absorbs the other.
+    // Without this the loop body never runs if clustering stops entirely.
+    expect(clusters).toHaveLength(2);
     for (const c of clusters) {
       const stems = new Set(
         c.members.map((m) => m.name.replace(/\s*\d+$/, ""))
@@ -192,8 +199,11 @@ describe("fuzzy clustering is never transitive", () => {
       true
     );
 
+    // `expect(undefined).not.toContain(...)` passes, so the structural cluster
+    // has to be proven to exist before its membership means anything.
     const structural = clusters.find((c) => !c.fuzzyOnly);
-    expect(structural?.members.map((m) => m.name)).not.toContain("WOOLWORTH");
+    expect(structural).toBeDefined();
+    expect(structural!.members.map((m) => m.name)).not.toContain("WOOLWORTH");
   });
 
   it("marks fuzzy-only clusters so scoring can treat them as weak", () => {

--- a/src/features/payee-cleanup/lib/clusterResolver.test.ts
+++ b/src/features/payee-cleanup/lib/clusterResolver.test.ts
@@ -1,0 +1,199 @@
+import { detectAll } from "./detectors";
+import { findFuzzyPairs } from "./fuzzy";
+import { resolveClusters } from "./clusterResolver";
+import type { PayeeCleanupCandidate } from "../types";
+
+function payee(id: string, name: string): PayeeCleanupCandidate {
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+    },
+  };
+}
+
+function cluster(names: string[], fuzzyPairs = false) {
+  // Ids are derived from the name, not the input index, so reordering the
+  // input does not silently reassign ids and make a determinism test lie.
+  const candidates = names.map((name) => payee(`p-${name}`, name));
+  const detected = detectAll(candidates);
+  return resolveClusters(detected, fuzzyPairs ? findFuzzyPairs(detected) : []);
+}
+
+describe("structural clustering", () => {
+  it("groups payees that share a stem after removing a store number", () => {
+    const clusters = cluster([
+      "WOOLWORTHS 0183",
+      "WOOLWORTHS 0291",
+      "WOOLWORTHS 8442",
+      "Woolworths",
+    ]);
+
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members.map((m) => m.name).sort()).toEqual([
+      "WOOLWORTHS 0183",
+      "WOOLWORTHS 0291",
+      "WOOLWORTHS 8442",
+      "Woolworths",
+    ]);
+    expect(clusters[0].fuzzyOnly).toBe(false);
+  });
+
+  it("carries the evidence that formed the group", () => {
+    const clusters = cluster(["WOOLWORTHS 0183", "WOOLWORTHS 0291"]);
+    const evidence = clusters[0].evidence;
+
+    expect(evidence.length).toBeGreaterThan(0);
+    expect(evidence.some((e) => e.detectorId === "full-reduction")).toBe(true);
+    expect(evidence.some((e) => e.kind === "structural")).toBe(true);
+    expect(evidence[0].label).toMatch(/store or terminal number/i);
+  });
+
+  it("reports each kind of evidence once, not once per member", () => {
+    // Members reduce along slightly different paths (their store numbers
+    // differ), which previously produced one duplicate evidence line per member.
+    const clusters = cluster([
+      "WOOLWORTHS 0183",
+      "WOOLWORTHS 0291",
+      "WOOLWORTHS 8442",
+    ]);
+    const labels = clusters[0].evidence.map((e) => e.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("offers a readable pattern, and none at all when the stem is junk", () => {
+    const clean = cluster(["WOOLWORTHS 0183", "WOOLWORTHS 0291"]);
+    expect(clean[0].evidence.find((e) => e.pattern)?.pattern).toBe(
+      "^WOOLWORTHS\\b.*$"
+    );
+
+    // A long stem of the very noise the user wants removed is not evidence, it
+    // is wallpaper — so a pattern is only offered while the stem stays readable.
+    const junk = cluster([
+      "SOME VERY LONG MERCHANT NAME THAT KEEPS GOING AND GOING BRANCH 0183",
+      "SOME VERY LONG MERCHANT NAME THAT KEEPS GOING AND GOING BRANCH 0291",
+    ]);
+    for (const evidence of junk[0]?.evidence ?? []) {
+      expect(evidence.pattern).toBeUndefined();
+    }
+  });
+
+  it("groups case-only variants", () => {
+    const clusters = cluster(["AMAZON", "Amazon", "amazon"]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members).toHaveLength(3);
+  });
+
+  it("does not create a cluster from a single payee", () => {
+    expect(cluster(["Woolworths"])).toHaveLength(0);
+    expect(cluster(["WOOLWORTHS 0183"])).toHaveLength(0);
+  });
+
+  it("keeps unrelated merchants in separate clusters", () => {
+    const clusters = cluster([
+      "WOOLWORTHS 0183",
+      "WOOLWORTHS 0291",
+      "TESCO 4821",
+      "TESCO 9001",
+    ]);
+
+    expect(clusters).toHaveLength(2);
+    for (const c of clusters) {
+      const names = c.members.map((m) => m.name);
+      expect(new Set(names.map((n) => n.split(" ")[0])).size).toBe(1);
+    }
+  });
+
+  it("puts each payee in at most one cluster", () => {
+    const clusters = cluster([
+      "AMAZON",
+      "Amazon",
+      "AMAZON 1234",
+      "AMAZON.COM",
+      "TESCO 1",
+      "TESCO 2",
+    ]);
+
+    const seen = new Set<string>();
+    for (const c of clusters) {
+      for (const member of c.members) {
+        expect(seen.has(member.id)).toBe(false);
+        seen.add(member.id);
+      }
+    }
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const names = ["WOOLWORTHS 0291", "Woolworths", "WOOLWORTHS 0183"];
+    const forward = cluster(names);
+    const reversed = cluster([...names].reverse());
+
+    expect(forward.map((c) => c.id)).toEqual(reversed.map((c) => c.id));
+    expect(forward[0].members.map((m) => m.name)).toEqual(
+      reversed[0].members.map((m) => m.name)
+    );
+  });
+});
+
+describe("fuzzy clustering is never transitive", () => {
+  it("does NOT chain A≈B and B≈C into one cluster", () => {
+    // The invariant RD-078 §6 forbids breaking. CARREFOUR/CARREFOURE/CARREFOURA
+    // are pairwise similar; chaining them would merge three payees on nothing
+    // but spelling distance.
+    const clusters = cluster(
+      ["CARREFOURE", "CARREFOURA", "CARREFOURI"],
+      true
+    );
+
+    for (const c of clusters) {
+      if (c.fuzzyOnly) expect(c.members).toHaveLength(2);
+    }
+    const clusteredIds = clusters.flatMap((c) => c.members.map((m) => m.id));
+    expect(new Set(clusteredIds).size).toBeLessThanOrEqual(2);
+  });
+
+  it("creates a two-member cluster from a genuine typo pair", () => {
+    const clusters = cluster(["Carrefour Market", "Carrefour Markt"], true);
+    const fuzzy = clusters.filter((c) => c.fuzzyOnly);
+
+    expect(fuzzy).toHaveLength(1);
+    expect(fuzzy[0].members).toHaveLength(2);
+    expect(fuzzy[0].evidence[0].detectorId).toBe("fuzzy-similarity");
+    expect(fuzzy[0].evidence[0].similarity).toBeGreaterThan(0.85);
+  });
+
+  it("never merges two existing structural clusters", () => {
+    const clusters = cluster(
+      ["TESCO 0001", "TESCO 0002", "TESC0 0001", "TESC0 0002"],
+      true
+    );
+
+    for (const c of clusters) {
+      const stems = new Set(
+        c.members.map((m) => m.name.replace(/\s*\d+$/, ""))
+      );
+      expect(stems.size).toBe(1);
+    }
+  });
+
+  it("does not add a fuzzy member to a structural cluster", () => {
+    // A payee already grouped by hard evidence is closed to fuzzy links.
+    const clusters = cluster(
+      ["WOOLWORTHS 0183", "WOOLWORTHS 0291", "WOOLWORTH"],
+      true
+    );
+
+    const structural = clusters.find((c) => !c.fuzzyOnly);
+    expect(structural?.members.map((m) => m.name)).not.toContain("WOOLWORTH");
+  });
+
+  it("marks fuzzy-only clusters so scoring can treat them as weak", () => {
+    const clusters = cluster(["Carrefour Market", "Carrefour Markt"], true);
+    expect(clusters.every((c) => c.fuzzyOnly)).toBe(true);
+  });
+});

--- a/src/features/payee-cleanup/lib/clusterResolver.test.ts
+++ b/src/features/payee-cleanup/lib/clusterResolver.test.ts
@@ -123,6 +123,7 @@ describe("structural clustering", () => {
       "TESCO 2",
     ]);
 
+    expect(clusters.length).toBeGreaterThan(0);
     const seen = new Set<string>();
     for (const c of clusters) {
       for (const member of c.members) {

--- a/src/features/payee-cleanup/lib/clusterResolver.test.ts
+++ b/src/features/payee-cleanup/lib/clusterResolver.test.ts
@@ -78,7 +78,11 @@ describe("structural clustering", () => {
       "SOME VERY LONG MERCHANT NAME THAT KEEPS GOING AND GOING BRANCH 0183",
       "SOME VERY LONG MERCHANT NAME THAT KEEPS GOING AND GOING BRANCH 0291",
     ]);
-    for (const evidence of junk[0]?.evidence ?? []) {
+    // Asserted before the loop: if the junk names failed to cluster at all, the
+    // loop body would never run and this test would pass having checked nothing.
+    expect(junk).toHaveLength(1);
+    expect(junk[0].evidence.length).toBeGreaterThan(0);
+    for (const evidence of junk[0].evidence) {
       expect(evidence.pattern).toBeUndefined();
     }
   });

--- a/src/features/payee-cleanup/lib/clusterResolver.ts
+++ b/src/features/payee-cleanup/lib/clusterResolver.ts
@@ -1,0 +1,316 @@
+/**
+ * Cluster resolution (RD-078 §6).
+ *
+ * Detectors emit per-payee stems and fuzzy emits pairs; neither decides what a
+ * *cluster* is. That decision lives here, under five invariants:
+ *
+ * - only eligible payees appear (the boundary already ran, but a cluster of one
+ *   is dropped rather than shown);
+ * - each live payee belongs to at most one cluster;
+ * - strong structural evidence forms groups;
+ * - **fuzzy transitivity alone can never form a group** — the rule that stops
+ *   `A≈B`, `B≈C` from silently merging three unrelated merchants;
+ * - output is deterministic for the same input.
+ */
+
+import type { DetectedPayee, DetectorId, EvidenceKind } from "./detectors";
+import type { FuzzyPair } from "./fuzzy";
+import type { PayeeCleanupCandidate } from "../types";
+
+/**
+ * Detectors that normalize a name without removing meaning. They fire on every
+ * payee, so on their own they prove nothing about why two payees belong
+ * together — see the evidence-attribution note in `buildCluster`.
+ */
+const IDENTITY_DETECTORS = new Set<DetectorId>([
+  "case-only",
+  "whitespace-only",
+  "punctuation",
+]);
+
+export type ClusterEvidence = {
+  detectorId: DetectorId | "fuzzy-similarity";
+  kind: EvidenceKind;
+  label: string;
+  /** The shared stem, or the compared names for fuzzy evidence. */
+  detail: string;
+  /** How many cluster members reached the stem through this detector. */
+  memberCount?: number;
+  /** Regex-ish description of the removed noise, shown as "pattern evidence". */
+  pattern?: string;
+  /** Highest similarity backing this evidence, fuzzy only. */
+  similarity?: number;
+};
+
+export type PayeeCluster = {
+  id: string;
+  members: PayeeCleanupCandidate[];
+  /** The stem every structural member reduced to, when there is one. */
+  stem: string | null;
+  evidence: ClusterEvidence[];
+  /** True when nothing but fuzzy similarity connects these payees. */
+  fuzzyOnly: boolean;
+  /**
+   * True when the user added or removed members.
+   *
+   * The stem and evidence describe the group the *detector* found. Once someone
+   * has combined two groups or dropped a member, that description no longer
+   * fits what is on screen — and worse, anything derived from the stale stem
+   * (the rule pattern above all) is derived from the wrong text.
+   */
+  userEdited?: boolean;
+};
+
+/**
+ * Minimal union-find. Used only for *structural and contextual* links — fuzzy
+ * pairs are deliberately never fed into it, because union-find is transitive by
+ * construction and that is precisely the behavior §6 forbids for fuzzy.
+ */
+class DisjointSet {
+  private parent = new Map<string, string>();
+
+  find(id: string): string {
+    const parent = this.parent.get(id);
+    if (parent === undefined) {
+      this.parent.set(id, id);
+      return id;
+    }
+    if (parent === id) return id;
+    const root = this.find(parent);
+    this.parent.set(id, root);
+    return root;
+  }
+
+  union(a: string, b: string): void {
+    const rootA = this.find(a);
+    const rootB = this.find(b);
+    if (rootA === rootB) return;
+    // Lexicographic root keeps the output deterministic regardless of input order.
+    if (rootA < rootB) this.parent.set(rootB, rootA);
+    else this.parent.set(rootA, rootB);
+  }
+}
+
+/**
+ * The stem the canonical name is built from.
+ *
+ * Two rules, both learned from wrong suggestions:
+ *
+ * - it must be a stem that actually **grouped** the cluster (two or more
+ *   members reached it). A reducing detector is worth reporting as evidence
+ *   even when only one member needed it, but its stem may still carry the
+ *   noise the other members never had — that is how `PAY PROTECT 393160543`
+ *   and `PAY PROTECT 407287028` came to be named "Pay Protect 393";
+ * - among the qualifying stems, prefer the fully-reduced one, since it is the
+ *   only stem that has had every class of noise removed.
+ */
+function chooseStem(evidence: ClusterEvidence[]): string | null {
+  const grouping = evidence.filter((e) => (e.memberCount ?? 0) >= 2);
+  if (grouping.length === 0) return null;
+
+  const reduced = grouping.find((e) => e.detectorId === "full-reduction");
+  if (reduced) return reduced.detail;
+
+  return [...grouping].sort(
+    (a, b) => a.detail.length - b.detail.length || a.detail.localeCompare(b.detail)
+  )[0].detail;
+}
+
+/**
+ * A regex-ish sketch of the noise, shown as "pattern evidence".
+ *
+ * Only offered when the stem is short enough to read. The earlier version built
+ * one from whatever stem a single-pass detector produced, which on real bank
+ * text meant a 60-character line of the very junk the user wanted removed.
+ */
+function describePattern(
+  detectorId: DetectorId | "fuzzy-similarity",
+  stem: string
+): string | undefined {
+  if (detectorId !== "full-reduction") return undefined;
+  if (stem.length > 40) return undefined;
+  return `^${escapeForDisplay(stem)}\\b.*$`;
+}
+
+/** Display-only escaping — this string is shown as evidence, never executed. */
+function escapeForDisplay(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function resolveClusters(
+  payees: DetectedPayee[],
+  fuzzyPairs: FuzzyPair[]
+): PayeeCluster[] {
+  const byId = new Map(payees.map((p) => [p.candidate.id, p]));
+
+  // ── Pass 1: group by shared stem, structural and contextual only ──────────
+  const set = new DisjointSet();
+  const stemGroups = new Map<string, string[]>();
+
+  // Grouped by **stem alone**, deliberately not by `detector:stem`.
+  //
+  // The whole point is "these names reduce to the same thing", and different
+  // payees reach the same stem by different routes: `WOOLWORTHS 0183` gets
+  // there via the terminal-suffix detector while the already-clean
+  // `Woolworths` gets there via punctuation normalization. Keying by detector
+  // kept those two apart — so the clean payee, which is usually the best merge
+  // target, never joined its own cluster.
+  for (const payee of payees) {
+    for (const hit of payee.hits) {
+      if (hit.kind === "fuzzy") continue;
+      const group = stemGroups.get(hit.stem);
+      if (group) {
+        if (!group.includes(payee.candidate.id)) group.push(payee.candidate.id);
+      } else {
+        stemGroups.set(hit.stem, [payee.candidate.id]);
+      }
+    }
+  }
+
+  const groupedKeys: string[] = [];
+  for (const [key, ids] of stemGroups) {
+    if (ids.length < 2) continue;
+    groupedKeys.push(key);
+    for (let i = 1; i < ids.length; i++) set.union(ids[0], ids[i]);
+  }
+
+  const clustersByRoot = new Map<string, string[]>();
+  for (const payee of payees) {
+    const id = payee.candidate.id;
+    // Only payees that actually participated in a shared stem get a root here.
+    if (!groupedKeys.some((stem) => stemGroups.get(stem)?.includes(id))) continue;
+    const root = set.find(id);
+    const members = clustersByRoot.get(root);
+    if (members) members.push(id);
+    else clustersByRoot.set(root, [id]);
+  }
+
+  const clustered = new Set<string>();
+  for (const members of clustersByRoot.values()) {
+    for (const id of members) clustered.add(id);
+  }
+
+  // ── Pass 2: fuzzy pairs, strictly non-transitive ──────────────────────────
+  //
+  // A fuzzy pair produces a cluster only when BOTH payees are still
+  // unclustered. Once a payee is in a cluster it is closed to further fuzzy
+  // links, so `A≈B` then `B≈C` yields {A,B} and drops B≈C — never {A,B,C}.
+  // A fuzzy pair also never merges two existing clusters, for the same reason.
+  const fuzzyClusters: string[][] = [];
+  for (const pair of fuzzyPairs) {
+    if (clustered.has(pair.leftId) || clustered.has(pair.rightId)) continue;
+    if (!byId.has(pair.leftId) || !byId.has(pair.rightId)) continue;
+    clustered.add(pair.leftId);
+    clustered.add(pair.rightId);
+    fuzzyClusters.push([pair.leftId, pair.rightId]);
+  }
+
+  // ── Build the output ──────────────────────────────────────────────────────
+  const fuzzyByPair = new Map(
+    fuzzyPairs.map((p) => [`${p.leftId}|${p.rightId}`, p])
+  );
+
+  const clusters: PayeeCluster[] = [];
+
+  for (const memberIds of clustersByRoot.values()) {
+    if (memberIds.length < 2) continue;
+    clusters.push(
+      buildCluster(memberIds, byId, stemGroups, fuzzyByPair, false)
+    );
+  }
+
+  for (const memberIds of fuzzyClusters) {
+    clusters.push(buildCluster(memberIds, byId, stemGroups, fuzzyByPair, true));
+  }
+
+  // Deterministic ordering: strongest evidence first, then by name.
+  return clusters.sort(
+    (a, b) =>
+      Number(a.fuzzyOnly) - Number(b.fuzzyOnly) ||
+      b.members.length - a.members.length ||
+      a.members[0].name.localeCompare(b.members[0].name)
+  );
+}
+
+function buildCluster(
+  memberIds: string[],
+  byId: Map<string, DetectedPayee>,
+  stemGroups: Map<string, string[]>,
+  fuzzyByPair: Map<string, FuzzyPair>,
+  fuzzyOnly: boolean
+): PayeeCluster {
+  const sortedIds = [...memberIds].sort();
+  const members = sortedIds
+    .map((id) => byId.get(id)?.candidate)
+    .filter((c): c is PayeeCleanupCandidate => Boolean(c));
+
+  const evidence: ClusterEvidence[] = [];
+
+  if (!fuzzyOnly) {
+    // Evidence must describe what actually *connects* these payees, which is
+    // not the same as "every detector that produced the cluster's stem".
+    //
+    // The identity detectors (case / whitespace / punctuation) emit a stem for
+    // every payee, including one that needed no cleaning at all. Counting those
+    // as evidence made `Acme` + `Acme Ltd` look like a hard structural match —
+    // `Acme`'s own case-folding reached the stem — when the only real link is
+    // the legal suffix, which is contextual and should score much lower.
+    //
+    // So: a *reducing* detector counts as soon as one member used it to reach
+    // the stem (it removed real text), while an *identity* detector counts only
+    // if two or more members reached the stem through it with genuinely
+    // different names.
+    const seenDetectors = new Set<string>();
+    for (const id of sortedIds) {
+      for (const hit of byId.get(id)?.hits ?? []) {
+        if (hit.kind === "fuzzy") continue;
+        const key = `${hit.detectorId}:${hit.stem}`;
+        if (seenDetectors.has(key)) continue;
+
+        const viaThisDetector = sortedIds.filter((memberId) =>
+          byId
+            .get(memberId)
+            ?.hits.some(
+              (h) => h.detectorId === hit.detectorId && h.stem === hit.stem
+            )
+        );
+
+        if (IDENTITY_DETECTORS.has(hit.detectorId)) {
+          const distinctNames = new Set(
+            viaThisDetector.map((memberId) => byId.get(memberId)?.candidate.name)
+          );
+          if (distinctNames.size < 2) continue;
+        } else if (viaThisDetector.length < 1 || !hit.removed) {
+          continue;
+        }
+
+        seenDetectors.add(key);
+        evidence.push({
+          detectorId: hit.detectorId,
+          kind: hit.kind,
+          label: hit.label,
+          detail: hit.stem,
+          memberCount: viaThisDetector.length,
+          pattern: describePattern(hit.detectorId, hit.stem),
+        });
+      }
+    }
+  } else {
+    const pair = fuzzyByPair.get(`${sortedIds[0]}|${sortedIds[1]}`);
+    evidence.push({
+      detectorId: "fuzzy-similarity",
+      kind: "fuzzy",
+      label: "Similar spelling only",
+      detail: members.map((m) => m.name).join(" · "),
+      similarity: pair?.similarity,
+    });
+  }
+
+  return {
+    id: sortedIds.join("+"),
+    members,
+    stem: chooseStem(evidence),
+    evidence,
+    fuzzyOnly,
+  };
+}

--- a/src/features/payee-cleanup/lib/confidence.ts
+++ b/src/features/payee-cleanup/lib/confidence.ts
@@ -83,14 +83,24 @@ export function computeConfidence(
         delta: 0,
         reason: `Names match exactly once this is removed: ${describeLabel(structural[0].label)}`,
       });
-    } else {
+    } else if (contextual.length > 0) {
       // Contextual only: a plausible transform, not a certainty.
       score = 68;
       reasons.push({
         delta: 0,
         reason: `Names match only after an interpreted change: ${describeLabel(
-          contextual[0]?.label ?? "contextual"
+          contextual[0].label
         )}`,
+      });
+    } else {
+      // No evidence survived attribution: the names converged, but nothing can
+      // say how. Naming a detector that never fired would be worse than
+      // admitting there is nothing to show, so this states the bare fact and
+      // scores low enough to stay out of the confident bands.
+      score = 60;
+      reasons.push({
+        delta: 0,
+        reason: "These names reduce to the same thing, but nothing explains why",
       });
     }
 

--- a/src/features/payee-cleanup/lib/confidence.ts
+++ b/src/features/payee-cleanup/lib/confidence.ts
@@ -1,0 +1,167 @@
+/**
+ * Cluster confidence (RD-078 §7).
+ *
+ * Confidence is derived from evidence, never assigned by a detector directly,
+ * so a proposal's score and its explanation cannot disagree. Every adjustment
+ * returns a reason string; the UI shows those reasons rather than the number
+ * alone.
+ *
+ * Deliberately extensible: 041c and 041f will pass rule conflicts, behavior
+ * conflicts and backtest results in through `signals`. Until then those signals
+ * are simply absent and the score reflects name evidence only.
+ */
+
+import { deriveForms, looksHumanReadable } from "./derivedForms";
+import type { PayeeCluster } from "./clusterResolver";
+
+export type ConfidenceBand = "high" | "strong" | "review" | "hidden";
+
+export type ConfidenceSignals = {
+  /** 041c: members disagree on favorite / learn_categories. */
+  behaviorConflict?: boolean;
+  /** 041c: a member is referenced by rules that resolve payees differently. */
+  ruleConflict?: boolean;
+  /** 041f: the proposed rule's backtest caught unrelated historical text. */
+  unexpectedBacktestMatches?: number;
+};
+
+export type ConfidenceReason = {
+  delta: number;
+  reason: string;
+};
+
+export type ConfidenceResult = {
+  score: number;
+  band: ConfidenceBand;
+  reasons: ConfidenceReason[];
+};
+
+/**
+ * Band thresholds from RD-078 §7. `hidden` proposals are computed but not shown
+ * by default — they still exist so a user can widen the filter rather than
+ * wonder why an obvious pair is missing.
+ */
+export function bandFor(score: number): ConfidenceBand {
+  if (score >= 95) return "high";
+  if (score >= 80) return "strong";
+  if (score >= 60) return "review";
+  return "hidden";
+}
+
+/**
+ * Evidence labels already read as "Removed the card number", so pasting one
+ * into "after removing …" produced "after removing removed the card number".
+ */
+function describeLabel(label: string): string {
+  return label.replace(/^removed\s+/i, "").toLowerCase();
+}
+
+export function computeConfidence(
+  cluster: PayeeCluster,
+  signals: ConfidenceSignals = {}
+): ConfidenceResult {
+  const reasons: ConfidenceReason[] = [];
+  let score: number;
+
+  if (cluster.fuzzyOnly) {
+    // §7.2: fuzzy similarity alone is the weakest possible basis. Start below
+    // the review line so a fuzzy pair can only surface for review, never as an
+    // auto-selectable high-confidence proposal.
+    const similarity = cluster.evidence[0]?.similarity ?? 0;
+    score = Math.round(45 + similarity * 20);
+    reasons.push({
+      delta: 0,
+      reason: "Similar spelling only — no structural evidence",
+    });
+  } else {
+    const structural = cluster.evidence.filter((e) => e.kind === "structural");
+    const contextual = cluster.evidence.filter((e) => e.kind === "contextual");
+
+    if (structural.length > 0) {
+      score = 90;
+      reasons.push({
+        delta: 0,
+        reason: `Names match exactly once this is removed: ${describeLabel(structural[0].label)}`,
+      });
+    } else {
+      // Contextual only: a plausible transform, not a certainty.
+      score = 68;
+      reasons.push({
+        delta: 0,
+        reason: `Names match only after an interpreted change: ${describeLabel(
+          contextual[0]?.label ?? "contextual"
+        )}`,
+      });
+    }
+
+    // Distinct detectors, not evidence entries. Counting entries produced
+    // "17 independent detectors agree" for a cluster that had three.
+    const distinctDetectors = new Set(structural.map((e) => e.detectorId)).size;
+    if (distinctDetectors > 1) {
+      score += 6;
+      reasons.push({
+        delta: 6,
+        reason: `${distinctDetectors} independent detectors agree`,
+      });
+    }
+
+    // §7.1 "repeated machine suffix pattern": one payee with a trailing number
+    // could be a coincidence, but three or more sharing the same generated
+    // shape is the pattern itself showing up in the data.
+    const repeated = structural.find((e) => (e.memberCount ?? 0) >= 3);
+    if (repeated) {
+      score += 4;
+      reasons.push({
+        delta: 4,
+        reason: `The same pattern repeats across ${repeated.memberCount} payees`,
+      });
+    }
+
+    // §7.1: a clean human-readable member is both a strong signal that the
+    // cluster is real and an obvious merge target.
+    if (cluster.members.some((m) => looksHumanReadable(deriveForms(m.name)))) {
+      score += 4;
+      reasons.push({
+        delta: 4,
+        reason: "A clean, human-readable payee already exists in this group",
+      });
+    }
+
+    // §7.2: an interpreted reduction (a company suffix, or text inferred from
+    // the rest of the budget) is a reason to look closer.
+    if (structural.length === 0 && contextual.length > 0) {
+      score -= 6;
+      reasons.push({
+        delta: -6,
+        reason: "These match only after an interpreted change — worth a look",
+      });
+    }
+  }
+
+  if (signals.behaviorConflict) {
+    score -= 5;
+    reasons.push({
+      delta: -5,
+      reason: "Members disagree on Favorite or Category learning",
+    });
+  }
+
+  if (signals.ruleConflict) {
+    score -= 10;
+    reasons.push({
+      delta: -10,
+      reason: "An existing rule resolves one of these payees differently",
+    });
+  }
+
+  if (signals.unexpectedBacktestMatches && signals.unexpectedBacktestMatches > 0) {
+    score -= 12;
+    reasons.push({
+      delta: -12,
+      reason: `Pattern also matches ${signals.unexpectedBacktestMatches} unrelated historical transactions`,
+    });
+  }
+
+  const clamped = Math.max(0, Math.min(100, Math.round(score)));
+  return { score: clamped, band: bandFor(clamped), reasons };
+}

--- a/src/features/payee-cleanup/lib/corpusAffixes.test.ts
+++ b/src/features/payee-cleanup/lib/corpusAffixes.test.ts
@@ -85,6 +85,23 @@ describe("the same mechanism on a bank it has never seen", () => {
   });
 });
 
+describe("non-Latin merchant names", () => {
+  it("learns a wrapper around remainders written in another script", () => {
+    // The numeric-remainder guard used to ask whether a remainder held an ASCII
+    // letter, so every Arabic merchant name counted as "just a branch number"
+    // and the shared wrapper was thrown away.
+    const names = [
+      "POS PURCHASE \u0643\u0627\u0631\u0641\u0648\u0631",
+      "POS PURCHASE \u0644\u0648\u0644\u0648",
+      "POS PURCHASE \u0633\u0628\u064a\u0646\u064a\u0632",
+      "POS PURCHASE \u0627\u0644\u0645\u0632\u0631\u0639\u0629",
+      "POS PURCHASE \u0646\u0648\u0646",
+      "POS PURCHASE \u0637\u0644\u0628\u0627\u062a",
+    ];
+    expect(phrases(names, "prefix")).toContain("POS PURCHASE");
+  });
+});
+
 describe("what it must refuse to learn", () => {
   it("does not treat a repeated merchant name as boilerplate", () => {
     // Three payees opening with WOOLWORTHS are the same shop, not a wrapper.

--- a/src/features/payee-cleanup/lib/corpusAffixes.test.ts
+++ b/src/features/payee-cleanup/lib/corpusAffixes.test.ts
@@ -1,0 +1,197 @@
+import { findCorpusAffixes } from "./corpusAffixes";
+import { reduceFully } from "./reduce";
+
+/**
+ * The corpus learner replaces every vocabulary the engine used to carry —
+ * cities, countries, channel prefixes, one bank's tag words.
+ *
+ * These tests use payee sets from three unrelated banks, plus an invented
+ * fourth, precisely to show the mechanism is not tuned to any of them: the same
+ * rule finds a UAE channel wrapper, an Australian source tag and a French one it
+ * has never seen.
+ */
+
+function phrases(names: string[], kind: "prefix" | "suffix"): string[] {
+  return findCorpusAffixes(names)
+    .filter((a) => a.kind === kind)
+    .map((a) => a.tokens.join(" "));
+}
+
+describe("learning a bank's boilerplate", () => {
+  const uae = [
+    "NFC - (AP-PAY)- DESCO COPY CENTRE DUBAI ARE",
+    "NFC - (SM-PAY)- MATALAN DUBAI UAE",
+    "NFC - (AP-PAY)- SUBWAY DUBAI UAE",
+    "NFC - (SM-PAY)- TIM HORTONS DUBAI 784",
+    "NFC - (SM-PAY)- PK MART DUBAI ARE",
+    "NFC - (AP-PAY)- MINI BOUNCE DUBAI 784",
+    "IAP - (AP-PAY)- talabat.com DUBAI DXB",
+    "NFC - (AP-PAY)- LC WAIKIKI DUBAI 784",
+  ];
+
+  it("finds the channel wrapper without being told it exists", () => {
+    // Punctuation drops out of the learned form, so the wrapper is recorded as
+    // its meaningful tokens.
+    expect(phrases(uae, "prefix")).toContain("NFC APPAY");
+  });
+
+  it("finds the trailing city and country as shared text", () => {
+    expect(phrases(uae, "suffix").some((p) => p.startsWith("DUBAI"))).toBe(true);
+  });
+
+  it("strips what it learned, so the same merchant converges", () => {
+    const affixes = findCorpusAffixes(uae);
+    const a = reduceFully("NFC - (AP-PAY)- DESCO COPY CENTRE DUBAI ARE", affixes).stem;
+    const b = reduceFully("NFC - (SM-PAY)- DESCO COPY CENTRE DUBAI ARE", affixes).stem;
+
+    // The point of the whole mechanism: two payees that differ only by a
+    // learned wrapper reduce to the same thing. Both channel variants have to
+    // clear the repetition threshold on their own — a wrapper seen twice is not
+    // yet house style.
+    expect(a).toBe(b);
+    expect(a).not.toContain("PAY");
+    expect(a).toContain("DESCO COPY CENTRE");
+  });
+
+  it("only learns a trailing fragment that repeats often enough", () => {
+    // `DUBAI 784` closes three of these seven and is learned; `DUBAI ARE`
+    // closes one and is not. A sample of one is not house style — which is why
+    // reduction improves as a budget grows rather than guessing early.
+    const affixes = findCorpusAffixes(uae);
+    const suffixes = affixes.filter((a) => a.kind === "suffix").map((a) => a.tokens.join(" "));
+    expect(suffixes).toContain("DUBAI 784");
+    expect(suffixes).not.toContain("DUBAI ARE");
+  });
+});
+
+describe("the same mechanism on a bank it has never seen", () => {
+  // Invented French-style records. Nothing in the engine knows these words.
+  const french = [
+    "CARTE 12/03 RETRAIT DAB BOULANGERIE MARTIN PARIS FR",
+    "CARTE 14/03 RETRAIT DAB PHARMACIE CENTRALE LYON FR",
+    "CARTE 19/03 RETRAIT DAB LIBRAIRIE DUPONT NANTES FR",
+    "CARTE 21/03 RETRAIT DAB FROMAGERIE BERNARD LILLE FR",
+    "CARTE 02/04 RETRAIT DAB QUINCAILLERIE ROUX NICE FR",
+  ];
+
+  it("learns the opening wrapper", () => {
+    // `CARTE` leads all five with five different continuations, so it is
+    // wrapping. No French vocabulary was needed to work that out.
+    expect(phrases(french, "prefix").some((p) => p.startsWith("CARTE"))).toBe(true);
+  });
+
+  it("learns the trailing country marker", () => {
+    expect(phrases(french, "suffix")).toContain("FR");
+  });
+});
+
+describe("what it must refuse to learn", () => {
+  it("does not treat a repeated merchant name as boilerplate", () => {
+    // Three payees opening with WOOLWORTHS are the same shop, not a wrapper.
+    // The remainders are too few and too similar for it to be structural.
+    const names = [
+      "WOOLWORTHS 0183",
+      "WOOLWORTHS 0291",
+      "WOOLWORTHS 8442",
+      "COLES 0559",
+      "ALDI 1102",
+    ];
+    expect(phrases(names, "prefix")).not.toContain("WOOLWORTHS");
+  });
+
+  it("never proposes an affix that would consume a whole name", () => {
+    const names = ["ACME PARIS", "ACME LYON", "ACME NICE", "ACME NANTES"];
+    for (const affix of findCorpusAffixes(names)) {
+      expect(affix.tokens.length).toBeLessThan(2);
+    }
+  });
+
+  it("ignores a fragment that is not repeated often enough", () => {
+    const names = [
+      "SHARED PREFIX ONE",
+      "SHARED PREFIX TWO",
+      "ALPHA",
+      "BRAVO",
+      "CHARLIE",
+      "DELTA",
+      "ECHO",
+      "FOXTROT",
+      "GOLF",
+      "HOTEL",
+      "INDIA",
+      "JULIET",
+    ];
+    // Two payees out of twelve is not evidence of house style.
+    expect(phrases(names, "prefix")).not.toContain("SHARED PREFIX");
+  });
+
+  it("returns nothing for an empty or tiny payee set", () => {
+    expect(findCorpusAffixes([])).toEqual([]);
+    expect(findCorpusAffixes(["ACME"])).toEqual([]);
+  });
+
+  it("prefers the longest affix and drops its redundant prefixes", () => {
+    const names = [
+      "BANK TRANSFER OUT ALPHA",
+      "BANK TRANSFER OUT BRAVO",
+      "BANK TRANSFER OUT CHARLIE",
+      "BANK TRANSFER OUT DELTA",
+    ];
+    const found = phrases(names, "prefix");
+    expect(found).toContain("BANK TRANSFER OUT");
+    expect(found).not.toContain("BANK");
+    expect(found).not.toContain("BANK TRANSFER");
+  });
+});
+
+describe("everything learned is contextual", () => {
+  it("marks corpus reductions as interpretive, so clusters land in review", () => {
+    // Repetition proves a fragment is shared, not that removing it is safe:
+    // `TRANSFER FROM` leads many payees and does carry meaning. The user sees
+    // the evidence and decides.
+    const names = [
+      "WRAPPER ALPHA CO",
+      "WRAPPER BRAVO CO",
+      "WRAPPER CHARLIE CO",
+      "WRAPPER DELTA CO",
+    ];
+    const affixes = findCorpusAffixes(names);
+    const result = reduceFully("WRAPPER ALPHA CO", affixes);
+
+    const corpusSteps = result.steps.filter(
+      (s) => s.id === "corpus-prefix" || s.id === "corpus-suffix"
+    );
+    expect(corpusSteps.length).toBeGreaterThan(0);
+    expect(corpusSteps.every((s) => s.contextual)).toBe(true);
+  });
+
+  it("keeps a structural stem that excludes the guesses", () => {
+    const names = [
+      "WRAPPER ALPHA 12/03/2024",
+      "WRAPPER BRAVO 13/03/2024",
+      "WRAPPER CHARLIE 14/03/2024",
+      "WRAPPER DELTA 15/03/2024",
+    ];
+    const affixes = findCorpusAffixes(names);
+    const result = reduceFully("WRAPPER ALPHA 12/03/2024", affixes);
+
+    // The date is certain, the wrapper is inferred — so the structural stem
+    // keeps the wrapper and the full stem does not.
+    expect(result.structuralStem).toContain("WRAPPER");
+    expect(result.stem).not.toContain("WRAPPER");
+  });
+
+  it("names the evidence in the step it took", () => {
+    const names = [
+      "WRAPPER ALPHA CO",
+      "WRAPPER BRAVO CO",
+      "WRAPPER CHARLIE CO",
+      "WRAPPER DELTA CO",
+    ];
+    const affixes = findCorpusAffixes(names);
+    const step = reduceFully("WRAPPER ALPHA CO", affixes).steps.find(
+      (s) => s.id === "corpus-prefix"
+    );
+    expect(step?.label).toMatch(/on \d+ payees/);
+  });
+});

--- a/src/features/payee-cleanup/lib/corpusAffixes.ts
+++ b/src/features/payee-cleanup/lib/corpusAffixes.ts
@@ -165,7 +165,10 @@ export function findCorpusAffixes(
 function mostlyNumeric(remainders: Set<string>): boolean {
   let numeric = 0;
   for (const remainder of remainders) {
-    if (!/[A-Za-z]/.test(remainder)) numeric += 1;
+    // Any Unicode letter counts as a word. An ASCII-only test called every
+    // non-Latin merchant name "numeric", so a shared wrapper around Arabic or
+    // Cyrillic remainders was rejected as a run of branch numbers.
+    if (!/\p{L}/u.test(remainder)) numeric += 1;
   }
   return numeric / remainders.size > 0.5;
 }

--- a/src/features/payee-cleanup/lib/corpusAffixes.ts
+++ b/src/features/payee-cleanup/lib/corpusAffixes.ts
@@ -51,7 +51,8 @@ const DEFAULTS = {
 
 type Candidate = {
   tokens: string[];
-  payees: Set<string>;
+  /** Indices into the input, so payees sharing a reduced stem still count separately. */
+  payees: Set<number>;
   remainders: Set<string>;
 };
 
@@ -79,8 +80,13 @@ export function findCorpusAffixes(
   if (names.length === 0) return [];
   const threshold = Math.max(minPayees, Math.ceil(names.length * minShare));
 
-  const tokenized = names.map((name) => ({
+  // Indexed, because the caller passes reduced stems and several payees can
+  // reduce to the same one. Keying the payee set by name collapsed those into a
+  // single entry, which both raised the frequency bar and understated the
+  // payee count shown as evidence.
+  const tokenized = names.map((name, index) => ({
     name,
+    index,
     tokens: name.trim().split(/\s+/).filter(Boolean).map(normalizeToken).filter(Boolean),
   }));
 
@@ -107,12 +113,12 @@ export function findCorpusAffixes(
         const key = slice.join(" ");
         const candidate = candidates.get(key);
         if (candidate) {
-          candidate.payees.add(entry.name);
+          candidate.payees.add(entry.index);
           candidate.remainders.add(remainder);
         } else {
           candidates.set(key, {
             tokens: slice,
-            payees: new Set([entry.name]),
+            payees: new Set([entry.index]),
             remainders: new Set([remainder]),
           });
         }

--- a/src/features/payee-cleanup/lib/corpusAffixes.ts
+++ b/src/features/payee-cleanup/lib/corpusAffixes.ts
@@ -1,0 +1,185 @@
+/**
+ * Learns a budget's own boilerplate from its payee set (RD-078 §8.3).
+ *
+ * Some noise cannot be recognized by shape. `DUBAI UAE`, `INTERNET BANKING` and
+ * `NFC - (AP-PAY)-` are ordinary words in ordinary positions; only knowing the
+ * institution tells you they are wrapping rather than naming. Hard-coding them
+ * would make the feature work for one user's bank and no one else's.
+ *
+ * The generic signal is repetition. A fragment that opens or closes *many
+ * otherwise unrelated* payees is structural — it cannot be what distinguishes a
+ * merchant, because it is on all of them. That reasoning holds for any bank in
+ * any country and needs no vocabulary at all: a French user's `CARTE 12/03
+ * RETRAIT DAB` is found by exactly the same rule as a UAE user's channel prefix.
+ *
+ * This is deliberately a *suggestion* engine. Repetition proves a fragment is
+ * shared, not that removing it is safe — `TRANSFER FROM` also leads many payees
+ * and does carry meaning. So everything found here is applied as a **contextual**
+ * reduction, which lands the resulting clusters in review with the evidence
+ * shown, rather than being treated as certain.
+ */
+
+import { normalizeToken } from "./reduce";
+
+export type CorpusAffix = {
+  kind: "prefix" | "suffix";
+  /** Normalized tokens, outermost first for a prefix, in reading order for a suffix. */
+  tokens: string[];
+  /** How many payees carry this affix. */
+  payeeCount: number;
+  /** How many distinct remainders it leaves — the evidence that it is wrapping. */
+  distinctRemainders: number;
+};
+
+export type CorpusAffixOptions = {
+  /** Longest affix considered, in tokens. */
+  maxTokens?: number;
+  /** Smallest number of payees an affix must appear on. */
+  minPayees?: number;
+  /** Share of the corpus an affix must appear on. */
+  minShare?: number;
+  /** Distinct remainders required, so a repeated *merchant* is never stripped. */
+  minDistinctRemainders?: number;
+};
+
+const DEFAULTS = {
+  maxTokens: 4,
+  minPayees: 3,
+  minShare: 0.02,
+  minDistinctRemainders: 3,
+} satisfies Required<CorpusAffixOptions>;
+
+type Candidate = {
+  tokens: string[];
+  payees: Set<string>;
+  remainders: Set<string>;
+};
+
+/**
+ * Finds the repeated opening and closing fragments in a set of payee names.
+ *
+ * Two conditions must both hold, and the second is what makes this safe:
+ *
+ * 1. **It repeats** — on at least `minPayees` payees and `minShare` of the set.
+ * 2. **It does not discriminate** — the payees carrying it are otherwise
+ *    different from each other (`minDistinctRemainders`). Three payees that
+ *    share the opening `WOOLWORTHS` are not evidence that `WOOLWORTHS` is
+ *    boilerplate; they are the same merchant, and stripping it would destroy
+ *    the only real word in the name.
+ */
+export function findCorpusAffixes(
+  names: string[],
+  options: CorpusAffixOptions = {}
+): CorpusAffix[] {
+  const { maxTokens, minPayees, minShare, minDistinctRemainders } = {
+    ...DEFAULTS,
+    ...options,
+  };
+
+  if (names.length === 0) return [];
+  const threshold = Math.max(minPayees, Math.ceil(names.length * minShare));
+
+  const tokenized = names.map((name) => ({
+    name,
+    tokens: name.trim().split(/\s+/).filter(Boolean).map(normalizeToken).filter(Boolean),
+  }));
+
+  const found: CorpusAffix[] = [];
+
+  for (const kind of ["prefix", "suffix"] as const) {
+    const candidates = new Map<string, Candidate>();
+
+    for (const entry of tokenized) {
+      // Never consider an affix that would consume the whole name — there has
+      // to be something left to be the payee.
+      const limit = Math.min(maxTokens, entry.tokens.length - 1);
+      for (let k = 1; k <= limit; k++) {
+        const slice =
+          kind === "prefix"
+            ? entry.tokens.slice(0, k)
+            : entry.tokens.slice(entry.tokens.length - k);
+        const remainder =
+          kind === "prefix"
+            ? entry.tokens.slice(k).join(" ")
+            : entry.tokens.slice(0, entry.tokens.length - k).join(" ");
+        if (!remainder) continue;
+
+        const key = slice.join(" ");
+        const candidate = candidates.get(key);
+        if (candidate) {
+          candidate.payees.add(entry.name);
+          candidate.remainders.add(remainder);
+        } else {
+          candidates.set(key, {
+            tokens: slice,
+            payees: new Set([entry.name]),
+            remainders: new Set([remainder]),
+          });
+        }
+      }
+    }
+
+    const qualifying = [...candidates.values()].filter(
+      (c) =>
+        c.payees.size >= threshold &&
+        c.remainders.size >= minDistinctRemainders &&
+        // A fragment shared by payees that are nearly all identical afterwards
+        // is a merchant name, not boilerplate.
+        c.remainders.size >= Math.min(3, Math.ceil(c.payees.size * 0.3)) &&
+        // Remainders that are mostly bare numbers mean the shared text is the
+        // merchant and the numbers are its branches — `WOOLWORTHS 0183 / 0291 /
+        // 8442`. Stripping the shared part there would delete the only real
+        // word in every one of those names.
+        !mostlyNumeric(c.remainders)
+    );
+
+    // Keep the longest affix of each family. `NFC` qualifies, but `NFC - (AP-PAY)-`
+    // removes more and is equally well evidenced, so the shorter one is redundant.
+    const longestFirst = [...qualifying].sort(
+      (a, b) => b.tokens.length - a.tokens.length
+    );
+    const kept: Candidate[] = [];
+    for (const candidate of longestFirst) {
+      const covered = kept.some((k) => isExtensionOf(k.tokens, candidate.tokens, kind));
+      if (!covered) kept.push(candidate);
+    }
+
+    for (const candidate of kept) {
+      found.push({
+        kind,
+        tokens: candidate.tokens,
+        payeeCount: candidate.payees.size,
+        distinctRemainders: candidate.remainders.size,
+      });
+    }
+  }
+
+  // Longest first so the most specific affix is applied before a shorter one
+  // that overlaps it.
+  return found.sort(
+    (a, b) => b.tokens.length - a.tokens.length || b.payeeCount - a.payeeCount
+  );
+}
+
+/** True when most of these remainders carry no word — i.e. they are branch numbers. */
+function mostlyNumeric(remainders: Set<string>): boolean {
+  let numeric = 0;
+  for (const remainder of remainders) {
+    if (!/[A-Za-z]/.test(remainder)) numeric += 1;
+  }
+  return numeric / remainders.size > 0.5;
+}
+
+/** True when `shorter` is the outer part of `longer` — i.e. already covered by it. */
+function isExtensionOf(
+  longer: string[],
+  shorter: string[],
+  kind: "prefix" | "suffix"
+): boolean {
+  if (shorter.length >= longer.length) return false;
+  const slice =
+    kind === "prefix"
+      ? longer.slice(0, shorter.length)
+      : longer.slice(longer.length - shorter.length);
+  return slice.every((t, i) => t === shorter[i]);
+}

--- a/src/features/payee-cleanup/lib/corrections.test.ts
+++ b/src/features/payee-cleanup/lib/corrections.test.ts
@@ -317,6 +317,41 @@ describe("suppressions", () => {
     expect(applyAffixSuppressions([affix], [suppression])).toEqual([]);
   });
 
+  it("does not let a rejected prefix suppress the reversed or opposite affix", () => {
+    // An affix is an ordered sequence at one end of a name. Compared as an
+    // unordered bag, rejecting the prefix ["BANK","TRANSFER"] also silenced a
+    // ["TRANSFER","BANK"] affix and the matching suffix — suggestions lost that
+    // the user never rejected.
+    const rejected = record({
+      ...buildAffixSuppression("b1", {
+        kind: "prefix",
+        tokens: ["BANK", "TRANSFER"],
+        payeeCount: 20,
+        distinctRemainders: 18,
+      }),
+      id: "s4",
+      createdAt: "2026-08-16T00:00:00.000Z",
+    });
+
+    const reversed = {
+      kind: "prefix" as const,
+      tokens: ["TRANSFER", "BANK"],
+      payeeCount: 20,
+      distinctRemainders: 18,
+    };
+    const sameTokensOtherEnd = {
+      kind: "suffix" as const,
+      tokens: ["BANK", "TRANSFER"],
+      payeeCount: 20,
+      distinctRemainders: 18,
+    };
+
+    expect(applyAffixSuppressions([reversed], [rejected])).toEqual([reversed]);
+    expect(applyAffixSuppressions([sameTokensOtherEnd], [rejected])).toEqual([
+      sameTokensOtherEnd,
+    ]);
+  });
+
   it("leaves other affixes alone", () => {
     const kept = {
       kind: "suffix" as const,

--- a/src/features/payee-cleanup/lib/corrections.test.ts
+++ b/src/features/payee-cleanup/lib/corrections.test.ts
@@ -273,6 +273,15 @@ describe("suppressions", () => {
     expect(applySuppressions([wider], [record()])).toHaveLength(1);
   });
 
+  it("does not suppress a cluster that merely reuses a normalized name", () => {
+    // `EMIRATES` and `Emirates` both key to EMIRATES, so this cluster's names
+    // are ["EMIRATES", "EMIRATES"]. Compared as sets that looked identical to a
+    // stored ["EMIRATES", "EMIRATES NBD"] and silently dropped a grouping the
+    // user never rejected — and case-only pairs are exactly what this finds.
+    const caseOnly = cluster([payee("p5", "EMIRATES"), payee("p6", "Emirates")]);
+    expect(suppressesCluster(record(), caseOnly)).toBe(false);
+  });
+
   it("does not suppress anything when the record has no matchable key", () => {
     expect(
       suppressesCluster(record({ payeeIds: [], normalizedNames: [] }), emirates)

--- a/src/features/payee-cleanup/lib/corrections.test.ts
+++ b/src/features/payee-cleanup/lib/corrections.test.ts
@@ -19,6 +19,7 @@ import {
   buildClusterSuppression,
   suppressesCluster,
 } from "./suppressions";
+import type { CorrectionMap } from "./corrections";
 import type { PayeeCluster } from "./clusterResolver";
 import type { PayeeCleanupCandidate } from "../types";
 import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
@@ -116,6 +117,18 @@ describe("cluster corrections", () => {
     expect(map.c1.excludedIds).toEqual(["p3", "p4"]);
   });
 
+  it("drops a hand-added member that the split removed", () => {
+    // `addedIds` bypassed `excludedIds` entirely, so a payee the user added and
+    // then split away came straight back through the other list.
+    const added = addMember({}, "c1", payee("p9")) as CorrectionMap;
+    const map = splitCluster(added, "c1", ["p1"], ["p1", "p2", "p9"]);
+    expect(
+      correctedMembers([payee("p1"), payee("p2")], map.c1, (id) =>
+        [payee("p1"), payee("p2"), payee("p9")].find((m) => m.id === id)
+      ).map((m) => m.id)
+    ).toEqual(["p1"]);
+  });
+
   it("drops a target that a split removed", () => {
     const withTarget = setTarget({}, "c1", payee("p3")) as Record<string, never>;
     const map = splitCluster(withTarget, "c1", ["p1", "p2"], ["p1", "p2", "p3"]);
@@ -172,6 +185,20 @@ describe("combineGroups", () => {
     );
     expect(map.B.decision).toBe("undecided");
     expect(map.B.targetId).toBeUndefined();
+  });
+
+  it("empties an absorbed group's added members too", () => {
+    // Otherwise the absorbed group keeps its hand-added payees, stays at two
+    // members and remains a live proposal claiming the same source payee as the
+    // survivor — which the validator then blocks, instead of the user getting
+    // the combine they asked for.
+    const withAdded = addMember({}, "B", payee("b9")) as CorrectionMap;
+    const map = combineGroups(
+      withAdded,
+      { clusterId: "A", finalName: "Optus" },
+      [{ clusterId: "B", memberIds: ["b1", "b2"] }]
+    );
+    expect(map.B.addedIds).toEqual([]);
   });
 
   it("is undone one group at a time", () => {

--- a/src/features/payee-cleanup/lib/corrections.test.ts
+++ b/src/features/payee-cleanup/lib/corrections.test.ts
@@ -1,0 +1,331 @@
+import {
+  addMember,
+  combineGroups,
+  correctedMembers,
+  EMPTY_CORRECTION,
+  excludeMember,
+  hasCorrections,
+  includeMember,
+  resetCluster,
+  setCanonicalName,
+  setDecision,
+  setTarget,
+  splitCluster,
+} from "./corrections";
+import {
+  applyAffixSuppressions,
+  applySuppressions,
+  buildAffixSuppression,
+  buildClusterSuppression,
+  suppressesCluster,
+} from "./suppressions";
+import type { PayeeCluster } from "./clusterResolver";
+import type { PayeeCleanupCandidate } from "../types";
+import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
+
+function payee(
+  id: string,
+  name = id.toUpperCase(),
+  overrides: Partial<PayeeCleanupCandidate["metadata"]> = {}
+): PayeeCleanupCandidate {
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+      ...overrides,
+    },
+  };
+}
+
+function cluster(members: PayeeCleanupCandidate[]): PayeeCluster {
+  return {
+    id: members.map((m) => m.id).join("+"),
+    members,
+    stem: "STEM",
+    evidence: [
+      {
+        detectorId: "full-reduction",
+        kind: "structural",
+        label: "Removed the card number",
+        detail: "STEM",
+      },
+    ],
+    fuzzyOnly: false,
+  };
+}
+
+describe("cluster corrections", () => {
+  it("records accept and reject decisions", () => {
+    let map = setDecision({}, "c1", "accepted");
+    expect(map.c1.decision).toBe("accepted");
+    map = setDecision(map, "c1", "rejected");
+    expect(map.c1.decision).toBe("rejected");
+  });
+
+  it("excludes and re-includes a member", () => {
+    let map = excludeMember({}, "c1", "p2");
+    expect(map.c1.excludedIds).toEqual(["p2"]);
+    map = includeMember(map, "c1", "p2");
+    expect(map.c1.excludedIds).toEqual([]);
+  });
+
+  it("clears the target when the target is excluded", () => {
+    // Leaving it would stage a merge into a payee the user just removed.
+    const withTarget = setTarget({}, "c1", payee("p1")) as Record<string, never>;
+    const map = excludeMember(withTarget, "c1", "p1");
+    expect(map.c1.targetId).toBeUndefined();
+  });
+
+  it("refuses to add a transfer payee, and says why", () => {
+    const result = addMember({}, "c1", payee("x", "Transfer", { transferAccountId: "a1" }));
+    expect(result).toBe("transfer-payee");
+  });
+
+  it("refuses to add a tombstoned payee", () => {
+    expect(addMember({}, "c1", payee("x", "Gone", { tombstone: true }))).toBe(
+      "tombstoned"
+    );
+  });
+
+  it("refuses a transfer payee as the merge target", () => {
+    // Actual's merge silently no-ops on a transfer target, so this would look
+    // like a success and change nothing.
+    expect(setTarget({}, "c1", payee("x", "Transfer", { transferAccountId: "a1" }))).toBe(
+      "transfer-payee"
+    );
+  });
+
+  it("adds an eligible payee the detector missed", () => {
+    const result = addMember({}, "c1", payee("p9"));
+    expect(typeof result).not.toBe("string");
+    expect((result as Record<string, { addedIds: string[] }>).c1.addedIds).toEqual(["p9"]);
+  });
+
+  it("treats an empty name override as no override", () => {
+    const map = setCanonicalName({}, "c1", "   ");
+    expect(map.c1.canonicalName).toBeUndefined();
+  });
+
+  it("splits a cluster by excluding everything not kept", () => {
+    const map = splitCluster({}, "c1", ["p1", "p2"], ["p1", "p2", "p3", "p4"]);
+    expect(map.c1.excludedIds).toEqual(["p3", "p4"]);
+  });
+
+  it("drops a target that a split removed", () => {
+    const withTarget = setTarget({}, "c1", payee("p3")) as Record<string, never>;
+    const map = splitCluster(withTarget, "c1", ["p1", "p2"], ["p1", "p2", "p3"]);
+    expect(map.c1.targetId).toBeUndefined();
+  });
+
+  it("resets a cluster back to the detector's proposal", () => {
+    let map = setDecision({}, "c1", "accepted");
+    map = excludeMember(map, "c1", "p2");
+    map = resetCluster(map, "c1");
+    expect(map.c1).toBeUndefined();
+  });
+
+  it("knows whether a proposal has been touched", () => {
+    expect(hasCorrections(EMPTY_CORRECTION)).toBe(false);
+    expect(hasCorrections(setDecision({}, "c1", "accepted").c1)).toBe(true);
+  });
+});
+
+describe("combineGroups", () => {
+  it("moves every member into the survivor and empties the others", () => {
+    const map = combineGroups(
+      {},
+      { clusterId: "A", finalName: "Optus" },
+      [
+        { clusterId: "B", memberIds: ["b1", "b2"] },
+        { clusterId: "C", memberIds: ["c1"] },
+      ]
+    );
+
+    expect(map.A.addedIds).toEqual(["b1", "b2", "c1"]);
+    expect(map.A.canonicalName).toBe("Optus");
+    // Emptied groups fall below two members and stop being proposals.
+    expect(map.B.excludedIds).toEqual(["b1", "b2"]);
+    expect(map.C.excludedIds).toEqual(["c1"]);
+  });
+
+  it("pins the name the user chose rather than re-deriving one", () => {
+    // The combined group's stem is a mix of the originals; re-deriving from it
+    // would rename the result to something the user never asked for.
+    const map = combineGroups(
+      { A: { ...EMPTY_CORRECTION, canonicalName: "Optus" } },
+      { clusterId: "A", finalName: "Optus" },
+      [{ clusterId: "B", memberIds: ["b1"] }]
+    );
+    expect(map.A.canonicalName).toBe("Optus");
+  });
+
+  it("clears the absorbed group's decision so it stops being staged", () => {
+    const map = combineGroups(
+      { B: { ...EMPTY_CORRECTION, decision: "accepted", targetId: "b1" } },
+      { clusterId: "A", finalName: "Optus" },
+      [{ clusterId: "B", memberIds: ["b1", "b2"] }]
+    );
+    expect(map.B.decision).toBe("undecided");
+    expect(map.B.targetId).toBeUndefined();
+  });
+
+  it("is undone one group at a time", () => {
+    let map = combineGroups(
+      {},
+      { clusterId: "A", finalName: "Optus" },
+      [{ clusterId: "B", memberIds: ["b1", "b2"] }]
+    );
+    map = resetCluster(map, "B");
+    expect(map.B).toBeUndefined();
+  });
+});
+
+describe("correctedMembers", () => {
+  const members = [payee("p1"), payee("p2"), payee("p3")];
+  const lookup = (id: string) => [...members, payee("p9")].find((m) => m.id === id);
+
+  it("returns the original list when nothing was corrected", () => {
+    expect(correctedMembers(members, EMPTY_CORRECTION, lookup)).toEqual(members);
+  });
+
+  it("removes excluded members", () => {
+    const result = correctedMembers(
+      members,
+      { ...EMPTY_CORRECTION, excludedIds: ["p2"] },
+      lookup
+    );
+    expect(result.map((m) => m.id)).toEqual(["p1", "p3"]);
+  });
+
+  it("appends added members", () => {
+    const result = correctedMembers(
+      members,
+      { ...EMPTY_CORRECTION, addedIds: ["p9"] },
+      lookup
+    );
+    expect(result.map((m) => m.id)).toEqual(["p1", "p2", "p3", "p9"]);
+  });
+
+  it("does not duplicate a member that is already present", () => {
+    const result = correctedMembers(
+      members,
+      { ...EMPTY_CORRECTION, addedIds: ["p1"] },
+      lookup
+    );
+    expect(result.map((m) => m.id)).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("ignores an added id that no longer resolves", () => {
+    const result = correctedMembers(
+      members,
+      { ...EMPTY_CORRECTION, addedIds: ["deleted"] },
+      lookup
+    );
+    expect(result.map((m) => m.id)).toEqual(["p1", "p2", "p3"]);
+  });
+});
+
+describe("suppressions", () => {
+  const emirates = cluster([payee("p1", "EMIRATES"), payee("p2", "EMIRATES NBD")]);
+
+  function record(
+    overrides: Partial<PayeeCleanupSuppressionRecord> = {}
+  ): PayeeCleanupSuppressionRecord {
+    return {
+      id: "s1",
+      budgetSyncId: "b1",
+      kind: "not-duplicates",
+      payeeIds: ["p1", "p2"],
+      normalizedNames: ["EMIRATES", "EMIRATES NBD"],
+      detectorIds: ["fuzzy-similarity"],
+      createdAt: "2026-08-16T00:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  it("suppresses the exact grouping the user rejected", () => {
+    expect(suppressesCluster(record(), emirates)).toBe(true);
+    expect(applySuppressions([emirates], [record()])).toEqual([]);
+  });
+
+  it("still matches after the payee ids have changed", () => {
+    // Ids do not survive a merge or a re-import, which is exactly when an old
+    // decision still needs to hold.
+    expect(
+      suppressesCluster(record({ payeeIds: ["gone-1", "gone-2"] }), emirates)
+    ).toBe(true);
+  });
+
+  it("does NOT suppress a different cluster containing one of the payees", () => {
+    // The rejected pair should stop being suggested; it must not veto a
+    // three-member proposal the user has never seen.
+    const wider = cluster([
+      payee("p1", "EMIRATES"),
+      payee("p3", "EMIRATES AIRLINE"),
+      payee("p4", "Emirates"),
+    ]);
+    expect(suppressesCluster(record(), wider)).toBe(false);
+    expect(applySuppressions([wider], [record()])).toHaveLength(1);
+  });
+
+  it("does not suppress anything when the record has no matchable key", () => {
+    expect(
+      suppressesCluster(record({ payeeIds: [], normalizedNames: [] }), emirates)
+    ).toBe(false);
+  });
+
+  it("ignores affix records when matching clusters", () => {
+    expect(suppressesCluster(record({ kind: "rejected-affix" }), emirates)).toBe(false);
+  });
+
+  it("builds a record carrying both ids and names", () => {
+    const built = buildClusterSuppression("b1", emirates);
+    expect(built.payeeIds).toEqual(["p1", "p2"]);
+    expect(built.normalizedNames).toEqual(["EMIRATES", "EMIRATES NBD"]);
+    expect(built.detectorIds).toEqual(["full-reduction"]);
+  });
+
+  it("removes a rejected learned affix so it stops being applied everywhere", () => {
+    // Rejecting one cluster does not stop an inference like `TRANSFER FROM`
+    // being applied to every other payee, so the affix itself is suppressible.
+    const affix = {
+      kind: "prefix" as const,
+      tokens: ["TRANSFER", "FROM"],
+      payeeCount: 40,
+      distinctRemainders: 30,
+    };
+    const suppression = record({
+      ...buildAffixSuppression("b1", affix),
+      id: "s2",
+      createdAt: "2026-08-16T00:00:00.000Z",
+    });
+
+    expect(applyAffixSuppressions([affix], [suppression])).toEqual([]);
+  });
+
+  it("leaves other affixes alone", () => {
+    const kept = {
+      kind: "suffix" as const,
+      tokens: ["DUBAI", "UAE"],
+      payeeCount: 40,
+      distinctRemainders: 30,
+    };
+    const rejected = record({
+      ...buildAffixSuppression("b1", {
+        kind: "prefix",
+        tokens: ["NFC", "APPAY"],
+        payeeCount: 20,
+        distinctRemainders: 18,
+      }),
+      id: "s3",
+      createdAt: "2026-08-16T00:00:00.000Z",
+    });
+
+    expect(applyAffixSuppressions([kept], [rejected])).toEqual([kept]);
+  });
+});

--- a/src/features/payee-cleanup/lib/corrections.ts
+++ b/src/features/payee-cleanup/lib/corrections.ts
@@ -1,0 +1,275 @@
+/**
+ * User corrections to a cleanup proposal (RD-078 §13).
+ *
+ * Detection will be wrong sometimes, so every part of a proposal has to be
+ * editable: which payees are in it, which one survives, and what it ends up
+ * called. This module holds that state as plain data and pure transitions, so
+ * the edits are testable without a component and every derived value can be
+ * recomputed from them.
+ *
+ * The eligibility boundary is enforced here as well as at scan time, because
+ * these functions accept ids coming back from the UI — a transfer payee must
+ * not be able to enter a cluster through the "add member" control any more than
+ * through detection.
+ */
+
+import { assertCleanupEligible } from "./eligibility";
+import type { IneligibleReason } from "./eligibility";
+import type { PayeeCleanupCandidate } from "../types";
+
+export type ClusterDecision = "undecided" | "accepted" | "rejected";
+
+export type ClusterCorrection = {
+  decision: ClusterDecision;
+  /** Members the user removed from the proposal. */
+  excludedIds: string[];
+  /** Members the user added by hand. */
+  addedIds: string[];
+  /** Overrides the suggested merge target. */
+  targetId?: string;
+  /** Overrides the suggested final name. */
+  canonicalName?: string;
+  /** Opt-in: also create the proposed normalization rule (041f). */
+  createRule?: boolean;
+  /** A pattern the user typed, replacing the generated one. */
+  rulePattern?: { field: "imported_payee" | "notes"; text: string };
+};
+
+export const EMPTY_CORRECTION: ClusterCorrection = {
+  decision: "undecided",
+  excludedIds: [],
+  addedIds: [],
+};
+
+export type CorrectionMap = Record<string, ClusterCorrection>;
+
+function current(corrections: CorrectionMap, clusterId: string): ClusterCorrection {
+  return corrections[clusterId] ?? EMPTY_CORRECTION;
+}
+
+function update(
+  corrections: CorrectionMap,
+  clusterId: string,
+  patch: Partial<ClusterCorrection>
+): CorrectionMap {
+  return {
+    ...corrections,
+    [clusterId]: { ...current(corrections, clusterId), ...patch },
+  };
+}
+
+export function setDecision(
+  corrections: CorrectionMap,
+  clusterId: string,
+  decision: ClusterDecision
+): CorrectionMap {
+  return update(corrections, clusterId, { decision });
+}
+
+/**
+ * Removes a member from the proposal.
+ *
+ * If the excluded payee was the target, the override is cleared so the scorer
+ * picks a new one — leaving a target that is no longer in the cluster would
+ * produce a merge into a payee the user just removed.
+ */
+export function excludeMember(
+  corrections: CorrectionMap,
+  clusterId: string,
+  payeeId: string
+): CorrectionMap {
+  const existing = current(corrections, clusterId);
+  return update(corrections, clusterId, {
+    excludedIds: [...new Set([...existing.excludedIds, payeeId])],
+    addedIds: existing.addedIds.filter((id) => id !== payeeId),
+    targetId: existing.targetId === payeeId ? undefined : existing.targetId,
+  });
+}
+
+export function includeMember(
+  corrections: CorrectionMap,
+  clusterId: string,
+  payeeId: string
+): CorrectionMap {
+  const existing = current(corrections, clusterId);
+  return update(corrections, clusterId, {
+    excludedIds: existing.excludedIds.filter((id) => id !== payeeId),
+  });
+}
+
+/**
+ * Adds a payee the detector missed.
+ *
+ * Returns the reason instead of the new state when the payee cannot take part,
+ * so the caller can explain the refusal rather than silently dropping it.
+ */
+export function addMember(
+  corrections: CorrectionMap,
+  clusterId: string,
+  candidate: PayeeCleanupCandidate
+): CorrectionMap | IneligibleReason {
+  const reason = assertCleanupEligible(candidate);
+  if (reason) return reason;
+
+  const existing = current(corrections, clusterId);
+  return update(corrections, clusterId, {
+    addedIds: [...new Set([...existing.addedIds, candidate.id])],
+    excludedIds: existing.excludedIds.filter((id) => id !== candidate.id),
+  });
+}
+
+/** Same guard for the target: a transfer or tombstoned payee can never survive a merge. */
+export function setTarget(
+  corrections: CorrectionMap,
+  clusterId: string,
+  candidate: PayeeCleanupCandidate
+): CorrectionMap | IneligibleReason {
+  const reason = assertCleanupEligible(candidate);
+  if (reason) return reason;
+  return update(corrections, clusterId, { targetId: candidate.id });
+}
+
+export function setCreateRule(
+  corrections: CorrectionMap,
+  clusterId: string,
+  createRule: boolean
+): CorrectionMap {
+  return update(corrections, clusterId, { createRule });
+}
+
+export function setRulePattern(
+  corrections: CorrectionMap,
+  clusterId: string,
+  pattern: { field: "imported_payee" | "notes"; text: string } | undefined
+): CorrectionMap {
+  const text = pattern?.text.trim();
+  // Clearing the box returns to the generated pattern rather than staging a
+  // rule that matches everything.
+  return update(corrections, clusterId, {
+    rulePattern: pattern && text ? { field: pattern.field, text } : undefined,
+  });
+}
+
+export function setCanonicalName(
+  corrections: CorrectionMap,
+  clusterId: string,
+  name: string
+): CorrectionMap {
+  const trimmed = name.trim();
+  // An empty override is not a name; fall back to the suggestion rather than
+  // staging a rename to nothing.
+  return update(corrections, clusterId, {
+    canonicalName: trimmed ? trimmed : undefined,
+  });
+}
+
+/**
+ * Splits a cluster: the named payees stay, everything else is excluded.
+ *
+ * Expressed through the same exclusion list rather than as a new cluster id, so
+ * a split can be undone by re-including members and nothing downstream has to
+ * know about synthetic clusters.
+ */
+export function splitCluster(
+  corrections: CorrectionMap,
+  clusterId: string,
+  keepIds: string[],
+  allMemberIds: string[]
+): CorrectionMap {
+  const keep = new Set(keepIds);
+  const excluded = allMemberIds.filter((id) => !keep.has(id));
+  const existing = current(corrections, clusterId);
+  return update(corrections, clusterId, {
+    excludedIds: excluded,
+    targetId:
+      existing.targetId && keep.has(existing.targetId) ? existing.targetId : undefined,
+  });
+}
+
+/**
+ * Folds several groups into one (RD-078 §13 "add member" / "split", combined).
+ *
+ * When the user names two or three groups the same thing, they have said those
+ * payees belong together — the scan simply could not see it, because the names
+ * reduce to different stems. Rather than refusing, cleanup can act on what the
+ * user just told it.
+ *
+ * Expressed entirely through the existing corrections: every member of the other
+ * groups is *added* to the surviving one, and each other group is emptied so it
+ * drops out of the list. No synthetic cluster ids, no new concept for the plan
+ * builder or the validator to understand, and `resetCluster` undoes any part of
+ * it.
+ *
+ * The final name is pinned explicitly, so the combined group keeps the name the
+ * user chose rather than re-deriving one from the merged stem.
+ */
+export function combineGroups(
+  corrections: CorrectionMap,
+  survivor: { clusterId: string; finalName: string },
+  absorbed: { clusterId: string; memberIds: string[] }[]
+): CorrectionMap {
+  let next = corrections;
+
+  for (const group of absorbed) {
+    for (const memberId of group.memberIds) {
+      const existing = current(next, survivor.clusterId);
+      next = update(next, survivor.clusterId, {
+        addedIds: [...new Set([...existing.addedIds, memberId])],
+        excludedIds: existing.excludedIds.filter((id) => id !== memberId),
+      });
+    }
+    // Emptying the group takes it below two members, so it stops being a
+    // proposal at all.
+    next = update(next, group.clusterId, {
+      excludedIds: [...new Set(group.memberIds)],
+      targetId: undefined,
+      decision: "undecided",
+    });
+  }
+
+  return update(next, survivor.clusterId, { canonicalName: survivor.finalName });
+}
+
+export function resetCluster(
+  corrections: CorrectionMap,
+  clusterId: string
+): CorrectionMap {
+  const next = { ...corrections };
+  delete next[clusterId];
+  return next;
+}
+
+/**
+ * The member list after corrections.
+ *
+ * A cluster reduced below two members is no longer a merge proposal, which the
+ * caller uses to drop it from the list.
+ */
+export function correctedMembers(
+  members: PayeeCleanupCandidate[],
+  correction: ClusterCorrection,
+  lookup: (id: string) => PayeeCleanupCandidate | undefined
+): PayeeCleanupCandidate[] {
+  const excluded = new Set(correction.excludedIds);
+  const kept = members.filter((m) => !excluded.has(m.id));
+
+  const existing = new Set(kept.map((m) => m.id));
+  const added = correction.addedIds
+    .filter((id) => !existing.has(id))
+    .map(lookup)
+    .filter((c): c is PayeeCleanupCandidate => Boolean(c));
+
+  return [...kept, ...added];
+}
+
+export function hasCorrections(correction: ClusterCorrection): boolean {
+  return (
+    correction.decision !== "undecided" ||
+    correction.excludedIds.length > 0 ||
+    correction.addedIds.length > 0 ||
+    correction.targetId !== undefined ||
+    correction.canonicalName !== undefined ||
+    correction.createRule === true ||
+    correction.rulePattern !== undefined
+  );
+}

--- a/src/features/payee-cleanup/lib/corrections.ts
+++ b/src/features/payee-cleanup/lib/corrections.ts
@@ -181,6 +181,9 @@ export function splitCluster(
   const existing = current(corrections, clusterId);
   return update(corrections, clusterId, {
     excludedIds: excluded,
+    // A split is a statement about the whole group, so a payee the user added
+    // by hand and then split away has to go too.
+    addedIds: existing.addedIds.filter((id) => keep.has(id)),
     targetId:
       existing.targetId && keep.has(existing.targetId) ? existing.targetId : undefined,
   });
@@ -222,6 +225,12 @@ export function combineGroups(
     // proposal at all.
     next = update(next, group.clusterId, {
       excludedIds: [...new Set(group.memberIds)],
+      // Cleared as well, or the absorbed group keeps its hand-added payees,
+      // stays at two members and remains a live proposal claiming the same
+      // source payee as the survivor — which the validator then blocks as a
+      // merge into more than one payee, instead of the combine the user asked
+      // for.
+      addedIds: [],
       targetId: undefined,
       decision: "undecided",
     });
@@ -255,7 +264,11 @@ export function correctedMembers(
 
   const existing = new Set(kept.map((m) => m.id));
   const added = correction.addedIds
-    .filter((id) => !existing.has(id))
+    // Exclusion wins over addition. The two lists are disjoint after
+    // `excludeMember` or `addMember`, but `splitCluster` and `combineGroups`
+    // write `excludedIds` wholesale, so a hand-added payee could come back
+    // through the side door after the user had removed it.
+    .filter((id) => !existing.has(id) && !excluded.has(id))
     .map(lookup)
     .filter((c): c is PayeeCleanupCandidate => Boolean(c));
 

--- a/src/features/payee-cleanup/lib/derivedForms.ts
+++ b/src/features/payee-cleanup/lib/derivedForms.ts
@@ -1,0 +1,151 @@
+/**
+ * Non-destructive derived forms for payee analysis (RD-078 §5.1).
+ *
+ * These are *analysis-only*. Nothing here is ever written back to a payee — a
+ * derived form is how detectors compare two names, not a proposed rename. The
+ * canonical-name suggestion is a separate, editable decision (§9).
+ *
+ * Computed once per payee and cached, because every detector and every fuzzy
+ * bucket reads them.
+ */
+
+import { normalizeForCompare, tokenize } from "@/lib/reconciliation/match/text";
+
+export type PayeeDerivedForms = {
+  /** Exactly as stored on the payee. */
+  rawName: string;
+  trimmed: string;
+  /** Interior runs of whitespace collapsed to one space. */
+  collapsedWhitespace: string;
+  /** Upper-cased, for case-insensitive equality. */
+  caseFolded: string;
+  /**
+   * Diacritics stripped, punctuation turned into spaces, whitespace collapsed,
+   * upper-cased. Punctuation becomes a space rather than vanishing so
+   * `AMZN Mktp AE*2J8G4` cannot glue two unrelated tokens together.
+   */
+  punctuationNormalized: string;
+  tokenized: string[];
+};
+
+export function deriveForms(rawName: string): PayeeDerivedForms {
+  const trimmed = rawName.trim();
+  const collapsedWhitespace = trimmed.replace(/\s+/g, " ");
+  // Reuses reconciliation's text primitives rather than adding a second
+  // normalizer — RD-078 §5.4 is explicit that cleanup must not grow a parallel
+  // fuzzy/normalization stack.
+  const punctuationNormalized = normalizeForCompare(rawName);
+
+  return {
+    rawName,
+    trimmed,
+    collapsedWhitespace,
+    caseFolded: collapsedWhitespace.toUpperCase(),
+    punctuationNormalized,
+    tokenized: tokenize(punctuationNormalized),
+  };
+}
+
+/**
+ * True when the name carries no machine-generated noise and reads like
+ * something a person would type.
+ *
+ * Feeds two decisions: which member is the better merge target (§8.1 "clean
+ * existing human-readable payee") and whether a canonical-name suggestion is
+ * even needed. Intentionally conservative — a name is "clean" only if nothing
+ * about it looks generated.
+ */
+export function looksHumanReadable(forms: PayeeDerivedForms): boolean {
+  const name = forms.collapsedWhitespace;
+  if (!name) return false;
+
+  // ALL CAPS across multiple tokens reads as bank text, not a typed name.
+  // A single all-caps token can be a legitimate brand (IKEA, HSBC).
+  if (forms.tokenized.length > 1 && name === name.toUpperCase()) return false;
+
+  // Any run of 3+ digits is a store, terminal, reference or date number.
+  // Originally this required whitespace on both sides, which let
+  // `... Value Date: 10/11/2025` pass as a clean human-readable name — the
+  // digits are delimited by slashes, not spaces.
+  if (/\d{3,}/.test(name)) return false;
+
+  // Card-suffix and reference markers.
+  if (/[*#]\s*\d+/.test(name)) return false;
+
+  // An unambiguous bank wrapper word at the front. Only the strong set — a
+  // name starting with "Card" or "Credit" is very often a real merchant.
+  if (STRONG_MACHINE_PREFIXES.has(forms.tokenized[0] ?? "")) return false;
+
+  return true;
+}
+
+/**
+ * Wrapper words banks prepend to the real merchant name, split by how safely
+ * they can be stripped. Kept in one place so the prefix detector and the
+ * readability heuristic cannot drift apart.
+ *
+ * **Strong** words are never the start of a real merchant name, so a leading
+ * one is proof of a wrapper.
+ */
+export const STRONG_MACHINE_PREFIXES = new Set([
+  "POS",
+  "VISA",
+  "MASTERCARD",
+  "PURCHASE",
+  "TXN",
+  "TRANSACTION",
+  "COMPRA",
+  "ACH",
+  "SEPA",
+  "IDEAL",
+  "PMT",
+]);
+
+/**
+ * **Weak** words appear in bank wrappers *and* in genuine merchant names —
+ * `Card Factory`, `Credit Union`, `Payment Plan`, `Debit Order Services`.
+ *
+ * Stripping one on its own produced exactly that false positive in testing
+ * (`CARD FACTORY` → `FACTORY`), so a weak word is only treated as a wrapper
+ * when it sits in a leading run that also contains a strong word — e.g.
+ * `CARD PURCHASE STARBUCKS`.
+ */
+export const WEAK_MACHINE_PREFIXES = new Set([
+  "CARD",
+  "DEBIT",
+  "CREDIT",
+  "PAYMENT",
+]);
+
+export function isMachinePrefixWord(token: string): boolean {
+  return STRONG_MACHINE_PREFIXES.has(token) || WEAK_MACHINE_PREFIXES.has(token);
+}
+
+/**
+ * Legal-entity suffixes. A difference that is *only* one of these is weak
+ * evidence — `Acme Ltd` and `Acme Inc` can be genuinely different entities —
+ * so the detector that uses this list scores low and lands in Needs Review.
+ */
+export const LEGAL_SUFFIXES = new Set([
+  "LTD",
+  "LIMITED",
+  "LLC",
+  "INC",
+  "INCORPORATED",
+  "PLC",
+  "GMBH",
+  "BV",
+  "NV",
+  "SA",
+  "SARL",
+  "SRL",
+  "PTY",
+  "CO",
+  "CORP",
+  "CORPORATION",
+  "LLP",
+  "AG",
+  "AS",
+  "OY",
+  "AB",
+]);

--- a/src/features/payee-cleanup/lib/derivedForms.ts
+++ b/src/features/payee-cleanup/lib/derivedForms.ts
@@ -61,7 +61,15 @@ export function looksHumanReadable(forms: PayeeDerivedForms): boolean {
 
   // ALL CAPS across multiple tokens reads as bank text, not a typed name.
   // A single all-caps token can be a legitimate brand (IKEA, HSBC).
-  if (forms.tokenized.length > 1 && name === name.toUpperCase()) return false;
+  //
+  // The test only means anything for a script that *has* case. Japanese, Arabic,
+  // Chinese, Hebrew and Thai all return themselves from `toUpperCase()`, so this
+  // rejected every multi-word name in those scripts — costing them the merge
+  // target bonus and the canonical-name preference for no reason.
+  const hasCase = name !== name.toLowerCase();
+  if (hasCase && forms.tokenized.length > 1 && name === name.toUpperCase()) {
+    return false;
+  }
 
   // Any run of 3+ digits is a store, terminal, reference or date number.
   // Originally this required whitespace on both sides, which let

--- a/src/features/payee-cleanup/lib/detectors.test.ts
+++ b/src/features/payee-cleanup/lib/detectors.test.ts
@@ -138,9 +138,15 @@ describe("detectAll", () => {
     // The resolver groups on the stem alone, so a one-character stem would
     // collect every unrelated payee that reduced to the same letter.
     const [detected] = detectAll([payee("A-- 1234")]);
-    for (const hit of detected.hits.filter((h) => h.detectorId === "full-reduction")) {
-      expect(hit.stem.length).toBeGreaterThanOrEqual(3);
-    }
+    expect(detected.hits.some((h) => h.detectorId === "full-reduction")).toBe(false);
+  });
+
+  it("still emits a reduction hit when the stem clears the floor", () => {
+    // The positive control for the guard above: it must drop short stems
+    // without quietly dropping every reduction.
+    const [detected] = detectAll([payee("COLES 1234")]);
+    const hit = detected.hits.find((h) => h.detectorId === "full-reduction");
+    expect(hit?.stem).toBe("COLES");
   });
 
   it("never emits a structural hit with nothing structural to report", () => {

--- a/src/features/payee-cleanup/lib/detectors.test.ts
+++ b/src/features/payee-cleanup/lib/detectors.test.ts
@@ -59,6 +59,14 @@ describe("looksHumanReadable", () => {
     expect(looksHumanReadable(deriveForms(name))).toBe(expected);
   });
 
+  it("accepts a multi-word name in a script with no case distinction", () => {
+    // `toUpperCase()` returns these unchanged, so the all-caps test was always
+    // true and every such name lost the merge-target bonus and the
+    // canonical-name preference.
+    expect(looksHumanReadable(deriveForms("\u6771\u4eac \u30b9\u30fc\u30d1\u30fc"))).toBe(true);
+    expect(looksHumanReadable(deriveForms("\u0645\u0637\u0639\u0645 \u0627\u0644\u0628\u064a\u062a"))).toBe(true);
+  });
+
   it("rejects a date even though its digits are punctuation-delimited", () => {
     // An earlier version required whitespace around a digit run, so a name
     // ending `Value Date: 10/11/2025` read as clean and was suggested verbatim
@@ -124,6 +132,31 @@ describe("detectAll", () => {
       (h) => h.detectorId === "full-reduction" && h.kind === "structural"
     );
     expect(structural.length).toBeGreaterThan(0);
+  });
+
+  it("does not emit a reduction hit whose stem is below the length floor", () => {
+    // The resolver groups on the stem alone, so a one-character stem would
+    // collect every unrelated payee that reduced to the same letter.
+    const [detected] = detectAll([payee("A-- 1234")]);
+    for (const hit of detected.hits.filter((h) => h.detectorId === "full-reduction")) {
+      expect(hit.stem.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("never emits a structural hit with nothing structural to report", () => {
+    // When every step was interpretive the structural hit was still built, with
+    // an empty label ("Removed ") and nothing recorded as removed.
+    for (const [detected] of [
+      detectAll([payee("Acme Pty Ltd")]),
+      detectAll([payee("Acme Pty Ltd 0559")]),
+    ].map((d) => d)) {
+      for (const hit of detected.hits.filter(
+        (h) => h.detectorId === "full-reduction" && h.kind === "structural"
+      )) {
+        expect(hit.label).not.toBe("Removed ");
+        expect(hit.removed).not.toBe("");
+      }
+    }
   });
 
   it("carries the reduction result for later slices", () => {

--- a/src/features/payee-cleanup/lib/detectors.test.ts
+++ b/src/features/payee-cleanup/lib/detectors.test.ts
@@ -1,0 +1,134 @@
+import { deriveForms, looksHumanReadable } from "./derivedForms";
+import { detectAll, runDetectors } from "./detectors";
+import type { PayeeCleanupCandidate } from "../types";
+
+/**
+ * Only the identity detectors live here now — case, whitespace and punctuation.
+ *
+ * Every detector that *removes* noise moved into the composable pipeline
+ * (`reduce.ts`, tested in `reduce.test.ts`). Their single-pass versions used to
+ * run alongside it and were actively harmful: each member of a cluster reduced
+ * to a slightly different stem, so a three-member cluster reported seven pieces
+ * of evidence and confidence claimed "17 independent detectors agree".
+ */
+
+function payee(name: string): PayeeCleanupCandidate {
+  const id = `p-${name}`;
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+    },
+  };
+}
+
+function stems(name: string): string[] {
+  return runDetectors(deriveForms(name)).map((h) => h.stem);
+}
+
+describe("deriveForms", () => {
+  it("produces analysis forms without altering the raw name", () => {
+    const forms = deriveForms("  WOOLWORTHS   0183 ");
+    expect(forms.rawName).toBe("  WOOLWORTHS   0183 ");
+    expect(forms.trimmed).toBe("WOOLWORTHS   0183");
+    expect(forms.collapsedWhitespace).toBe("WOOLWORTHS 0183");
+    expect(forms.punctuationNormalized).toBe("WOOLWORTHS 0183");
+    expect(forms.tokenized).toEqual(["WOOLWORTHS", "0183"]);
+  });
+
+  it("strips diacritics and turns punctuation into separators", () => {
+    expect(deriveForms("Café AMZN*2J8").punctuationNormalized).toBe("CAFE AMZN 2J8");
+  });
+});
+
+describe("looksHumanReadable", () => {
+  it.each([
+    ["Woolworths", true],
+    ["McDonald's", true],
+    ["IKEA", true],
+    ["WOOLWORTHS 0183", false],
+    ["AMAZON MARKETPLACE", false],
+    ["NETFLIX *4821", false],
+    ["MARKET BOYS PTY LTD Sydney Value Date: 10/11/2025", false],
+  ])("%s → %s", (name, expected) => {
+    expect(looksHumanReadable(deriveForms(name))).toBe(expected);
+  });
+
+  it("rejects a date even though its digits are punctuation-delimited", () => {
+    // An earlier version required whitespace around a digit run, so a name
+    // ending `Value Date: 10/11/2025` read as clean and was suggested verbatim
+    // as the canonical name.
+    expect(looksHumanReadable(deriveForms("ACME 10/11/2025"))).toBe(false);
+  });
+});
+
+describe("identity detectors", () => {
+  it("gives case variants the same stem", () => {
+    expect(stems("AMAZON")).toContain("AMAZON");
+    expect(stems("Amazon")).toContain("AMAZON");
+    expect(stems("amazon")).toContain("AMAZON");
+  });
+
+  it("gives whitespace variants the same stem", () => {
+    expect(stems("WOOLWORTHS   ")).toContain("WOOLWORTHS");
+    expect(stems("WOOLWORTHS")).toContain("WOOLWORTHS");
+  });
+
+  it("gives punctuation variants the same stem", () => {
+    expect(stems("AMAZON.COM")).toContain("AMAZON COM");
+    expect(stems("AMAZON COM")).toContain("AMAZON COM");
+  });
+
+  it("does not remove anything", () => {
+    // Identity detectors normalize; they never take content away. That is what
+    // makes them safe to run on every payee.
+    for (const hit of runDetectors(deriveForms("WOOLWORTHS 0183"))) {
+      expect(hit.removed).toBe("");
+      expect(hit.stem).toContain("WOOLWORTHS");
+    }
+  });
+});
+
+describe("detectAll", () => {
+  it("adds the pipeline's stem as a reduction hit", () => {
+    const [detected] = detectAll([payee("COLES 0559")]);
+    const reduction = detected.hits.find((h) => h.detectorId === "full-reduction");
+
+    expect(reduction?.stem).toBe("COLES");
+    expect(reduction?.label).toMatch(/store or terminal number/i);
+  });
+
+  it("emits no reduction hit for an already-clean payee", () => {
+    // Nothing was removed, so there is nothing to explain — the identity
+    // detectors carry that payee into its cluster instead.
+    const [detected] = detectAll([payee("Woolworths")]);
+    expect(detected.hits.some((h) => h.detectorId === "full-reduction")).toBe(false);
+  });
+
+  it("reports an interpreted reduction as contextual", () => {
+    const [detected] = detectAll([payee("Acme Pty Ltd 0559")]);
+    const hits = detected.hits.filter((h) => h.detectorId === "full-reduction");
+    expect(hits.some((h) => h.kind === "contextual")).toBe(true);
+  });
+
+  it("also exposes a structural-only stem when a guess was involved", () => {
+    // Two payees agreeing on the structural stem are a hard match even if both
+    // also carry text that only interpretation could remove.
+    const [detected] = detectAll([payee("Acme Pty Ltd 0559")]);
+    const structural = detected.hits.filter(
+      (h) => h.detectorId === "full-reduction" && h.kind === "structural"
+    );
+    expect(structural.length).toBeGreaterThan(0);
+  });
+
+  it("carries the reduction result for later slices", () => {
+    const [detected] = detectAll([payee("COLES 0559")]);
+    expect(detected.reduction.stem).toBe("COLES");
+    expect(detected.reduction.steps.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/payee-cleanup/lib/detectors.ts
+++ b/src/features/payee-cleanup/lib/detectors.ts
@@ -1,0 +1,212 @@
+/**
+ * Payee variant detectors (RD-078 §5.2, §5.3).
+ *
+ * Every detector answers one question: *after removing one specific class of
+ * noise, do these names become the same thing?* The removed text is the
+ * evidence, which is why detectors return a stem plus a description rather than
+ * a bare boolean — a proposal the user cannot interrogate is a proposal they
+ * cannot safely accept.
+ *
+ * Two families, and the difference matters to the cluster resolver:
+ *
+ * - **structural** — a deterministic transform collapses the names to an
+ *   identical stem. Strong enough to form a group.
+ * - **contextual** — a plausible but interpretive transform (legal suffixes,
+ *   location fragments). Lower confidence; forms a group but lands in review.
+ *
+ * Fuzzy similarity lives in `fuzzy.ts` and is neither: it is evidence only and
+ * can never chain payees together.
+ */
+
+import { deriveForms, type PayeeDerivedForms } from "./derivedForms";
+import { reduceFully, type ReductionResult } from "./reduce";
+import type { CorpusAffix } from "./corpusAffixes";
+import type { PayeeCleanupCandidate } from "../types";
+
+export type DetectorId =
+  | "case-only"
+  | "whitespace-only"
+  | "punctuation"
+  | "full-reduction";
+
+export type EvidenceKind = "structural" | "contextual" | "fuzzy";
+
+export type DetectorResult = {
+  /**
+   * The shared stem this detector reduced the name to. Two payees group when
+   * their stems are equal *and* non-trivial.
+   */
+  stem: string;
+  /** What was removed, for the evidence line shown to the user. */
+  removed: string;
+};
+
+export type Detector = {
+  id: DetectorId;
+  kind: EvidenceKind;
+  /** Shown as the cluster's evidence, e.g. "Variable 4-digit store number". */
+  label: string;
+  /**
+   * Returns null when the detector does not apply to this name. Returning a
+   * stem equal to the input contributes nothing and is treated as no-match.
+   */
+  reduce(forms: PayeeDerivedForms): DetectorResult | null;
+};
+
+/**
+ * A stem shorter than this is too generic to group on — collapsing to `A` or
+ * `THE` would sweep unrelated merchants together.
+ */
+const MIN_STEM_LENGTH = 3;
+
+// ─── Identity detectors ──────────────────────────────────────────────────────
+
+/**
+ * `AMAZON` / `Amazon` / `amazon` — identical once case is ignored.
+ * The stem is the case-folded name itself, so equality *is* the grouping.
+ */
+const caseOnly: Detector = {
+  id: "case-only",
+  kind: "structural",
+  label: "Same name, different capitalization",
+  reduce: (forms) =>
+    forms.caseFolded.length >= MIN_STEM_LENGTH
+      ? { stem: forms.caseFolded, removed: "" }
+      : null,
+};
+
+/** `WOOLWORTHS` vs `WOOLWORTHS  ` / `WOOL  WORTHS` — whitespace only. */
+const whitespaceOnly: Detector = {
+  id: "whitespace-only",
+  kind: "structural",
+  label: "Same name, different spacing",
+  reduce: (forms) =>
+    forms.collapsedWhitespace.length >= MIN_STEM_LENGTH
+      ? { stem: forms.collapsedWhitespace, removed: "" }
+      : null,
+};
+
+/** `AMAZON.COM` vs `AMAZON COM` — punctuation only. */
+const punctuation: Detector = {
+  id: "punctuation",
+  kind: "structural",
+  label: "Same name, different punctuation",
+  reduce: (forms) =>
+    forms.punctuationNormalized.length >= MIN_STEM_LENGTH
+      ? { stem: forms.punctuationNormalized, removed: "" }
+      : null,
+};
+/**
+ * Only the **identity** detectors remain here.
+ *
+ * They normalize a name without removing meaning, so they produce the same stem
+ * for every member of a cluster — and they are what lets an already-clean payee
+ * join its noisy variants, since the pipeline leaves such a name untouched and
+ * emits no reduction hit for it.
+ *
+ * Everything that *removes* noise now lives in `reduce.ts`, applied composably.
+ * Single-pass versions used to run alongside it and were actively harmful: each
+ * member reduced to a slightly different stem (the dates differ), so a
+ * three-member cluster reported seven pieces of evidence, none of which was the
+ * stem that actually grouped it, and confidence claimed "17 independent
+ * detectors agree".
+ */
+export const DETECTORS: Detector[] = [caseOnly, whitespaceOnly, punctuation];
+
+export type DetectorHit = {
+  detectorId: DetectorId;
+  kind: EvidenceKind;
+  label: string;
+  stem: string;
+  removed: string;
+};
+
+/** Runs every detector over one payee, returning each one that applied. */
+export function runDetectors(forms: PayeeDerivedForms): DetectorHit[] {
+  const hits: DetectorHit[] = [];
+  for (const detector of DETECTORS) {
+    const result = detector.reduce(forms);
+    if (!result) continue;
+    hits.push({
+      detectorId: detector.id,
+      kind: detector.kind,
+      label: detector.label,
+      stem: result.stem,
+      removed: result.removed,
+    });
+  }
+  return hits;
+}
+
+export type DetectedPayee = {
+  candidate: PayeeCleanupCandidate;
+  forms: PayeeDerivedForms;
+  hits: DetectorHit[];
+  /** The composed reduction — see `reduce.ts`. */
+  reduction: ReductionResult;
+};
+
+/**
+ * The composed pipeline, surfaced as one more detector hit so the cluster
+ * resolver can group on its stem alongside the single-pass detectors.
+ *
+ * Reported as `contextual` when any interpretive step fired (a location or a
+ * company suffix was removed), so those clusters land in review rather than
+ * claiming the certainty of a purely structural match.
+ */
+function reductionHit(reduction: ReductionResult): DetectorHit | null {
+  if (reduction.steps.length === 0) return null;
+
+  const contextual = reduction.steps.some((s) => s.contextual);
+  const labels = [...new Set(reduction.steps.map((s) => s.label))];
+
+  return {
+    detectorId: "full-reduction",
+    kind: contextual ? "contextual" : "structural",
+    label: `Removed ${labels.join(", ").toLowerCase()}`,
+    stem: reduction.stem,
+    removed: reduction.steps.map((s) => s.removed).join(" · "),
+  };
+}
+
+export function detectAll(
+  candidates: PayeeCleanupCandidate[],
+  affixes: CorpusAffix[] = []
+): DetectedPayee[] {
+  return candidates.map((candidate) => {
+    const forms = deriveForms(candidate.name);
+    const reduction = reduceFully(candidate.name, affixes);
+    const hits = runDetectors(forms);
+
+    const reduced = reductionHit(reduction);
+    // Only add it when it says something the single-pass detectors did not.
+    if (reduced && !hits.some((h) => h.stem === reduced.stem)) {
+      hits.push(reduced);
+    }
+
+    // The structural-only stem, when the full reduction needed an interpretive
+    // step to get further. Two payees that already match here differ only in
+    // noise we are certain about, so the cluster earns structural confidence.
+    if (
+      reduction.structuralStem !== reduction.stem &&
+      !hits.some((h) => h.stem === reduction.structuralStem)
+    ) {
+      hits.push({
+        detectorId: "full-reduction",
+        kind: "structural",
+        label: `Removed ${[
+          ...new Set(reduction.steps.filter((s) => !s.contextual).map((s) => s.label)),
+        ]
+          .join(", ")
+          .toLowerCase()}`,
+        stem: reduction.structuralStem,
+        removed: reduction.steps
+          .filter((s) => !s.contextual)
+          .map((s) => s.removed)
+          .join(" · "),
+      });
+    }
+
+    return { candidate, forms, hits, reduction };
+  });
+}

--- a/src/features/payee-cleanup/lib/detectors.ts
+++ b/src/features/payee-cleanup/lib/detectors.ts
@@ -156,6 +156,11 @@ export type DetectedPayee = {
  */
 function reductionHit(reduction: ReductionResult): DetectorHit | null {
   if (reduction.steps.length === 0) return null;
+  // The individual reducers guard their intermediate text, but the composed
+  // stem can still come out below the floor — `A-- 1234` reduces to `A`. The
+  // resolver groups on the stem alone, so a one-character stem would collect
+  // every unrelated payee that happened to reduce to the same letter.
+  if (reduction.stem.length < MIN_STEM_LENGTH) return null;
 
   const contextual = reduction.steps.some((s) => s.contextual);
   const labels = [...new Set(reduction.steps.map((s) => s.label))];
@@ -187,23 +192,24 @@ export function detectAll(
     // The structural-only stem, when the full reduction needed an interpretive
     // step to get further. Two payees that already match here differ only in
     // noise we are certain about, so the cluster earns structural confidence.
+    // Only when a structural step actually fired. If every step was
+    // interpretive there is nothing structural to report, and the hit was being
+    // built with an empty label ("Removed ") and nothing removed.
+    const structuralSteps = reduction.steps.filter((s) => !s.contextual);
     if (
+      structuralSteps.length > 0 &&
+      reduction.structuralStem.length >= MIN_STEM_LENGTH &&
       reduction.structuralStem !== reduction.stem &&
       !hits.some((h) => h.stem === reduction.structuralStem)
     ) {
       hits.push({
         detectorId: "full-reduction",
         kind: "structural",
-        label: `Removed ${[
-          ...new Set(reduction.steps.filter((s) => !s.contextual).map((s) => s.label)),
-        ]
+        label: `Removed ${[...new Set(structuralSteps.map((s) => s.label))]
           .join(", ")
           .toLowerCase()}`,
         stem: reduction.structuralStem,
-        removed: reduction.steps
-          .filter((s) => !s.contextual)
-          .map((s) => s.removed)
-          .join(" · "),
+        removed: structuralSteps.map((s) => s.removed).join(" · "),
       });
     }
 

--- a/src/features/payee-cleanup/lib/eligibility.test.ts
+++ b/src/features/payee-cleanup/lib/eligibility.test.ts
@@ -1,0 +1,130 @@
+import {
+  assertCleanupEligible,
+  ineligibleReason,
+  isCleanupEligible,
+  partitionByEligibility,
+} from "./eligibility";
+import type { PayeeCleanupCandidate, PayeeCleanupMetadata } from "../types";
+
+function metadata(
+  overrides: Partial<PayeeCleanupMetadata> = {}
+): PayeeCleanupMetadata {
+  return {
+    id: "p1",
+    favorite: false,
+    learnCategories: true,
+    tombstone: false,
+    transferAccountId: null,
+    ...overrides,
+  };
+}
+
+function candidate(
+  id: string,
+  overrides: Partial<PayeeCleanupMetadata> = {}
+): PayeeCleanupCandidate {
+  return {
+    id,
+    name: `Payee ${id}`,
+    metadata: metadata({ id, ...overrides }),
+  };
+}
+
+describe("isCleanupEligible", () => {
+  it("accepts an ordinary live payee", () => {
+    expect(isCleanupEligible(metadata())).toBe(true);
+  });
+
+  it("rejects a transfer payee", () => {
+    // Actual's merge silently no-ops on a transfer target and drops transfer
+    // sources, so one reaching a plan produces a merge that reports success and
+    // changes nothing.
+    expect(isCleanupEligible(metadata({ transferAccountId: "acct-1" }))).toBe(
+      false
+    );
+  });
+
+  it("rejects a tombstoned payee", () => {
+    expect(isCleanupEligible(metadata({ tombstone: true }))).toBe(false);
+  });
+
+  it("rejects a payee that is both", () => {
+    expect(
+      isCleanupEligible(metadata({ transferAccountId: "acct-1", tombstone: true }))
+    ).toBe(false);
+  });
+
+  it("treats an empty transfer account id as no transfer account", () => {
+    // The metadata reader normalizes "" to null; this guards the boundary
+    // against a raw row slipping through with an empty string.
+    expect(isCleanupEligible(metadata({ transferAccountId: null }))).toBe(true);
+  });
+});
+
+describe("ineligibleReason", () => {
+  it("returns null for an eligible payee", () => {
+    expect(ineligibleReason(metadata())).toBeNull();
+  });
+
+  it("reports transfer ahead of tombstone", () => {
+    expect(
+      ineligibleReason(metadata({ transferAccountId: "acct-1", tombstone: true }))
+    ).toBe("transfer-payee");
+  });
+
+  it("reports tombstoned when that is the only reason", () => {
+    expect(ineligibleReason(metadata({ tombstone: true }))).toBe("tombstoned");
+  });
+});
+
+describe("partitionByEligibility", () => {
+  it("splits candidates into eligible and the two exclusion buckets", () => {
+    const partition = partitionByEligibility([
+      candidate("a"),
+      candidate("b", { transferAccountId: "acct-1" }),
+      candidate("c", { tombstone: true }),
+      candidate("d"),
+    ]);
+
+    expect(partition.eligible.map((p) => p.id)).toEqual(["a", "d"]);
+    expect(partition.excludedTransfer.map((p) => p.id)).toEqual(["b"]);
+    expect(partition.excludedTombstoned.map((p) => p.id)).toEqual(["c"]);
+  });
+
+  it("keeps exclusion counts so the scan summary can report them", () => {
+    const partition = partitionByEligibility([
+      candidate("a", { transferAccountId: "acct-1" }),
+      candidate("b", { transferAccountId: "acct-2" }),
+      candidate("c"),
+    ]);
+
+    expect(partition.excludedTransfer).toHaveLength(2);
+    expect(partition.eligible).toHaveLength(1);
+  });
+
+  it("returns empty buckets for an empty budget", () => {
+    const partition = partitionByEligibility([]);
+    expect(partition.eligible).toEqual([]);
+    expect(partition.excludedTransfer).toEqual([]);
+    expect(partition.excludedTombstoned).toEqual([]);
+  });
+});
+
+describe("assertCleanupEligible", () => {
+  it("passes an eligible candidate", () => {
+    expect(assertCleanupEligible(candidate("a"))).toBeNull();
+  });
+
+  it("blocks a transfer payee being added to a cluster or chosen as target", () => {
+    // The guard every later slice calls when the UI hands back a payee id.
+    expect(assertCleanupEligible(candidate("b", { transferAccountId: "acct-1" }))).toBe(
+      "transfer-payee"
+    );
+  });
+
+  it("blocks a tombstoned payee", () => {
+    expect(assertCleanupEligible(candidate("c", { tombstone: true }))).toBe(
+      "tombstoned"
+    );
+  });
+});

--- a/src/features/payee-cleanup/lib/eligibility.test.ts
+++ b/src/features/payee-cleanup/lib/eligibility.test.ts
@@ -55,9 +55,14 @@ describe("isCleanupEligible", () => {
   });
 
   it("treats an empty transfer account id as no transfer account", () => {
-    // The metadata reader normalizes "" to null; this guards the boundary
-    // against a raw row slipping through with an empty string.
-    expect(isCleanupEligible(metadata({ transferAccountId: null }))).toBe(true);
+    // The reader normalizes "" to null (payeeMetadata.test.ts covers that), but
+    // this predicate is also reachable from a raw row, so the empty string is
+    // exercised here rather than assumed away.
+    expect(
+      isCleanupEligible(
+        metadata({ transferAccountId: "" as unknown as string | null })
+      )
+    ).toBe(true);
   });
 });
 

--- a/src/features/payee-cleanup/lib/eligibility.ts
+++ b/src/features/payee-cleanup/lib/eligibility.ts
@@ -1,0 +1,96 @@
+/**
+ * Payee Cleanup eligibility boundary (RD-078 §4).
+ *
+ * Two classes of payee can never take part in cleanup, and both must be
+ * rejected *before* derived forms, pair generation, fuzzy matching, cluster
+ * resolution, target selection or deletion — not filtered out later in the UI:
+ *
+ * - **Transfer payees** (`transfer_acct` set) are account-backed and managed by
+ *   Actual. They are read-only: not renameable, deleteable, mergeable or
+ *   batch-selectable. Actual's own `db.mergePayees` silently *no-ops* when the
+ *   target is a transfer payee and silently drops transfer payees from the
+ *   source list — so letting one into a plan produces a merge that reports
+ *   success while doing nothing.
+ * - **Tombstoned payees** are already deleted. Surfacing them would resurrect
+ *   dead entities as candidates and let suppressions bind to ids that no longer
+ *   exist.
+ *
+ * Their rules may still be inspected when analysing rule overlap globally; that
+ * is a separate concern from being a cleanup *candidate*.
+ */
+
+import type { PayeeCleanupCandidate, PayeeCleanupMetadata } from "../types";
+
+export type IneligibleReason = "transfer-payee" | "tombstoned";
+
+/**
+ * The eligibility predicate. Accepts anything carrying the metadata fields, so
+ * it can be applied to a raw metadata row before the full candidate is built.
+ */
+export function isCleanupEligible(
+  payee: Pick<PayeeCleanupMetadata, "tombstone" | "transferAccountId">
+): boolean {
+  return payee.transferAccountId == null && !payee.tombstone;
+}
+
+/**
+ * Why a payee was excluded, or `null` when it is eligible.
+ *
+ * Transfer is reported ahead of tombstone so a deleted transfer payee reads as
+ * the more specific "this is not an ordinary merchant" case.
+ */
+export function ineligibleReason(
+  payee: Pick<PayeeCleanupMetadata, "tombstone" | "transferAccountId">
+): IneligibleReason | null {
+  if (payee.transferAccountId != null) return "transfer-payee";
+  if (payee.tombstone) return "tombstoned";
+  return null;
+}
+
+export type EligibilityPartition = {
+  eligible: PayeeCleanupCandidate[];
+  /** Kept so the dashboard can report "N transfer payees excluded" honestly. */
+  excludedTransfer: PayeeCleanupCandidate[];
+  excludedTombstoned: PayeeCleanupCandidate[];
+};
+
+/**
+ * Splits the candidate set at the boundary. Callers pass `partition.eligible`
+ * into detection and use the excluded counts for the scan summary.
+ */
+export function partitionByEligibility(
+  candidates: PayeeCleanupCandidate[]
+): EligibilityPartition {
+  const partition: EligibilityPartition = {
+    eligible: [],
+    excludedTransfer: [],
+    excludedTombstoned: [],
+  };
+
+  for (const candidate of candidates) {
+    switch (ineligibleReason(candidate.metadata)) {
+      case "transfer-payee":
+        partition.excludedTransfer.push(candidate);
+        break;
+      case "tombstoned":
+        partition.excludedTombstoned.push(candidate);
+        break;
+      default:
+        partition.eligible.push(candidate);
+    }
+  }
+
+  return partition;
+}
+
+/**
+ * Guard for every later slice that accepts a payee id from the UI — adding a
+ * cluster member (041d), choosing a merge target (041e), staging a deletion.
+ * Returns the reason so callers can explain the refusal rather than silently
+ * dropping the id.
+ */
+export function assertCleanupEligible(
+  candidate: PayeeCleanupCandidate
+): IneligibleReason | null {
+  return ineligibleReason(candidate.metadata);
+}

--- a/src/features/payee-cleanup/lib/eligibility.ts
+++ b/src/features/payee-cleanup/lib/eligibility.ts
@@ -30,7 +30,11 @@ export type IneligibleReason = "transfer-payee" | "tombstoned";
 export function isCleanupEligible(
   payee: Pick<PayeeCleanupMetadata, "tombstone" | "transferAccountId">
 ): boolean {
-  return payee.transferAccountId == null && !payee.tombstone;
+  // Falsy rather than nullish. This predicate is documented as safe to run on a
+  // raw metadata row, and a raw row can carry `transfer_acct: ""` — never a real
+  // account id, but enough to hide an ordinary payee from cleanup with no
+  // explanation anywhere in the UI.
+  return !payee.transferAccountId && !payee.tombstone;
 }
 
 /**
@@ -42,7 +46,7 @@ export function isCleanupEligible(
 export function ineligibleReason(
   payee: Pick<PayeeCleanupMetadata, "tombstone" | "transferAccountId">
 ): IneligibleReason | null {
-  if (payee.transferAccountId != null) return "transfer-payee";
+  if (payee.transferAccountId) return "transfer-payee";
   if (payee.tombstone) return "tombstoned";
   return null;
 }

--- a/src/features/payee-cleanup/lib/fuzzy.ts
+++ b/src/features/payee-cleanup/lib/fuzzy.ts
@@ -1,0 +1,146 @@
+/**
+ * Conservative fuzzy candidate matching (RD-078 §5.4).
+ *
+ * Two hard rules, both enforced here rather than downstream:
+ *
+ * 1. **Bucket before comparing.** A budget can hold thousands of payees;
+ *    comparing every pair is quadratic and pointless — two names that share no
+ *    leading characters are not typo variants of each other.
+ * 2. **Fuzzy similarity is evidence, not proof.** This module returns *pairs*
+ *    only. It never builds groups, and the resolver refuses to chain the pairs
+ *    it returns (see `clusterResolver.ts`).
+ */
+
+import { bigramDice, normalizeForCompare } from "@/lib/reconciliation/match/text";
+import type { DetectedPayee } from "./detectors";
+
+/**
+ * Character-level similarity floor.
+ *
+ * Uses `bigramDice` rather than the module's blended `symmetricSimilarity`.
+ * That blend (0.6 Dice + 0.4 token overlap) is tuned for matching a bank
+ * statement line against a payee, where sharing whole tokens is the strongest
+ * available signal. Here it is actively wrong in both directions, as the tests
+ * for this module show:
+ *
+ * - it *under*-scores real typos, because a single-token misspelling shares no
+ *   tokens at all (`CARREFOURE` / `CARREFOURA` → overlap 0);
+ * - it *over*-scores sub-brands, because a subset shares all of the smaller
+ *   side's tokens (`EMIRATES` / `EMIRATES NBD` → overlap 1.0).
+ *
+ * Character bigrams measure what fuzzy matching is actually for here: is this
+ * the same word, spelled slightly differently?
+ */
+export const FUZZY_THRESHOLD = 0.85;
+
+/** Bucket key length. Short enough to survive a first-character typo rarely, long enough to prune hard. */
+const BUCKET_PREFIX = 3;
+
+export type FuzzyPair = {
+  leftId: string;
+  rightId: string;
+  similarity: number;
+};
+
+/**
+ * Buckets payees by the first characters of their normalized name *and* by
+ * their first token, so `AMAZON MARKETPLACE` and `AMAZON` land together even
+ * though a raw prefix bucket would already have matched them — the second key
+ * is what catches variants that differ early but share a stem word.
+ */
+function bucketsFor(payee: DetectedPayee): string[] {
+  const normalized = payee.forms.punctuationNormalized;
+  if (!normalized) return [];
+
+  const keys = new Set<string>();
+  keys.add(normalized.slice(0, BUCKET_PREFIX));
+  const firstToken = payee.forms.tokenized[0];
+  if (firstToken) keys.add(`T:${firstToken}`);
+  return [...keys];
+}
+
+/**
+ * Returns candidate pairs above the similarity floor, strongest first.
+ *
+ * Pairs are deduplicated across buckets and ordered deterministically so the
+ * same budget always produces the same suggestions.
+ */
+export function findFuzzyPairs(
+  payees: DetectedPayee[],
+  threshold: number = FUZZY_THRESHOLD
+): FuzzyPair[] {
+  const buckets = new Map<string, DetectedPayee[]>();
+  for (const payee of payees) {
+    for (const key of bucketsFor(payee)) {
+      const bucket = buckets.get(key);
+      if (bucket) bucket.push(payee);
+      else buckets.set(key, [payee]);
+    }
+  }
+
+  const seen = new Set<string>();
+  const pairs: FuzzyPair[] = [];
+
+  for (const bucket of buckets.values()) {
+    // A bucket that swallowed most of the budget is not a useful signal — it
+    // means the prefix is generic. Skip it rather than doing the quadratic work.
+    if (bucket.length < 2 || bucket.length > MAX_BUCKET_SIZE) continue;
+
+    for (let i = 0; i < bucket.length; i++) {
+      for (let j = i + 1; j < bucket.length; j++) {
+        const left = bucket[i];
+        const right = bucket[j];
+        const [leftId, rightId] =
+          left.candidate.id < right.candidate.id
+            ? [left.candidate.id, right.candidate.id]
+            : [right.candidate.id, left.candidate.id];
+
+        const key = `${leftId}|${rightId}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        // A subset pair is an *extra word*, not a misspelling — `EMIRATES` vs
+        // `EMIRATES NBD`, `WOOLWORTHS` vs `WOOLWORTHS MOBILE`. Those are very
+        // often genuinely different businesses, and character similarity is
+        // high precisely because one name contains the other. Rejecting them
+        // here is what keeps §7.2's "ambiguous branch/sub-brand naming" out of
+        // the suggestions list rather than relying on the score to bury it.
+        if (isTokenSubset(left.forms.tokenized, right.forms.tokenized)) continue;
+
+        const similarity = bigramDice(
+          normalizeForCompare(left.candidate.name),
+          normalizeForCompare(right.candidate.name)
+        );
+        if (similarity >= threshold) {
+          pairs.push({ leftId, rightId, similarity });
+        }
+      }
+    }
+  }
+
+  return pairs.sort(
+    (a, b) =>
+      b.similarity - a.similarity ||
+      a.leftId.localeCompare(b.leftId) ||
+      a.rightId.localeCompare(b.rightId)
+  );
+}
+
+/**
+ * Above this, a bucket is generic rather than informative. Comparing 500
+ * payees that merely start with the same three letters produces noise, not
+ * suggestions.
+ */
+const MAX_BUCKET_SIZE = 200;
+
+/** True when either token set contains the other — i.e. the difference is whole words. */
+function isTokenSubset(left: string[], right: string[]): boolean {
+  const a = new Set(left);
+  const b = new Set(right);
+  if (a.size === 0 || b.size === 0) return false;
+  const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a];
+  for (const token of smaller) {
+    if (!larger.has(token)) return false;
+  }
+  return true;
+}

--- a/src/features/payee-cleanup/lib/impact.test.ts
+++ b/src/features/payee-cleanup/lib/impact.test.ts
@@ -1,0 +1,294 @@
+import {
+  buildClusterImpact,
+  classifyRuleReferences,
+  compareBehavior,
+  impactSignals,
+} from "./impact";
+import { findOrphanPayees } from "./orphans";
+import type { PayeeCluster } from "./clusterResolver";
+import type { PayeeCleanupCandidate } from "../types";
+import type { Rule, Schedule } from "@/types/entities";
+import type { StagedMap } from "@/types/staged";
+
+function payee(
+  id: string,
+  overrides: Partial<PayeeCleanupCandidate["metadata"]> = {}
+): PayeeCleanupCandidate {
+  return {
+    id,
+    name: id.toUpperCase(),
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+      ...overrides,
+    },
+  };
+}
+
+function rule(id: string, payeeId: string, where: "condition" | "action"): Rule {
+  const part = { field: "payee", op: "is", value: payeeId };
+  return {
+    id,
+    stage: "default",
+    conditionsOp: "and",
+    conditions: where === "condition" ? [part] : [],
+    actions: where === "action" ? [part] : [],
+  };
+}
+
+function staged(rules: Rule[]): StagedMap<Rule> {
+  const map: StagedMap<Rule> = {};
+  for (const r of rules) {
+    map[r.id] = {
+      entity: r,
+      original: r,
+      isNew: false,
+      isUpdated: false,
+      isDeleted: false,
+      validationErrors: {},
+    };
+  }
+  return map;
+}
+
+function schedule(id: string, ruleId: string, completed: boolean): Schedule {
+  return { id, ruleId, completed, postsTransaction: true };
+}
+
+function cluster(members: PayeeCleanupCandidate[]): PayeeCluster {
+  return {
+    id: members.map((m) => m.id).join("+"),
+    members,
+    stem: "STEM",
+    evidence: [],
+    fuzzyOnly: false,
+  };
+}
+
+describe("classifyRuleReferences", () => {
+  it("separates regular rules from schedule-linked ones", () => {
+    // A schedule reaches its payee *through* a rule, so counting "3 rules and
+    // 1 schedule" would report the same relationship twice.
+    const rules = staged([
+      rule("r1", "p1", "condition"),
+      rule("r2", "p1", "condition"),
+      rule("r3", "p1", "condition"),
+    ]);
+    const schedules = [schedule("s1", "r3", false)];
+
+    expect(classifyRuleReferences(["p1"], rules, schedules)).toEqual({
+      regular: 2,
+      activeSchedule: 1,
+      completedSchedule: 0,
+    });
+  });
+
+  it("keeps completed schedules out of the active count", () => {
+    // Matches Actual's own `getPayeeRuleCounts`, which skips them.
+    const rules = staged([rule("r1", "p1", "condition"), rule("r2", "p1", "condition")]);
+    const schedules = [schedule("s1", "r1", true), schedule("s2", "r2", false)];
+
+    expect(classifyRuleReferences(["p1"], rules, schedules)).toEqual({
+      regular: 0,
+      activeSchedule: 1,
+      completedSchedule: 1,
+    });
+  });
+
+  it("counts a rule that references any member of the cluster", () => {
+    const rules = staged([rule("r1", "p2", "condition")]);
+    expect(classifyRuleReferences(["p1", "p2"], rules, []).regular).toBe(1);
+  });
+
+  it("counts a rule that only sets the payee in an action", () => {
+    const rules = staged([rule("r1", "p1", "action")]);
+    expect(classifyRuleReferences(["p1"], rules, []).regular).toBe(1);
+  });
+
+  it("ignores rules staged for deletion", () => {
+    const rules = staged([rule("r1", "p1", "condition")]);
+    rules["r1"].isDeleted = true;
+    expect(classifyRuleReferences(["p1"], rules, []).regular).toBe(0);
+  });
+
+  it("counts a rule once even when it names the payee twice", () => {
+    const r: Rule = {
+      id: "r1",
+      stage: "default",
+      conditionsOp: "and",
+      conditions: [{ field: "payee", op: "is", value: "p1" }],
+      actions: [{ field: "payee", op: "set", value: "p1" }],
+    };
+    expect(classifyRuleReferences(["p1"], staged([r]), []).regular).toBe(1);
+  });
+});
+
+describe("compareBehavior", () => {
+  it("reports a favorite difference and which value survives", () => {
+    const members = [payee("p1", { favorite: true }), payee("p2", { favorite: false })];
+    const behavior = compareBehavior(members, "p2");
+
+    expect(behavior.favoriteDiffers).toBe(true);
+    // The target's own value survives — merge does not combine them.
+    expect(behavior.survivingFavorite).toBe(false);
+  });
+
+  it("reports a category-learning difference", () => {
+    const members = [
+      payee("p1", { learnCategories: true }),
+      payee("p2", { learnCategories: false }),
+    ];
+    expect(compareBehavior(members, "p1").learnCategoriesDiffers).toBe(true);
+    expect(compareBehavior(members, "p1").survivingLearnCategories).toBe(true);
+  });
+
+  it("reports agreement when every member matches", () => {
+    const members = [payee("p1", { favorite: true }), payee("p2", { favorite: true })];
+    const behavior = compareBehavior(members, "p1");
+    expect(behavior.favoriteDiffers).toBe(false);
+    expect(behavior.survivingFavorite).toBe(true);
+  });
+});
+
+describe("buildClusterImpact", () => {
+  const members = [payee("p1"), payee("p2")];
+
+  it("totals transactions across the cluster", () => {
+    const impact = buildClusterImpact(cluster(members), "p1", {
+      stagedRules: {},
+      schedules: [],
+      transactionCounts: new Map([
+        ["p1", 47],
+        ["p2", 23],
+      ]),
+      transactionsLoading: false,
+    });
+
+    expect(impact.transactionTotal).toBe(70);
+    expect(impact.members.map((m) => m.transactionCount)).toEqual([47, 23]);
+  });
+
+  it("never reports a total while counts are still loading", () => {
+    // Showing 0 during load would read as "this payee is unused", which is the
+    // opposite of the truth and would drive a wrong decision.
+    const impact = buildClusterImpact(cluster(members), "p1", {
+      stagedRules: {},
+      schedules: [],
+      transactionCounts: undefined,
+      transactionsLoading: true,
+    });
+
+    expect(impact.transactionTotal).toBeUndefined();
+    expect(impact.transactionsLoading).toBe(true);
+  });
+
+  it("treats a loaded map with no entry as a real zero", () => {
+    const impact = buildClusterImpact(cluster(members), "p1", {
+      stagedRules: {},
+      schedules: [],
+      transactionCounts: new Map(),
+      transactionsLoading: false,
+    });
+    expect(impact.transactionTotal).toBe(0);
+  });
+});
+
+describe("impactSignals", () => {
+  const base = {
+    stagedRules: {},
+    schedules: [],
+    transactionCounts: new Map<string, number>(),
+    transactionsLoading: false,
+  };
+
+  it("flags a behaviour conflict", () => {
+    const impact = buildClusterImpact(
+      cluster([payee("p1", { favorite: true }), payee("p2")]),
+      "p1",
+      base
+    );
+    expect(impactSignals(impact).behaviorConflict).toBe(true);
+  });
+
+  it("flags a rule conflict when more than one member carries rules", () => {
+    const impact = buildClusterImpact(cluster([payee("p1"), payee("p2")]), "p1", {
+      ...base,
+      stagedRules: staged([rule("r1", "p1", "condition"), rule("r2", "p2", "condition")]),
+    });
+    expect(impactSignals(impact).ruleConflict).toBe(true);
+  });
+
+  it("does not flag a conflict when only the target carries rules", () => {
+    const impact = buildClusterImpact(cluster([payee("p1"), payee("p2")]), "p1", {
+      ...base,
+      stagedRules: staged([rule("r1", "p1", "condition")]),
+    });
+    expect(impactSignals(impact).ruleConflict).toBe(false);
+  });
+});
+
+describe("findOrphanPayees", () => {
+  const candidates = [payee("p1"), payee("p2"), payee("p3")];
+
+  it("finds payees with no transactions and no rules", () => {
+    const orphans = findOrphanPayees({
+      candidates,
+      stagedRules: {},
+      transactionCounts: new Map([["p1", 5]]),
+    });
+    expect(orphans.map((o) => o.payee.id)).toEqual(["p2", "p3"]);
+  });
+
+  it("excludes a payee referenced by a rule condition", () => {
+    const orphans = findOrphanPayees({
+      candidates,
+      stagedRules: staged([rule("r1", "p2", "condition")]),
+      transactionCounts: new Map(),
+    });
+    expect(orphans.map((o) => o.payee.id)).not.toContain("p2");
+  });
+
+  it("excludes a payee that only a rule ACTION targets", () => {
+    // Actual's native query checks conditions only. Bench also checks actions,
+    // because deleting a payee a rule writes to would break that rule — the
+    // deliberate divergence documented in the module.
+    const orphans = findOrphanPayees({
+      candidates,
+      stagedRules: staged([rule("r1", "p3", "action")]),
+      transactionCounts: new Map(),
+    });
+    expect(orphans.map((o) => o.payee.id)).not.toContain("p3");
+  });
+
+  it("excludes transfer and tombstoned payees", () => {
+    const orphans = findOrphanPayees({
+      candidates: [
+        payee("x", { transferAccountId: "acct-1" }),
+        payee("y", { tombstone: true }),
+      ],
+      stagedRules: {},
+      transactionCounts: new Map(),
+    });
+    expect(orphans).toEqual([]);
+  });
+
+  it("returns nothing while transaction counts are unknown", () => {
+    // Fail closed: without counts, every payee would look unused and the list
+    // would offer to delete the entire budget's payees.
+    expect(
+      findOrphanPayees({ candidates, stagedRules: {}, transactionCounts: undefined })
+    ).toEqual([]);
+  });
+
+  it("sorts by name so the list is stable", () => {
+    const orphans = findOrphanPayees({
+      candidates,
+      stagedRules: {},
+      transactionCounts: new Map(),
+    });
+    expect(orphans.map((o) => o.payee.name)).toEqual(["P1", "P2", "P3"]);
+  });
+});

--- a/src/features/payee-cleanup/lib/impact.ts
+++ b/src/features/payee-cleanup/lib/impact.ts
@@ -1,0 +1,187 @@
+/**
+ * What a cleanup proposal would actually touch (RD-078 §10).
+ *
+ * Merging payees changes which rules match and which transactions display under
+ * which name. A proposal is only safe to accept if its blast radius is visible
+ * first, expressed in Actual's real concepts rather than an invented
+ * "metadata conflict" bucket.
+ *
+ * Three findings from the native-semantics verification shape this module:
+ *
+ * - **Schedules are rules.** Actual links a schedule to a payee *through* its
+ *   rule, and `getPayeeRuleCounts` deliberately skips rules belonging to
+ *   completed schedules. Reporting "3 rules · 1 schedule" would count the same
+ *   relationship twice, so the three kinds are separated instead.
+ * - **Merge does not rewrite rules.** `db.mergePayees` never touches the rules
+ *   table; conditions keep the old payee id and resolve through
+ *   `payee_mapping`. The UI must say what actually happens.
+ * - **`favorite` and `learn_categories` cannot be written** through any
+ *   supported API, so they are reported as read-only differences. Choosing the
+ *   target *is* how the user resolves them.
+ */
+
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import type { Rule, Schedule } from "@/types/entities";
+import type { StagedMap } from "@/types/staged";
+import type { PayeeCluster } from "./clusterResolver";
+import type { PayeeCleanupCandidate } from "../types";
+
+/** Payee-referencing condition/action fields, matching the Usage Inspector. */
+const PAYEE_FIELDS = ["payee", "imported_payee"];
+
+export type RuleImpact = {
+  /** Rules that are not attached to a schedule. */
+  regular: number;
+  /** Rules belonging to a schedule that is still running. */
+  activeSchedule: number;
+  /**
+   * Rules belonging to a completed schedule. Reported separately and excluded
+   * from the active count — the same choice Actual makes internally.
+   */
+  completedSchedule: number;
+};
+
+export type BehaviorImpact = {
+  favoriteDiffers: boolean;
+  learnCategoriesDiffers: boolean;
+  /** The values that will survive: the target's own, because merge does not combine them. */
+  survivingFavorite: boolean;
+  survivingLearnCategories: boolean;
+};
+
+export type MemberImpact = {
+  payeeId: string;
+  name: string;
+  transactionCount: number | undefined;
+  ruleCount: number;
+};
+
+export type ClusterImpact = {
+  /** Undefined until the counts have loaded — never conflated with zero. */
+  transactionTotal: number | undefined;
+  transactionsLoading: boolean;
+  rules: RuleImpact;
+  behavior: BehaviorImpact;
+  members: MemberImpact[];
+};
+
+export type ImpactSources = {
+  stagedRules: StagedMap<Rule>;
+  schedules: Schedule[];
+  /** Undefined while loading; an empty map means "loaded, none found". */
+  transactionCounts: Map<string, number> | undefined;
+  transactionsLoading: boolean;
+};
+
+/**
+ * Splits rule references into regular / active-schedule / completed-schedule.
+ *
+ * A rule is schedule-linked when a schedule names it in `ruleId`; the schedule's
+ * `completed` flag then decides which bucket it lands in.
+ */
+export function classifyRuleReferences(
+  payeeIds: string[],
+  stagedRules: StagedMap<Rule>,
+  schedules: Schedule[]
+): RuleImpact {
+  const scheduleByRuleId = new Map<string, Schedule>();
+  for (const schedule of schedules) {
+    if (schedule.ruleId) scheduleByRuleId.set(schedule.ruleId, schedule);
+  }
+
+  const ids = new Set(payeeIds);
+  const impact: RuleImpact = { regular: 0, activeSchedule: 0, completedSchedule: 0 };
+
+  for (const staged of Object.values(stagedRules)) {
+    if (staged.isDeleted) continue;
+    const rule = staged.entity;
+
+    const referencesCluster = [...rule.conditions, ...rule.actions].some((part) => {
+      if (!part.field || !PAYEE_FIELDS.includes(part.field)) return false;
+      const values = Array.isArray(part.value) ? part.value : [part.value];
+      return values.some((v) => typeof v === "string" && ids.has(v));
+    });
+    if (!referencesCluster) continue;
+
+    const schedule = scheduleByRuleId.get(rule.id);
+    if (!schedule) impact.regular += 1;
+    else if (schedule.completed) impact.completedSchedule += 1;
+    else impact.activeSchedule += 1;
+  }
+
+  return impact;
+}
+
+/**
+ * Favorite / category-learning differences across the cluster.
+ *
+ * Reports what *survives* rather than what the user might want, because Bench
+ * cannot write either field: the target keeps its own values and the sources are
+ * tombstoned.
+ */
+export function compareBehavior(
+  members: PayeeCleanupCandidate[],
+  targetId: string
+): BehaviorImpact {
+  const target = members.find((m) => m.id === targetId) ?? members[0];
+
+  return {
+    favoriteDiffers: new Set(members.map((m) => m.metadata.favorite)).size > 1,
+    learnCategoriesDiffers:
+      new Set(members.map((m) => m.metadata.learnCategories)).size > 1,
+    survivingFavorite: target.metadata.favorite,
+    survivingLearnCategories: target.metadata.learnCategories,
+  };
+}
+
+export function buildClusterImpact(
+  cluster: PayeeCluster,
+  targetId: string,
+  sources: ImpactSources
+): ClusterImpact {
+  const memberIds = cluster.members.map((m) => m.id);
+  const ruleCounts = buildRuleReferenceMap(sources.stagedRules, PAYEE_FIELDS);
+
+  const members: MemberImpact[] = cluster.members.map((member) => ({
+    payeeId: member.id,
+    name: member.name,
+    // A loaded map with no row for this payee means zero, not unknown. Reading
+    // it as unknown rendered "counting…" forever next to every payee that has
+    // no transactions — which is exactly the payee a user is deciding about.
+    transactionCount: sources.transactionCounts
+      ? (sources.transactionCounts.get(member.id) ?? 0)
+      : undefined,
+    ruleCount: ruleCounts.get(member.id) ?? 0,
+  }));
+
+  const transactionTotal = sources.transactionCounts
+    ? memberIds.reduce((sum, id) => sum + (sources.transactionCounts?.get(id) ?? 0), 0)
+    : undefined;
+
+  return {
+    transactionTotal,
+    transactionsLoading: sources.transactionsLoading,
+    rules: classifyRuleReferences(memberIds, sources.stagedRules, sources.schedules),
+    behavior: compareBehavior(cluster.members, targetId),
+    members,
+  };
+}
+
+/**
+ * Signals the confidence model and target scorer consume, derived from impact.
+ *
+ * Keeping this a separate step means 041b's pure pipeline stays usable without
+ * any of the data this module needs.
+ */
+export function impactSignals(impact: ClusterImpact): {
+  behaviorConflict: boolean;
+  ruleConflict: boolean;
+} {
+  return {
+    behaviorConflict:
+      impact.behavior.favoriteDiffers || impact.behavior.learnCategoriesDiffers,
+    // More than one member carrying rules means the merge changes which rules
+    // point where, and the user should look before accepting.
+    ruleConflict: impact.members.filter((m) => m.ruleCount > 0).length > 1,
+  };
+}

--- a/src/features/payee-cleanup/lib/importedTextIndex.ts
+++ b/src/features/payee-cleanup/lib/importedTextIndex.ts
@@ -28,7 +28,7 @@ function toText(value: unknown): string | null {
 async function readField(
   connection: ConnectionInstance,
   field: SourceField
-): Promise<ImportedTextRow[]> {
+): Promise<{ rows: ImportedTextRow[]; hitLimit: boolean }> {
   const response = await runQuery<{ data: QueryRow[] }>(connection, {
     ActualQLquery: {
       table: "transactions",
@@ -44,8 +44,14 @@ async function readField(
     },
   });
 
+  const returned = response.data ?? [];
+  // Recorded before filtering. Blank and unusable rows are dropped below, so a
+  // limit-sized response containing one of them would otherwise come back
+  // *under* the limit and be reported as a complete read.
+  const hitLimit = returned.length >= ROW_LIMIT;
+
   const rows: ImportedTextRow[] = [];
-  for (const row of response.data ?? []) {
+  for (const row of returned) {
     const text = toText(row[field]);
     if (!text) continue;
     rows.push({
@@ -60,7 +66,7 @@ async function readField(
         typeof row.transactionCount === "number" ? row.transactionCount : 0,
     });
   }
-  return rows;
+  return { rows, hitLimit };
 }
 
 /**
@@ -90,8 +96,7 @@ export async function getImportedTextIndex(
   const notes = await readField(connection, "notes");
 
   return {
-    rows: [...importedPayee, ...notes],
-    truncated:
-      importedPayee.length >= ROW_LIMIT || notes.length >= ROW_LIMIT,
+    rows: [...importedPayee.rows, ...notes.rows],
+    truncated: importedPayee.hitLimit || notes.hitLimit,
   };
 }

--- a/src/features/payee-cleanup/lib/importedTextIndex.ts
+++ b/src/features/payee-cleanup/lib/importedTextIndex.ts
@@ -1,0 +1,97 @@
+/**
+ * The budget's own import history, as a backtest corpus (RD-078 §17).
+ *
+ * Grouped rather than per-transaction. A budget can hold tens of thousands of
+ * transactions but only hundreds of distinct import strings, and it is the
+ * distinct strings a pattern is tested against — grouping turns an unbounded
+ * read into a bounded one and costs nothing in accuracy, since the transaction
+ * count comes back with each group.
+ *
+ * Both source fields are read. Where a bank puts the merchant in the memo, the
+ * discriminating text is in `notes`, and a rule that can only look at
+ * `imported_payee` would have nothing to match on.
+ */
+
+import { runQuery } from "@/lib/api/query";
+import type { ConnectionInstance } from "@/store/connection";
+import type { ImportedTextRow, SourceField } from "./ruleCandidates";
+
+/** Guard against a pathological budget; well above any realistic distinct-string count. */
+const ROW_LIMIT = 5000;
+
+type QueryRow = Record<string, unknown> & { transactionCount?: number };
+
+function toText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function readField(
+  connection: ConnectionInstance,
+  field: SourceField
+): Promise<ImportedTextRow[]> {
+  const response = await runQuery<{ data: QueryRow[] }>(connection, {
+    ActualQLquery: {
+      table: "transactions",
+      filter: { [field]: { $ne: null } },
+      groupBy: [field, "payee", "payee.name"],
+      select: [
+        field,
+        "payee",
+        "payee.name",
+        { transactionCount: { $count: "$id" } },
+      ],
+      limit: ROW_LIMIT,
+    },
+  });
+
+  const rows: ImportedTextRow[] = [];
+  for (const row of response.data ?? []) {
+    const text = toText(row[field]);
+    if (!text) continue;
+    rows.push({
+      field,
+      text,
+      payeeId: toText(row.payee),
+      // The name comes back alongside the id so a row can be attributed even if
+      // the id serialization differs, and so the UI can say *which* payee an
+      // unexpected match belongs to instead of showing a bare id.
+      payeeName: toText(row["payee.name"]),
+      transactionCount:
+        typeof row.transactionCount === "number" ? row.transactionCount : 0,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Reads both source fields.
+ *
+ * Sequential rather than parallel: the Direct runtime serializes work against
+ * one budget anyway, and a failure on one field should not be masked by the
+ * other.
+ */
+export type ImportedTextIndex = {
+  rows: ImportedTextRow[];
+  /**
+   * True when either read hit `ROW_LIMIT`.
+   *
+   * It matters because a backtest over a truncated sample can report "and
+   * nothing else" about a rule that would in fact catch transactions the query
+   * never returned. Silently basing a safety claim on a partial read is worse
+   * than admitting the limit.
+   */
+  truncated: boolean;
+};
+
+export async function getImportedTextIndex(
+  connection: ConnectionInstance
+): Promise<ImportedTextIndex> {
+  const importedPayee = await readField(connection, "imported_payee");
+  const notes = await readField(connection, "notes");
+
+  return {
+    rows: [...importedPayee, ...notes],
+    truncated:
+      importedPayee.length >= ROW_LIMIT || notes.length >= ROW_LIMIT,
+  };
+}

--- a/src/features/payee-cleanup/lib/nativeSemantics.test.ts
+++ b/src/features/payee-cleanup/lib/nativeSemantics.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Source-pinning tests for the Actual payee semantics RD-078 depends on.
+ *
+ * RD-078 §28 (Milestone 0) requires the native behavior to be verified before
+ * any write path is designed, and §31 says "if any answer is unknown, do not
+ * guess." The verification was done against the pinned `@actual-app/core` and
+ * `@actual-app/api` sources; these tests pin the *structural* findings so an
+ * upstream bump that invalidates them fails here instead of silently changing
+ * what cleanup promises the user.
+ *
+ * Scope note: this repo has no live-Actual integration harness (jsdom + mocks
+ * only), so the *behavioral* findings — merge tombstones sources, transactions
+ * follow through `payee_mapping`, rules are not rewritten, Bench's orphan
+ * predicate matches Actual's — are verified by hand against the dev server and
+ * recorded in `agents/knowledge.md`. What can be asserted mechanically is
+ * asserted here.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Reads a source file straight out of the installed package.
+ *
+ * `require.resolve` is not usable here — Jest's resolver honours the package's
+ * `exports` map, which does not publish these internal paths.
+ */
+function readPackageSource(pkg: string, relativePath: string): string {
+  const path = join(process.cwd(), "node_modules", pkg, relativePath);
+  if (!existsSync(path)) {
+    throw new Error(
+      `Cannot pin Actual payee semantics: ${pkg}/${relativePath} is missing. ` +
+        `The upstream layout changed — re-run RD-078's Milestone 0 verification ` +
+        `(see agents/pr-specs/PR-041) before trusting the cleanup capability report.`
+    );
+  }
+  return readFileSync(path, "utf8");
+}
+
+describe("Actual native payee semantics (pinned)", () => {
+  describe("the public payee model", () => {
+    const apiModels = readPackageSource(
+      "@actual-app/core",
+      "src/server/api-models.ts"
+    );
+
+    it("exposes only id, name and transfer_acct — so favorite/learn_categories cannot be written", () => {
+      // `updatePayee` takes Partial<APIPayeeEntity>. If this widens upstream,
+      // `writePayeeBehaviorFields` in lib/capabilities.ts can become true and
+      // RD-078 §10.3's "proposed final behavior" editor becomes buildable.
+      expect(apiModels).toContain(
+        "export type APIPayeeEntity = Pick<PayeeEntity, 'id' | 'name' | 'transfer_acct'>"
+      );
+    });
+
+    it("drops `category` when converting a payee to its external shape", () => {
+      // Bench's `Payee.categoryId` and `ApiPayee.category` are vestigial (F-095):
+      // actual-http-api still declares `category` in its schema, but upstream
+      // never populates it.
+      const toExternal = apiModels.slice(
+        apiModels.indexOf("export const payeeModel"),
+        apiModels.indexOf("export type APITagEntity")
+      );
+      expect(toExternal).toContain("id: payee.id");
+      expect(toExternal).toContain("name: payee.name");
+      expect(toExternal).toContain("transfer_acct: payee.transfer_acct");
+      expect(toExternal).not.toContain("category:");
+    });
+  });
+
+  describe("the internal payee entity", () => {
+    const payeeModel = readPackageSource(
+      "@actual-app/core",
+      "src/types/models/payee.ts"
+    );
+
+    it("carries favorite, learn_categories and tombstone but no category", () => {
+      expect(payeeModel).toContain("favorite?: boolean");
+      expect(payeeModel).toContain("learn_categories?: boolean");
+      expect(payeeModel).toContain("tombstone?: boolean");
+      expect(payeeModel).not.toContain("category");
+    });
+  });
+
+  describe("the AQL payees schema", () => {
+    const schema = readPackageSource(
+      "@actual-app/core",
+      "src/server/aql/schema/index.ts"
+    );
+    const payeesTable = schema.slice(
+      schema.indexOf("  payees: {"),
+      schema.indexOf("  accounts: {")
+    );
+
+    it("exposes the fields cleanup reads over ActualQL", () => {
+      // This is what makes `getPayeeCleanupMetadata` work in BOTH transports.
+      // If a field disappears here, the metadata read must be revisited before
+      // detection can rely on it.
+      expect(payeesTable).toContain("favorite: f('boolean')");
+      expect(payeesTable).toContain("learn_categories: f('boolean')");
+      expect(payeesTable).toContain("tombstone: f('boolean')");
+      expect(payeesTable).toContain("transfer_acct: f('id'");
+    });
+
+    it("does not expose a category field", () => {
+      expect(payeesTable).not.toContain("category");
+    });
+  });
+
+  describe("native merge", () => {
+    const db = readPackageSource("@actual-app/core", "src/server/db/index.ts");
+    const mergePayees = db.slice(
+      db.indexOf("export async function mergePayees"),
+      db.indexOf("export function getPayees()")
+    );
+
+    it("no-ops when the target is a transfer payee", () => {
+      // Why the eligibility boundary must reject transfer payees *before*
+      // planning: a merge into a transfer payee reports success and does
+      // nothing at all.
+      expect(mergePayees).toContain("if (payees[target].transfer_acct != null)");
+      expect(mergePayees).toContain("return;");
+    });
+
+    it("silently drops transfer payees from the source list", () => {
+      expect(mergePayees).toContain(
+        "ids = ids.filter(id => payees[id].transfer_acct == null)"
+      );
+    });
+
+    it("works by repointing payee_mapping and tombstoning the sources", () => {
+      // Transactions are NOT rewritten — they resolve through payee_mapping —
+      // which is why RD-078 §1.5 forbids reimplementing merge as
+      // reassign/rename/delete.
+      expect(mergePayees).toContain("payee_mapping");
+      expect(mergePayees).toContain("delete_('payees', id)");
+    });
+
+    it("does not touch the rules table", () => {
+      // Rule conditions keep the old payee id and resolve through the mapping,
+      // so cleanup must not claim a merge repoints rules.
+      expect(mergePayees).not.toContain("'rules'");
+    });
+
+    it("does not reassign payee locations", () => {
+      // Basis for `readPayeeLocations: false` and the documented limitation.
+      expect(mergePayees).not.toContain("payee_locations");
+    });
+  });
+
+  describe("transactions resolve payees through payee_mapping", () => {
+    const schema = readPackageSource(
+      "@actual-app/core",
+      "src/server/aql/schema/index.ts"
+    );
+
+    it("maps the transaction payee to pm.targetId", () => {
+      expect(schema).toContain("payee: 'pm.targetId'");
+      expect(schema).toContain("LEFT JOIN payee_mapping pm ON pm.id = _.description");
+    });
+  });
+
+  describe("the native orphan predicate", () => {
+    const db = readPackageSource("@actual-app/core", "src/server/db/index.ts");
+    const query = db.slice(
+      db.indexOf("const orphanedPayeesQuery"),
+      db.indexOf("export function syncGetOrphanedPayees")
+    );
+
+    it("excludes tombstoned and transfer payees", () => {
+      expect(query).toContain("p.tombstone = 0");
+      expect(query).toContain("p.transfer_acct IS NULL");
+    });
+
+    it("requires no alive transaction via the payee mapping", () => {
+      expect(query).toContain("LEFT JOIN payee_mapping pm ON pm.id = p.id");
+      expect(query).toContain("v_transactions_internal_alive t ON t.payee = pm.targetId");
+      expect(query).toContain("t.id IS NULL");
+    });
+
+    it("only checks rule CONDITIONS on the payee field", () => {
+      // Bench's reimplementation also counts rule *actions* and the
+      // `imported_payee` field, making it strictly more conservative. That
+      // divergence is deliberate for a deletion workflow and is surfaced in the
+      // UI copy (see explainMissingCapability('nativeOrphanHandler')).
+      expect(query).toContain("json_extract(cond.value, '$.field') = 'description'");
+      expect(query).not.toContain("r.actions");
+    });
+  });
+
+  describe("payee rule counts", () => {
+    const payeesApp = readPackageSource(
+      "@actual-app/core",
+      "src/server/payees/app.ts"
+    );
+
+    it("excludes rules belonging to completed schedules", () => {
+      // Basis for 041c splitting regular / active-schedule / completed-schedule
+      // rules instead of one flat count.
+      expect(payeesApp).toContain("getCompletedScheduleRuleIds");
+      expect(payeesApp).toContain("completedScheduleRules.has(rule.id)");
+    });
+
+    it("keeps orphan and location handlers internal to `send` (no public API)", () => {
+      // Basis for `nativeOrphanHandler: false` in HTTP mode and
+      // `readPayeeLocations: false` everywhere.
+      expect(payeesApp).toContain("'payees-get-orphaned'");
+      expect(payeesApp).toContain("'payee-locations-get'");
+    });
+  });
+});

--- a/src/features/payee-cleanup/lib/nativeSemantics.test.ts
+++ b/src/features/payee-cleanup/lib/nativeSemantics.test.ts
@@ -37,6 +37,25 @@ function readPackageSource(pkg: string, relativePath: string): string {
   return readFileSync(path, "utf8");
 }
 
+/**
+ * Slices between two markers, failing loudly when either is missing.
+ *
+ * These tests exist to pin upstream behaviour, and every assertion in the sliced
+ * region is a `not.toContain`. A renamed marker makes `indexOf` return -1, the
+ * slice comes back empty or wrong, and the negative assertions all pass for the
+ * wrong reason — the exact failure mode pinning tests are supposed to prevent.
+ */
+function sliceBetween(source: string, from: string, to: string): string {
+  const start = source.indexOf(from);
+  const end = source.indexOf(to);
+  if (start === -1) throw new Error(`Upstream marker not found: ${from}`);
+  if (end === -1) throw new Error(`Upstream marker not found: ${to}`);
+  if (end <= start) {
+    throw new Error(`Upstream markers out of order: ${from} / ${to}`);
+  }
+  return source.slice(start, end);
+}
+
 describe("Actual native payee semantics (pinned)", () => {
   describe("the public payee model", () => {
     const apiModels = readPackageSource(
@@ -57,9 +76,10 @@ describe("Actual native payee semantics (pinned)", () => {
       // Bench's `Payee.categoryId` and `ApiPayee.category` are vestigial (F-095):
       // actual-http-api still declares `category` in its schema, but upstream
       // never populates it.
-      const toExternal = apiModels.slice(
-        apiModels.indexOf("export const payeeModel"),
-        apiModels.indexOf("export type APITagEntity")
+      const toExternal = sliceBetween(
+        apiModels,
+        "export const payeeModel",
+        "export type APITagEntity"
       );
       expect(toExternal).toContain("id: payee.id");
       expect(toExternal).toContain("name: payee.name");
@@ -87,10 +107,7 @@ describe("Actual native payee semantics (pinned)", () => {
       "@actual-app/core",
       "src/server/aql/schema/index.ts"
     );
-    const payeesTable = schema.slice(
-      schema.indexOf("  payees: {"),
-      schema.indexOf("  accounts: {")
-    );
+    const payeesTable = sliceBetween(schema, "  payees: {", "  accounts: {");
 
     it("exposes the fields cleanup reads over ActualQL", () => {
       // This is what makes `getPayeeCleanupMetadata` work in BOTH transports.
@@ -109,9 +126,10 @@ describe("Actual native payee semantics (pinned)", () => {
 
   describe("native merge", () => {
     const db = readPackageSource("@actual-app/core", "src/server/db/index.ts");
-    const mergePayees = db.slice(
-      db.indexOf("export async function mergePayees"),
-      db.indexOf("export function getPayees()")
+    const mergePayees = sliceBetween(
+      db,
+      "export async function mergePayees",
+      "export function getPayees()"
     );
 
     it("no-ops when the target is a transfer payee", () => {
@@ -162,9 +180,10 @@ describe("Actual native payee semantics (pinned)", () => {
 
   describe("the native orphan predicate", () => {
     const db = readPackageSource("@actual-app/core", "src/server/db/index.ts");
-    const query = db.slice(
-      db.indexOf("const orphanedPayeesQuery"),
-      db.indexOf("export function syncGetOrphanedPayees")
+    const query = sliceBetween(
+      db,
+      "const orphanedPayeesQuery",
+      "export function syncGetOrphanedPayees"
     );
 
     it("excludes tombstoned and transfer payees", () => {

--- a/src/features/payee-cleanup/lib/orphans.ts
+++ b/src/features/payee-cleanup/lib/orphans.ts
@@ -1,0 +1,66 @@
+/**
+ * Unused (orphaned) payees (RD-078 §10.5, §19).
+ *
+ * Actual has a native answer for this — `payees-get-orphaned` — but it is an
+ * internal `send` handler with no actual-http-api route, so it is reachable in
+ * Direct mode only. Rather than offer the feature in one transport and not the
+ * other, Bench reimplements the predicate. Its exact SQL, pinned in
+ * `nativeSemantics.test.ts`:
+ *
+ *   tombstone = 0
+ *   AND transfer_acct IS NULL
+ *   AND no alive transaction resolves to it through payee_mapping
+ *   AND not referenced by a rule *condition* on the payee field
+ *
+ * **Bench is deliberately stricter on the last clause.** Actual checks only rule
+ * conditions with `field = 'description'`; Bench also counts rule *actions* and
+ * the `imported_payee` field, so a payee that some rule writes to is never
+ * offered for deletion. Stricter is the right direction for a destructive
+ * operation — the cost is leaving a genuinely unused payee in place, which is
+ * recoverable, versus deleting one that a rule still targets, which is not.
+ *
+ * That divergence is disclosed in the UI (see `explainMissingCapability`), never
+ * silent.
+ */
+
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import type { Rule } from "@/types/entities";
+import type { StagedMap } from "@/types/staged";
+import { isCleanupEligible } from "./eligibility";
+import type { PayeeCleanupCandidate } from "../types";
+
+const PAYEE_FIELDS = ["payee", "imported_payee"];
+
+export type OrphanPayee = {
+  payee: PayeeCleanupCandidate;
+  /** Why it qualifies, for the row's explanation. */
+  reason: "no transactions, no rules";
+};
+
+export type OrphanInputs = {
+  candidates: PayeeCleanupCandidate[];
+  stagedRules: StagedMap<Rule>;
+  /**
+   * Transaction counts for the candidates. **Required** — a missing map means
+   * "not loaded", and treating that as zero would offer every payee in the
+   * budget for deletion.
+   */
+  transactionCounts: Map<string, number> | undefined;
+};
+
+export function findOrphanPayees(inputs: OrphanInputs): OrphanPayee[] {
+  // Fail closed: without counts we cannot know a payee is unused.
+  if (!inputs.transactionCounts) return [];
+
+  const ruleCounts = buildRuleReferenceMap(inputs.stagedRules, PAYEE_FIELDS);
+
+  return inputs.candidates
+    .filter((candidate) => {
+      if (!isCleanupEligible(candidate.metadata)) return false;
+      if ((inputs.transactionCounts?.get(candidate.id) ?? 0) > 0) return false;
+      if ((ruleCounts.get(candidate.id) ?? 0) > 0) return false;
+      return true;
+    })
+    .map((payee) => ({ payee, reason: "no transactions, no rules" as const }))
+    .sort((a, b) => a.payee.name.localeCompare(b.payee.name));
+}

--- a/src/features/payee-cleanup/lib/orphans.ts
+++ b/src/features/payee-cleanup/lib/orphans.ts
@@ -13,9 +13,11 @@
  *   AND not referenced by a rule *condition* on the payee field
  *
  * **Bench is deliberately stricter on the last clause.** Actual checks only rule
- * conditions with `field = 'description'`; Bench also counts rule *actions* and
- * the `imported_payee` field, so a payee that some rule writes to is never
- * offered for deletion. Stricter is the right direction for a destructive
+ * conditions with `field = 'description'`; Bench also counts rule *actions*, so
+ * a payee that some rule writes to is never offered for deletion. Only
+ * payee-*id* conditions and actions protect a candidate: an `imported_payee`
+ * condition carries merchant text rather than an id, so it could never match one
+ * and is not consulted. Stricter is the right direction for a destructive
  * operation — the cost is leaving a genuinely unused payee in place, which is
  * recoverable, versus deleting one that a rule still targets, which is not.
  *
@@ -29,7 +31,12 @@ import type { StagedMap } from "@/types/staged";
 import { isCleanupEligible } from "./eligibility";
 import type { PayeeCleanupCandidate } from "../types";
 
-const PAYEE_FIELDS = ["payee", "imported_payee"];
+/**
+ * The rule fields whose values are payee ids. `imported_payee` is deliberately
+ * absent: it holds the bank's text, so it can never equal a payee id and only
+ * gave the appearance of a wider check.
+ */
+const PAYEE_FIELDS = ["payee"];
 
 export type OrphanPayee = {
   payee: PayeeCleanupCandidate;

--- a/src/features/payee-cleanup/lib/payeeMetadata.test.ts
+++ b/src/features/payee-cleanup/lib/payeeMetadata.test.ts
@@ -1,0 +1,156 @@
+import { fallbackMetadata, getPayeeCleanupMetadata } from "./payeeMetadata";
+import { runQuery } from "../../../lib/api/query";
+import type { ConnectionInstance } from "@/store/connection";
+
+jest.mock("../../../lib/api/query", () => ({
+  runQuery: jest.fn(),
+}));
+
+const mockRunQuery = runQuery as jest.MockedFunction<typeof runQuery>;
+
+const httpConnection = { id: "c1", mode: "http-api" } as ConnectionInstance;
+const directConnection = { id: "c2", mode: "browser-api" } as ConnectionInstance;
+
+beforeEach(() => {
+  mockRunQuery.mockReset();
+});
+
+describe("getPayeeCleanupMetadata", () => {
+  it("queries the AQL payees table for the fields getPayees() cannot return", () => {
+    mockRunQuery.mockResolvedValue({ data: [] });
+
+    return getPayeeCleanupMetadata(httpConnection).then(() => {
+      expect(mockRunQuery).toHaveBeenCalledWith(httpConnection, {
+        ActualQLquery: {
+          table: "payees",
+          select: [
+            "id",
+            "favorite",
+            "learn_categories",
+            "tombstone",
+            "transfer_acct",
+          ],
+        },
+      });
+    });
+  });
+
+  it("never selects `category` — upstream does not populate it (F-095)", async () => {
+    mockRunQuery.mockResolvedValue({ data: [] });
+    await getPayeeCleanupMetadata(httpConnection);
+
+    const body = mockRunQuery.mock.calls[0][1] as {
+      ActualQLquery: { select: string[] };
+    };
+    expect(body.ActualQLquery.select).not.toContain("category");
+  });
+
+  it("normalizes SQLite 1/0 booleans from the HTTP transport", async () => {
+    mockRunQuery.mockResolvedValue({
+      data: [
+        {
+          id: "p1",
+          favorite: 1,
+          learn_categories: 0,
+          tombstone: 0,
+          transfer_acct: null,
+        },
+      ],
+    });
+
+    const map = await getPayeeCleanupMetadata(httpConnection);
+    expect(map.get("p1")).toEqual({
+      id: "p1",
+      favorite: true,
+      learnCategories: false,
+      tombstone: false,
+      transferAccountId: null,
+    });
+  });
+
+  it("normalizes real booleans from the Direct transport to the same shape", async () => {
+    mockRunQuery.mockResolvedValue({
+      data: [
+        {
+          id: "p1",
+          favorite: true,
+          learn_categories: false,
+          tombstone: false,
+          transfer_acct: undefined,
+        },
+      ],
+    });
+
+    const map = await getPayeeCleanupMetadata(directConnection);
+    expect(map.get("p1")).toEqual({
+      id: "p1",
+      favorite: true,
+      learnCategories: false,
+      tombstone: false,
+      transferAccountId: null,
+    });
+  });
+
+  it("keeps tombstoned rows so the eligibility boundary can exclude them", async () => {
+    // Filtering here would under-report the analyzed payee count and hide the
+    // reason a payee is missing from the suggestions list.
+    mockRunQuery.mockResolvedValue({
+      data: [{ id: "dead", favorite: 0, learn_categories: 1, tombstone: 1 }],
+    });
+
+    const map = await getPayeeCleanupMetadata(httpConnection);
+    expect(map.get("dead")?.tombstone).toBe(true);
+  });
+
+  it("preserves the transfer account id that makes a payee ineligible", async () => {
+    mockRunQuery.mockResolvedValue({
+      data: [{ id: "xfer", transfer_acct: "acct-9" }],
+    });
+
+    const map = await getPayeeCleanupMetadata(httpConnection);
+    expect(map.get("xfer")?.transferAccountId).toBe("acct-9");
+  });
+
+  it("normalizes an empty transfer_acct string to null", async () => {
+    mockRunQuery.mockResolvedValue({
+      data: [{ id: "p1", transfer_acct: "" }],
+    });
+
+    const map = await getPayeeCleanupMetadata(httpConnection);
+    expect(map.get("p1")?.transferAccountId).toBeNull();
+  });
+
+  it("skips rows with no usable id rather than keying on undefined", async () => {
+    mockRunQuery.mockResolvedValue({
+      data: [{ id: null }, { favorite: 1 }, { id: "good" }],
+    });
+
+    const map = await getPayeeCleanupMetadata(httpConnection);
+    expect([...map.keys()]).toEqual(["good"]);
+  });
+
+  it("tolerates a response with no data array", async () => {
+    mockRunQuery.mockResolvedValue({} as { data: [] });
+    await expect(getPayeeCleanupMetadata(httpConnection)).resolves.toEqual(
+      new Map()
+    );
+  });
+});
+
+describe("fallbackMetadata", () => {
+  it("treats an unmatched payee as live with no preferences set", () => {
+    // getPayees() already excludes tombstoned rows, so assuming tombstoned here
+    // would silently drop a real cleanup candidate.
+    expect(fallbackMetadata("p1", null)).toEqual({
+      id: "p1",
+      favorite: false,
+      learnCategories: false,
+      tombstone: false,
+      transferAccountId: null,
+    });
+  });
+
+  it("carries through a known transfer account so eligibility still rejects it", () => {
+    expect(fallbackMetadata("xfer", "acct-1").transferAccountId).toBe("acct-1");
+  });
+});

--- a/src/features/payee-cleanup/lib/payeeMetadata.ts
+++ b/src/features/payee-cleanup/lib/payeeMetadata.ts
@@ -1,0 +1,101 @@
+/**
+ * Reads the payee fields cleanup needs that no supported transport API returns.
+ *
+ * `getPayees()` resolves to `APIPayeeEntity` — `Pick<PayeeEntity, 'id' | 'name'
+ * | 'transfer_acct'>` — in Direct mode, and actual-http-api's `Payee` schema is
+ * `{id, name, category, transfer_acct}`. Neither carries `favorite`,
+ * `learn_categories` or `tombstone`.
+ *
+ * Actual's AQL `payees` schema does expose all three, and Bench has ActualQL in
+ * both transports, so one query covers Direct and HTTP identically.
+ *
+ * `category` is deliberately not selected: `DbPayee.category` is annotated
+ * "Unused in the codebase" upstream, it is absent from the AQL payees schema,
+ * and `payeeModel.toExternal` drops it. See F-095.
+ */
+
+import { runQuery } from "@/lib/api/query";
+import type { ConnectionInstance } from "@/store/connection";
+import type { PayeeCleanupMetadata } from "../types";
+
+type PayeeMetadataRow = {
+  id?: unknown;
+  favorite?: unknown;
+  learn_categories?: unknown;
+  tombstone?: unknown;
+  transfer_acct?: unknown;
+};
+
+/**
+ * AQL booleans arrive as SQLite 1/0 through the HTTP transport and as real
+ * booleans through Direct, so both shapes are normalized here rather than at
+ * each call site. Anything unrecognized is treated as false — the conservative
+ * reading for `favorite` (don't claim a preference the user didn't set) and for
+ * `tombstone` (a row we can see is presumed alive; eligibility still rejects it
+ * if Actual says otherwise).
+ */
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") return value === "1" || value === "true";
+  return false;
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Loads cleanup metadata for every payee in the budget, keyed by payee id.
+ *
+ * Tombstoned payees are intentionally *included* in the result: the eligibility
+ * boundary needs to see them to exclude them, and a caller that silently
+ * filtered them here would report a smaller "analyzed" count than the budget
+ * actually holds.
+ */
+export async function getPayeeCleanupMetadata(
+  connection: ConnectionInstance
+): Promise<Map<string, PayeeCleanupMetadata>> {
+  const response = await runQuery<{ data: PayeeMetadataRow[] }>(connection, {
+    ActualQLquery: {
+      table: "payees",
+      select: ["id", "favorite", "learn_categories", "tombstone", "transfer_acct"],
+    },
+  });
+
+  const map = new Map<string, PayeeCleanupMetadata>();
+  for (const row of response.data ?? []) {
+    const id = toNullableString(row.id);
+    if (!id) continue;
+
+    map.set(id, {
+      id,
+      favorite: toBoolean(row.favorite),
+      learnCategories: toBoolean(row.learn_categories),
+      tombstone: toBoolean(row.tombstone),
+      transferAccountId: toNullableString(row.transfer_acct),
+    });
+  }
+  return map;
+}
+
+/**
+ * Fallback metadata for a payee the ActualQL read did not return.
+ *
+ * A payee present in `getPayees()` but missing from the metadata query is
+ * treated as an ordinary live payee with no preferences set — `getPayees()`
+ * already excludes tombstoned rows, so the alternative (assuming tombstoned)
+ * would silently drop a real cleanup candidate.
+ */
+export function fallbackMetadata(
+  id: string,
+  transferAccountId: string | null
+): PayeeCleanupMetadata {
+  return {
+    id,
+    favorite: false,
+    learnCategories: false,
+    tombstone: false,
+    transferAccountId,
+  };
+}

--- a/src/features/payee-cleanup/lib/plan.test.ts
+++ b/src/features/payee-cleanup/lib/plan.test.ts
@@ -1,0 +1,374 @@
+import { buildPlan, planIsEmpty, validatePlan, type CleanupPlan } from "./plan";
+import type { CleanupSuggestion } from "./scan";
+import type { PayeeCleanupCandidate } from "../types";
+
+function payee(
+  id: string,
+  name = id.toUpperCase(),
+  overrides: Partial<PayeeCleanupCandidate["metadata"]> = {}
+): PayeeCleanupCandidate {
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+      ...overrides,
+    },
+  };
+}
+
+function context(...payees: PayeeCleanupCandidate[]) {
+  return { byId: new Map(payees.map((p) => [p.id, p])) };
+}
+
+function suggestion(
+  members: PayeeCleanupCandidate[],
+  targetId: string,
+  canonicalName: string,
+  decision: "accepted" | "undecided" | "rejected" = "accepted"
+): CleanupSuggestion {
+  return {
+    cluster: {
+      id: members.map((m) => m.id).join("+"),
+      members,
+      stem: "STEM",
+      evidence: [],
+      fuzzyOnly: false,
+    },
+    target: { targetId, scores: [], reasons: [] },
+    canonicalName,
+    membersToMerge: members.filter((m) => m.id !== targetId),
+    confidence: { score: 95, band: "high", reasons: [] },
+    correction: { decision, excludedIds: [], addedIds: [] },
+  };
+}
+
+describe("buildPlan", () => {
+  const members = [payee("p1", "WOOLWORTHS 0183"), payee("p2", "Woolworths")];
+
+  it("stages a native merge with the target and its sources", () => {
+    const plan = buildPlan([suggestion(members, "p2", "Woolworths")]);
+
+    expect(plan.merges).toEqual([
+      {
+        kind: "merge-payees",
+        targetId: "p2",
+        mergeIds: ["p1"],
+        targetName: "Woolworths",
+        memberNames: ["WOOLWORTHS 0183"],
+      },
+    ]);
+  });
+
+  it("ignores proposals the user has not accepted", () => {
+    expect(planIsEmpty(buildPlan([suggestion(members, "p2", "Woolworths", "undecided")]))).toBe(
+      true
+    );
+    expect(planIsEmpty(buildPlan([suggestion(members, "p2", "Woolworths", "rejected")]))).toBe(
+      true
+    );
+  });
+
+  it("adds a rename only when the final name actually differs", () => {
+    // Renaming a payee to what it is already called is a write with no effect,
+    // and it would appear in the review screen as work the user never asked for.
+    expect(buildPlan([suggestion(members, "p2", "Woolworths")]).renames).toEqual([]);
+
+    const renamed = buildPlan([suggestion(members, "p1", "Woolworths")]);
+    expect(renamed.renames).toEqual([
+      { kind: "rename-payee", payeeId: "p1", from: "WOOLWORTHS 0183", to: "Woolworths" },
+    ]);
+  });
+
+  it("emits no merge when the cluster is down to the target alone", () => {
+    const single = suggestion([payee("p1")], "p1", "Renamed");
+    expect(buildPlan([single]).merges).toEqual([]);
+  });
+
+  it("includes orphan deletions", () => {
+    const plan = buildPlan([], [payee("p9", "Old Test Payee")]);
+    expect(plan.deletions).toEqual([
+      { kind: "delete-payee", payeeId: "p9", name: "Old Test Payee" },
+    ]);
+  });
+});
+
+describe("validatePlan", () => {
+  const target = payee("t1", "Woolworths");
+  const source = payee("s1", "WOOLWORTHS 0183");
+
+  function merge(overrides: Partial<CleanupPlan["merges"][number]> = {}) {
+    return {
+      merges: [
+        {
+          kind: "merge-payees" as const,
+          targetId: "t1",
+          mergeIds: ["s1"],
+          targetName: "Woolworths",
+          memberNames: ["WOOLWORTHS 0183"],
+          ...overrides,
+        },
+      ],
+      renames: [],
+      deletions: [],
+      rules: [],
+    };
+  }
+
+  it("accepts a well-formed plan", () => {
+    expect(validatePlan(merge(), context(target, source))).toEqual([]);
+  });
+
+  it("blocks a merge into a payee that no longer exists", () => {
+    const problems = validatePlan(merge(), context(source));
+    expect(problems[0].message).toMatch(/no longer exists/i);
+  });
+
+  it("blocks a transfer payee as the target", () => {
+    // Actual returns early and silently here, so the merge would report success
+    // and change nothing at all.
+    const transferTarget = payee("t1", "Transfer", { transferAccountId: "a1" });
+    const problems = validatePlan(merge(), context(transferTarget, source));
+    expect(problems.some((p) => /Actual manages it/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a transfer payee as a source", () => {
+    const transferSource = payee("s1", "Transfer", { transferAccountId: "a1" });
+    const problems = validatePlan(merge(), context(target, transferSource));
+    expect(problems.some((p) => /Actual manages it/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a payee merging into itself", () => {
+    const problems = validatePlan(
+      merge({ mergeIds: ["t1"] }),
+      context(target, source)
+    );
+    expect(problems.some((p) => /into itself/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks the same payee listed twice in one merge", () => {
+    const problems = validatePlan(
+      merge({ mergeIds: ["s1", "s1"] }),
+      context(target, source)
+    );
+    expect(problems.some((p) => /same payee twice/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks one payee merging into two different targets", () => {
+    const other = payee("t2", "Woolies");
+    const plan: CleanupPlan = {
+      merges: [
+        { kind: "merge-payees", targetId: "t1", mergeIds: ["s1"], targetName: "Woolworths", memberNames: ["x"] },
+        { kind: "merge-payees", targetId: "t2", mergeIds: ["s1"], targetName: "Woolies", memberNames: ["x"] },
+      ],
+      renames: [],
+      deletions: [],
+      rules: [],
+    };
+    const problems = validatePlan(plan, context(target, other, source));
+    expect(problems.some((p) => /more than one payee/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a target that another merge is taking away", () => {
+    // The merge would point at a payee Actual is about to tombstone.
+    const other = payee("t2", "Woolies");
+    const plan: CleanupPlan = {
+      merges: [
+        { kind: "merge-payees", targetId: "t1", mergeIds: ["s1"], targetName: "Woolworths", memberNames: ["x"] },
+        { kind: "merge-payees", targetId: "t2", mergeIds: ["t1"], targetName: "Woolies", memberNames: ["y"] },
+      ],
+      renames: [],
+      deletions: [],
+      rules: [],
+    };
+    const problems = validatePlan(plan, context(target, other, source));
+    expect(problems.some((p) => /cannot also be the one kept/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a rename aimed at a payee being merged away", () => {
+    // The save pipeline renames before it merges, so this rename would be lost.
+    const plan: CleanupPlan = {
+      ...merge(),
+      renames: [{ kind: "rename-payee", payeeId: "s1", from: "WOOLWORTHS 0183", to: "Woolworths" }],
+    };
+    const problems = validatePlan(plan, context(target, source));
+    expect(problems.some((p) => /being merged away/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a rename to an empty name", () => {
+    const plan: CleanupPlan = {
+      merges: [],
+      renames: [{ kind: "rename-payee", payeeId: "t1", from: "Woolworths", to: "  " }],
+      deletions: [],
+      rules: [],
+    };
+    const problems = validatePlan(plan, context(target));
+    expect(problems.some((p) => /empty name/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks deleting a payee that a merge is keeping", () => {
+    const plan: CleanupPlan = {
+      ...merge(),
+      deletions: [{ kind: "delete-payee", payeeId: "t1", name: "Woolworths" }],
+    };
+    const problems = validatePlan(plan, context(target, source));
+    expect(problems.some((p) => /kept by a merge/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a payee set to be both merged and deleted", () => {
+    const plan: CleanupPlan = {
+      ...merge(),
+      deletions: [{ kind: "delete-payee", payeeId: "s1", name: "WOOLWORTHS 0183" }],
+    };
+    const problems = validatePlan(plan, context(target, source));
+    expect(problems.some((p) => /merged and deleted/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks deleting a transfer payee", () => {
+    const plan: CleanupPlan = {
+      merges: [],
+      renames: [],
+      deletions: [{ kind: "delete-payee", payeeId: "x1", name: "Transfer" }],
+      rules: [],
+    };
+    const problems = validatePlan(
+      plan,
+      context(payee("x1", "Transfer", { transferAccountId: "a1" }))
+    );
+    expect(problems.some((p) => /Actual manages it/i.test(p.message))).toBe(true);
+  });
+
+  it("reports every problem at once", () => {
+    // Fixing them one at a time through repeated re-validation is a bad
+    // afternoon, so the plan reports the whole graph's issues together.
+    const plan: CleanupPlan = {
+      merges: [
+        { kind: "merge-payees", targetId: "gone", mergeIds: ["also-gone"], targetName: "Gone", memberNames: ["x"] },
+      ],
+      renames: [{ kind: "rename-payee", payeeId: "missing", from: "Missing", to: "New" }],
+      deletions: [{ kind: "delete-payee", payeeId: "absent", name: "Absent" }],
+      rules: [],
+    };
+    expect(validatePlan(plan, context()).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("blocks a rule pointing at a payee being merged away", () => {
+    // RD-078 §21: rule creation must never target a payee scheduled to vanish.
+    const plan: CleanupPlan = {
+      ...merge(),
+      rules: [
+        {
+          kind: "create-rule",
+          targetPayeeId: "s1",
+          targetName: "WOOLWORTHS 0183",
+          field: "imported_payee",
+          op: "matches",
+          value: "^WOOLWORTHS\\b",
+          description: 'starts with "WOOLWORTHS"',
+          expectedMatches: 40,
+        },
+      ],
+    };
+    const problems = validatePlan(plan, context(target, source));
+    expect(problems.some((p) => /being merged away/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks a rule with no pattern", () => {
+    const plan: CleanupPlan = {
+      merges: [],
+      renames: [],
+      deletions: [],
+      rules: [
+        {
+          kind: "create-rule",
+          targetPayeeId: "t1",
+          targetName: "Woolworths",
+          field: "imported_payee",
+          op: "contains",
+          value: "  ",
+          description: "empty",
+          expectedMatches: 0,
+        },
+      ],
+    };
+    const problems = validatePlan(plan, context(target));
+    expect(problems.some((p) => /no pattern/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks two groups that would both end up with the same name", () => {
+    // The defect this guard exists for: three "Optus" groups each merging
+    // validly, then all renaming their survivor to "Optus" — leaving three
+    // payees called Optus and reintroducing the duplication the user came here
+    // to remove. Each merge is individually fine, so only a whole-plan check
+    // catches it.
+    const a = payee("a1", "OPTUS 636aeb98050");
+    const b = payee("b1", "Optus PrePaid Melbourne");
+    const plan: CleanupPlan = {
+      merges: [
+        { kind: "merge-payees", targetId: "a1", mergeIds: ["a2"], targetName: "OPTUS 636aeb98050", memberNames: ["x"] },
+        { kind: "merge-payees", targetId: "b1", mergeIds: ["b2"], targetName: "Optus PrePaid Melbourne", memberNames: ["y"] },
+      ],
+      renames: [
+        { kind: "rename-payee", payeeId: "a1", from: "OPTUS 636aeb98050", to: "Optus" },
+        { kind: "rename-payee", payeeId: "b1", from: "Optus PrePaid Melbourne", to: "Optus" },
+      ],
+      deletions: [],
+      rules: [],
+    };
+
+    const problems = validatePlan(
+      plan,
+      context(a, b, payee("a2"), payee("b2"))
+    );
+    expect(
+      problems.some((p) => /would all end up named "OPTUS"/i.test(p.message))
+    ).toBe(true);
+  });
+
+  it("compares final names ignoring case and spacing", () => {
+    const plan: CleanupPlan = {
+      merges: [],
+      renames: [
+        { kind: "rename-payee", payeeId: "t1", from: "Woolworths", to: "coles" },
+        { kind: "rename-payee", payeeId: "s1", from: "WOOLWORTHS 0183", to: "COLES  " },
+      ],
+      deletions: [],
+      rules: [],
+    };
+    const problems = validatePlan(plan, context(target, source));
+    expect(problems.some((p) => /all end up named/i.test(p.message))).toBe(true);
+  });
+
+  it("blocks renaming onto a payee the cleanup is not touching", () => {
+    const bystander = payee("x1", "Optus");
+    const plan: CleanupPlan = {
+      merges: [],
+      renames: [{ kind: "rename-payee", payeeId: "t1", from: "Woolworths", to: "Optus" }],
+      deletions: [],
+      rules: [],
+    };
+    const problems = validatePlan(plan, context(target, bystander));
+    expect(
+      problems.some((p) => /already exists and is not part of this cleanup/i.test(p.message))
+    ).toBe(true);
+  });
+
+  it("does not complain when the colliding payee is being merged away", () => {
+    // Merging `Woolworths 0183` into `Woolworths` and renaming the survivor to
+    // `Woolworths` is the normal case, not a collision.
+    const plan: CleanupPlan = {
+      ...merge(),
+      renames: [{ kind: "rename-payee", payeeId: "t1", from: "Woolworths", to: "WOOLWORTHS 0183" }],
+    };
+    expect(validatePlan(plan, context(target, source))).toEqual([]);
+  });
+
+  it("marks everything it reports as blocking", () => {
+    const problems = validatePlan(merge(), context(source));
+    expect(problems.every((p) => p.severity === "blocking")).toBe(true);
+  });
+});

--- a/src/features/payee-cleanup/lib/plan.test.ts
+++ b/src/features/payee-cleanup/lib/plan.test.ts
@@ -324,8 +324,10 @@ describe("validatePlan", () => {
       plan,
       context(a, b, payee("a2"), payee("b2"))
     );
+    // Quoted as the user typed it. Echoing the normalized key back — "OPTUS" —
+    // reads like the app renamed the payee behind their back.
     expect(
-      problems.some((p) => /would all end up named "OPTUS"/i.test(p.message))
+      problems.some((p) => p.message.includes('would all end up named "Optus"'))
     ).toBe(true);
   });
 

--- a/src/features/payee-cleanup/lib/plan.ts
+++ b/src/features/payee-cleanup/lib/plan.ts
@@ -163,7 +163,12 @@ export type ValidationContext = {
   byId: Map<string, PayeeCleanupCandidate>;
 };
 
-/** Names compare case- and punctuation-insensitively, as Actual matches them. */
+/**
+ * The comparison form for a final payee name: case-folded, whitespace
+ * collapsed. Punctuation is deliberately significant — `Optus` and `Optus.` are
+ * two different payees to Actual, so treating them as a collision would block a
+ * plan that is in fact fine.
+ */
 function nameKey(value: string): string {
   return value.trim().toUpperCase().replace(/\s+/g, " ");
 }

--- a/src/features/payee-cleanup/lib/plan.ts
+++ b/src/features/payee-cleanup/lib/plan.ts
@@ -298,17 +298,24 @@ export function validatePlan(
   // This is checked across the plan *and* against the payees already in the
   // budget, since renaming onto an existing name collides just as badly.
   const finalNames = new Map<string, string[]>();
+  // Keyed by the comparison form, but reported as the user typed it: telling
+  // someone their groups "would all end up named OPTUS PREPAID" when they typed
+  // "Optus PrePaid" reads like the app renamed it behind their back.
+  const displayNames = new Map<string, string>();
+
+  const recordFinalName = (finalName: string, payeeId: string) => {
+    const key = nameKey(finalName);
+    finalNames.set(key, [...(finalNames.get(key) ?? []), payeeId]);
+    if (!displayNames.has(key)) displayNames.set(key, finalName);
+  };
 
   for (const merge of plan.merges) {
     const rename = plan.renames.find((r) => r.payeeId === merge.targetId);
-    const finalName = rename ? rename.to : merge.targetName;
-    const key = nameKey(finalName);
-    finalNames.set(key, [...(finalNames.get(key) ?? []), merge.targetId]);
+    recordFinalName(rename ? rename.to : merge.targetName, merge.targetId);
   }
   for (const rename of plan.renames) {
     if (plan.merges.some((m) => m.targetId === rename.payeeId)) continue;
-    const key = nameKey(rename.to);
-    finalNames.set(key, [...(finalNames.get(key) ?? []), rename.payeeId]);
+    recordFinalName(rename.to, rename.payeeId);
   }
 
   const survivingIds = new Set([
@@ -320,7 +327,7 @@ export function validatePlan(
   for (const [key, payeeIds] of finalNames) {
     if (payeeIds.length > 1) {
       block(
-        `${payeeIds.length} groups would all end up named "${key}" — that leaves ${payeeIds.length} payees with the same name. Give them different names, or put them in one group.`,
+        `${payeeIds.length} groups would all end up named "${displayNames.get(key) ?? key}" — that leaves ${payeeIds.length} payees with the same name. Give them different names, or put them in one group.`,
         payeeIds
       );
       continue;

--- a/src/features/payee-cleanup/lib/plan.ts
+++ b/src/features/payee-cleanup/lib/plan.ts
@@ -1,0 +1,396 @@
+/**
+ * Turning accepted proposals into staged operations (RD-078 §20–§22).
+ *
+ * Three rules from the native-semantics verification govern everything here:
+ *
+ * - **Merge is Actual's operation, not ours.** The plan stages
+ *   `mergePayees(targetId, mergeIds)` and lets Actual repoint `payee_mapping`
+ *   and tombstone the sources. Bench never reassigns transactions or rewrites
+ *   rules itself.
+ * - **A transfer payee must never appear.** Actual's merge returns early and
+ *   silently when the target is one, so a plan containing it would report
+ *   success having changed nothing.
+ * - **Rename before merge is equivalent to rename after.** The target survives
+ *   the merge, and the existing save pipeline runs updates before merges — so
+ *   the plan keeps that order and instead guarantees no rename ever names a
+ *   payee that is inside some `mergeIds`.
+ *
+ * The plan is pure data. Validation runs over the whole graph rather than per
+ * proposal, because the dangerous cases are all cross-proposal: the same payee
+ * merged into two different targets, a rename aimed at a payee about to vanish,
+ * a deletion of something another proposal keeps.
+ */
+
+import { isCleanupEligible } from "./eligibility";
+import type { CleanupSuggestion } from "./scan";
+import type { PayeeCleanupCandidate } from "../types";
+
+export type MergeOperation = {
+  kind: "merge-payees";
+  targetId: string;
+  mergeIds: string[];
+  /** For the review screen. */
+  targetName: string;
+  memberNames: string[];
+};
+
+export type RenameOperation = {
+  kind: "rename-payee";
+  payeeId: string;
+  from: string;
+  to: string;
+};
+
+export type DeleteOperation = {
+  kind: "delete-payee";
+  payeeId: string;
+  name: string;
+};
+
+export type CreateRuleOperation = {
+  kind: "create-rule";
+  /** The payee the rule will resolve to — always the surviving one. */
+  targetPayeeId: string;
+  targetName: string;
+  field: "imported_payee" | "notes";
+  op: "contains" | "matches";
+  value: string;
+  description: string;
+  expectedMatches: number;
+};
+
+export type CleanupOperation =
+  | MergeOperation
+  | RenameOperation
+  | DeleteOperation
+  | CreateRuleOperation;
+
+export type CleanupPlan = {
+  merges: MergeOperation[];
+  renames: RenameOperation[];
+  deletions: DeleteOperation[];
+  rules: CreateRuleOperation[];
+};
+
+export type PlanProblem = {
+  severity: "blocking" | "warning";
+  message: string;
+  payeeIds: string[];
+};
+
+export const EMPTY_PLAN: CleanupPlan = {
+  merges: [],
+  renames: [],
+  deletions: [],
+  rules: [],
+};
+
+/**
+ * Builds the plan from the proposals the user accepted.
+ *
+ * A rename is emitted only when the surviving payee's name actually differs
+ * from the chosen final name — renaming a payee to what it is already called is
+ * a write with no effect, and it would show up in the review screen as work the
+ * user did not ask for.
+ */
+export function buildPlan(
+  suggestions: CleanupSuggestion[],
+  orphansToDelete: PayeeCleanupCandidate[] = []
+): CleanupPlan {
+  const merges: MergeOperation[] = [];
+  const renames: RenameOperation[] = [];
+  const rules: CreateRuleOperation[] = [];
+
+  for (const suggestion of suggestions) {
+    if (suggestion.correction.decision !== "accepted") continue;
+
+    const target = suggestion.cluster.members.find(
+      (m) => m.id === suggestion.target.targetId
+    );
+    if (!target) continue;
+
+    const mergeIds = suggestion.membersToMerge.map((m) => m.id);
+    if (mergeIds.length > 0) {
+      merges.push({
+        kind: "merge-payees",
+        targetId: target.id,
+        mergeIds,
+        targetName: target.name,
+        memberNames: suggestion.membersToMerge.map((m) => m.name),
+      });
+    }
+
+    // A rule is only ever created for a proposal whose rule the user opted into.
+    const recommended = suggestion.futureResolution?.recommended;
+    if (suggestion.correction.createRule && recommended) {
+      rules.push({
+        kind: "create-rule",
+        targetPayeeId: target.id,
+        targetName: target.name,
+        field: recommended.candidate.field,
+        op: recommended.candidate.op,
+        value: recommended.candidate.value,
+        description: recommended.candidate.description,
+        expectedMatches: recommended.expectedMatches,
+      });
+    }
+
+    const finalName = suggestion.canonicalName.trim();
+    if (finalName && finalName !== target.name) {
+      renames.push({
+        kind: "rename-payee",
+        payeeId: target.id,
+        from: target.name,
+        to: finalName,
+      });
+    }
+  }
+
+  return {
+    merges,
+    renames,
+    rules,
+    deletions: orphansToDelete.map((payee) => ({
+      kind: "delete-payee" as const,
+      payeeId: payee.id,
+      name: payee.name,
+    })),
+  };
+}
+
+export type ValidationContext = {
+  /** Every payee still known to be live, by id. */
+  byId: Map<string, PayeeCleanupCandidate>;
+};
+
+/** Names compare case- and punctuation-insensitively, as Actual matches them. */
+function nameKey(value: string): string {
+  return value.trim().toUpperCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Validates the whole plan graph (RD-078 §22).
+ *
+ * Everything here is a *blocking* problem except where noted: these are the
+ * conditions under which applying the plan would do something other than what
+ * the review screen showed.
+ */
+export function validatePlan(
+  plan: CleanupPlan,
+  context: ValidationContext
+): PlanProblem[] {
+  const problems: PlanProblem[] = [];
+  const block = (message: string, payeeIds: string[]) =>
+    problems.push({ severity: "blocking", message, payeeIds });
+
+  const disappearing = new Set(plan.merges.flatMap((m) => m.mergeIds));
+  const targets = new Set(plan.merges.map((m) => m.targetId));
+  const deleted = new Set(plan.deletions.map((d) => d.payeeId));
+
+  const sourceOwners = new Map<string, string[]>();
+
+  for (const merge of plan.merges) {
+    const target = context.byId.get(merge.targetId);
+
+    if (!target) {
+      block(`"${merge.targetName}" no longer exists, so nothing can merge into it.`, [
+        merge.targetId,
+      ]);
+    } else if (!isCleanupEligible(target.metadata)) {
+      // Actual would return early and change nothing, reporting success.
+      block(
+        `"${target.name}" cannot be kept — Actual manages it and will not merge into it.`,
+        [target.id]
+      );
+    }
+
+    if (merge.mergeIds.length === 0) {
+      block(`"${merge.targetName}" has nothing to merge into it.`, [merge.targetId]);
+    }
+
+    if (merge.mergeIds.includes(merge.targetId)) {
+      block(`"${merge.targetName}" cannot be merged into itself.`, [merge.targetId]);
+    }
+
+    if (new Set(merge.mergeIds).size !== merge.mergeIds.length) {
+      block(`"${merge.targetName}" lists the same payee twice.`, [merge.targetId]);
+    }
+
+    for (const sourceId of merge.mergeIds) {
+      const source = context.byId.get(sourceId);
+      if (!source) {
+        block(`A payee merging into "${merge.targetName}" no longer exists.`, [sourceId]);
+        continue;
+      }
+      if (!isCleanupEligible(source.metadata)) {
+        block(
+          `"${source.name}" cannot be merged — Actual manages it.`,
+          [source.id]
+        );
+      }
+      if (deleted.has(sourceId)) {
+        block(
+          `"${source.name}" is set to be both merged and deleted.`,
+          [source.id]
+        );
+      }
+      const owners = sourceOwners.get(sourceId) ?? [];
+      owners.push(merge.targetName);
+      sourceOwners.set(sourceId, owners);
+    }
+
+    if (deleted.has(merge.targetId)) {
+      block(
+        `"${merge.targetName}" is set to be kept and deleted at the same time.`,
+        [merge.targetId]
+      );
+    }
+
+    // A target that is itself being merged away elsewhere would leave this
+    // merge pointing at a tombstone.
+    if (disappearing.has(merge.targetId)) {
+      block(
+        `"${merge.targetName}" is being merged into another payee, so it cannot also be the one kept here.`,
+        [merge.targetId]
+      );
+    }
+  }
+
+  for (const [sourceId, owners] of sourceOwners) {
+    if (owners.length > 1) {
+      const name = context.byId.get(sourceId)?.name ?? sourceId;
+      block(
+        `"${name}" is set to merge into more than one payee (${owners.join(", ")}).`,
+        [sourceId]
+      );
+    }
+  }
+
+  for (const rename of plan.renames) {
+    if (disappearing.has(rename.payeeId)) {
+      // The ordering guarantee: the save pipeline renames before it merges, so
+      // a rename aimed at a payee that is about to be tombstoned would be lost.
+      block(
+        `"${rename.from}" is being merged away, so it cannot be renamed to "${rename.to}".`,
+        [rename.payeeId]
+      );
+    }
+    if (deleted.has(rename.payeeId)) {
+      block(`"${rename.from}" is set to be renamed and deleted.`, [rename.payeeId]);
+    }
+    if (!context.byId.has(rename.payeeId)) {
+      block(`"${rename.from}" no longer exists, so it cannot be renamed.`, [
+        rename.payeeId,
+      ]);
+    }
+    if (!rename.to.trim()) {
+      block(`"${rename.from}" cannot be renamed to an empty name.`, [rename.payeeId]);
+    }
+  }
+
+  // ── Would this plan leave two payees with the same name? ─────────────────
+  //
+  // The whole point of the feature is to end up with *one* payee per merchant.
+  // Two groups that both settle on "Optus" produce two payees called Optus —
+  // reintroducing exactly the duplication the user came here to remove, and
+  // doing it silently, because each merge is individually valid.
+  //
+  // This is checked across the plan *and* against the payees already in the
+  // budget, since renaming onto an existing name collides just as badly.
+  const finalNames = new Map<string, string[]>();
+
+  for (const merge of plan.merges) {
+    const rename = plan.renames.find((r) => r.payeeId === merge.targetId);
+    const finalName = rename ? rename.to : merge.targetName;
+    const key = nameKey(finalName);
+    finalNames.set(key, [...(finalNames.get(key) ?? []), merge.targetId]);
+  }
+  for (const rename of plan.renames) {
+    if (plan.merges.some((m) => m.targetId === rename.payeeId)) continue;
+    const key = nameKey(rename.to);
+    finalNames.set(key, [...(finalNames.get(key) ?? []), rename.payeeId]);
+  }
+
+  const survivingIds = new Set([
+    ...plan.merges.map((m) => m.targetId),
+    ...plan.renames.map((r) => r.payeeId),
+  ]);
+  const disappearingOrDeleted = new Set([...disappearing, ...deleted]);
+
+  for (const [key, payeeIds] of finalNames) {
+    if (payeeIds.length > 1) {
+      block(
+        `${payeeIds.length} groups would all end up named "${key}" — that leaves ${payeeIds.length} payees with the same name. Give them different names, or put them in one group.`,
+        payeeIds
+      );
+      continue;
+    }
+
+    // A name already in use by a payee this plan is not touching.
+    for (const [id, payee] of context.byId) {
+      if (survivingIds.has(id) || disappearingOrDeleted.has(id)) continue;
+      if (nameKey(payee.name) !== key) continue;
+      block(
+        `"${payee.name}" already exists and is not part of this cleanup — renaming to it would create a second payee with that name.`,
+        [payeeIds[0], id]
+      );
+    }
+  }
+
+  for (const rule of plan.rules) {
+    if (disappearing.has(rule.targetPayeeId)) {
+      // RD-078 §21: rule creation must never target a payee scheduled to vanish.
+      block(
+        `The rule for "${rule.targetName}" would point at a payee that is being merged away.`,
+        [rule.targetPayeeId]
+      );
+    }
+    if (deleted.has(rule.targetPayeeId)) {
+      block(`The rule for "${rule.targetName}" would point at a deleted payee.`, [
+        rule.targetPayeeId,
+      ]);
+    }
+    if (!context.byId.has(rule.targetPayeeId)) {
+      block(`The rule for "${rule.targetName}" points at a payee that no longer exists.`, [
+        rule.targetPayeeId,
+      ]);
+    }
+    if (!rule.value.trim()) {
+      block(`The rule for "${rule.targetName}" has no pattern to match.`, [
+        rule.targetPayeeId,
+      ]);
+    }
+  }
+
+  for (const deletion of plan.deletions) {
+    const payee = context.byId.get(deletion.payeeId);
+    if (!payee) {
+      block(`"${deletion.name}" no longer exists.`, [deletion.payeeId]);
+      continue;
+    }
+    if (!isCleanupEligible(payee.metadata)) {
+      block(`"${payee.name}" cannot be deleted — Actual manages it.`, [payee.id]);
+    }
+    if (targets.has(deletion.payeeId)) {
+      block(
+        `"${payee.name}" is being kept by a merge, so it cannot be deleted.`,
+        [payee.id]
+      );
+    }
+  }
+
+  return problems;
+}
+
+export function planIsEmpty(plan: CleanupPlan): boolean {
+  return planOperationCount(plan) === 0;
+}
+
+export function planOperationCount(plan: CleanupPlan): number {
+  return (
+    plan.merges.length +
+    plan.renames.length +
+    plan.deletions.length +
+    plan.rules.length
+  );
+}

--- a/src/features/payee-cleanup/lib/reduce.test.ts
+++ b/src/features/payee-cleanup/lib/reduce.test.ts
@@ -1,0 +1,200 @@
+import { reduceFully } from "./reduce";
+
+/**
+ * Shape-reducer tests. Every case here must reduce from the name **alone**,
+ * with no corpus and no vocabulary — that is the definition of a shape rule.
+ *
+ * Anything that needs to know the institution (a channel wrapper, a city, a
+ * bank's "INTERNET BANKING" tag) belongs in `corpusAffixes.test.ts` instead,
+ * where it is learned from the payee set rather than hard-coded.
+ *
+ * The fixtures come from real Australian, UAE and Saudi exports, because
+ * invented examples are too tidy to catch anything. They are evidence, not
+ * configuration: no reducer knows they exist.
+ */
+
+function stem(name: string): string {
+  return reduceFully(name).stem;
+}
+
+describe("dates", () => {
+  it.each([
+    ["ACME STORE 12/03/2024", "ACME STORE"],
+    ["ACME STORE 2023-09-02", "ACME STORE"],
+    ["ACME STORE 06MAR25", "ACME STORE"],
+    ["ACME STORE 05MAR2025", "ACME STORE"],
+    ["SALARY PAYMENT Oct 2025", "SALARY PAYMENT"],
+    ["ACME 1.12.2024", "ACME"],
+  ])("%s → %s", (input, expected) => {
+    expect(stem(input)).toBe(expected);
+  });
+
+  it("takes the labelled form with its label", () => {
+    expect(stem("MARKET BOYS Value Date: 12/03/2024")).toBe("MARKET BOYS");
+  });
+
+  it("leaves a number that is not a date", () => {
+    expect(stem("STUDIO 54")).toContain("STUDIO");
+  });
+});
+
+describe("times", () => {
+  it.each([
+    ["ACME STORE 19:40:27", "ACME STORE"],
+    ["ACME STORE 09:24", "ACME STORE"],
+  ])("%s → %s", (input, expected) => {
+    expect(stem(input)).toBe(expected);
+  });
+});
+
+describe("card numbers", () => {
+  it.each([
+    ["ACME STORE Card xx9166", "ACME STORE"],
+    ["ACME STORE xx4534", "ACME STORE"],
+    ["ACME STORE ****1234", "ACME STORE"],
+    ["ACME STORE Card Ending with 5070", "ACME STORE"],
+    ["ACME STORE CARD NO: ***132", "ACME STORE"],
+  ])("%s → %s", (input, expected) => {
+    expect(stem(input)).toBe(expected);
+  });
+
+  it("removes the CARD label with the number, leaving no stray word", () => {
+    // Leaving a bare "Card" behind blocks later reducers from reaching the end
+    // of the name.
+    expect(stem("MARKET BOYS Card xx4534")).not.toContain("CARD");
+  });
+});
+
+describe("reference and authorization numbers", () => {
+  it.each([
+    ["PAY PROTECT 393160543", "PAY PROTECT"],
+    ["ACME STORE A88898560", "ACME STORE"],
+    ["ACME STORE IBAG41116", "ACME STORE"],
+    ["ACME STORE REF A896-13013", "ACME STORE"],
+    ["ACME STORE SEQ:00001181", "ACME STORE"],
+    ["ACME STORE HIB- 97340X909334", "ACME STORE"],
+  ])("%s → %s", (input, expected) => {
+    expect(stem(input)).toBe(expected);
+  });
+
+  it("keeps an account number that identifies the counterparty", () => {
+    // No single part of `030-176408-001` is long enough to be a reference, and
+    // it is the only thing distinguishing one transfer from another.
+    expect(stem("TRANSFER FROM 030-176408-001 IBAG41116")).toBe(
+      "TRANSFER FROM 030 176408 001"
+    );
+  });
+
+  it("keeps a merchant name that merely contains digits", () => {
+    expect(stem("7 ELEVEN")).toBe("7 ELEVEN");
+    expect(stem("CARREFOUR2")).toBe("CARREFOUR2");
+  });
+});
+
+describe("store and terminal numbers", () => {
+  it.each([
+    ["COLES 0559", "COLES"],
+    ["WOOLWORTHS 0183", "WOOLWORTHS"],
+    ["ENOC SITE 1092", "ENOC SITE"],
+  ])("%s → %s", (input, expected) => {
+    expect(stem(input)).toBe(expected);
+  });
+
+  it("never reduces a purely numeric name to nothing", () => {
+    expect(stem("12345").length).toBeGreaterThan(0);
+  });
+});
+
+describe("the statement tail", () => {
+  it("removes the whole record when the merchant leads it", () => {
+    expect(
+      stem("COLES 0559 02MAR25 ATMA896 19:40:27 0640     VISA        AUD COLES 0559 647986 MELBOURNE    AU A88898560 ATM")
+    ).toBe("COLES");
+  });
+
+  it("handles a merchant with punctuation", () => {
+    expect(
+      stem("M, O & F PTY. LTD. 01MAR25 ATMA896 11:48:22 0640     VISA        AUD M, O & F PTY. LTD. 564633 Melbourne    AU A88839934 ATM")
+    ).toBe("M O F");
+  });
+
+  it("does not fire when the record starts with the date", () => {
+    // Nothing precedes the date, so there is no merchant to keep. The narrower
+    // reducers take what they can rather than erasing the name.
+    const result = stem("31OCT25 ATMA896 15:22:13 0640 VISA AUD APPLE.COM/BILL 428592 SYDNEY AU");
+    expect(result).toContain("APPLE");
+  });
+});
+
+describe("processor prefixes", () => {
+  it("strips a short abbreviation before a star", () => {
+    expect(stem("SQ *BANGKOKSQUARE")).toBe("BANGKOKSQUARE");
+    expect(stem("ZLR*Schnitz")).toBe("SCHNITZ");
+  });
+
+  it("keeps a four-letter word before a star, because that is a merchant", () => {
+    // `UBER *TRIP` must not become `TRIP`. Processor tags are terse; merchant
+    // names are not.
+    expect(stem("UBER *TRIP")).toBe("UBER TRIP");
+  });
+});
+
+describe("web addresses", () => {
+  it("removes a trailing address appended to a merchant", () => {
+    expect(stem("UBER *TRIP HELP.UBER.COM")).toBe("UBER TRIP");
+  });
+
+  it("keeps a domain that IS the merchant", () => {
+    expect(stem("Amazon.ae")).toBe("AMAZON AE");
+    expect(stem("talabat.com")).toBe("TALABAT COM");
+  });
+});
+
+describe("exchange-rate fragments", () => {
+  it.each([
+    ["ADVANCE CAR RENTAL AUD/AED .427637511", "ADVANCE CAR RENTAL"],
+    ["TRANSFER FX SAR 36147.46 AT 0.9869742", "TRANSFER"],
+  ])("%s → %s", (input, expected) => {
+    expect(stem(input)).toBe(expected);
+  });
+});
+
+describe("card networks and terminals", () => {
+  it("removes standalone network and terminal tokens", () => {
+    expect(stem("ACME STORE VISA ATMA896")).toBe("ACME STORE");
+  });
+});
+
+describe("safety", () => {
+  it("leaves an already-clean payee completely untouched", () => {
+    for (const name of ["Woolworths", "Netflix", "McDonald's", "IKEA", "Bath & Body Works"]) {
+      expect(reduceFully(name).steps).toHaveLength(0);
+    }
+  });
+
+  it("never reduces a name to nothing", () => {
+    for (const name of ["UAE", "784", "ATM", "VISA", "0640", "12/03/2024"]) {
+      expect(reduceFully(name).stem.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps a merchant whose name begins with a wrapper-ish word", () => {
+    expect(stem("CARD FACTORY")).toBe("CARD FACTORY");
+  });
+
+  it("reduces stacked noise in one pass", () => {
+    // Five classes at once: legal suffix, card number and date are all shape
+    // rules; the city and country are left for the corpus to identify.
+    expect(stem("MARKET BOYS PTY LTD Card xx4534 Value Date: 12/03/2024")).toBe(
+      "MARKET BOYS"
+    );
+  });
+
+  it("reports every step it took, so the result is explainable", () => {
+    const result = reduceFully("MARKET BOYS PTY LTD Card xx4534 Value Date: 12/03/2024");
+    const ids = result.steps.map((s) => s.id);
+    expect(ids).toContain("card-number");
+    expect(ids).toContain("legal-suffix");
+    expect(result.steps.every((s) => s.removed.length > 0)).toBe(true);
+  });
+});

--- a/src/features/payee-cleanup/lib/reduce.test.ts
+++ b/src/features/payee-cleanup/lib/reduce.test.ts
@@ -163,6 +163,27 @@ describe("card networks and terminals", () => {
   it("removes standalone network and terminal tokens", () => {
     expect(stem("ACME STORE VISA ATMA896")).toBe("ACME STORE");
   });
+
+  it("keeps ordinary words that merely start with a terminal prefix", () => {
+    // A generated terminal id always carries a number. Matching on the letters
+    // alone deleted `POSTAL` and `ATMOS` — real words, not scaffolding.
+    expect(stem("AUSTRALIA POSTAL")).toBe("AUSTRALIA POSTAL");
+    expect(stem("ATMOS ENERGY")).toBe("ATMOS ENERGY");
+  });
+});
+
+describe("currency amounts", () => {
+  it("removes a code with a real amount beside it", () => {
+    expect(stem("HOTEL BOOKING AUD 1,234.56")).toBe("HOTEL BOOKING");
+    expect(stem("HOTEL BOOKING AED 45.90")).toBe("HOTEL BOOKING");
+  });
+
+  it("keeps a three-letter merchant followed by a store number", () => {
+    // The amount has to look like money. Accepting a bare integer made every
+    // three-letter name plus a branch number look like a charge, and `KFC 1234
+    // SYDNEY` reduced to `SYDNEY`.
+    expect(stem("KFC 1234 SYDNEY")).toBe("KFC 1234 SYDNEY");
+  });
 });
 
 describe("safety", () => {

--- a/src/features/payee-cleanup/lib/reduce.ts
+++ b/src/features/payee-cleanup/lib/reduce.ts
@@ -1,0 +1,532 @@
+/**
+ * Composable noise reduction for bank-generated payee names (RD-078 §5.2, §5.3).
+ *
+ * The single-pass detectors in `detectors.ts` each remove one class of noise
+ * from the raw name. That is enough for `WOOLWORTHS 0183`, but real bank text
+ * stacks several classes at once, and with one removal per name the stems never
+ * converge. This module applies every reducer in sequence, repeatedly, until the
+ * name stops changing, recording what each step removed so the result stays
+ * explainable.
+ *
+ * **Everything here is shape-based.** A reducer recognizes noise by its
+ * *structure* — a date looks like a date in any country, a reference number is a
+ * long alphanumeric run at any bank — never by matching a list of merchants,
+ * cities, processors or one institution's vocabulary. Text that can only be
+ * identified by knowing the bank is handled by `corpusAffixes.ts`, which learns
+ * it from the user's own payee set instead of from a hard-coded list.
+ *
+ * It runs on lightly-normalized text (whitespace collapsed, punctuation intact)
+ * because the patterns that matter — `Value Date:`, `12/03/2024`, `SEQ:00001181`
+ * — are made of the punctuation that full normalization would destroy.
+ */
+
+import {
+  isMachinePrefixWord,
+  LEGAL_SUFFIXES,
+  STRONG_MACHINE_PREFIXES,
+} from "./derivedForms";
+import type { CorpusAffix } from "./corpusAffixes";
+
+export type ReducerId =
+  | "statement-tail"
+  | "processor-prefix"
+  | "machine-prefix"
+  | "network-scaffold"
+  | "domain-fragment"
+  | "labelled-metadata"
+  | "date-fragment"
+  | "time-fragment"
+  | "fx-fragment"
+  | "currency-amount"
+  | "card-number"
+  | "reference-token"
+  | "legal-suffix"
+  | "terminal-suffix"
+  | "corpus-prefix"
+  | "corpus-suffix";
+
+export type ReductionStep = {
+  id: ReducerId;
+  /** Human-readable, shown as cluster evidence. */
+  label: string;
+  /** The text this step removed. */
+  removed: string;
+  /** Contextual steps are interpretive and lower the cluster's confidence. */
+  contextual: boolean;
+};
+
+export type ReductionResult = {
+  /** The reduced name. Upper-cased and whitespace-collapsed, never empty. */
+  stem: string;
+  /**
+   * The same reduction with the interpretive steps left out.
+   *
+   * This separates "these differ only in noise we are certain about" from "we
+   * had to infer". Two payees that already agree here are a hard structural
+   * match even if both also carry text only the corpus could identify.
+   */
+  structuralStem: string;
+  steps: ReductionStep[];
+};
+
+/** Guard: never reduce a name below this, or unrelated merchants collapse together. */
+const MIN_STEM_LENGTH = 3;
+
+type Reducer = {
+  id: ReducerId;
+  label: string;
+  contextual?: boolean;
+  /** Returns the shortened text, or null when the reducer does not apply. */
+  apply(text: string): { text: string; removed: string } | null;
+};
+
+// ─── Shape patterns ──────────────────────────────────────────────────────────
+
+/**
+ * Dates in the layouts banks actually emit: `12/03/2024`, `2023-09-02`,
+ * `06MAR25`, `05MAR2025`, `Oct 2025`. Month names are the only words involved,
+ * and those are calendar vocabulary rather than anything bank-specific.
+ */
+const DATE_PATTERN =
+  /\b(\d{1,2}[/.-]\d{1,2}[/.-]\d{2,4}|\d{4}-\d{2}-\d{2}|\d{1,2}[A-Z]{3}\d{2,4}|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)[A-Z]*\.?\s+\d{2,4})\b/i;
+
+/** `19:40:27`, `13:55`. */
+const TIME_PATTERN = /\b\d{1,2}:\d{2}(:\d{2})?\b/;
+
+/**
+ * Card numbers in their common maskings: `xx9166`, `****1234`, `x-1234`,
+ * `Card Ending with 5070`. The `CARD` label is consumed along with the number —
+ * removing only the digits leaves a stray word that blocks later reducers.
+ */
+const CARD_PATTERN =
+  /(?:\bCARD\s*(?:NO\.?|NUMBER)?\s*:?\s*)?(?:ENDING\s+(?:WITH\s+)?)?(?:\bX{1,2}[\s-]?\d{3,4}\b|\*{2,}[\s-]?\d{3,4}\b)|\bCARD\s+ENDING\s+(?:WITH\s+)?\d{3,4}\b/i;
+
+/**
+ * Currency conversion fragments: `AUD/AED .430449172`, `FX SAR 36147.46 AT 0.98`.
+ * A three-letter ISO code is a shape, not a list of the user's currencies.
+ */
+/**
+ * A currency code with its amount: `AUD 14.95`, `SAR 1,234.56`, `USD 20`.
+ *
+ * Real statements print the charged amount into the payee field, and it varies
+ * per transaction — so it both survives into the payee name and stops variants
+ * from converging. A three-letter code beside a number is a shape, not a list of
+ * anyone's currencies.
+ */
+const CURRENCY_AMOUNT_PATTERN = /\b[A-Z]{3}\s*[\d,]+(\.\d{1,2})?\b/;
+
+const FX_PATTERN =
+  /\b([A-Z]{3}\/[A-Z]{3}\s*\.?[\d.]+|FX\s+[A-Z]{3}\s+[\d,.]+\s+AT\s+[\d.]+)\b/i;
+
+/**
+ * `LABEL: value` metadata where the value looks machine-generated.
+ *
+ * Generic by construction: a one- or two-word label followed by a colon and a
+ * run of digits or reference characters. It finds `Value Date: 12/03/2024`,
+ * `SEQ:00001181` and `Ref: 8837/22` without being told those labels exist, and
+ * leaves `Joe's Diner: The Best Burgers` alone because the value is prose.
+ *
+ * The label is a single word on purpose. Allowing two let it reach back across a
+ * real one — `ACME STORE SEQ:00001181` matched `STORE SEQ:` and the merchant
+ * lost half its name. Multi-word labels are recognized only where a second
+ * signal disambiguates them: see `statementTail`.
+ */
+const LABELLED_PATTERN =
+  /\b([A-Z][A-Z.]*)\s*:\s*[*#]*[\dA-Z]{2,}(?:[-/][\dA-Z]+)*\b/i;
+
+/**
+ * Card networks and terminal identifiers appearing as standalone scaffolding.
+ * Card-industry terms, not one bank's wording.
+ */
+const NETWORK_TOKEN =
+  /^(VISA|MASTERCARD|MAESTRO|AMEX|DISCOVER|EFTPOS|CIRRUS|ATM[A-Z0-9]{2,6}|POS[A-Z0-9]{2,6})$/i;
+
+// ─── Reducers ────────────────────────────────────────────────────────────────
+
+/**
+ * Everything from the first date token onwards, when a merchant name precedes it.
+ *
+ * Banks that print a whole transaction record into one field almost always put
+ * the merchant first and the machine detail after the date, so one rule collapses
+ * an entire family of formats without knowing any of them.
+ *
+ * Requires real content before the date, so a record that *starts* with the date
+ * is left to the narrower reducers rather than erased.
+ */
+const statementTail: Reducer = {
+  id: "statement-tail",
+  label: "Statement details after the date",
+  apply: (text) => {
+    const match = DATE_PATTERN.exec(text);
+    if (!match || match.index === undefined) return null;
+    const head = text.slice(0, match.index).trim();
+    const tail = text.slice(match.index).trim();
+    if (tail.length < 6) return null;
+
+    // A colon-terminated label immediately before the date belongs to the date,
+    // not to the merchant: `MARKET BOYS Value Date: 12/03/2024`. The colon is
+    // what makes this unambiguous — up to two words are taken with it, which is
+    // safe here in a way a bare two-word label never is.
+    const labelled = /\s*(?:\S+\s+)?\S+:\s*$/.exec(head);
+    const merchant = labelled ? head.slice(0, labelled.index).trim() : head;
+    if (merchant.length < 6) return null;
+
+    return {
+      text: merchant,
+      removed: (labelled ? head.slice(labelled.index).trim() + " " : "") + tail,
+    };
+  },
+};
+
+/**
+ * Payment-processor tags: `SQ *BANGKOKSQUARE`, `ZLR*Schnitz`, `PP*STORE`.
+ *
+ * Identified by shape — a short abbreviation before a star — capped at three
+ * characters. A general "anything before a star" rule ate the merchant in
+ * `UBER *TRIP`; real processor tags are terse, merchant names are not.
+ */
+const processorPrefix: Reducer = {
+  id: "processor-prefix",
+  label: "Payment processor prefix",
+  apply: (text) => {
+    const match = /^\s*([A-Za-z0-9]{2,3})\s*\*\s*/.exec(text);
+    if (!match) return null;
+    const rest = text.slice(match[0].length).trim();
+    if (rest.length < MIN_STEM_LENGTH) return null;
+    return { text: rest, removed: match[0].trim() };
+  },
+};
+
+/** `POS `, `VISA POS `, `CARD PURCHASE ` — see `derivedForms` for the vocabulary split. */
+const machinePrefix: Reducer = {
+  id: "machine-prefix",
+  label: "Bank prefix",
+  apply: (text) => {
+    const tokens = text.split(/\s+/);
+    const removed: string[] = [];
+    while (tokens.length > 1 && isMachinePrefixWord(tokens[0].toUpperCase())) {
+      removed.push(tokens.shift() as string);
+    }
+    if (removed.length === 0) return null;
+    if (!removed.some((t) => STRONG_MACHINE_PREFIXES.has(t.toUpperCase()))) return null;
+    return { text: tokens.join(" "), removed: removed.join(" ") };
+  },
+};
+
+/** Standalone card-network / terminal tokens anywhere in the name. */
+const networkScaffold: Reducer = {
+  id: "network-scaffold",
+  label: "Card network and terminal codes",
+  apply: (text) => {
+    const tokens = text.split(/\s+/);
+    for (let i = 0; i < tokens.length; i++) {
+      if (!NETWORK_TOKEN.test(tokens[i])) continue;
+      const next = [...tokens.slice(0, i), ...tokens.slice(i + 1)].join(" ").trim();
+      if (next.length < MIN_STEM_LENGTH) continue;
+      return { text: next, removed: tokens[i] };
+    }
+    return null;
+  },
+};
+
+/**
+ * A trailing web address appended to the merchant name:
+ * `UBER *TRIP HELP.UBER.COM` → `UBER *TRIP`.
+ *
+ * Only when something else remains — `Amazon.ae` and `talabat.com` *are* the
+ * merchant, so a name that is nothing but a domain is left alone.
+ */
+const domainFragment: Reducer = {
+  id: "domain-fragment",
+  label: "Web address",
+  apply: (text) => {
+    const tokens = text.split(/\s+/);
+    if (tokens.length < 2) return null;
+    const last = tokens[tokens.length - 1];
+    if (!/^[A-Z0-9][A-Z0-9.-]*\.[A-Z]{2,4}$/i.test(last)) return null;
+    const next = tokens.slice(0, -1).join(" ").trim();
+    if (next.length < MIN_STEM_LENGTH) return null;
+    return { text: next, removed: last };
+  },
+};
+
+function stripPattern(id: ReducerId, label: string, pattern: RegExp): Reducer {
+  return {
+    id,
+    label,
+    apply: (text) => {
+      const match = pattern.exec(text);
+      if (!match || match.index === undefined) return null;
+      const next = (text.slice(0, match.index) + " " + text.slice(match.index + match[0].length))
+        .replace(/\s+/g, " ")
+        .trim();
+      if (next.length < MIN_STEM_LENGTH) return null;
+      return { text: next, removed: match[0].trim() };
+    },
+  };
+}
+
+const labelledMetadata = stripPattern(
+  "labelled-metadata",
+  "Reference details",
+  LABELLED_PATTERN
+);
+const dateFragment = stripPattern("date-fragment", "Transaction date", DATE_PATTERN);
+const timeFragment = stripPattern("time-fragment", "Transaction time", TIME_PATTERN);
+const fxFragment = stripPattern("fx-fragment", "Exchange rate", FX_PATTERN);
+const cardNumber = stripPattern("card-number", "Card number", CARD_PATTERN);
+const currencyAmount = stripPattern(
+  "currency-amount",
+  "Charged amount",
+  CURRENCY_AMOUNT_PATTERN
+);
+
+/**
+ * Long machine tokens: mixed alphanumeric references (`A88898560`, `IBAG41116`)
+ * and long pure-digit runs (`393160543`).
+ *
+ * Bounded so an account number like `030-176408-001` survives — it identifies
+ * the counterparty, and no individual part of it is long enough to qualify.
+ */
+const referenceToken: Reducer = {
+  id: "reference-token",
+  label: "Reference number",
+  apply: (text) => {
+    const tokens = text.split(/\s+/);
+    for (let i = 0; i < tokens.length; i++) {
+      if (!isReferenceToken(tokens[i])) continue;
+
+      // Take the label sitting immediately before the value with it — `REF
+      // A896-13013`, `HIB- 97340X909334`. Otherwise the value goes and a
+      // meaningless `REF` stays behind, which then differs between payees for
+      // no reason.
+      //
+      // Shape-based rather than a list of label words: a label here is either
+      // very short, or punctuated as a label. That keeps `ACME STORE A88898560`
+      // intact, where the preceding word is part of the merchant name.
+      const start =
+        i > 0 && isAdjacentLabel(tokens[i - 1]) && i - 1 > 0 ? i - 1 : i;
+
+      const next = [...tokens.slice(0, start), ...tokens.slice(i + 1)]
+        .join(" ")
+        .trim();
+      if (next.length < MIN_STEM_LENGTH) continue;
+      return { text: next, removed: tokens.slice(start, i + 1).join(" ") };
+    }
+    return null;
+  },
+};
+
+function isAdjacentLabel(token: string): boolean {
+  if (/[-:.]$/.test(token) && /^[A-Za-z]{2,6}[-:.]$/.test(token)) return true;
+  return /^[A-Za-z]{2,3}$/.test(token);
+}
+
+function isReferenceToken(raw: string): boolean {
+  // A structured account number — digit groups joined by dashes or slashes —
+  // is the counterparty's identity, not a per-transaction reference. It is the
+  // only thing telling two transfers apart, so it must survive.
+  if (isStructuredNumber(raw)) return false;
+
+  const token = raw.toUpperCase().replace(/[^A-Z0-9@]/g, "");
+  if (token.length < 6) return false;
+  const digits = (token.match(/\d/g) ?? []).length;
+  const letters = (token.match(/[A-Z]/g) ?? []).length;
+  if (digits === 0) return false;
+  if (letters === 0) return token.length >= 7;
+  return digits / token.length >= 0.3;
+}
+
+/** `PTY LTD`, `LLC`, `GmbH`, `PTY. LTD.` — trailing company suffixes. */
+const legalSuffix: Reducer = {
+  id: "legal-suffix",
+  label: "Company suffix",
+  contextual: true,
+  apply: (text) => {
+    const tokens = text.split(/\s+/);
+    const removed: string[] = [];
+    while (tokens.length > 1) {
+      const bare = tokens[tokens.length - 1].toUpperCase().replace(/[^A-Z]/g, "");
+      if (!LEGAL_SUFFIXES.has(bare)) break;
+      removed.unshift(tokens.pop() as string);
+    }
+    if (removed.length === 0) return null;
+    const next = tokens.join(" ").trim();
+    if (next.length < MIN_STEM_LENGTH) return null;
+    return { text: next, removed: removed.join(" ") };
+  },
+};
+
+/** A trailing store or terminal number: `COLES 0559` → `COLES`. */
+const terminalSuffix: Reducer = {
+  id: "terminal-suffix",
+  label: "Store or terminal number",
+  apply: (text) => {
+    const tokens = text.split(/\s+/);
+    const last = tokens[tokens.length - 1];
+    if (tokens.length < 2) return null;
+
+    // `030-176408-001` is one identifier, not a name followed by a number.
+    // Peeling `001` off the end of it silently destroys the counterparty.
+    if (isStructuredNumber(last)) return null;
+
+    const bare = /^(\d{2,6})$/.exec(last);
+    const attached = /^(.*[A-Za-z].*?)[#-](\d{2,6})$/.exec(last);
+    if (!bare && !attached) return null;
+
+    const head = bare
+      ? tokens.slice(0, -1).join(" ")
+      : [...tokens.slice(0, -1), attached![1]].join(" ");
+    if (!/[A-Za-z]/.test(head)) return null;
+
+    const next = head.trim();
+    if (next.length < MIN_STEM_LENGTH) return null;
+    return { text: next, removed: bare ? bare[1] : attached![2] };
+  },
+};
+
+/** Digit groups joined by dashes or slashes: an account or contract number. */
+function isStructuredNumber(token: string): boolean {
+  return /^\d{2,}([-/]\d{2,})+$/.test(token);
+}
+
+/**
+ * Order matters. The statement tail goes first because it removes the largest
+ * span, and running a prefix reducer ahead of it can shorten the head below the
+ * length this one requires.
+ */
+const SHAPE_REDUCERS: Reducer[] = [
+  statementTail,
+  processorPrefix,
+  // Card numbers before generic labelled metadata: `CARD NO: ***132` is one
+  // phrase, and letting the generic rule take `NO: ***132` first strands `CARD`.
+  cardNumber,
+  labelledMetadata,
+  fxFragment,
+  // After the FX fragment, which is the richer form of the same thing.
+  currencyAmount,
+  dateFragment,
+  timeFragment,
+  networkScaffold,
+  machinePrefix,
+  domainFragment,
+  referenceToken,
+  legalSuffix,
+  terminalSuffix,
+];
+
+/** Enough passes for the deepest stacking seen in real statements. */
+const MAX_PASSES = 8;
+
+export function normalizeToken(token: string): string {
+  return token.toUpperCase().replace(/[^\p{L}\p{N}]/gu, "");
+}
+
+/**
+ * Turns a corpus-learned affix into a reducer.
+ *
+ * Always contextual. The corpus can show that a fragment repeats; it cannot show
+ * that removing it is safe. A channel wrapper and a meaningful word like
+ * `TRANSFER` are structurally indistinguishable — both lead many payees — so
+ * these clusters are proposed for review with the evidence attached rather than
+ * treated as certain.
+ */
+function affixReducer(affix: CorpusAffix): Reducer {
+  const phrase = affix.tokens.join(" ");
+  return {
+    id: affix.kind === "prefix" ? "corpus-prefix" : "corpus-suffix",
+    label:
+      affix.kind === "prefix"
+        ? `Shared opening text ("${phrase}", on ${affix.payeeCount} payees)`
+        : `Shared trailing text ("${phrase}", on ${affix.payeeCount} payees)`,
+    contextual: true,
+    apply: (text) => {
+      const tokens = text.split(/\s+/).filter(Boolean);
+
+      // Affixes are learned from normalized text, so match through the same
+      // view: tokens that normalize to nothing (a lone `-`, say) are invisible
+      // for comparison but must still be consumed, or `NFC - (AP-PAY)-` would
+      // never line up with the learned `NFC APPAY`.
+      const meaningful = tokens
+        .map((raw, index) => ({ index, norm: normalizeToken(raw) }))
+        .filter((t) => t.norm.length > 0);
+      if (meaningful.length <= affix.tokens.length) return null;
+
+      const slice =
+        affix.kind === "prefix"
+          ? meaningful.slice(0, affix.tokens.length)
+          : meaningful.slice(-affix.tokens.length);
+      if (!slice.every((t, i) => t.norm === affix.tokens[i])) return null;
+
+      const kept =
+        affix.kind === "prefix"
+          ? tokens.slice(slice[slice.length - 1].index + 1)
+          : tokens.slice(0, slice[0].index);
+      const removed =
+        affix.kind === "prefix"
+          ? tokens.slice(0, slice[slice.length - 1].index + 1)
+          : tokens.slice(slice[0].index);
+
+      const next = kept.join(" ").trim();
+      if (next.length < MIN_STEM_LENGTH) return null;
+      return { text: next, removed: removed.join(" ") };
+    },
+  };
+}
+
+export function reduceFully(
+  rawName: string,
+  affixes: CorpusAffix[] = []
+): ReductionResult {
+  let text = rawName.trim().replace(/\s+/g, " ");
+  const steps: ReductionStep[] = [];
+  let structuralText: string | null = null;
+
+  const reducers = [...SHAPE_REDUCERS, ...affixes.map(affixReducer)];
+
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    let changed = false;
+    for (const reducer of reducers) {
+      const result = reducer.apply(text);
+      if (!result || result.text === text) continue;
+      const next = result.text.trim().replace(/\s+/g, " ");
+      if (next.length < MIN_STEM_LENGTH) continue;
+
+      // Snapshot the text just before the first interpretive step, so the
+      // structural-only stem is available without a second pass.
+      if ((reducer.contextual ?? false) && structuralText === null) {
+        structuralText = text;
+      }
+      text = next;
+      steps.push({
+        id: reducer.id,
+        label: reducer.label,
+        removed: result.removed,
+        contextual: reducer.contextual ?? false,
+      });
+      changed = true;
+    }
+    if (!changed) break;
+  }
+
+  return {
+    stem: normalizeStem(text),
+    structuralStem: normalizeStem(structuralText ?? text),
+    steps,
+  };
+}
+
+/**
+ * Final comparison form: upper-cased, punctuation to spaces, collapsed. Applied
+ * only at the end, because the reducers need the punctuation to find their
+ * patterns.
+ */
+function normalizeStem(text: string): string {
+  return text
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "")
+    .toUpperCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/features/payee-cleanup/lib/reduce.ts
+++ b/src/features/payee-cleanup/lib/reduce.ts
@@ -106,14 +106,21 @@ const CARD_PATTERN =
  * A three-letter ISO code is a shape, not a list of the user's currencies.
  */
 /**
- * A currency code with its amount: `AUD 14.95`, `SAR 1,234.56`, `USD 20`.
+ * A currency code with its amount: `AUD 14.95`, `SAR 1,234.56`.
  *
  * Real statements print the charged amount into the payee field, and it varies
  * per transaction — so it both survives into the payee name and stops variants
  * from converging. A three-letter code beside a number is a shape, not a list of
  * anyone's currencies.
+ *
+ * The number must *look like money* — a decimal part, or grouped thousands.
+ * Accepting a bare integer matched any three-letter word followed by a store
+ * number, so `KFC 1234 SYDNEY` reduced to `SYDNEY`: a real merchant deleted on
+ * the strength of its name being three letters long. Losing `USD 20` to that
+ * guard is the cheaper mistake.
  */
-const CURRENCY_AMOUNT_PATTERN = /\b[A-Z]{3}\s*[\d,]+(\.\d{1,2})?\b/;
+const CURRENCY_AMOUNT_PATTERN =
+  /\b[A-Z]{3}\s*(?:\d{1,3}(?:,\d{3})+(?:\.\d{1,2})?|\d+\.\d{1,2})\b/;
 
 const FX_PATTERN =
   /\b([A-Z]{3}\/[A-Z]{3}\s*\.?[\d.]+|FX\s+[A-Z]{3}\s+[\d,.]+\s+AT\s+[\d.]+)\b/i;
@@ -137,9 +144,13 @@ const LABELLED_PATTERN =
 /**
  * Card networks and terminal identifiers appearing as standalone scaffolding.
  * Card-industry terms, not one bank's wording.
+ *
+ * A terminal code must carry a digit. `ATM[A-Z0-9]{2,6}` alone deleted `ATMOS`,
+ * and the `POS` form deleted `POSTAL` — ordinary words that happen to start with
+ * a terminal prefix. A generated terminal id never lacks a number.
  */
 const NETWORK_TOKEN =
-  /^(VISA|MASTERCARD|MAESTRO|AMEX|DISCOVER|EFTPOS|CIRRUS|ATM[A-Z0-9]{2,6}|POS[A-Z0-9]{2,6})$/i;
+  /^(VISA|MASTERCARD|MAESTRO|AMEX|DISCOVER|EFTPOS|CIRRUS|(?:ATM|POS)(?=[A-Z0-9]{2,6}$)[A-Z0-9]*\d[A-Z0-9]*)$/i;
 
 // ─── Reducers ────────────────────────────────────────────────────────────────
 

--- a/src/features/payee-cleanup/lib/ruleCandidates.test.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.test.ts
@@ -1,0 +1,446 @@
+import {
+  analyzeFutureResolution,
+  buildCandidates,
+  candidateStems,
+  buildNormalizationRule,
+  classifyRelatedRules,
+  exactNameCoverage,
+  rankCandidates,
+  scoreCandidate,
+  type ImportedTextRow,
+} from "./ruleCandidates";
+import type { Rule } from "@/types/entities";
+import type { PayeeCleanupCandidate } from "../types";
+
+function payee(id: string, name = id): PayeeCleanupCandidate {
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+    },
+  };
+}
+
+function row(
+  text: string,
+  payeeId: string | null,
+  transactionCount = 1,
+  field: ImportedTextRow["field"] = "imported_payee",
+  payeeName: string | null = null
+): ImportedTextRow {
+  return { field, text, payeeId, payeeName, transactionCount };
+}
+
+describe("buildCandidates", () => {
+  it("anchors every pattern on the reduced stem", () => {
+    // A pattern built from a raw name would match exactly one transaction.
+    const candidates = buildCandidates("WOOLWORTHS", "imported_payee");
+    expect(candidates.map((c) => c.value)).toEqual([
+      "^WOOLWORTHS\\b",
+      "\\bWOOLWORTHS\\b",
+      "WOOLWORTHS",
+    ]);
+  });
+
+  it("tolerates the punctuation the stem normalized away", () => {
+    // The stem is `TEMU COM`; the text it must match is `TEMU.COM`. A literal
+    // space here means every merchant with a dot, slash or ampersand in its
+    // name silently gets no rule at all.
+    const [anchored] = buildCandidates("TEMU COM PARRAMATTA", "imported_payee");
+    expect(new RegExp(anchored.value, "i").test("TEMU.COM PARRAMATTA NS AUS")).toBe(
+      true
+    );
+  });
+
+  it("escapes regex metacharacters in a merchant name", () => {
+    const [first] = buildCandidates("M.O.F", "imported_payee");
+    expect(first.value).toBe("^M\\.O\\.F\\b");
+    expect(() => new RegExp(first.value)).not.toThrow();
+  });
+
+  it("refuses a stem too short to be discriminating", () => {
+    expect(buildCandidates("AB", "imported_payee")).toEqual([]);
+  });
+});
+
+describe("scoreCandidate", () => {
+  const rows = [
+    row("WOOLWORTHS 0183", "p1", 47),
+    row("WOOLWORTHS 0291", "p2", 23),
+    row("WOOLWORTHS MOBILE 12", "other", 9),
+    row("TESCO 4821", "other2", 5),
+  ];
+  const cluster = new Set(["p1", "p2"]);
+
+  it("counts this payee's transactions as expected", () => {
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    const score = scoreCandidate(anchored, rows, cluster);
+
+    expect(score.expectedMatches).toBe(70);
+  });
+
+  it("counts other payees' transactions as unexpected, with examples", () => {
+    // `WOOLWORTHS MOBILE` is a different business; a rule that swallows it is
+    // worse than no rule.
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    const score = scoreCandidate(anchored, rows, cluster);
+
+    expect(score.unexpectedMatches).toBe(9);
+    expect(score.unexpectedExamples[0].text).toBe("WOOLWORTHS MOBILE 12");
+  });
+
+  it("ignores rows from the other source field", () => {
+    const notesRows = [row("WOOLWORTHS 0183", "p1", 47, "notes")];
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    expect(scoreCandidate(anchored, notesRows, cluster).expectedMatches).toBe(0);
+  });
+
+  it("scores a pattern that cannot compile as matching nothing", () => {
+    const broken = {
+      field: "imported_payee" as const,
+      op: "matches" as const,
+      value: "([",
+      description: "broken",
+    };
+    expect(scoreCandidate(broken, rows, cluster).expectedMatches).toBe(0);
+  });
+
+  it("attributes a row by payee NAME when the id does not line up", () => {
+    // A grouped query can return either shape. Mis-attributing a payee's own
+    // transactions as someone else's makes a perfectly safe rule look
+    // dangerous — which is exactly how it looked in testing.
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    const named = [row("WOOLWORTHS 0183", null, 47, "imported_payee", "WOOLWORTHS 0183")];
+    const score = scoreCandidate(
+      anchored,
+      named,
+      new Set(["p1"]),
+      new Set(["WOOLWORTHS 0183"])
+    );
+
+    expect(score.expectedMatches).toBe(47);
+    expect(score.unexpectedMatches).toBe(0);
+  });
+
+  it("ignores a row that belongs to no payee at all", () => {
+    // Counting it against the rule reports a conflict with a payee that does
+    // not exist.
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    const orphaned = [row("WOOLWORTHS 9999", null, 12)];
+    expect(scoreCandidate(anchored, orphaned, cluster).unexpectedMatches).toBe(0);
+  });
+
+  it("names the payee an unexpected match belongs to", () => {
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    const rival = [row("WOOLWORTHS MOBILE", "other", 9, "imported_payee", "Woolworths Mobile")];
+    const score = scoreCandidate(anchored, rival, cluster);
+
+    expect(score.unexpectedExamples[0].payeeName).toBe("Woolworths Mobile");
+  });
+
+  it("matches case-insensitively, because import text is not upper-cased", () => {
+    const [anchored] = buildCandidates("WOOLWORTHS", "imported_payee");
+    const mixed = [row("Woolworths 0183", "p1", 5)];
+    expect(scoreCandidate(anchored, mixed, cluster).expectedMatches).toBe(5);
+  });
+});
+
+describe("rankCandidates", () => {
+  const base = {
+    candidate: { field: "imported_payee" as const, op: "contains" as const, value: "X", description: "" },
+    unexpectedExamples: [],
+    matchedTexts: 1,
+  };
+
+  it("puts safety first, whatever else a pattern does well", () => {
+    // A rule that steals another payee's transactions loses to one that catches
+    // less but catches only this payee.
+    const ranked = rankCandidates([
+      { ...base, expectedMatches: 500, unexpectedMatches: 3 },
+      { ...base, expectedMatches: 20, unexpectedMatches: 0 },
+    ]);
+    expect(ranked[0].expectedMatches).toBe(20);
+  });
+
+  it("prefers the pattern that catches more, among safe ones", () => {
+    const ranked = rankCandidates([
+      { ...base, expectedMatches: 20, unexpectedMatches: 0 },
+      { ...base, expectedMatches: 80, unexpectedMatches: 0 },
+    ]);
+    expect(ranked[0].expectedMatches).toBe(80);
+  });
+
+  it("prefers the narrowest pattern when the rest ties", () => {
+    const anchored = {
+      ...base,
+      candidate: { field: "imported_payee" as const, op: "matches" as const, value: "^X\\b", description: "" },
+      expectedMatches: 20,
+      unexpectedMatches: 0,
+    };
+    const broad = { ...base, expectedMatches: 20, unexpectedMatches: 0 };
+    expect(rankCandidates([broad, anchored])[0]).toBe(anchored);
+  });
+});
+
+describe("candidateStems", () => {
+  it("offers the final name as well as the reduced stem", () => {
+    // A cluster reduced to `HUNGRY JACKS MELBOURNE` whose final name is
+    // `Hungry Jacks` must be able to propose a rule catching `HUNGRY JACKS` —
+    // the narrower stem would miss every import from a different suburb.
+    expect(candidateStems("HUNGRY JACKS MELBOURNE", "Hungry Jacks")).toEqual([
+      "HUNGRY JACKS MELBOURNE",
+      "HUNGRY JACKS",
+    ]);
+  });
+
+  it("does not repeat itself when they agree", () => {
+    expect(candidateStems("WOOLWORTHS", "Woolworths")).toEqual(["WOOLWORTHS"]);
+  });
+
+  it("drops a stem too short to discriminate", () => {
+    expect(candidateStems("A", "Ab")).toEqual([]);
+  });
+});
+
+describe("exactNameCoverage", () => {
+  it("counts imports the surviving name already resolves", () => {
+    const rows = [row("Woolworths", "p1", 30), row("WOOLWORTHS 0183", "p2", 5)];
+    expect(exactNameCoverage("Woolworths", rows)).toEqual({
+      covered: 1,
+      transactionCount: 30,
+    });
+  });
+
+  it("ignores the notes field, which Actual does not match names against", () => {
+    const rows = [row("Woolworths", "p1", 30, "notes")];
+    expect(exactNameCoverage("Woolworths", rows).covered).toBe(0);
+  });
+});
+
+describe("classifyRelatedRules", () => {
+  function rule(id: string, parts: Partial<Rule>): Rule {
+    return {
+      id,
+      stage: "default",
+      conditionsOp: "and",
+      conditions: [],
+      actions: [],
+      ...parts,
+    };
+  }
+
+  it("recognises a rule that already resolves this payee text", () => {
+    const existing = rule("r1", {
+      conditions: [{ field: "imported_payee", op: "contains", value: "WOOLWORTHS" }],
+      actions: [{ field: "payee", op: "set", value: "p1" }],
+    });
+    const [related] = classifyRelatedRules([existing], new Set(["p1"]), "WOOLWORTHS");
+
+    expect(related.kind).toBe("payee-resolution");
+    expect(related.interaction).toBe("already-resolves");
+  });
+
+  it("treats a category rule referencing the payee as compatible", () => {
+    // It is unaffected by the merge and does not compete with a new rule.
+    const existing = rule("r2", {
+      conditions: [{ field: "payee", op: "is", value: "p1" }],
+      actions: [{ field: "category", op: "set", value: "c1" }],
+    });
+    const [related] = classifyRelatedRules([existing], new Set(["p1"]), "WOOLWORTHS");
+
+    expect(related.kind).toBe("category-or-other-action");
+    expect(related.interaction).toBe("compatible");
+  });
+
+  it("ignores rules with nothing to do with this cluster", () => {
+    const unrelated = rule("r3", {
+      conditions: [{ field: "imported_payee", op: "contains", value: "TESCO" }],
+      actions: [{ field: "payee", op: "set", value: "other" }],
+    });
+    expect(classifyRelatedRules([unrelated], new Set(["p1"]), "WOOLWORTHS")).toEqual([]);
+  });
+});
+
+describe("analyzeFutureResolution", () => {
+  const members = [payee("p1", "WOOLWORTHS 0183"), payee("p2", "WOOLWORTHS 0291")];
+
+  it("recommends a safe rule and marks it selectable", () => {
+    const result = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [row("WOOLWORTHS 0183", "p1", 47), row("WOOLWORTHS 0291", "p2", 23)],
+      rules: [],
+    });
+
+    expect(result.recommended?.expectedMatches).toBe(70);
+    expect(result.recommended?.unexpectedMatches).toBe(0);
+    expect(result.safeToPreselect).toBe(true);
+    expect(result.skipReason).toBeNull();
+  });
+
+  it("does not preselect a rule that would catch other payees", () => {
+    // RD-078 §17: a rule with unexplained unexpected matches must not be
+    // preselected.
+    const result = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [
+        row("WOOLWORTHS 0183", "p1", 5),
+        row("WOOLWORTHS MOBILE", "other", 40),
+      ],
+      rules: [],
+    });
+
+    expect(result.safeToPreselect).toBe(false);
+  });
+
+  it("skips the rule when every past import already matches the surviving name", () => {
+    const result = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [row("Woolworths", "p1", 100)],
+      rules: [],
+    });
+
+    expect(result.skipReason).toBe("already-resolved-by-name");
+    expect(result.recommended).toBeNull();
+  });
+
+  it("still proposes a rule for the variants exact-name matching would miss", () => {
+    // Most of the history matching by name is not a reason to skip — what
+    // matters is whether anything is left over that would create a new payee
+    // again on the next import.
+    const result = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [row("Woolworths", "p1", 100), row("WOOLWORTHS 0183", "p2", 2)],
+      rules: [],
+    });
+
+    expect(result.skipReason).toBeNull();
+    expect(result.recommended).not.toBeNull();
+  });
+
+  it("skips the rule when an existing rule already does the job", () => {
+    const result = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [row("WOOLWORTHS 0183", "p1", 47)],
+      rules: [
+        {
+          id: "r1",
+          stage: "default",
+          conditionsOp: "and",
+          conditions: [{ field: "imported_payee", op: "contains", value: "WOOLWORTHS" }],
+          actions: [{ field: "payee", op: "set", value: "p1" }],
+        },
+      ],
+    });
+
+    expect(result.skipReason).toBe("existing-rule-covers-it");
+    expect(result.recommended).toBeNull();
+  });
+
+  it("prefers a broader pattern from the final name when it is still safe", () => {
+    // The user renamed the cluster to `Hungry Jacks`; the rule should catch
+    // that, not just the suburb the reduction happened to leave behind.
+    const result = analyzeFutureResolution({
+      stem: "HUNGRY JACKS MELBOURNE",
+      finalName: "Hungry Jacks",
+      members: [payee("p1", "Hungry Jacks Melbourne"), payee("p2", "Hungry Jacks Sydney")],
+      rows: [
+        row("HUNGRY JACKS MELBOURNE 12", "p1", 4),
+        row("HUNGRY JACKS SYDNEY 88", "p2", 6),
+      ],
+      rules: [],
+    });
+
+    expect(result.recommended?.candidate.value).toBe("^HUNGRY[^A-Za-z0-9]*JACKS\\b");
+    expect(result.recommended?.expectedMatches).toBe(10);
+  });
+
+  it("uses the pattern the user typed instead of the generated ones", () => {
+    const result = analyzeFutureResolution({
+      stem: "HUNGRY JACKS MELBOURNE",
+      finalName: "Hungry Jacks",
+      members: [payee("p1", "Hungry Jacks Melbourne")],
+      rows: [row("HUNGRY JACKS MELBOURNE 12", "p1", 4)],
+      rules: [],
+      override: { field: "imported_payee", text: "HUNGRY JACKS" },
+    });
+
+    expect(result.matchText).toBe("HUNGRY JACKS");
+    expect(result.recommended?.candidate.value).toBe("^HUNGRY[^A-Za-z0-9]*JACKS\\b");
+  });
+
+  it("distinguishes 'nothing matched' from 'everything caught others'", () => {
+    // Telling a user "no pattern catches this without catching others" when in
+    // truth nothing matched at all sends them hunting for a conflict that does
+    // not exist.
+    const nothing = analyzeFutureResolution({
+      stem: "ZZZ WIDGETS",
+      finalName: "Zzz Widgets",
+      members,
+      rows: [row("SOMETHING ELSE", "other", 3)],
+      rules: [],
+    });
+    expect(nothing.skipReason).toBe("no-matching-pattern");
+
+    const unsafe = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [row("WOOLWORTHS 0183", "p1", 1), row("WOOLWORTHS MOBILE", "other", 40)],
+      rules: [],
+    });
+    expect(unsafe.recommended).not.toBeNull();
+    expect(unsafe.safeToPreselect).toBe(false);
+  });
+
+  it("considers the notes field as well as the imported payee", () => {
+    // Where a bank puts the merchant in the memo, a rule that can only read
+    // imported_payee has nothing to match on.
+    const result = analyzeFutureResolution({
+      stem: "WOOLWORTHS",
+      finalName: "Woolworths",
+      members,
+      rows: [row("WOOLWORTHS 0183", "p1", 47, "notes")],
+      rules: [],
+    });
+
+    expect(result.recommended?.candidate.field).toBe("notes");
+  });
+});
+
+describe("buildNormalizationRule", () => {
+  it("builds a rule using native primitives, targeting the surviving payee", () => {
+    const rule = buildNormalizationRule(
+      {
+        field: "imported_payee",
+        op: "matches",
+        value: "^WOOLWORTHS\\b",
+        description: "",
+      },
+      "target-1",
+      "rule-1"
+    );
+
+    expect(rule.conditions).toEqual([
+      { field: "imported_payee", op: "matches", value: "^WOOLWORTHS\\b", type: "string" },
+    ]);
+    expect(rule.actions).toEqual([
+      { field: "payee", op: "set", value: "target-1", type: "id" },
+    ]);
+    expect(rule.stage).toBe("default");
+  });
+});

--- a/src/features/payee-cleanup/lib/ruleCandidates.test.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.test.ts
@@ -5,6 +5,7 @@ import {
   buildNormalizationRule,
   classifyRelatedRules,
   exactNameCoverage,
+  normalizePatternText,
   rankCandidates,
   scoreCandidate,
   type ImportedTextRow,
@@ -257,6 +258,25 @@ describe("classifyRelatedRules", () => {
     expect(related.interaction).toBe("compatible");
   });
 
+  it("recognises a oneOf rule that already resolves this payee text", () => {
+    // An `imported_payee oneOf [...]` rule carries an array. Reading only string
+    // values classified it as a conflict and proposed a second rule for a
+    // merchant already handled — the rule sprawl this ordering exists to stop.
+    const existing = rule("r4", {
+      conditions: [
+        {
+          field: "imported_payee",
+          op: "oneOf",
+          value: ["WOOLWORTHS 0183", "WOOLWORTHS 0291"],
+        },
+      ],
+      actions: [{ field: "payee", op: "set", value: "p1" }],
+    });
+    const [related] = classifyRelatedRules([existing], new Set(["p1"]), "WOOLWORTHS");
+
+    expect(related.interaction).toBe("already-resolves");
+  });
+
   it("ignores rules with nothing to do with this cluster", () => {
     const unrelated = rule("r3", {
       conditions: [{ field: "imported_payee", op: "contains", value: "TESCO" }],
@@ -419,6 +439,17 @@ describe("analyzeFutureResolution", () => {
     });
 
     expect(result.recommended?.candidate.field).toBe("notes");
+  });
+});
+
+describe("pattern text normalization", () => {
+  it("collapses repeated whitespace in text the user typed", () => {
+    // Splitting raw text on a single space produced an empty segment, so the
+    // pattern gained two adjacent `[^A-Za-z0-9]*` quantifiers — ambiguous, and
+    // quadratic to backtrack over a long run of separators.
+    expect(normalizePatternText("HUNGRY  JACKS")).toBe("HUNGRY JACKS");
+    expect(buildCandidates(normalizePatternText("HUNGRY  JACKS"), "imported_payee")[0]
+      .value).toBe("^HUNGRY[^A-Za-z0-9]*JACKS\\b");
   });
 });
 

--- a/src/features/payee-cleanup/lib/ruleCandidates.test.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.test.ts
@@ -292,6 +292,18 @@ describe("classifyRelatedRules", () => {
     expect(related.interaction).toBe("potential-conflict");
   });
 
+  it("does not treat a two-character condition value as an overlap", () => {
+    // `CO` is a substring of a great many stems. Reading that as "this rule
+    // already covers the merchant" suppressed the rule cleanup needed.
+    const existing = rule("r6", {
+      conditions: [{ field: "imported_payee", op: "contains", value: "CO" }],
+      actions: [{ field: "payee", op: "set", value: "p1" }],
+    });
+    const related = classifyRelatedRules([existing], new Set(["p1"]), "WOOLWORTHS");
+
+    expect(related.every((r) => r.interaction !== "already-resolves")).toBe(true);
+  });
+
   it("ignores rules with nothing to do with this cluster", () => {
     const unrelated = rule("r3", {
       conditions: [{ field: "imported_payee", op: "contains", value: "TESCO" }],

--- a/src/features/payee-cleanup/lib/ruleCandidates.test.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.test.ts
@@ -277,6 +277,21 @@ describe("classifyRelatedRules", () => {
     expect(related.interaction).toBe("already-resolves");
   });
 
+  it("treats a matching rule that assigns a different payee as a conflict", () => {
+    // Text that overlaps this merchant but resolves to someone else does not
+    // cover it. Calling that "already resolves" set skipReason to
+    // existing-rule-covers-it and dropped the rule cleanup actually needed.
+    const existing = rule("r5", {
+      conditions: [
+        { field: "imported_payee", op: "oneOf", value: ["WOOLWORTHS 0183"] },
+      ],
+      actions: [{ field: "payee", op: "set", value: "someone-else" }],
+    });
+    const [related] = classifyRelatedRules([existing], new Set(["p1"]), "WOOLWORTHS");
+
+    expect(related.interaction).toBe("potential-conflict");
+  });
+
   it("ignores rules with nothing to do with this cluster", () => {
     const unrelated = rule("r3", {
       conditions: [{ field: "imported_payee", op: "contains", value: "TESCO" }],

--- a/src/features/payee-cleanup/lib/ruleCandidates.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.ts
@@ -386,7 +386,15 @@ export function analyzeFutureResolution(input: {
   // *residual*. A merchant whose every past import already equals the surviving
   // name needs no rule; one that also arrives as `WOOLWORTHS 0183` does, however
   // much of its history matched by name.
-  const residual = best ? best.expectedMatches - exactName.transactionCount : 0;
+  //
+  // Only an `imported_payee` candidate can be netted off this way:
+  // `exactNameCoverage` counts `imported_payee` rows, and subtracting those from
+  // a `notes` candidate's matches drove the residual to zero and declared the
+  // merchant "already resolved by name" for text name matching never sees.
+  const residual =
+    best && best.candidate.field === "imported_payee"
+      ? best.expectedMatches - exactName.transactionCount
+      : (best?.expectedMatches ?? 0);
 
   let skipReason: FutureResolution["skipReason"] = null;
   if (relatedRules.some((r) => r.interaction === "already-resolves")) {

--- a/src/features/payee-cleanup/lib/ruleCandidates.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.ts
@@ -267,12 +267,18 @@ export function classifyRelatedRules(
     // proposed rule even when it names no payee in the cluster.
     const matchesStem = rule.conditions.some((c) => {
       if (c.field !== "imported_payee" && c.field !== "notes") return false;
-      return (
-        typeof c.value === "string" &&
-        stemUpper.length > 0 &&
-        (c.value.toUpperCase().includes(stemUpper) ||
-          stemUpper.includes(c.value.toUpperCase()))
-      );
+      if (stemUpper.length === 0) return false;
+      // Arrays too: an `imported_payee oneOf [...]` rule already resolves this
+      // merchant. Reading only string values classified it as a conflict and
+      // proposed a second rule for something already handled — the rule sprawl
+      // this decision order exists to prevent. `referencesCluster` above
+      // already normalizes arrays; these two agreed on nothing else.
+      const values = Array.isArray(c.value) ? c.value : [c.value];
+      return values.some((value) => {
+        if (typeof value !== "string") return false;
+        const upper = value.toUpperCase();
+        return upper.includes(stemUpper) || stemUpper.includes(upper);
+      });
     });
 
     if (!referencesCluster && !matchesStem) continue;
@@ -330,14 +336,26 @@ export type FutureResolution = {
  * offer a rule catching `HUNGRY JACKS` — the narrower stem would miss every
  * future import from a different suburb.
  */
+/**
+ * The comparison form for text a pattern is built from.
+ *
+ * Shared with the override path on purpose. Passing the user's raw text through
+ * meant `HUNGRY  JACKS` split on a single space into an empty segment, so the
+ * pattern gained two adjacent `[^A-Za-z0-9]*` quantifiers — ambiguous to match,
+ * quadratic to backtrack over a long run of separators — and the double space
+ * leaked into the description and the editor.
+ */
+export function normalizePatternText(value: string): string {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function candidateStems(stem: string, finalName: string): string[] {
-  const normalize = (value: string) =>
-    value
-      .trim()
-      .toUpperCase()
-      .replace(/[^\p{L}\p{N}]+/gu, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+  const normalize = normalizePatternText;
 
   return [...new Set([normalize(stem), normalize(finalName)])].filter(
     (value) => value.length >= 3
@@ -361,7 +379,7 @@ export function analyzeFutureResolution(input: {
   const relatedRules = classifyRelatedRules(input.rules, clusterPayeeIds, input.stem);
 
   const stems = input.override
-    ? [input.override.text]
+    ? [normalizePatternText(input.override.text)].filter(Boolean)
     : candidateStems(input.stem, input.finalName);
   const fields: SourceField[] = input.override
     ? [input.override.field]

--- a/src/features/payee-cleanup/lib/ruleCandidates.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.ts
@@ -1,0 +1,437 @@
+/**
+ * Generating and scoring the rule that best catches a payee (RD-078 §15–§17).
+ *
+ * The decision order matters more than the pattern:
+ *
+ *   1. will the surviving payee's own name already resolve this? Actual matches
+ *      an imported name to an existing payee by exact name, so cleanup alone
+ *      often fixes future imports and no rule is needed;
+ *   2. does an existing rule already resolve it?
+ *   3. only then, is a new narrow rule worth adding?
+ *
+ * Skipping that order is how a budget ends up with a rule per merchant variant,
+ * which is the mess this feature exists to clean up.
+ *
+ * **Verified against the rule engine** (`@actual-app/core/src/shared/rules.ts`,
+ * `transaction-rules.ts`) rather than assumed, as 041a required:
+ * `imported_payee` and `notes` are both `string` fields; `matches` compiles to
+ * `$regexp` and `contains` to `$like`; `notes` disallows `oneOf`/`notOneOf`.
+ */
+
+import type { Rule } from "@/types/entities";
+import type { PayeeCleanupCandidate } from "../types";
+
+/** The two fields a bank's raw merchant text can land in. */
+export type SourceField = "imported_payee" | "notes";
+
+/**
+ * One row of the historical index: a distinct piece of raw text, the payee it
+ * currently resolves to, and how often it occurs.
+ *
+ * Grouped rather than per-transaction — a budget can hold tens of thousands of
+ * transactions but only hundreds of distinct import strings, and the distinct
+ * strings are what a pattern is tested against.
+ */
+export type ImportedTextRow = {
+  field: SourceField;
+  text: string;
+  payeeId: string | null;
+  /** Carried so an unexpected match can be attributed to a payee by name. */
+  payeeName?: string | null;
+  transactionCount: number;
+};
+
+export type RuleCandidate = {
+  field: SourceField;
+  op: "contains" | "matches";
+  value: string;
+  /** Shown to the user as the rule they are about to create. */
+  description: string;
+};
+
+export type CandidateScore = {
+  candidate: RuleCandidate;
+  /** Transactions already belonging to this cluster that the pattern catches. */
+  expectedMatches: number;
+  /** Transactions belonging to *other* payees that it would also catch. */
+  unexpectedMatches: number;
+  /** A sample of the unexpected ones, so the user can judge them. */
+  unexpectedExamples: { text: string; payeeName: string | null }[];
+  /** Distinct import strings matched, for the "will this catch new variants" question. */
+  matchedTexts: number;
+};
+
+const UNEXPECTED_SAMPLE = 5;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds the candidate patterns for a cluster, narrowest first.
+ *
+ * All three are anchored on the *reduced stem* — the merchant text with the
+ * noise already removed — because that is the part that stays constant across
+ * variants. A pattern built from a raw name would match one transaction.
+ */
+export function buildCandidates(stem: string, field: SourceField): RuleCandidate[] {
+  const trimmed = stem.trim();
+  if (trimmed.length < 3) return [];
+
+  // The stem has had its punctuation normalized to spaces, but the text a rule
+  // runs against has not. `TEMU COM PARRAMATTA` must still match
+  // `TEMU.COM PARRAMATTA`, so word gaps become "any run of non-alphanumerics"
+  // rather than a literal space — otherwise every merchant with a dot, slash or
+  // ampersand in its name silently gets no rule at all.
+  const flexible = trimmed
+    .split(" ")
+    .map(escapeRegex)
+    .join("[^A-Za-z0-9]*");
+
+  return [
+    {
+      field,
+      op: "matches",
+      value: `^${flexible}\\b`,
+      description: `starts with "${trimmed}"`,
+    },
+    {
+      field,
+      op: "matches",
+      value: `\\b${flexible}\\b`,
+      description: `contains the whole words "${trimmed}"`,
+    },
+    {
+      field,
+      op: "contains",
+      value: trimmed,
+      description: `contains "${trimmed}"`,
+    },
+  ];
+}
+
+function matchesText(candidate: RuleCandidate, text: string): boolean {
+  if (candidate.op === "contains") {
+    return text.toUpperCase().includes(candidate.value.toUpperCase());
+  }
+  try {
+    // Actual compiles `matches` to `$regexp`; case-insensitive here because the
+    // stem is upper-cased and real import text is not.
+    return new RegExp(candidate.value, "i").test(text);
+  } catch {
+    // A pattern that will not compile can never be offered.
+    return false;
+  }
+}
+
+/**
+ * Scores one candidate against the budget's own history.
+ *
+ * "Expected" is a transaction that already belongs to this cluster — the rule
+ * would have done the right thing. "Unexpected" is one belonging to some other
+ * payee, which is the number that decides whether the rule is safe.
+ */
+export function scoreCandidate(
+  candidate: RuleCandidate,
+  rows: ImportedTextRow[],
+  clusterPayeeIds: Set<string>,
+  clusterPayeeNames: Set<string> = new Set()
+): CandidateScore {
+  let expectedMatches = 0;
+  let unexpectedMatches = 0;
+  let matchedTexts = 0;
+  const unexpectedExamples: CandidateScore["unexpectedExamples"] = [];
+
+  for (const row of rows) {
+    if (row.field !== candidate.field) continue;
+    if (!matchesText(candidate, row.text)) continue;
+
+    matchedTexts += 1;
+
+    // Attribution accepts the id *or* the name. The two are checked because a
+    // grouped query can return either depending on how the field serializes,
+    // and mis-attributing a payee's own transactions as belonging to someone
+    // else makes a perfectly safe rule look dangerous.
+    const belongsToCluster =
+      (row.payeeId !== null && clusterPayeeIds.has(row.payeeId)) ||
+      (row.payeeName != null && clusterPayeeNames.has(row.payeeName.toUpperCase()));
+
+    if (belongsToCluster) {
+      expectedMatches += row.transactionCount;
+      continue;
+    }
+
+    // A row with no payee belongs to nobody. Counting it against the rule would
+    // report a conflict with a payee that does not exist.
+    if (row.payeeId === null && !row.payeeName) continue;
+
+    unexpectedMatches += row.transactionCount;
+    if (unexpectedExamples.length < UNEXPECTED_SAMPLE) {
+      unexpectedExamples.push({ text: row.text, payeeName: row.payeeName ?? null });
+    }
+  }
+
+  return {
+    candidate,
+    expectedMatches,
+    unexpectedMatches,
+    unexpectedExamples,
+    matchedTexts,
+  };
+}
+
+/**
+ * Picks the pattern that best catches this payee.
+ *
+ * Ordering, in priority:
+ *
+ * 1. **no unexpected matches** — a rule that steals another payee's
+ *    transactions is worse than no rule at all, whatever else it does well;
+ * 2. **most expected matches** — among safe patterns, the one that catches the
+ *    most of this merchant's history will catch the most of its future;
+ * 3. **narrowest** — `matches ^stem\b` before a bare `contains`, so the rule
+ *    stays specific as the budget grows.
+ */
+export function rankCandidates(scores: CandidateScore[]): CandidateScore[] {
+  const narrowness = (c: RuleCandidate) =>
+    c.op === "matches" && c.value.startsWith("^") ? 0 : c.op === "matches" ? 1 : 2;
+
+  return [...scores].sort((a, b) => {
+    const aSafe = a.unexpectedMatches === 0 ? 0 : 1;
+    const bSafe = b.unexpectedMatches === 0 ? 0 : 1;
+    if (aSafe !== bSafe) return aSafe - bSafe;
+    if (b.expectedMatches !== a.expectedMatches) {
+      return b.expectedMatches - a.expectedMatches;
+    }
+    return narrowness(a.candidate) - narrowness(b.candidate);
+  });
+}
+
+/**
+ * How many historical import strings the surviving payee's own name already
+ * resolves (RD-078 §1.3).
+ *
+ * Actual matches an imported name to an existing payee by exact name, so these
+ * need no rule at all — and proposing one for them is the rule sprawl this
+ * decision order exists to avoid.
+ */
+export function exactNameCoverage(
+  finalName: string,
+  rows: ImportedTextRow[]
+): { covered: number; transactionCount: number } {
+  const target = finalName.trim().toUpperCase();
+  if (!target) return { covered: 0, transactionCount: 0 };
+
+  let covered = 0;
+  let transactionCount = 0;
+  for (const row of rows) {
+    if (row.field !== "imported_payee") continue;
+    if (row.text.trim().toUpperCase() !== target) continue;
+    covered += 1;
+    transactionCount += row.transactionCount;
+  }
+  return { covered, transactionCount };
+}
+
+export type RelatedRule = {
+  rule: Rule;
+  /** What the rule does, not merely that it mentions the payee. */
+  kind: "payee-resolution" | "category-or-other-action" | "references-payee";
+  interaction: "compatible" | "already-resolves" | "potential-conflict";
+};
+
+/**
+ * Classifies the rules already touching this cluster (RD-078 §18).
+ *
+ * The distinction that matters: a rule that *sets* the payee already does this
+ * job — proposing another is duplication — whereas a rule that merely
+ * references the payee to set a category is unaffected and compatible.
+ */
+export function classifyRelatedRules(
+  rules: Rule[],
+  clusterPayeeIds: Set<string>,
+  stem: string
+): RelatedRule[] {
+  const stemUpper = stem.trim().toUpperCase();
+  const related: RelatedRule[] = [];
+
+  for (const rule of rules) {
+    const setsPayee = rule.actions.some((a) => a.field === "payee");
+    const referencesCluster = [...rule.conditions, ...rule.actions].some((part) => {
+      if (part.field !== "payee" && part.field !== "imported_payee") return false;
+      const values = Array.isArray(part.value) ? part.value : [part.value];
+      return values.some((v) => typeof v === "string" && clusterPayeeIds.has(v));
+    });
+
+    // A condition whose text overlaps this merchant would compete with the
+    // proposed rule even when it names no payee in the cluster.
+    const matchesStem = rule.conditions.some((c) => {
+      if (c.field !== "imported_payee" && c.field !== "notes") return false;
+      return (
+        typeof c.value === "string" &&
+        stemUpper.length > 0 &&
+        (c.value.toUpperCase().includes(stemUpper) ||
+          stemUpper.includes(c.value.toUpperCase()))
+      );
+    });
+
+    if (!referencesCluster && !matchesStem) continue;
+
+    if (setsPayee && matchesStem) {
+      related.push({
+        rule,
+        kind: "payee-resolution",
+        interaction: "already-resolves",
+      });
+    } else if (setsPayee) {
+      related.push({ rule, kind: "payee-resolution", interaction: "potential-conflict" });
+    } else if (referencesCluster) {
+      related.push({ rule, kind: "category-or-other-action", interaction: "compatible" });
+    } else {
+      related.push({ rule, kind: "references-payee", interaction: "potential-conflict" });
+    }
+  }
+
+  return related;
+}
+
+export type FutureResolution = {
+  /** Import strings the surviving name already handles, needing no rule. */
+  exactName: { covered: number; transactionCount: number };
+  relatedRules: RelatedRule[];
+  /** Ranked best-first; empty when no pattern could be built. */
+  candidates: CandidateScore[];
+  /** The one offered, or null when a rule should not be proposed at all. */
+  recommended: CandidateScore | null;
+  /** Why no rule is recommended, when that is the case. */
+  skipReason:
+    | "already-resolved-by-name"
+    | "existing-rule-covers-it"
+    | "no-safe-pattern"
+    | "no-matching-pattern"
+    | null;
+  /**
+   * False when the best candidate still catches other payees' transactions.
+   * The UI must not pre-select such a rule (RD-078 §17).
+   */
+  safeToPreselect: boolean;
+  /** The text the recommended pattern was built from, for the editor. */
+  matchText: string;
+  /** True when the backtest ran over a truncated read of the history. */
+  historyTruncated: boolean;
+};
+
+/**
+ * The texts a pattern can be built from.
+ *
+ * Both the reduced stem *and* the final name, because they often differ and the
+ * final name is the one the user chose. A cluster reduced to
+ * `HUNGRY JACKS MELBOURNE` whose final name is `Hungry Jacks` should be able to
+ * offer a rule catching `HUNGRY JACKS` — the narrower stem would miss every
+ * future import from a different suburb.
+ */
+export function candidateStems(stem: string, finalName: string): string[] {
+  const normalize = (value: string) =>
+    value
+      .trim()
+      .toUpperCase()
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+  return [...new Set([normalize(stem), normalize(finalName)])].filter(
+    (value) => value.length >= 3
+  );
+}
+
+export function analyzeFutureResolution(input: {
+  stem: string;
+  finalName: string;
+  members: PayeeCleanupCandidate[];
+  rows: ImportedTextRow[];
+  rules: Rule[];
+  /** A pattern the user typed, which replaces the generated ones. */
+  override?: { field: SourceField; text: string };
+  /** Set when the history read hit its row cap. */
+  historyTruncated?: boolean;
+}): FutureResolution {
+  const clusterPayeeIds = new Set(input.members.map((m) => m.id));
+  const clusterPayeeNames = new Set(input.members.map((m) => m.name.toUpperCase()));
+  const exactName = exactNameCoverage(input.finalName, input.rows);
+  const relatedRules = classifyRelatedRules(input.rules, clusterPayeeIds, input.stem);
+
+  const stems = input.override
+    ? [input.override.text]
+    : candidateStems(input.stem, input.finalName);
+  const fields: SourceField[] = input.override
+    ? [input.override.field]
+    : ["imported_payee", "notes"];
+
+  const scored = fields.flatMap((field) =>
+    stems.flatMap((stem) =>
+      buildCandidates(stem, field).map((candidate) =>
+        scoreCandidate(candidate, input.rows, clusterPayeeIds, clusterPayeeNames)
+      )
+    )
+  );
+  // A pattern that catches nothing is not a candidate.
+  const matching = scored.filter((s) => s.expectedMatches > 0);
+  const candidates = rankCandidates(matching);
+  const best = candidates[0] ?? null;
+
+  // Decision order (§15), in order.
+  //
+  // The question for step 2 is not "does exact-name matching cover a lot?" but
+  // "does the rule catch anything exact-name matching would miss?" — the
+  // *residual*. A merchant whose every past import already equals the surviving
+  // name needs no rule; one that also arrives as `WOOLWORTHS 0183` does, however
+  // much of its history matched by name.
+  const residual = best ? best.expectedMatches - exactName.transactionCount : 0;
+
+  let skipReason: FutureResolution["skipReason"] = null;
+  if (relatedRules.some((r) => r.interaction === "already-resolves")) {
+    skipReason = "existing-rule-covers-it";
+  } else if (!best) {
+    // Two different failures, and telling a user "no pattern catches this
+    // without catching others" when in truth nothing matched at all sends them
+    // hunting for a conflict that does not exist.
+    skipReason = scored.some((s) => s.unexpectedMatches > 0)
+      ? "no-safe-pattern"
+      : "no-matching-pattern";
+  } else if (exactName.covered > 0 && residual <= 0) {
+    skipReason = "already-resolved-by-name";
+  }
+
+  return {
+    exactName,
+    relatedRules,
+    candidates,
+    recommended: skipReason ? null : best,
+    skipReason,
+    // Never pre-select a rule whose safety rests on a partial read.
+    safeToPreselect:
+      Boolean(best) &&
+      best!.unexpectedMatches === 0 &&
+      !skipReason &&
+      !input.historyTruncated,
+    matchText: input.override?.text ?? stems[0] ?? "",
+    historyTruncated: input.historyTruncated === true,
+  };
+}
+
+/** The staged rule for the recommended candidate, targeting the surviving payee. */
+export function buildNormalizationRule(
+  candidate: RuleCandidate,
+  targetPayeeId: string,
+  id: string
+): Rule {
+  return {
+    id,
+    stage: "default",
+    conditionsOp: "and",
+    conditions: [
+      { field: candidate.field, op: candidate.op, value: candidate.value, type: "string" },
+    ],
+    actions: [{ field: "payee", op: "set", value: targetPayeeId, type: "id" }],
+  };
+}

--- a/src/features/payee-cleanup/lib/ruleCandidates.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.ts
@@ -257,6 +257,15 @@ export function classifyRelatedRules(
 
   for (const rule of rules) {
     const setsPayee = rule.actions.some((a) => a.field === "payee");
+    // ...and specifically to a payee in this cluster. A rule whose text matches
+    // this merchant but which assigns *someone else* does not resolve it;
+    // treating it as though it did set `existing-rule-covers-it` and dropped the
+    // rule the cleanup actually needed.
+    const setsClusterPayee = rule.actions.some((a) => {
+      if (a.field !== "payee") return false;
+      const values = Array.isArray(a.value) ? a.value : [a.value];
+      return values.some((v) => typeof v === "string" && clusterPayeeIds.has(v));
+    });
     const referencesCluster = [...rule.conditions, ...rule.actions].some((part) => {
       if (part.field !== "payee" && part.field !== "imported_payee") return false;
       const values = Array.isArray(part.value) ? part.value : [part.value];
@@ -283,7 +292,7 @@ export function classifyRelatedRules(
 
     if (!referencesCluster && !matchesStem) continue;
 
-    if (setsPayee && matchesStem) {
+    if (setsClusterPayee && matchesStem) {
       related.push({
         rule,
         kind: "payee-resolution",

--- a/src/features/payee-cleanup/lib/ruleCandidates.ts
+++ b/src/features/payee-cleanup/lib/ruleCandidates.ts
@@ -285,8 +285,14 @@ export function classifyRelatedRules(
       const values = Array.isArray(c.value) ? c.value : [c.value];
       return values.some((value) => {
         if (typeof value !== "string") return false;
-        const upper = value.toUpperCase();
-        return upper.includes(stemUpper) || stemUpper.includes(upper);
+        const upper = value.toUpperCase().trim();
+        if (upper.includes(stemUpper)) return true;
+        // The reverse direction needs a floor. A two-character condition value
+        // like `CO` is a substring of a great many stems, and treating that as
+        // an overlap let an unrelated rule be read as covering this merchant —
+        // which then suppressed the rule cleanup needed. Three characters, the
+        // same floor `buildCandidates` uses.
+        return upper.length >= 3 && stemUpper.includes(upper);
       });
     });
 

--- a/src/features/payee-cleanup/lib/scan.test.ts
+++ b/src/features/payee-cleanup/lib/scan.test.ts
@@ -1,0 +1,217 @@
+import { scanForCleanup } from "./scan";
+import { partitionByEligibility } from "./eligibility";
+import type { PayeeCleanupCandidate } from "../types";
+
+function payee(
+  name: string,
+  overrides: Partial<PayeeCleanupCandidate["metadata"]> = {}
+): PayeeCleanupCandidate {
+  const id = `p-${name}`;
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+      ...overrides,
+    },
+  };
+}
+
+function scan(candidates: PayeeCleanupCandidate[]) {
+  return scanForCleanup(partitionByEligibility(candidates));
+}
+
+describe("scanForCleanup", () => {
+  it("reports what was analyzed and what was excluded", () => {
+    const result = scan([
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("Transfer: Savings", { transferAccountId: "acct-1" }),
+      payee("Deleted Payee", { tombstone: true }),
+    ]);
+
+    expect(result.analyzedCount).toBe(2);
+    expect(result.excludedTransferCount).toBe(1);
+    expect(result.excludedTombstonedCount).toBe(1);
+  });
+
+  it("produces a suggestion with evidence, confidence, target and final name", () => {
+    const result = scan([
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("WOOLWORTHS 8442"),
+      payee("Woolworths"),
+    ]);
+
+    expect(result.suggestions).toHaveLength(1);
+    const suggestion = result.suggestions[0];
+
+    expect(suggestion.cluster.members).toHaveLength(4);
+    expect(suggestion.cluster.evidence.length).toBeGreaterThan(0);
+    expect(suggestion.confidence.band).toBe("high");
+    // The clean, human-readable payee should win the target score and supply
+    // the final name — no invention needed.
+    expect(
+      suggestion.cluster.members.find((m) => m.id === suggestion.target.targetId)
+        ?.name
+    ).toBe("Woolworths");
+    expect(suggestion.canonicalName).toBe("Woolworths");
+    expect(suggestion.membersToMerge).toHaveLength(3);
+  });
+
+  it("excludes the target from the members to merge", () => {
+    const result = scan([payee("AMAZON"), payee("Amazon"), payee("amazon")]);
+    const suggestion = result.suggestions[0];
+
+    expect(
+      suggestion.membersToMerge.map((m) => m.id)
+    ).not.toContain(suggestion.target.targetId);
+  });
+
+  it("prefers a favorite payee as the merge target", () => {
+    // Merge does not transfer `favorite`; the target's own value survives, so
+    // choosing the favorite is how the user keeps it.
+    const result = scan([
+      payee("AMAZON 1234"),
+      payee("AMAZON 5678"),
+      payee("AMAZON", { favorite: true }),
+    ]);
+
+    const suggestion = result.suggestions[0];
+    const target = suggestion.cluster.members.find(
+      (m) => m.id === suggestion.target.targetId
+    );
+    expect(target?.name).toBe("AMAZON");
+    expect(suggestion.target.reasons.join(" ")).toContain("favorite");
+  });
+
+  it("counts suggestions by confidence band", () => {
+    const result = scan([
+      payee("WOOLWORTHS 0183"),
+      payee("WOOLWORTHS 0291"),
+      payee("Acme Ltd"),
+      payee("Acme"),
+    ]);
+
+    expect(result.counts.high + result.counts.strong).toBeGreaterThanOrEqual(1);
+    expect(result.suggestions.length).toBe(2);
+  });
+
+  it("scores a legal-suffix-only difference below a structural match", () => {
+    const structural = scan([payee("TESCO 0001"), payee("TESCO 0002")])
+      .suggestions[0];
+    const legal = scan([payee("Acme Ltd"), payee("Acme")]).suggestions[0];
+
+    expect(legal.confidence.score).toBeLessThan(structural.confidence.score);
+    expect(legal.confidence.reasons.map((r) => r.reason).join(" ")).toContain(
+      "interpreted change"
+    );
+  });
+
+  it("orders suggestions strongest first", () => {
+    const result = scan([
+      payee("Acme Ltd"),
+      payee("Acme"),
+      payee("TESCO 0001"),
+      payee("TESCO 0002"),
+    ]);
+
+    const scores = result.suggestions.map((s) => s.confidence.score);
+    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+  });
+
+  it("returns nothing for a budget with no variants", () => {
+    const result = scan([
+      payee("Woolworths"),
+      payee("Tesco"),
+      payee("Netflix"),
+    ]);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it("returns nothing for an empty budget", () => {
+    const result = scan([]);
+    expect(result.analyzedCount).toBe(0);
+    expect(result.suggestions).toEqual([]);
+  });
+});
+
+describe("a group the user has edited", () => {
+  function scanWith(candidates: PayeeCleanupCandidate[], corrections: Record<string, unknown>) {
+    return scanForCleanup(partitionByEligibility(candidates), {
+      corrections: corrections as never,
+    });
+  }
+
+  it("drops the detector's stem once members were added", () => {
+    // The stem described the payees the detector grouped. Keeping it after the
+    // user combined two groups builds the rule from text most of the group does
+    // not contain — a pattern of `LEVEL 5 406 VI` for a payee named "Optus".
+    const candidates = [
+      payee("COLES 0559"),
+      payee("COLES 0291"),
+      payee("Optus"),
+    ];
+
+    const before = scanWith(candidates, {});
+    const first = before.suggestions[0];
+    expect(first.cluster.stem).toBe("COLES");
+
+    const after = scanWith(candidates, {
+      [first.cluster.id]: {
+        decision: "undecided",
+        excludedIds: [],
+        addedIds: [candidates[2].id],
+      },
+    });
+    const edited = after.suggestions.find((s) => s.cluster.id === first.cluster.id);
+
+    expect(edited?.cluster.userEdited).toBe(true);
+    expect(edited?.cluster.stem).toBeNull();
+  });
+
+  it("leaves an untouched group's stem alone", () => {
+    const result = scanWith([payee("COLES 0559"), payee("COLES 0291")], {});
+    expect(result.suggestions[0].cluster.userEdited).toBeUndefined();
+    expect(result.suggestions[0].cluster.stem).not.toBeNull();
+  });
+});
+
+describe("false-positive corpus", () => {
+  /**
+   * Names that must NEVER be clustered together. Each pair is a real-world
+   * shape where an over-eager detector would merge two genuinely different
+   * businesses — the failure mode that would make this feature untrustworthy.
+   */
+  const mustNotCluster: Array<[string, string, string]> = [
+    ["EMIRATES", "EMIRATES NBD", "airline vs bank — one name contains the other"],
+    ["WOOLWORTHS", "WOOLWORTHS MOBILE", "retailer vs its phone brand"],
+    ["HSBC UAE", "HSBC UK", "same bank, deliberately separate countries"],
+    ["Apple", "Apple Store", "extra word is a different entity"],
+    ["CARD FACTORY", "FACTORY", "a real shop starting with a wrapper-ish word"],
+    ["Uber", "Uber Eats", "ride-hailing vs food delivery"],
+    ["Tesco", "Costa", "unrelated names of similar length"],
+    ["Shell", "Shelter", "shared prefix, different merchants"],
+  ];
+
+  it.each(mustNotCluster)("keeps %s and %s apart (%s)", (left, right) => {
+    const result = scan([payee(left), payee(right)]);
+
+    for (const suggestion of result.suggestions) {
+      const names = suggestion.cluster.members.map((m) => m.name);
+      expect(names.includes(left) && names.includes(right)).toBe(false);
+    }
+  });
+
+  it("does not merge a sub-brand into its parent even at high character similarity", () => {
+    // `EMIRATES` vs `EMIRATES NBD` scores very highly on raw character overlap
+    // precisely because one contains the other. The subset guard, not the
+    // threshold, is what keeps them apart.
+    const result = scan([payee("EMIRATES"), payee("EMIRATES NBD")]);
+    expect(result.suggestions).toEqual([]);
+  });
+});

--- a/src/features/payee-cleanup/lib/scan.ts
+++ b/src/features/payee-cleanup/lib/scan.ts
@@ -1,0 +1,222 @@
+/**
+ * The read-only cleanup scan (RD-078 §5–§9, Milestone 1).
+ *
+ * One pure function over an already-partitioned candidate set, so the whole
+ * detection pipeline is testable without a connection, a store or a component:
+ *
+ *   eligible payees → derived forms → detectors → fuzzy pairs →
+ *   cluster resolver → confidence → target + canonical name
+ *
+ * Nothing here reads rules, transactions or the budget, and nothing here
+ * mutates anything.
+ */
+
+import { detectAll } from "./detectors";
+import { findCorpusAffixes } from "./corpusAffixes";
+import { applyAffixSuppressions, applySuppressions } from "./suppressions";
+import {
+  correctedMembers,
+  EMPTY_CORRECTION,
+  type CorrectionMap,
+} from "./corrections";
+import { reduceFully } from "./reduce";
+import { findFuzzyPairs } from "./fuzzy";
+import { resolveClusters } from "./clusterResolver";
+import { computeConfidence, type ConfidenceResult } from "./confidence";
+import { buildProposal, type ClusterProposal } from "./targetSelection";
+import { buildClusterImpact, impactSignals, type ClusterImpact, type ImpactSources } from "./impact";
+import { findOrphanPayees, type OrphanPayee } from "./orphans";
+import { buildRuleReferenceMap } from "@/lib/referenceCheck";
+import type { EligibilityPartition } from "./eligibility";
+import type { ClusterCorrection } from "./corrections";
+import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
+import { analyzeFutureResolution, type FutureResolution, type ImportedTextRow } from "./ruleCandidates";
+import type { Rule } from "@/types/entities";
+
+export type CleanupSuggestion = ClusterProposal & {
+  confidence: ConfidenceResult;
+  /** The user's edits to this proposal, if any. */
+  correction: ClusterCorrection;
+  /** Undefined until the import history has loaded (041f). */
+  futureResolution?: FutureResolution;
+  /** Undefined when the scan ran without impact data (041b's pure pipeline). */
+  impact?: ClusterImpact;
+};
+
+export type CleanupScanResult = {
+  /** Boilerplate learned from this budget's own payees, shown as scan evidence. */
+  learnedAffixes: ReturnType<typeof findCorpusAffixes>;
+  /** Every eligible payee that was analyzed. */
+  analyzedCount: number;
+  excludedTransferCount: number;
+  excludedTombstonedCount: number;
+  /** Ordered strongest-first; includes `hidden`-band suggestions. */
+  suggestions: CleanupSuggestion[];
+  /** Payees with no transactions and no rule references. */
+  orphans: OrphanPayee[];
+  counts: {
+    high: number;
+    strong: number;
+    review: number;
+    hidden: number;
+  };
+};
+
+export type ScanOptions = {
+  impactSources?: ImpactSources;
+  /** The user's rejected clusters and rejected learned affixes. */
+  suppressions?: PayeeCleanupSuppressionRecord[];
+  /** Per-cluster edits: excluded/added members, target and name overrides. */
+  corrections?: CorrectionMap;
+  /** Historical import text, for backtesting proposed rules. */
+  importedText?: ImportedTextRow[];
+  /** True when that history was truncated by its row cap. */
+  importedTextTruncated?: boolean;
+  /** The budget's rules, for the "does one already resolve this?" step. */
+  rules?: Rule[];
+};
+
+export function scanForCleanup(
+  partition: EligibilityPartition,
+  options: ScanOptions = {}
+): CleanupScanResult {
+  const {
+    impactSources,
+    suppressions = [],
+    corrections = {},
+    importedText,
+    importedTextTruncated = false,
+    rules = [],
+  } = options;
+  // Learn this budget's own boilerplate first: the shape reducers cannot see
+  // that `DUBAI UAE` or `INTERNET BANKING` is wrapping, but repetition across
+  // otherwise-unrelated payees can.
+  //
+  // Learned from the shape-reduced names rather than the raw ones, so the
+  // learner only ever sees what the certain rules could not remove. Otherwise
+  // `WOOLWORTHS 0183 / 0291 / 8442` looks exactly like a wrapper with three
+  // different continuations, and the merchant's own name gets stripped.
+  const learnedAffixes = applyAffixSuppressions(
+    findCorpusAffixes(partition.eligible.map((p) => reduceFully(p.name).stem)),
+    suppressions
+  );
+  const detected = detectAll(partition.eligible, learnedAffixes);
+  const fuzzyPairs = findFuzzyPairs(detected);
+
+  const byId = new Map(partition.eligible.map((c) => [c.id, c]));
+  const clusters = applySuppressions(resolveClusters(detected, fuzzyPairs), suppressions)
+    // Apply the user's edits before anything is scored, so confidence, target
+    // and impact all describe the proposal as it now stands rather than the one
+    // the detector originally produced.
+    .map((cluster) => {
+      const correction = corrections[cluster.id] ?? EMPTY_CORRECTION;
+      // Ask the correction whether it changes membership, rather than comparing
+      // arrays: `correctedMembers` always builds a new one, so an identity check
+      // marked every cluster as edited and stripped every stem.
+      const membershipChanged =
+        correction.excludedIds.length > 0 || correction.addedIds.length > 0;
+      if (!membershipChanged) return cluster;
+
+      const members = correctedMembers(cluster.members, correction, (id) => byId.get(id));
+
+      // The detector's stem described the original members. Keeping it after
+      // the user combined two groups produced a rule built from text most of
+      // the group does not contain — `\bLEVEL 5 406 VI\b` for a payee the user
+      // had named "Optus". Dropping it makes the rule fall back to the name the
+      // user chose, which is the only description that still fits.
+      return { ...cluster, members, stem: null, userEdited: true };
+    })
+    // A cluster edited down to one payee is no longer a merge proposal.
+    .filter((cluster) => cluster.members.length >= 2);
+
+  // Impact feeds both the target score (a payee's usage and rule references are
+  // reasons to keep it) and confidence (behaviour or rule conflicts are reasons
+  // to look closer). Without it the scan still works — it just scores on name
+  // evidence alone.
+  const targetSignals = impactSources
+    ? {
+        transactionCounts: impactSources.transactionCounts,
+        ruleCounts: buildRuleReferenceMap(impactSources.stagedRules, [
+          "payee",
+          "imported_payee",
+        ]),
+      }
+    : {};
+
+  const suggestions: CleanupSuggestion[] = clusters.map((cluster) => {
+    const correction = corrections[cluster.id] ?? EMPTY_CORRECTION;
+    const suggested = buildProposal(cluster, targetSignals);
+
+    // A user override always wins over the scorer, but only while the payee it
+    // names is still in the cluster.
+    const overrideTarget =
+      correction.targetId && cluster.members.some((m) => m.id === correction.targetId)
+        ? correction.targetId
+        : undefined;
+
+    const proposal = {
+      ...suggested,
+      target: overrideTarget
+        ? { ...suggested.target, targetId: overrideTarget, reasons: ["You chose this payee"] }
+        : suggested.target,
+      canonicalName: correction.canonicalName ?? suggested.canonicalName,
+      membersToMerge: cluster.members.filter(
+        (m) => m.id !== (overrideTarget ?? suggested.target.targetId)
+      ),
+    };
+    const impact = impactSources
+      ? buildClusterImpact(cluster, proposal.target.targetId, impactSources)
+      : undefined;
+
+    // Only analyse future resolution once the history is loaded — without it
+    // every cluster would look like it needs a rule.
+    const futureResolution =
+      importedText && importedText.length > 0
+        ? analyzeFutureResolution({
+            stem: cluster.stem ?? "",
+            finalName: proposal.canonicalName,
+            members: cluster.members,
+            rows: importedText,
+            rules,
+            override: correction.rulePattern,
+            historyTruncated: importedTextTruncated,
+          })
+        : undefined;
+
+    return {
+      ...proposal,
+      impact,
+      correction,
+      futureResolution,
+      confidence: computeConfidence(cluster, impact ? impactSignals(impact) : {}),
+    };
+  });
+
+  // Highest confidence first; ties broken by name so the list is stable.
+  suggestions.sort(
+    (a, b) =>
+      b.confidence.score - a.confidence.score ||
+      a.cluster.members[0].name.localeCompare(b.cluster.members[0].name)
+  );
+
+  const counts = { high: 0, strong: 0, review: 0, hidden: 0 };
+  for (const suggestion of suggestions) counts[suggestion.confidence.band]++;
+
+  const orphans = impactSources
+    ? findOrphanPayees({
+        candidates: partition.eligible,
+        stagedRules: impactSources.stagedRules,
+        transactionCounts: impactSources.transactionCounts,
+      })
+    : [];
+
+  return {
+    learnedAffixes,
+    orphans,
+    analyzedCount: partition.eligible.length,
+    excludedTransferCount: partition.excludedTransfer.length,
+    excludedTombstonedCount: partition.excludedTombstoned.length,
+    suggestions,
+    counts,
+  };
+}

--- a/src/features/payee-cleanup/lib/suppressions.ts
+++ b/src/features/payee-cleanup/lib/suppressions.ts
@@ -1,0 +1,141 @@
+/**
+ * Applying the user's "not duplicates" decisions (RD-078 §14).
+ *
+ * Two rules govern this module, and both exist because the obvious
+ * implementation is wrong:
+ *
+ * 1. **A suppression hides a relationship, not a payee.** Marking `EMIRATES`
+ *    and `EMIRATES NBD` as unrelated must not remove either from a different,
+ *    well-evidenced cluster. So a suppression matches only when the cluster it
+ *    is being tested against is *the same grouping* — every suppressed payee
+ *    present, and no meaningful extras.
+ * 2. **Ids alone are not a durable key.** Payee ids vanish when the payees are
+ *    merged or deleted, which is precisely what happens after a successful
+ *    cleanup; normalized names outlive them but can be reused by a genuinely
+ *    new payee. Matching on either, and requiring the whole grouping to line
+ *    up, keeps an old decision meaningful without letting it silence something
+ *    new.
+ */
+
+import { normalizeToken } from "./reduce";
+import type { PayeeCleanupSuppressionRecord } from "@/lib/app-db/types";
+import type { CorpusAffix } from "./corpusAffixes";
+import type { PayeeCluster } from "./clusterResolver";
+
+/** The comparison form for a payee name inside a suppression. */
+export function suppressionKey(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map(normalizeToken)
+    .filter(Boolean)
+    .join(" ");
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = new Set(a);
+  return b.every((value) => left.has(value));
+}
+
+/**
+ * True when this suppression covers exactly this cluster.
+ *
+ * Deliberately an exact-grouping test rather than "any member overlaps". A
+ * rejected pair should stop being suggested; it should not veto a three-member
+ * cluster that happens to include one of the same payees, because that is a
+ * different proposal the user has never seen.
+ */
+export function suppressesCluster(
+  suppression: PayeeCleanupSuppressionRecord,
+  cluster: PayeeCluster
+): boolean {
+  if (suppression.kind !== "not-duplicates") return false;
+
+  const clusterIds = cluster.members.map((m) => m.id);
+  if (
+    suppression.payeeIds.length > 0 &&
+    sameSet(suppression.payeeIds, clusterIds)
+  ) {
+    return true;
+  }
+
+  // The ids no longer exist, or never matched: fall back to the names, which
+  // survive a merge that removed the original payees.
+  const clusterNames = cluster.members.map((m) => suppressionKey(m.name));
+  return (
+    suppression.normalizedNames.length > 0 &&
+    sameSet(suppression.normalizedNames, clusterNames)
+  );
+}
+
+/** Drops the clusters the user has already rejected. */
+export function applySuppressions(
+  clusters: PayeeCluster[],
+  suppressions: PayeeCleanupSuppressionRecord[]
+): PayeeCluster[] {
+  if (suppressions.length === 0) return clusters;
+  return clusters.filter(
+    (cluster) => !suppressions.some((s) => suppressesCluster(s, cluster))
+  );
+}
+
+/**
+ * Drops learned affixes the user has rejected.
+ *
+ * The corpus learner cannot tell a channel wrapper from a meaningful word like
+ * `TRANSFER` — both open many payees. Rejecting one cluster does not stop the
+ * affix being applied everywhere else, so the affix itself has to be
+ * suppressible, or the user would be re-rejecting the same inference forever.
+ */
+export function applyAffixSuppressions(
+  affixes: CorpusAffix[],
+  suppressions: PayeeCleanupSuppressionRecord[]
+): CorpusAffix[] {
+  const rejected = suppressions.filter((s) => s.kind === "rejected-affix");
+  if (rejected.length === 0) return affixes;
+
+  return affixes.filter(
+    (affix) => !rejected.some((s) => sameSet(s.normalizedNames, affix.tokens))
+  );
+}
+
+/** The record to persist when the user rejects a cluster. */
+export function buildClusterSuppression(
+  budgetSyncId: string,
+  cluster: PayeeCluster
+): {
+  budgetSyncId: string;
+  kind: "not-duplicates";
+  payeeIds: string[];
+  normalizedNames: string[];
+  detectorIds: string[];
+} {
+  return {
+    budgetSyncId,
+    kind: "not-duplicates",
+    payeeIds: cluster.members.map((m) => m.id),
+    normalizedNames: cluster.members.map((m) => suppressionKey(m.name)),
+    detectorIds: [...new Set(cluster.evidence.map((e) => e.detectorId))],
+  };
+}
+
+/** The record to persist when the user rejects a piece of learned boilerplate. */
+export function buildAffixSuppression(
+  budgetSyncId: string,
+  affix: CorpusAffix
+): {
+  budgetSyncId: string;
+  kind: "rejected-affix";
+  payeeIds: string[];
+  normalizedNames: string[];
+  detectorIds: string[];
+} {
+  return {
+    budgetSyncId,
+    kind: "rejected-affix",
+    payeeIds: [],
+    normalizedNames: affix.tokens,
+    detectorIds: [affix.kind === "prefix" ? "corpus-prefix" : "corpus-suffix"],
+  };
+}

--- a/src/features/payee-cleanup/lib/suppressions.ts
+++ b/src/features/payee-cleanup/lib/suppressions.ts
@@ -32,10 +32,25 @@ export function suppressionKey(name: string): string {
     .join(" ");
 }
 
-function sameSet(a: string[], b: string[]): boolean {
+/**
+ * Multiset equality, not set equality.
+ *
+ * `suppressionKey` folds case and punctuation, so one cluster can legitimately
+ * hold two members with the same key — `EMIRATES` and `Emirates` are exactly the
+ * kind of pair this feature exists to find. Comparing as sets made
+ * `["EMIRATES", "EMIRATES"]` equal to `["EMIRATES", "EMIRATES NBD"]` and
+ * suppressed a cluster the user had never rejected.
+ */
+function sameMultiset(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false;
-  const left = new Set(a);
-  return b.every((value) => left.has(value));
+  const counts = new Map<string, number>();
+  for (const value of a) counts.set(value, (counts.get(value) ?? 0) + 1);
+  for (const value of b) {
+    const remaining = counts.get(value);
+    if (!remaining) return false;
+    counts.set(value, remaining - 1);
+  }
+  return true;
 }
 
 /**
@@ -55,7 +70,7 @@ export function suppressesCluster(
   const clusterIds = cluster.members.map((m) => m.id);
   if (
     suppression.payeeIds.length > 0 &&
-    sameSet(suppression.payeeIds, clusterIds)
+    sameMultiset(suppression.payeeIds, clusterIds)
   ) {
     return true;
   }
@@ -65,7 +80,7 @@ export function suppressesCluster(
   const clusterNames = cluster.members.map((m) => suppressionKey(m.name));
   return (
     suppression.normalizedNames.length > 0 &&
-    sameSet(suppression.normalizedNames, clusterNames)
+    sameMultiset(suppression.normalizedNames, clusterNames)
   );
 }
 
@@ -96,7 +111,7 @@ export function applyAffixSuppressions(
   if (rejected.length === 0) return affixes;
 
   return affixes.filter(
-    (affix) => !rejected.some((s) => sameSet(s.normalizedNames, affix.tokens))
+    (affix) => !rejected.some((s) => sameMultiset(s.normalizedNames, affix.tokens))
   );
 }
 

--- a/src/features/payee-cleanup/lib/suppressions.ts
+++ b/src/features/payee-cleanup/lib/suppressions.ts
@@ -110,8 +110,21 @@ export function applyAffixSuppressions(
   const rejected = suppressions.filter((s) => s.kind === "rejected-affix");
   if (rejected.length === 0) return affixes;
 
+  // Ordered, and matched on kind. An affix is a token *sequence* at one end of a
+  // name, so an unordered comparison let a rejected prefix ["BANK","TRANSFER"]
+  // suppress a learned ["TRANSFER","BANK"], and rejecting a prefix silenced the
+  // matching suffix — a suggestion lost that the user never rejected.
+  const affixDetectorId = (affix: CorpusAffix) =>
+    affix.kind === "prefix" ? "corpus-prefix" : "corpus-suffix";
+
   return affixes.filter(
-    (affix) => !rejected.some((s) => sameMultiset(s.normalizedNames, affix.tokens))
+    (affix) =>
+      !rejected.some(
+        (s) =>
+          s.detectorIds.includes(affixDetectorId(affix)) &&
+          s.normalizedNames.length === affix.tokens.length &&
+          s.normalizedNames.every((token, i) => token === affix.tokens[i])
+      )
   );
 }
 

--- a/src/features/payee-cleanup/lib/targetSelection.ts
+++ b/src/features/payee-cleanup/lib/targetSelection.ts
@@ -1,0 +1,180 @@
+/**
+ * Merge-target selection and canonical-name suggestion (RD-078 §8, §9).
+ *
+ * Two decisions the spec insists on keeping apart:
+ *
+ * - **which payee id survives** — this is what Actual's native
+ *   `mergePayees(targetId, mergeIds)` takes, and it carries the surviving
+ *   payee's `favorite` / `learn_categories` (neither of which Bench can write,
+ *   so choosing the target *is* how the user resolves a behavior difference);
+ * - **what the surviving payee should be called** — an ordinary rename, staged
+ *   separately and freely editable.
+ *
+ * §8 also warns against applying its ranking rigidly. So this is a transparent
+ * additive score with a reason per contribution, not a priority list: the UI
+ * shows why a target was suggested and the user can override it.
+ */
+
+import { deriveForms, looksHumanReadable } from "./derivedForms";
+import type { PayeeCluster } from "./clusterResolver";
+import type { PayeeCleanupCandidate } from "../types";
+
+/**
+ * Impact signals that only exist once 041c has run. Passed in rather than
+ * fetched so target selection stays a pure function and 041b can suggest a
+ * target with name evidence alone.
+ */
+export type TargetSignals = {
+  /** Transaction count per payee id. */
+  transactionCounts?: Map<string, number>;
+  /** Count of rules referencing each payee id. */
+  ruleCounts?: Map<string, number>;
+};
+
+export type TargetScore = {
+  payeeId: string;
+  score: number;
+  reasons: string[];
+};
+
+export type TargetSuggestion = {
+  targetId: string;
+  scores: TargetScore[];
+  reasons: string[];
+};
+
+export function suggestTarget(
+  cluster: PayeeCluster,
+  signals: TargetSignals = {}
+): TargetSuggestion {
+  const maxTransactions = Math.max(
+    1,
+    ...cluster.members.map((m) => signals.transactionCounts?.get(m.id) ?? 0)
+  );
+
+  const scores: TargetScore[] = cluster.members.map((member) => {
+    const reasons: string[] = [];
+    let score = 0;
+
+    if (looksHumanReadable(deriveForms(member.name))) {
+      score += 40;
+      reasons.push("Clean, human-readable name");
+    }
+
+    if (member.metadata.favorite) {
+      // §1.7: favorite is real user intent, and merge does not transfer it —
+      // the target's own value survives. Weighted heavily for that reason.
+      score += 25;
+      reasons.push("Marked as a favorite payee");
+    }
+
+    const rules = signals.ruleCounts?.get(member.id) ?? 0;
+    if (rules > 0) {
+      score += 15;
+      reasons.push(`Referenced by ${rules} existing ${rules === 1 ? "rule" : "rules"}`);
+    }
+
+    const transactions = signals.transactionCounts?.get(member.id);
+    if (transactions !== undefined && transactions > 0) {
+      // Scaled, not absolute: being the most-used name in the group is a
+      // signal, but a machine-generated name with the most transactions should
+      // still lose to a clean one.
+      const scaled = Math.round((transactions / maxTransactions) * 15);
+      score += scaled;
+      if (scaled > 0) {
+        reasons.push(`Used by ${transactions} transactions`);
+      }
+    }
+
+    // Shorter names are usually the canonical merchant rather than a variant
+    // carrying extra machine text. Small weight — it is a tiebreaker.
+    score += Math.max(0, 10 - Math.floor(member.name.length / 6));
+
+    return { payeeId: member.id, score, reasons };
+  });
+
+  // Deterministic: score, then name, then id — never input order.
+  const ranked = [...scores].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const nameA = cluster.members.find((m) => m.id === a.payeeId)?.name ?? "";
+    const nameB = cluster.members.find((m) => m.id === b.payeeId)?.name ?? "";
+    return nameA.localeCompare(nameB) || a.payeeId.localeCompare(b.payeeId);
+  });
+
+  return {
+    targetId: ranked[0].payeeId,
+    scores: ranked,
+    reasons: ranked[0].reasons,
+  };
+}
+
+/**
+ * Suggests the final display name for the surviving payee (§9).
+ *
+ * Order of preference:
+ * 1. an existing clean member name — the user already typed it, so it needs no
+ *    invention and no title-casing guesswork;
+ * 2. the cluster's shared stem, title-cased;
+ * 3. the shortest member name, unchanged.
+ *
+ * Never enriched from an external source, and always editable downstream.
+ */
+export function suggestCanonicalName(cluster: PayeeCluster): string {
+  const clean = cluster.members
+    .filter((m) => looksHumanReadable(deriveForms(m.name)))
+    .sort((a, b) => a.name.length - b.name.length || a.name.localeCompare(b.name));
+
+  if (clean.length > 0) return clean[0].name.trim();
+
+  if (cluster.stem) return titleCase(cluster.stem);
+
+  const shortest = [...cluster.members].sort(
+    (a, b) => a.name.length - b.name.length || a.name.localeCompare(b.name)
+  )[0];
+  return shortest.name.trim();
+}
+
+/**
+ * Title-cases a normalized (upper-case) stem.
+ *
+ * Short vowel-less tokens stay upper-case, because those are acronyms — `FB`,
+ * `HSBC`, `DXB`. Everything else is title-cased. An earlier version kept every
+ * short token upper-case, which produced "PAY Protect" and "Desco COPY Centre";
+ * the vowel test separates acronyms from ordinary short words.
+ *
+ * Not infallible (`IKEA` becomes `Ikea`), which is fine — the name is a
+ * suggestion the user can edit before anything is staged.
+ */
+function titleCase(stem: string): string {
+  return stem
+    .split(" ")
+    .map((token) => {
+      if (token.length <= 4 && !/[AEIOU]/.test(token)) return token;
+      return token.charAt(0) + token.slice(1).toLowerCase();
+    })
+    .join(" ");
+}
+
+/**
+ * The full read-only proposal for one cluster — everything 041b can determine
+ * without touching rules, transactions or the budget.
+ */
+export type ClusterProposal = {
+  cluster: PayeeCluster;
+  target: TargetSuggestion;
+  canonicalName: string;
+  membersToMerge: PayeeCleanupCandidate[];
+};
+
+export function buildProposal(
+  cluster: PayeeCluster,
+  signals: TargetSignals = {}
+): ClusterProposal {
+  const target = suggestTarget(cluster, signals);
+  return {
+    cluster,
+    target,
+    canonicalName: suggestCanonicalName(cluster),
+    membersToMerge: cluster.members.filter((m) => m.id !== target.targetId),
+  };
+}

--- a/src/features/payee-cleanup/lib/triage.test.ts
+++ b/src/features/payee-cleanup/lib/triage.test.ts
@@ -103,6 +103,22 @@ describe("triageBadges", () => {
     expect(settings?.tone).toBe("warning");
   });
 
+  it("does not say counting once the load has stopped without a number", () => {
+    // A failed or disabled query leaves the total unknown and nothing running,
+    // and "counting…" forever describes work that is not happening.
+    const badges = triageBadges(
+      suggestion({
+        impact: {
+          ...suggestion().impact!,
+          transactionTotal: undefined,
+          transactionsLoading: false,
+        },
+      })
+    );
+    expect(badges[0].label).toMatch(/unavailable/i);
+    expect(badges[0].tone).toBe("warning");
+  });
+
   it("does not claim a transaction count while it is loading", () => {
     const badges = triageBadges(
       suggestion({

--- a/src/features/payee-cleanup/lib/triage.test.ts
+++ b/src/features/payee-cleanup/lib/triage.test.ts
@@ -1,0 +1,375 @@
+import {
+  annotateNoise,
+  detectionSummary,
+  findNameCollisions,
+  isSafeForBulkAccept,
+  triageBadges,
+} from "./triage";
+import type { CleanupSuggestion } from "./scan";
+import type { PayeeCleanupCandidate } from "../types";
+
+function payee(id: string, name = id): PayeeCleanupCandidate {
+  return {
+    id,
+    name,
+    metadata: {
+      id,
+      favorite: false,
+      learnCategories: true,
+      tombstone: false,
+      transferAccountId: null,
+    },
+  };
+}
+
+function suggestion(overrides: Partial<CleanupSuggestion> = {}): CleanupSuggestion {
+  const members = [payee("p1"), payee("p2")];
+  return {
+    cluster: {
+      id: "c1",
+      members,
+      stem: "STEM",
+      evidence: [
+        {
+          detectorId: "full-reduction",
+          kind: "structural",
+          label: "Removed the card number",
+          detail: "STEM",
+        },
+      ],
+      fuzzyOnly: false,
+    },
+    target: { targetId: "p1", scores: [], reasons: [] },
+    canonicalName: "Result",
+    membersToMerge: [members[1]],
+    confidence: { score: 96, band: "high", reasons: [] },
+    correction: { decision: "undecided", excludedIds: [], addedIds: [] },
+    impact: {
+      transactionTotal: 12,
+      transactionsLoading: false,
+      rules: { regular: 0, activeSchedule: 0, completedSchedule: 0 },
+      behavior: {
+        favoriteDiffers: false,
+        learnCategoriesDiffers: false,
+        survivingFavorite: false,
+        survivingLearnCategories: true,
+      },
+      members: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("triageBadges", () => {
+  it("keeps a clean result quiet", () => {
+    const badges = triageBadges(suggestion());
+    expect(badges.map((b) => b.label)).toEqual([
+      "12 transactions",
+      "No rules affected",
+      "Settings match",
+    ]);
+    expect(badges.every((b) => b.tone !== "warning")).toBe(true);
+  });
+
+  it("says how many rules reference the payees, not that they conflict", () => {
+    // Merging does not rewrite rules, so "1 rule conflict" would invent a
+    // problem that does not exist.
+    const badges = triageBadges(
+      suggestion({
+        impact: {
+          ...suggestion().impact!,
+          rules: { regular: 1, activeSchedule: 0, completedSchedule: 0 },
+        },
+      })
+    );
+    expect(badges.map((b) => b.label)).toContain("1 rule reference these");
+  });
+
+  it("raises a warning when payee settings differ", () => {
+    const badges = triageBadges(
+      suggestion({
+        impact: {
+          ...suggestion().impact!,
+          behavior: {
+            favoriteDiffers: true,
+            learnCategoriesDiffers: false,
+            survivingFavorite: false,
+            survivingLearnCategories: true,
+          },
+        },
+      })
+    );
+    const settings = badges.find((b) => b.id === "settings");
+    expect(settings?.tone).toBe("warning");
+  });
+
+  it("does not claim a transaction count while it is loading", () => {
+    const badges = triageBadges(
+      suggestion({
+        impact: { ...suggestion().impact!, transactionTotal: undefined, transactionsLoading: true },
+      })
+    );
+    expect(badges[0].label).toMatch(/counting/i);
+  });
+});
+
+describe("isSafeForBulkAccept", () => {
+  it("accepts a structural match with no conflicts", () => {
+    expect(isSafeForBulkAccept(suggestion())).toBe(true);
+  });
+
+  it("refuses anything below the confident bands", () => {
+    expect(
+      isSafeForBulkAccept(
+        suggestion({ confidence: { score: 70, band: "review", reasons: [] } })
+      )
+    ).toBe(false);
+  });
+
+  it("refuses a fuzzy-only match however it scored", () => {
+    const base = suggestion();
+    expect(
+      isSafeForBulkAccept({
+        ...base,
+        cluster: { ...base.cluster, fuzzyOnly: true },
+      })
+    ).toBe(false);
+  });
+
+  it("refuses a match that needed an interpreted step", () => {
+    // Corpus-learned boilerplate and company suffixes are guesses. "Accept
+    // everything above 90%" would sweep up exactly the cases this feature
+    // exists to catch.
+    const base = suggestion();
+    expect(
+      isSafeForBulkAccept({
+        ...base,
+        cluster: {
+          ...base.cluster,
+          evidence: [
+            ...base.cluster.evidence,
+            {
+              detectorId: "full-reduction",
+              kind: "contextual",
+              label: 'Shared trailing text ("au aus", on 29 payees)',
+              detail: "STEM",
+            },
+          ],
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("refuses when payee settings differ", () => {
+    expect(
+      isSafeForBulkAccept(
+        suggestion({
+          impact: {
+            ...suggestion().impact!,
+            behavior: {
+              favoriteDiffers: true,
+              learnCategoriesDiffers: false,
+              survivingFavorite: false,
+              survivingLearnCategories: true,
+            },
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("refuses while the blast radius is still unknown", () => {
+    expect(
+      isSafeForBulkAccept(
+        suggestion({
+          impact: {
+            ...suggestion().impact!,
+            transactionTotal: undefined,
+            transactionsLoading: true,
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("refuses when a proposed rule would catch other payees", () => {
+    expect(
+      isSafeForBulkAccept(
+        suggestion({
+          futureResolution: {
+            exactName: { covered: 0, transactionCount: 0 },
+            relatedRules: [],
+            candidates: [],
+            recommended: {
+              candidate: {
+                field: "imported_payee",
+                op: "matches",
+                value: "^X",
+                description: "",
+              },
+              expectedMatches: 10,
+              unexpectedMatches: 2,
+              unexpectedExamples: [],
+              matchedTexts: 3,
+            },
+            skipReason: null,
+            safeToPreselect: false,
+            matchText: "X",
+            historyTruncated: false,
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("refuses when the backtest ran over a truncated history", () => {
+    // "Catches nothing else" from a partial read is not a basis for accepting
+    // without looking.
+    expect(
+      isSafeForBulkAccept(
+        suggestion({
+          futureResolution: {
+            exactName: { covered: 0, transactionCount: 0 },
+            relatedRules: [],
+            candidates: [],
+            recommended: {
+              candidate: {
+                field: "imported_payee",
+                op: "matches",
+                value: "^X",
+                description: "",
+              },
+              expectedMatches: 10,
+              unexpectedMatches: 0,
+              unexpectedExamples: [],
+              matchedTexts: 3,
+            },
+            skipReason: null,
+            safeToPreselect: false,
+            matchText: "X",
+            historyTruncated: true,
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("refuses when an existing rule might conflict", () => {
+    expect(
+      isSafeForBulkAccept(
+        suggestion({
+          futureResolution: {
+            exactName: { covered: 0, transactionCount: 0 },
+            relatedRules: [
+              {
+                rule: {
+                  id: "r1",
+                  stage: "default",
+                  conditionsOp: "and",
+                  conditions: [],
+                  actions: [],
+                },
+                kind: "payee-resolution",
+                interaction: "potential-conflict",
+              },
+            ],
+            candidates: [],
+            recommended: null,
+            skipReason: null,
+            safeToPreselect: false,
+            matchText: "X",
+            historyTruncated: false,
+          },
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("detectionSummary", () => {
+  it("does not describe a grouping the user has since changed", () => {
+    const base = suggestion();
+    expect(
+      detectionSummary({
+        ...base,
+        cluster: { ...base.cluster, userEdited: true },
+      })
+    ).toBe("Grouped by you");
+  });
+
+  it("summarises the detector's findings for an untouched group", () => {
+    expect(detectionSummary(suggestion())).toMatch(/^Detected /);
+  });
+});
+
+describe("findNameCollisions", () => {
+  function accepted(name: string, id: string): CleanupSuggestion {
+    const base = suggestion();
+    return {
+      ...base,
+      cluster: { ...base.cluster, id },
+      canonicalName: name,
+      correction: { ...base.correction, decision: "accepted" },
+    };
+  }
+
+  it("finds accepted groups that would share a payee name", () => {
+    const collisions = findNameCollisions([
+      accepted("Optus", "a"),
+      accepted("Optus", "b"),
+      accepted("Woolworths", "c"),
+    ]);
+
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].finalName).toBe("Optus");
+    expect(collisions[0].suggestions).toHaveLength(2);
+  });
+
+  it("ignores groups the user has not accepted", () => {
+    // An un-accepted group is not going to be staged, so it cannot collide.
+    const base = suggestion();
+    expect(
+      findNameCollisions([
+        accepted("Optus", "a"),
+        { ...base, cluster: { ...base.cluster, id: "b" }, canonicalName: "Optus" },
+      ])
+    ).toEqual([]);
+  });
+
+  it("compares names ignoring case and spacing", () => {
+    expect(
+      findNameCollisions([accepted("Optus", "a"), accepted("OPTUS  ", "b")])
+    ).toHaveLength(1);
+  });
+});
+
+describe("annotateNoise", () => {
+  it("marks the removed spans so the user can see why", () => {
+    const parts = annotateNoise("COLES 0559 02MAR25", ["0559 02MAR25"]);
+    expect(parts.map((p) => p.text).join("")).toBe("COLES 0559 02MAR25");
+    expect(parts.some((p) => p.noise)).toBe(true);
+  });
+
+  it("handles a removal recorded as several pieces", () => {
+    const parts = annotateNoise("ACME Card xx1234 12/03/2024", [
+      "Card xx1234 · 12/03/2024",
+    ]);
+    const noise = parts.filter((p) => p.noise).map((p) => p.text);
+    expect(noise).toContain("Card xx1234");
+    expect(noise).toContain("12/03/2024");
+  });
+
+  it("leaves the name intact when a removal cannot be located", () => {
+    // An earlier step may already have rewritten that span; approximating it
+    // would strike through the wrong characters.
+    expect(annotateNoise("ACME", ["something else"])).toEqual([
+      { text: "ACME", noise: false },
+    ]);
+  });
+
+  it("never loses or duplicates a character", () => {
+    const raw = "TARGET 5121 PRESTON AU AUS Card xx9166 Value Date: 07/01/2025";
+    const parts = annotateNoise(raw, ["AU AUS", "Card xx9166", "Value Date: 07/01/2025"]);
+    expect(parts.map((p) => p.text).join("")).toBe(raw);
+  });
+});

--- a/src/features/payee-cleanup/lib/triage.test.ts
+++ b/src/features/payee-cleanup/lib/triage.test.ts
@@ -367,6 +367,16 @@ describe("annotateNoise", () => {
     ]);
   });
 
+  it("keeps the offsets aligned when upper-casing would change length", () => {
+    // `ß` upper-cases to `SS`, so searching an upper-cased copy and slicing the
+    // original shifted every later index and struck through the wrong letters.
+    const parts = annotateNoise("STRAßE 12 Card xx4534", ["Card xx4534"]);
+    expect(parts.map((p) => p.text).join("")).toBe("STRAßE 12 Card xx4534");
+    expect(parts.filter((p) => p.noise).map((p) => p.text)).toEqual([
+      "Card xx4534",
+    ]);
+  });
+
   it("never loses or duplicates a character", () => {
     const raw = "TARGET 5121 PRESTON AU AUS Card xx9166 Value Date: 07/01/2025";
     const parts = annotateNoise(raw, ["AU AUS", "Card xx9166", "Value Date: 07/01/2025"]);

--- a/src/features/payee-cleanup/lib/triage.ts
+++ b/src/features/payee-cleanup/lib/triage.ts
@@ -33,11 +33,16 @@ export function triageBadges(suggestion: CleanupSuggestion): TriageBadge[] {
     const total = impact.transactionTotal;
     badges.push({
       id: "transactions",
-      tone: "neutral",
+      tone: total === undefined && !impact.transactionsLoading ? "warning" : "neutral",
       label:
-        total === undefined
-          ? "counting transactions…"
-          : `${total.toLocaleString("en-US")} ${total === 1 ? "transaction" : "transactions"}`,
+        total !== undefined
+          ? `${total.toLocaleString("en-US")} ${total === 1 ? "transaction" : "transactions"}`
+          : impact.transactionsLoading
+            ? "counting transactions…"
+            : // Not loading and still unknown means the read failed or never
+              // ran. Saying "counting…" forever would describe work that is not
+              // happening.
+              "transaction count unavailable",
     });
 
     const activeRules = impact.rules.regular + impact.rules.activeSchedule;

--- a/src/features/payee-cleanup/lib/triage.ts
+++ b/src/features/payee-cleanup/lib/triage.ts
@@ -213,6 +213,10 @@ export function detectionSummary(suggestion: CleanupSuggestion): string {
  * because an earlier step already rewrote that span — is simply not highlighted
  * rather than approximated.
  */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function annotateNoise(
   rawName: string,
   removals: string[]
@@ -223,9 +227,12 @@ export function annotateNoise(
     for (const piece of removal.split(" · ")) {
       const needle = piece.trim();
       if (needle.length < 2) continue;
-      const index = rawName.toUpperCase().indexOf(needle.toUpperCase());
-      if (index === -1) continue;
-      spans.push({ start: index, end: index + needle.length });
+      // Searched case-insensitively against the original string rather than an
+      // upper-cased copy: upper-casing can change length (`ß` → `SS`), which
+      // shifts every later index and strikes through the wrong characters.
+      const match = new RegExp(escapeRegex(needle), "i").exec(rawName);
+      if (!match) continue;
+      spans.push({ start: match.index, end: match.index + match[0].length });
     }
   }
 

--- a/src/features/payee-cleanup/lib/triage.ts
+++ b/src/features/payee-cleanup/lib/triage.ts
@@ -1,0 +1,255 @@
+/**
+ * What a user needs to triage a suggestion, and what makes one safe to accept
+ * in bulk (RD-078 §11; F-096 follow-up).
+ *
+ * The main screen is for *decisions*, not investigation. Everything here answers
+ * one question — "do I agree these payees should become this payee?" — and
+ * everything that answers "why does Bench think so?" belongs in the review
+ * drawer.
+ */
+
+import type { CleanupSuggestion } from "./scan";
+
+export type TriageBadge = {
+  id: string;
+  label: string;
+  tone: "neutral" | "positive" | "warning";
+};
+
+/**
+ * The badges shown on a compact card.
+ *
+ * Normal is compressed, exceptional is expanded: a clean result collapses to a
+ * couple of quiet chips, while a genuine conflict gets a warning tone and stays
+ * visible. Wording stays literal — a rule *referencing* these payees is not a
+ * conflict, because merging does not rewrite rules, so the badge says how many
+ * rules there are rather than implying a problem that does not exist.
+ */
+export function triageBadges(suggestion: CleanupSuggestion): TriageBadge[] {
+  const badges: TriageBadge[] = [];
+  const impact = suggestion.impact;
+
+  if (impact) {
+    const total = impact.transactionTotal;
+    badges.push({
+      id: "transactions",
+      tone: "neutral",
+      label:
+        total === undefined
+          ? "counting transactions…"
+          : `${total.toLocaleString("en-US")} ${total === 1 ? "transaction" : "transactions"}`,
+    });
+
+    const activeRules = impact.rules.regular + impact.rules.activeSchedule;
+    badges.push(
+      activeRules === 0
+        ? { id: "rules", tone: "positive", label: "No rules affected" }
+        : {
+            id: "rules",
+            tone: "neutral",
+            label: `${activeRules} ${activeRules === 1 ? "rule" : "rules"} reference these`,
+          }
+    );
+
+    const settingsDiffer =
+      impact.behavior.favoriteDiffers || impact.behavior.learnCategoriesDiffers;
+    badges.push(
+      settingsDiffer
+        ? {
+            id: "settings",
+            tone: "warning",
+            label: "Payee settings differ — the one you keep decides",
+          }
+        : { id: "settings", tone: "positive", label: "Settings match" }
+    );
+  }
+
+  const future = suggestion.futureResolution;
+  if (future?.recommended) {
+    badges.push(
+      future.recommended.unexpectedMatches === 0
+        ? { id: "rule", tone: "positive", label: "Safe future-import rule" }
+        : {
+            id: "rule",
+            tone: "warning",
+            label: `Future rule would also catch ${future.recommended.unexpectedMatches} other transactions`,
+          }
+    );
+  } else if (future?.skipReason === "already-resolved-by-name") {
+    badges.push({
+      id: "rule",
+      tone: "positive",
+      label: "Future imports resolve by name",
+    });
+  }
+
+  if (future?.relatedRules.some((r) => r.interaction === "potential-conflict")) {
+    badges.push({
+      id: "rule-overlap",
+      tone: "warning",
+      label: "An existing rule may conflict",
+    });
+  }
+
+  return badges;
+}
+
+/**
+ * Whether a suggestion can be accepted without opening it.
+ *
+ * Deliberately stricter than "the score is high". A bulk action that means
+ * "accept everything above 90%" would sweep up the cases this feature exists to
+ * catch — an interpreted reduction, a settings conflict, a rule that steals
+ * another payee's transactions. Every clause below is a reason a human should
+ * look:
+ *
+ * - the match must be **structural**, not inferred from corpus repetition or
+ *   spelling similarity;
+ * - the payees must agree on Favorite and Category learning, since the merge
+ *   silently resolves that by whichever payee survives;
+ * - no proposed rule may catch a transaction belonging to anyone else;
+ * - no existing rule may be flagged as potentially conflicting.
+ *
+ * Bulk-accepted suggestions are still only *staged*: the plan, its validation
+ * and an explicit Save all still stand between this and the budget.
+ */
+export function isSafeForBulkAccept(suggestion: CleanupSuggestion): boolean {
+  const { confidence, cluster, impact, futureResolution } = suggestion;
+
+  if (confidence.band !== "high" && confidence.band !== "strong") return false;
+  if (cluster.fuzzyOnly) return false;
+
+  // An interpreted step — a company suffix, or text the corpus inferred — is
+  // exactly the kind of guess a person should confirm.
+  const structural = cluster.evidence.some((e) => e.kind === "structural");
+  const contextual = cluster.evidence.some((e) => e.kind === "contextual");
+  if (!structural || contextual) return false;
+
+  if (impact) {
+    if (impact.behavior.favoriteDiffers || impact.behavior.learnCategoriesDiffers) {
+      return false;
+    }
+    // Counts still loading: not knowing the blast radius is a reason to wait.
+    if (impact.transactionTotal === undefined) return false;
+  }
+
+  if (futureResolution) {
+    // A "catches nothing else" claim built on a truncated history is not a
+    // basis for accepting without looking.
+    if (futureResolution.historyTruncated) return false;
+    if (
+      futureResolution.recommended &&
+      futureResolution.recommended.unexpectedMatches > 0
+    ) {
+      return false;
+    }
+    if (
+      futureResolution.relatedRules.some((r) => r.interaction === "potential-conflict")
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export type NameCollision = {
+  /** The shared final name, as the user typed it on the first group. */
+  finalName: string;
+  suggestions: CleanupSuggestion[];
+};
+
+/**
+ * Accepted groups that would end up with the same payee name.
+ *
+ * This is the signal behind both the block and the offer to combine: the user
+ * has effectively said these payees are one merchant, so cleanup can either
+ * refuse or act on it. Refusing alone leaves them to reconcile it by hand.
+ */
+export function findNameCollisions(
+  suggestions: CleanupSuggestion[]
+): NameCollision[] {
+  const byName = new Map<string, CleanupSuggestion[]>();
+
+  for (const suggestion of suggestions) {
+    if (suggestion.correction.decision !== "accepted") continue;
+    const key = suggestion.canonicalName.trim().toUpperCase().replace(/\s+/g, " ");
+    if (!key) continue;
+    byName.set(key, [...(byName.get(key) ?? []), suggestion]);
+  }
+
+  return [...byName.values()]
+    .filter((group) => group.length > 1)
+    .map((group) => ({ finalName: group[0].canonicalName.trim(), suggestions: group }));
+}
+
+/** A short, human summary of what the scan removed. */
+export function detectionSummary(suggestion: CleanupSuggestion): string {
+  // The evidence describes what the detector found. Once the user has combined
+  // groups or dropped members, repeating it would explain a grouping that no
+  // longer exists.
+  if (suggestion.cluster.userEdited) return "Grouped by you";
+
+  // Deduplicated by *part*, not by whole label. A cluster carries both the full
+  // reduction and the structural-only one, whose labels overlap — joining them
+  // verbatim printed "statement details after the date, card number" twice.
+  const parts = new Set<string>();
+  for (const evidence of suggestion.cluster.evidence) {
+    for (const part of evidence.label.replace(/^removed\s+/i, "").split(", ")) {
+      const cleaned = part.trim().toLowerCase();
+      if (cleaned) parts.add(cleaned);
+    }
+  }
+  if (parts.size === 0) return "Similar names";
+  return `Detected ${[...parts].join(", ")}`;
+}
+
+/**
+ * Splits a raw payee name into the parts the reduction removed and the parts it
+ * kept, so the card can show *why* a name was grouped without making the user
+ * decipher a hundred characters of bank text.
+ *
+ * Best-effort by design: a removal that cannot be located in the original —
+ * because an earlier step already rewrote that span — is simply not highlighted
+ * rather than approximated.
+ */
+export function annotateNoise(
+  rawName: string,
+  removals: string[]
+): { text: string; noise: boolean }[] {
+  const spans: { start: number; end: number }[] = [];
+
+  for (const removal of removals) {
+    for (const piece of removal.split(" · ")) {
+      const needle = piece.trim();
+      if (needle.length < 2) continue;
+      const index = rawName.toUpperCase().indexOf(needle.toUpperCase());
+      if (index === -1) continue;
+      spans.push({ start: index, end: index + needle.length });
+    }
+  }
+
+  if (spans.length === 0) return [{ text: rawName, noise: false }];
+
+  spans.sort((a, b) => a.start - b.start);
+  const merged: { start: number; end: number }[] = [];
+  for (const span of spans) {
+    const last = merged[merged.length - 1];
+    if (last && span.start <= last.end) last.end = Math.max(last.end, span.end);
+    else merged.push({ ...span });
+  }
+
+  const parts: { text: string; noise: boolean }[] = [];
+  let cursor = 0;
+  for (const span of merged) {
+    if (span.start > cursor) {
+      parts.push({ text: rawName.slice(cursor, span.start), noise: false });
+    }
+    parts.push({ text: rawName.slice(span.start, span.end), noise: true });
+    cursor = span.end;
+  }
+  if (cursor < rawName.length) {
+    parts.push({ text: rawName.slice(cursor), noise: false });
+  }
+  return parts;
+}

--- a/src/features/payee-cleanup/types.ts
+++ b/src/features/payee-cleanup/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Payee Cleanup Assistant (RD-078 / PR-041) — feature-local types.
+ *
+ * Cleanup reasons about payee fields that the *supported* transport APIs do not
+ * return: `favorite`, `learn_categories` and `tombstone` are absent from
+ * `APIPayeeEntity` (`Pick<PayeeEntity, 'id' | 'name' | 'transfer_acct'>`) and
+ * from actual-http-api's `Payee` schema, but all three are exposed by the AQL
+ * `payees` schema and so are readable through ActualQL in both transports.
+ *
+ * These extra fields stay in this feature-local view model on purpose — the
+ * shared `Payee` entity type describes what the entity CRUD surface can read
+ * and write, and none of these are writable through a supported API.
+ */
+
+import type { Payee } from "@/types/entities";
+
+/**
+ * Payee analysis metadata read via ActualQL, keyed by payee id.
+ *
+ * All three fields are read-only for Bench: `updatePayee` cannot carry
+ * `favorite` or `learn_categories` in either transport (see
+ * `lib/nativeSemantics.test.ts`), and `tombstone` is Actual's own sync state.
+ */
+export type PayeeCleanupMetadata = {
+  id: string;
+  /**
+   * Actual's `favorite` flag — surfaces the payee prominently in autocomplete.
+   * Read-only: informs target selection, never written by cleanup.
+   */
+  favorite: boolean;
+  /**
+   * Actual's per-payee category-learning switch.
+   * Read-only: informs target selection, never written by cleanup.
+   */
+  learnCategories: boolean;
+  /** Actual's soft-delete/sync marker. Tombstoned payees are never cleanup candidates. */
+  tombstone: boolean;
+  /** Set when this is an account-backed transfer payee. Never a cleanup candidate. */
+  transferAccountId: string | null;
+};
+
+/**
+ * A payee joined with its ActualQL-only analysis metadata — the unit every
+ * detector, cluster and impact calculation works on.
+ */
+export type PayeeCleanupCandidate = Payee & {
+  metadata: PayeeCleanupMetadata;
+};

--- a/src/lib/app-db/migrationUpgrade.test.ts
+++ b/src/lib/app-db/migrationUpgrade.test.ts
@@ -9,6 +9,10 @@ import {
   listReconciliationProfiles,
   listStatementRows,
 } from "./reconciliationRepository";
+import {
+  createPayeeCleanupSuppression,
+  listPayeeCleanupSuppressions,
+} from "./payeeCleanupSuppressionRepository";
 
 /**
  * Upgrading a database that already holds real work.
@@ -222,6 +226,31 @@ describe("upgrading an existing database", () => {
         dateFormat: "dmy",
         columns: { date: 0, importedPayee: 1, amount: 2, reference: 3 },
       });
+    } finally {
+      resetAppDbForTests();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("adds the payee-cleanup suppression table to an older database (v17)", () => {
+    // Purely additive, so the thing worth proving is that an install carrying
+    // real reconciliation work gains the table without losing any of it.
+    const { root, path } = olderDatabase();
+    try {
+      const db = getAppDb(path);
+
+      const created = createPayeeCleanupSuppression(db, {
+        budgetSyncId: "budget-1",
+        kind: "not-duplicates",
+        payeeIds: ["p1", "p2"],
+        normalizedNames: ["EMIRATES", "EMIRATES NBD"],
+        detectorIds: ["fuzzy-similarity"],
+      });
+      expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(1);
+      expect(created.budgetSyncId).toBe("budget-1");
+
+      // The pre-existing session is still there.
+      expect(getReconciliationSession(db, "sess-old")).not.toBeNull();
     } finally {
       resetAppDbForTests();
       rmSync(root, { recursive: true, force: true });

--- a/src/lib/app-db/migrations.ts
+++ b/src/lib/app-db/migrations.ts
@@ -9,6 +9,8 @@ import {
   RECONCILIATION_SESSION_TABLE_SQL,
   RECONCILIATION_STATEMENT_ROW_TABLE_SQL,
   REMEMBERED_BUDGET_TABLE_SQL,
+  PAYEE_CLEANUP_SUPPRESSION_INDEX_SQL,
+  PAYEE_CLEANUP_SUPPRESSION_TABLE_SQL,
   SAVED_QUERY_TABLE_SQL,
   SERVER_CREDENTIAL_TABLE_SQL,
   FX_INDEX_SQL,
@@ -28,7 +30,7 @@ import {
 import { KDF_VERSION_META_KEY, SALT_META_KEY, VERIFIER_META_KEY } from "./vaultMetaKeys";
 import { AppDbUnavailableError } from "./errors";
 
-export const LATEST_SCHEMA_VERSION = 16;
+export const LATEST_SCHEMA_VERSION = 17;
 
 type Migration = {
   version: number;
@@ -205,6 +207,15 @@ const MIGRATIONS: readonly Migration[] = [
     // channels become the two Actual fields they belong to, and the write
     // configuration stops framing payee and notes as an either/or.
     apply: applyReconciliationImportSemantics,
+  },
+  {
+    version: 17,
+    // Payee Cleanup's "not duplicates" decisions (RD-078). Purely additive: a
+    // new table and its index, nothing existing is touched.
+    statements: [
+      PAYEE_CLEANUP_SUPPRESSION_TABLE_SQL,
+      PAYEE_CLEANUP_SUPPRESSION_INDEX_SQL,
+    ],
   },
 ];
 

--- a/src/lib/app-db/payeeCleanupSuppressionRepository.test.ts
+++ b/src/lib/app-db/payeeCleanupSuppressionRepository.test.ts
@@ -120,9 +120,19 @@ describe("payee cleanup suppression repository", () => {
     const db = tempDb();
     const created = createPayeeCleanupSuppression(db, base);
 
-    expect(deletePayeeCleanupSuppression(db, created.id)).toBe(true);
-    expect(deletePayeeCleanupSuppression(db, "not-a-real-id")).toBe(false);
+    expect(deletePayeeCleanupSuppression(db, created.id, "budget-1")).toBe(true);
+    expect(deletePayeeCleanupSuppression(db, "not-a-real-id", "budget-1")).toBe(false);
     expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(0);
+  });
+
+  it("will not delete another budget's decision by id", () => {
+    // Ids are guessable and every other operation on this table is
+    // budget-scoped; the id alone must not be enough.
+    const db = tempDb();
+    const created = createPayeeCleanupSuppression(db, base);
+
+    expect(deletePayeeCleanupSuppression(db, created.id, "budget-2")).toBe(false);
+    expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(1);
   });
 
   it("clears every decision for one budget only", () => {

--- a/src/lib/app-db/payeeCleanupSuppressionRepository.test.ts
+++ b/src/lib/app-db/payeeCleanupSuppressionRepository.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AppDbValidationError } from "./errors";
+import { getAppDb, resetAppDbForTests } from "./connection";
+import {
+  clearPayeeCleanupSuppressions,
+  createPayeeCleanupSuppression,
+  deletePayeeCleanupSuppression,
+  listPayeeCleanupSuppressions,
+} from "./payeeCleanupSuppressionRepository";
+import type { SqliteDatabase } from "./types";
+
+function tempDb(): SqliteDatabase {
+  const root = mkdtempSync(join(tmpdir(), "actual-bench-payee-suppression-db-"));
+  return getAppDb(join(root, "metadata.sqlite"));
+}
+
+const base = {
+  budgetSyncId: "budget-1",
+  kind: "not-duplicates" as const,
+  payeeIds: ["p1", "p2"],
+  normalizedNames: ["EMIRATES", "EMIRATES NBD"],
+  detectorIds: ["fuzzy-similarity"],
+};
+
+describe("payee cleanup suppression repository", () => {
+  afterEach(() => {
+    resetAppDbForTests();
+  });
+
+  it("creates and lists suppressions for a budget", () => {
+    const db = tempDb();
+    const created = createPayeeCleanupSuppression(db, base);
+
+    expect(created.id).toBeTruthy();
+    expect(created.payeeIds).toEqual(["p1", "p2"]);
+    expect(created.normalizedNames).toEqual(["EMIRATES", "EMIRATES NBD"]);
+
+    expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(1);
+  });
+
+  it("scopes decisions to one budget", () => {
+    // Payee ids and names belong to a budget file. A decision about the
+    // household budget must not silence a suggestion in the business one.
+    const db = tempDb();
+    createPayeeCleanupSuppression(db, base);
+    createPayeeCleanupSuppression(db, { ...base, budgetSyncId: "budget-2" });
+
+    expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(1);
+    expect(listPayeeCleanupSuppressions(db, "budget-2")).toHaveLength(1);
+    expect(listPayeeCleanupSuppressions(db, "budget-3")).toHaveLength(0);
+  });
+
+  it("requires a budget", () => {
+    const db = tempDb();
+    expect(() =>
+      createPayeeCleanupSuppression(db, { ...base, budgetSyncId: "" })
+    ).toThrow(AppDbValidationError);
+  });
+
+  it("rejects a record with nothing to match on", () => {
+    // It could never match again, so it would silently do nothing — worse than
+    // an error, because the user would think their decision was saved.
+    const db = tempDb();
+    expect(() =>
+      createPayeeCleanupSuppression(db, {
+        ...base,
+        payeeIds: [],
+        normalizedNames: [],
+      })
+    ).toThrow(AppDbValidationError);
+  });
+
+  it("accepts names alone, for a decision that must outlive the payee ids", () => {
+    const db = tempDb();
+    const created = createPayeeCleanupSuppression(db, { ...base, payeeIds: [] });
+    expect(created.normalizedNames).toHaveLength(2);
+  });
+
+  it("rejects an unknown kind", () => {
+    const db = tempDb();
+    expect(() =>
+      createPayeeCleanupSuppression(db, { ...base, kind: "delete-everything" })
+    ).toThrow(AppDbValidationError);
+  });
+
+  it("stores an affix rejection", () => {
+    const db = tempDb();
+    const created = createPayeeCleanupSuppression(db, {
+      budgetSyncId: "budget-1",
+      kind: "rejected-affix",
+      payeeIds: [],
+      normalizedNames: ["TRANSFER", "FROM"],
+      detectorIds: ["corpus-prefix"],
+    });
+    expect(created.kind).toBe("rejected-affix");
+  });
+
+  it("deduplicates and trims the lists it stores", () => {
+    const db = tempDb();
+    const created = createPayeeCleanupSuppression(db, {
+      ...base,
+      payeeIds: [" p1 ", "p1", "p2"],
+    });
+    expect(created.payeeIds).toEqual(["p1", "p2"]);
+  });
+
+  it("caps list sizes rather than storing unbounded input", () => {
+    const db = tempDb();
+    expect(() =>
+      createPayeeCleanupSuppression(db, {
+        ...base,
+        payeeIds: Array.from({ length: 60 }, (_, i) => `p${i}`),
+      })
+    ).toThrow(AppDbValidationError);
+  });
+
+  it("deletes one decision and reports an unknown id", () => {
+    const db = tempDb();
+    const created = createPayeeCleanupSuppression(db, base);
+
+    expect(deletePayeeCleanupSuppression(db, created.id)).toBe(true);
+    expect(deletePayeeCleanupSuppression(db, "not-a-real-id")).toBe(false);
+    expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(0);
+  });
+
+  it("clears every decision for one budget only", () => {
+    const db = tempDb();
+    createPayeeCleanupSuppression(db, base);
+    createPayeeCleanupSuppression(db, { ...base, payeeIds: ["p3", "p4"] });
+    createPayeeCleanupSuppression(db, { ...base, budgetSyncId: "budget-2" });
+
+    expect(clearPayeeCleanupSuppressions(db, "budget-1")).toBe(2);
+    expect(listPayeeCleanupSuppressions(db, "budget-1")).toHaveLength(0);
+    expect(listPayeeCleanupSuppressions(db, "budget-2")).toHaveLength(1);
+  });
+
+  it("rejects a payload that is not an object", () => {
+    const db = tempDb();
+    expect(() => createPayeeCleanupSuppression(db, "nope")).toThrow(
+      AppDbValidationError
+    );
+    expect(() => createPayeeCleanupSuppression(db, [1, 2, 3])).toThrow(
+      AppDbValidationError
+    );
+  });
+});

--- a/src/lib/app-db/payeeCleanupSuppressionRepository.ts
+++ b/src/lib/app-db/payeeCleanupSuppressionRepository.ts
@@ -1,0 +1,168 @@
+import { generateId } from "@/lib/uuid";
+import { AppDbValidationError } from "./errors";
+import type { PayeeCleanupSuppressionRecord, SqliteDatabase } from "./types";
+
+/**
+ * Persistence for Payee Cleanup suppressions (RD-078 §14 / PR-041d).
+ *
+ * Stores only the user's own decisions about their own payees — no credentials,
+ * no copied budget data, no transaction detail.
+ *
+ * Budget-scoped, because payee ids and names belong to one budget file. A user
+ * with a household budget and a business budget should not have a decision in
+ * one silence a genuine suggestion in the other.
+ */
+
+type SuppressionRow = {
+  id: string;
+  budget_sync_id: string;
+  kind: string;
+  payee_ids: string;
+  normalized_names: string;
+  detector_ids: string;
+  note: string | null;
+  created_at: string;
+};
+
+const KINDS = new Set(["not-duplicates", "rejected-affix"]);
+const NOTE_MAX = 500;
+const LIST_MAX = 50;
+
+function parseList(value: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function rowToRecord(row: SuppressionRow): PayeeCleanupSuppressionRecord {
+  return {
+    id: row.id,
+    budgetSyncId: row.budget_sync_id,
+    kind: row.kind === "rejected-affix" ? "rejected-affix" : "not-duplicates",
+    payeeIds: parseList(row.payee_ids),
+    normalizedNames: parseList(row.normalized_names),
+    detectorIds: parseList(row.detector_ids),
+    note: row.note ?? undefined,
+    createdAt: row.created_at,
+  };
+}
+
+function normalizeList(value: unknown, label: string): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new AppDbValidationError(`${label} must be an array of strings`);
+  }
+  const list = value
+    .filter((v): v is string => typeof v === "string")
+    .map((v) => v.trim())
+    .filter(Boolean);
+  if (list.length > LIST_MAX) {
+    throw new AppDbValidationError(`${label} must hold ${LIST_MAX} entries or fewer`);
+  }
+  return [...new Set(list)];
+}
+
+export function listPayeeCleanupSuppressions(
+  db: SqliteDatabase,
+  budgetSyncId: string
+): PayeeCleanupSuppressionRecord[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM payee_cleanup_suppressions
+       WHERE budget_sync_id = ?
+       ORDER BY created_at DESC`
+    )
+    .all(budgetSyncId) as SuppressionRow[];
+  return rows.map(rowToRecord);
+}
+
+export function createPayeeCleanupSuppression(
+  db: SqliteDatabase,
+  input: unknown
+): PayeeCleanupSuppressionRecord {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new AppDbValidationError("Suppression payload must be an object");
+  }
+  const body = input as Record<string, unknown>;
+
+  const budgetSyncId =
+    typeof body.budgetSyncId === "string" ? body.budgetSyncId.trim() : "";
+  if (!budgetSyncId) {
+    throw new AppDbValidationError("budgetSyncId is required");
+  }
+
+  const kind = typeof body.kind === "string" ? body.kind : "not-duplicates";
+  if (!KINDS.has(kind)) {
+    throw new AppDbValidationError(`Unknown suppression kind "${kind}"`);
+  }
+
+  const payeeIds = normalizeList(body.payeeIds, "payeeIds");
+  const normalizedNames = normalizeList(body.normalizedNames, "normalizedNames");
+  const detectorIds = normalizeList(body.detectorIds, "detectorIds");
+
+  // Without one of these the record can never match anything again, so it would
+  // silently do nothing — better to reject it than to store a dead row.
+  if (payeeIds.length === 0 && normalizedNames.length === 0) {
+    throw new AppDbValidationError(
+      "A suppression needs payee ids or normalized names to match on"
+    );
+  }
+
+  const note =
+    typeof body.note === "string" && body.note.trim()
+      ? body.note.trim().slice(0, NOTE_MAX)
+      : null;
+
+  const record: SuppressionRow = {
+    id: generateId(),
+    budget_sync_id: budgetSyncId,
+    kind,
+    payee_ids: JSON.stringify(payeeIds),
+    normalized_names: JSON.stringify(normalizedNames),
+    detector_ids: JSON.stringify(detectorIds),
+    note,
+    created_at: new Date().toISOString(),
+  };
+
+  db.prepare(
+    `INSERT INTO payee_cleanup_suppressions
+       (id, budget_sync_id, kind, payee_ids, normalized_names, detector_ids, note, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    record.id,
+    record.budget_sync_id,
+    record.kind,
+    record.payee_ids,
+    record.normalized_names,
+    record.detector_ids,
+    record.note,
+    record.created_at
+  );
+
+  return rowToRecord(record);
+}
+
+/** Returns true when a row was removed, so the caller can 404 an unknown id. */
+export function deletePayeeCleanupSuppression(
+  db: SqliteDatabase,
+  id: string
+): boolean {
+  const result = db
+    .prepare("DELETE FROM payee_cleanup_suppressions WHERE id = ?")
+    .run(id);
+  return result.changes > 0;
+}
+
+/** Clears every suppression for one budget — the "start over" action. */
+export function clearPayeeCleanupSuppressions(
+  db: SqliteDatabase,
+  budgetSyncId: string
+): number {
+  const result = db
+    .prepare("DELETE FROM payee_cleanup_suppressions WHERE budget_sync_id = ?")
+    .run(budgetSyncId);
+  return result.changes;
+}

--- a/src/lib/app-db/payeeCleanupSuppressionRepository.ts
+++ b/src/lib/app-db/payeeCleanupSuppressionRepository.ts
@@ -145,14 +145,23 @@ export function createPayeeCleanupSuppression(
   return rowToRecord(record);
 }
 
-/** Returns true when a row was removed, so the caller can 404 an unknown id. */
+/**
+ * Returns true when a row was removed, so the caller can 404 an unknown id.
+ *
+ * Scoped to the budget as well as the id: every other read and write here is
+ * budget-scoped, and an id alone would let one budget delete another budget's
+ * decision.
+ */
 export function deletePayeeCleanupSuppression(
   db: SqliteDatabase,
-  id: string
+  id: string,
+  budgetSyncId: string
 ): boolean {
   const result = db
-    .prepare("DELETE FROM payee_cleanup_suppressions WHERE id = ?")
-    .run(id);
+    .prepare(
+      "DELETE FROM payee_cleanup_suppressions WHERE id = ? AND budget_sync_id = ?"
+    )
+    .run(id, budgetSyncId);
   return result.changes > 0;
 }
 

--- a/src/lib/app-db/schema.ts
+++ b/src/lib/app-db/schema.ts
@@ -209,6 +209,35 @@ CREATE TABLE IF NOT EXISTS saved_queries (
 );
 `;
 
+// ── Payee cleanup suppressions (RD-078 / PR-041d) ────────────────────────────
+//
+// A user's "these are not duplicates" decisions. Budget-scoped, because payee
+// ids and names belong to one budget file.
+//
+// Both `payee_ids` and `normalized_names` are stored on purpose. Ids are the
+// precise key but do not survive the merge or deletion of the payees involved;
+// normalized names outlive them but can collide with a genuinely new payee. A
+// suppression matches when *either* still identifies the same relationship, and
+// the pair as a whole is what is suppressed — never an individual payee, which
+// must stay eligible for other clusters.
+export const PAYEE_CLEANUP_SUPPRESSION_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS payee_cleanup_suppressions (
+  id text PRIMARY KEY,
+  budget_sync_id text NOT NULL,
+  kind text NOT NULL,
+  payee_ids text NOT NULL,
+  normalized_names text NOT NULL,
+  detector_ids text NOT NULL,
+  note text,
+  created_at text NOT NULL
+);
+`;
+
+export const PAYEE_CLEANUP_SUPPRESSION_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_payee_cleanup_suppressions_budget
+  ON payee_cleanup_suppressions (budget_sync_id);
+`;
+
 // ── FX / multi-currency consolidation (RD-056 / PR-025a) ─────────────────────
 // The database is the authoritative FX registry; Frankfurter only populates it.
 export const FX_RATE_IMPORT_BATCH_TABLE_SQL = `

--- a/src/lib/app-db/types.ts
+++ b/src/lib/app-db/types.ts
@@ -379,6 +379,28 @@ export type RememberedBudgetInput = {
 // Global (not budget-scoped). `isFavorite` is stored as an integer column and
 // normalized to boolean by the repository. Shape is structurally compatible
 // with the query feature's client-side `SavedQuery` type.
+/**
+ * A "these are not duplicates" decision, or a rejected learned affix
+ * (RD-078 §14 / PR-041d).
+ *
+ * Suppression is a property of the *relationship*, not of a payee: marking
+ * `EMIRATES` and `EMIRATES NBD` as unrelated must not hide either of them from
+ * a different, well-evidenced cluster.
+ */
+export type PayeeCleanupSuppressionRecord = {
+  id: string;
+  budgetSyncId: string;
+  kind: "not-duplicates" | "rejected-affix";
+  /** Precise, but gone once the payees are merged or deleted. */
+  payeeIds: string[];
+  /** Outlives the ids; for an affix, the affix tokens. */
+  normalizedNames: string[];
+  /** Which detector or reducer produced the rejected proposal, when known. */
+  detectorIds: string[];
+  note?: string;
+  createdAt: string;
+};
+
 export type SavedQueryRecord = {
   id: string;
   name: string;


### PR DESCRIPTION
Bank imports create a payee per distinct piece of text, so one shop becomes many payees — the text carries a date, a card number, a store number or a location that changes every transaction. This adds **Payee Cleanup** (Tools → Payee Cleanup) to find those groups, show exactly what merging them would change, and fix the budget in one reviewed pass.

## How it finds duplicates

Two layers, deliberately kept distinguishable in the UI:

- **Shape rules** remove text that identifies itself by its structure — dates in any common layout, times, card numbers, long reference and authorization numbers, `Label: value` metadata, exchange rates, trailing store numbers and web addresses. No bank, country or merchant vocabulary is hard-coded, so this behaves the same for any institution.
- **Learned boilerplate** covers wrapping no pattern can identify, by finding fragments that repeat across many otherwise unrelated payees in that budget. Anything learned this way is treated as a guess: it lowers confidence and lands in *Needs review*, because repetition proves a fragment is shared, not that removing it is safe.

## Deciding

Each suggestion is one card in three columns — the result and the payees behind it, what changes, and future imports — with no dialog to open. Struck-through text shows what each name lost; *Reasoning* expands the detector's account.

*What changes* reports transactions that will move, rules split into regular / active schedule-linked / completed schedule-linked, and any disagreement over Favorite or Category learning.

Corrections are free: drop a member, add one the scan missed, choose which payee survives, edit the final name, or dismiss the group as *not duplicates* — remembered per budget and reversible from the Dismissed tab, including a learned fragment you disagreed with. `A` / `R` / `N` triage the focused card.

*Accept n safe* is stricter than a score threshold: structural match only, no settings conflict, counts loaded, and no rule — proposed or existing — reaching beyond the group.

## Future imports

Merging alone often fixes future imports, since Actual resolves an imported name that exactly equals an existing payee, and an existing rule may already cover it. Both are checked before a rule is proposed. Where one is worth it, the rule is backtested against import history and never pre-selected if it would also catch another payee's transactions; the matched text and the field it matches on are editable and re-run the backtest.

## Safety

- Scan → review → accept → **Stage cleanup** → **Save**. Staging goes through the normal staged-changes flow; nothing is written until you save on the Payees page.
- The plan is validated as a whole: two accepted groups heading for the same payee name are blocked and offered as one combined group instead, so cleanup cannot create the duplicate it exists to remove.
- Merging uses Actual's own operation. Transactions follow automatically; rules are not rewritten. Actual Bench never rewrites transactions or rules itself.
- Transfer payees and tombstoned payees are excluded throughout — Actual's merge silently no-ops on a transfer target.
- The unused-payee check is slightly stricter than Actual's, since it also counts rules that *set* a payee.
- A truncated import-history read is disclosed and blocks both pre-selection and bulk accept.

## Also

- New app-DB table (schema v17, additive) plus API routes for dismissals.
- An overview card links to the page.
- Docs: new user-guide page, a cross-link from Payees, and a FEATURES entry.
