### PR TITLE
Rules: clear all active filters in one click

### DIFF
--- a/src/features/rules/components/FilterBar.tsx
+++ b/src/features/rules/components/FilterBar.tsx
@@ -26,6 +26,7 @@ export function FilterBar({
   categoryId, categoryName,
   accountId, accountName,
   onClearPayee, onClearCategory, onClearAccount,
+  onClearAll,
   rowCount, totalVisible,
   selectedCount,
   onDeleteSelected, onMerge, onDeselect,
@@ -39,12 +40,21 @@ export function FilterBar({
   onClearPayee: () => void;
   onClearCategory: () => void;
   onClearAccount: () => void;
+  onClearAll: () => void;
   rowCount: number; totalVisible: number;
   selectedCount: number;
   onDeleteSelected: () => void;
   onMerge: () => void;
   onDeselect: () => void;
 }) {
+  const hasFilters =
+    Boolean(search) ||
+    stageFilter !== "all" ||
+    actionTypeFilter !== "all" ||
+    Boolean(payeeId) ||
+    Boolean(categoryId) ||
+    Boolean(accountId);
+
   if (selectedCount >= 1) {
     return (
       <div className="flex flex-wrap items-center gap-2 border-b border-border/40 bg-primary/5 px-2 py-1.5">
@@ -152,6 +162,15 @@ export function FilterBar({
             <X className="h-3 w-3" />
           </button>
         </div>
+      )}
+
+      {hasFilters && (
+        <button
+          onClick={onClearAll}
+          className="text-xs text-muted-foreground underline hover:text-foreground"
+        >
+          Clear
+        </button>
       )}
 
       <span className="ml-auto text-xs text-muted-foreground whitespace-nowrap">

--- a/src/features/rules/components/RulesTable.tsx
+++ b/src/features/rules/components/RulesTable.tsx
@@ -227,6 +227,10 @@ export function RulesTable({ onEdit, onMerge, payeeId, categoryId, accountId }: 
         onClearPayee={() => router.push("/rules")}
         onClearCategory={() => router.push("/rules")}
         onClearAccount={() => router.push("/rules")}
+        onClearAll={() => {
+          clearFilters();
+          if (payeeId || categoryId || accountId) router.push("/rules");
+        }}
         rowCount={rows.length}
         totalVisible={totalVisible}
         selectedCount={activeSelectedIds.length}


### PR DESCRIPTION
## Problem

The Rules page filter bar had no way to reset all active filters at once. Users could remove filters individually (the X on each payee/category/account chip, the X in the search box) or hit **Clear filters** in the empty state — but only when the filters happened to match nothing. The Payees page already shows a **Clear** link whenever any filter is active.

## Change

Add the same **Clear** link to the Rules filter bar. It appears when search, stage, action type, or the payee/category/account URL filters are active, and reuses the existing `clearFilters` handler, navigating back to `/rules` to drop the URL-driven filters.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on both changed files — clean