### PR TITLE
Make the Automations page tell the truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ── Dependencies ──────────────────────────────────────────────────────────────
-node_modules/
+# No trailing slash: a trailing slash matches directories only, so a *symlink*
+# named node_modules is not ignored — which is how one reached a commit.
+node_modules
 
 # ── Next.js build output ──────────────────────────────────────────────────────
 .next/

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -79,7 +79,12 @@ the run history, or the UI.
 ## Budget File Sync as an automation
 
 A sync flow set to **"Auto-sync on a server schedule (unattended)"** appears here automatically —
-you do not create it twice. Its schedule and enabled state carry over from the flow.
+you do not create it twice. Its schedule and enabled state carry over from the flow, and a flow you
+enrol while the server is running appears as soon as you open or refresh this page, rather than at
+the next restart. (The engine also sweeps once a minute, so it is picked up even with no page open.)
+
+A flow set to manual review, or to sync while Bench is open, is deliberately **not** listed here:
+those are not unattended, and showing them would imply the server runs them.
 
 Full sync history stays in Budget File Sync, which is where the detail belongs (previews, items,
 the review queue). Each automation run links to the sync run it produced.

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/coder/projects/actual-bench/node_modules

--- a/src/app/api/automations/health/route.ts
+++ b/src/app/api/automations/health/route.ts
@@ -1,16 +1,19 @@
 import { NextResponse } from "next/server";
 import { getAppDb } from "@/lib/app-db/connection";
 import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { reconcileJobTypes } from "@/lib/automation/engine";
 import { buildAutomationHealth, overallAutomationStatus } from "@/lib/automation/health";
 import { ensureAutomationJobTypesRegistered } from "@/lib/automation/bootstrap";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export function GET() {
+export async function GET() {
   try {
     ensureAutomationJobTypesRegistered();
-    const report = buildAutomationHealth(getAppDb());
+    const db = getAppDb();
+    await reconcileJobTypes(db);
+    const report = buildAutomationHealth(db);
     return NextResponse.json({ ...report, overall: overallAutomationStatus(report) });
   } catch (error) {
     return appDbErrorResponse(error);

--- a/src/app/api/automations/route.test.ts
+++ b/src/app/api/automations/route.test.ts
@@ -12,6 +12,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resetAppDbForTests } from "@/lib/app-db/connection";
 import { GET, POST } from "./route";
+import { getAppDb } from "@/lib/app-db/connection";
+import { createSyncFlow } from "@/lib/app-db/syncFlowRepository";
+import {
+  __resetBudgetFileSyncRegistrationForTests,
+  registerBudgetFileSyncJobType,
+} from "@/lib/automation/jobs/budgetFileSync";
+import { __resetAutomationRegistryForTests } from "@/lib/automation/registry";
 import type { AutomationDefinition } from "@/lib/app-db/types";
 
 function request(body: unknown): Request {
@@ -36,6 +43,8 @@ describe("/api/automations", () => {
   });
 
   afterEach(() => {
+    __resetAutomationRegistryForTests();
+    __resetBudgetFileSyncRegistrationForTests();
     resetAppDbForTests();
     delete process.env.ACTUAL_BENCH_DB_PATH;
     rmSync(root, { recursive: true, force: true });
@@ -48,7 +57,7 @@ describe("/api/automations", () => {
     const body = (await response.json()) as { automation: AutomationDefinition };
     expect(body.automation.type).toBe("budget-file-sync");
 
-    const list = (await GET().json()) as { automations: unknown[]; jobTypes: { type: string }[] };
+    const list = (await (await GET()).json()) as { automations: unknown[]; jobTypes: { type: string }[] };
     expect(list.automations).toHaveLength(1);
     expect(list.jobTypes.map((jobType) => jobType.type)).toContain("budget-file-sync");
   });
@@ -62,7 +71,7 @@ describe("/api/automations", () => {
     expect(body.error).toMatch(/No automation of type "not-a-real-type"/);
     expect(body.error).toMatch(/budget-file-sync/);
 
-    const list = (await GET().json()) as { automations: unknown[] };
+    const list = (await (await GET()).json()) as { automations: unknown[] };
     expect(list.automations).toHaveLength(0);
   });
 
@@ -73,5 +82,29 @@ describe("/api/automations", () => {
     expect(response.status).toBe(400);
     const body = (await response.json()) as { error: string };
     expect(body.error).toMatch(/must be an object/);
+  });
+
+  it("shows a flow enrolled since the last tick, without waiting for one", async () => {
+    const db = getAppDb();
+    registerBudgetFileSyncJobType();
+
+    // Someone enrols a flow for unattended sync in the Sync UI.
+    createSyncFlow(db, {
+      name: "Just created",
+      legs: [
+        {
+          sourceRef: { version: 1, data: { connectionFingerprint: "a", budgetSyncId: "b" } },
+          targetRef: { version: 1, data: { connectionFingerprint: "c", budgetSyncId: "d" } },
+          filter: { version: 1, data: {} },
+          transform: { version: 1, data: {} },
+          options: { version: 1, data: { reviewPolicy: "auto_sync_unattended", intervalMinutes: 30 } },
+        },
+      ],
+    });
+
+    // No engine tick has run. The page must still show it rather than reporting
+    // "No automations yet" about something that plainly exists.
+    const list = (await (await GET()).json()) as { automations: { name: string }[] };
+    expect(list.automations.map((automation) => automation.name)).toEqual(["Just created"]);
   });
 });

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -5,7 +5,8 @@ import { createAutomation, listAutomations } from "@/lib/app-db/automationReposi
 import { ensureAutomationJobTypesRegistered } from "@/lib/automation/bootstrap";
 import { getAutomationJobType, listAutomationJobTypes } from "@/lib/automation/registry";
 import { describeSchedule } from "@/lib/automation/schedule";
-import { isAutomationRunning } from "@/lib/automation/engine";
+import { buildAutomationHealth } from "@/lib/automation/health";
+import { isAutomationRunning, reconcileJobTypes } from "@/lib/automation/engine";
 import { listAutomationRuns } from "@/lib/app-db/automationRunRepository";
 
 export const dynamic = "force-dynamic";
@@ -16,18 +17,33 @@ export const runtime = "nodejs";
  * an automation without a second request: its plain-language schedule, whether
  * it is running right now, and its most recent run.
  */
-export function GET() {
+export async function GET() {
   try {
     ensureAutomationJobTypesRegistered();
     const db = getAppDb();
+    // Pick up anything enrolled since the last tick, so the page cannot tell
+    // someone the flow they just created does not exist.
+    await reconcileJobTypes(db);
+
+    // Status comes from the health module rather than being re-derived in the
+    // UI: "is this healthy" is a judgement with rules (a stale run is a warning,
+    // a cancelled one is neither success nor failure), and two implementations
+    // of it would eventually disagree on the same screen.
+    const health = new Map(
+      buildAutomationHealth(db).automations.map((entry) => [entry.id, entry])
+    );
 
     const automations = listAutomations(db).map((automation) => {
       const [lastRun] = listAutomationRuns(db, { automationId: automation.id, limit: 1 });
+      const entry = health.get(automation.id);
       return {
         ...automation,
         scheduleLabel: describeSchedule(automation),
         running: isAutomationRunning(automation),
         lastRun: lastRun ?? null,
+        typeLabel: entry?.typeLabel ?? automation.type,
+        status: entry?.status ?? "idle",
+        statusSummary: entry?.summary ?? "",
       };
     });
 

--- a/src/features/automations/components/AutomationsTable.tsx
+++ b/src/features/automations/components/AutomationsTable.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { AlertTriangle, CircleDot, Loader2, Pause, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { executionModeCopy, formatDateTime, relativeTime } from "../lib/presentation";
+import type { AutomationListItem } from "../lib/automationsApi";
+
+/**
+ * The Automations list (RD-079).
+ *
+ * A table, like the rest of Actual Bench's list pages, because this is an
+ * operational screen: the question is "is everything fine, what ran, what is
+ * next", and that is a scanning task. One line per automation answers it; the
+ * side sheet holds the detail.
+ *
+ * Two rules shape the layout:
+ *
+ *   * **Space in proportion to trouble.** A healthy automation gets one line. A
+ *     failing or paused one gets a second, carrying the reason — the only text
+ *     here worth interrupting a scan for.
+ *   * **Say the type.** A name like "Test 2" means nothing once bank sync sits
+ *     beside budget file sync, so the job type is a column rather than
+ *     something you infer from the result wording.
+ *
+ * The execution-mode explanation is stated once for the page instead of being
+ * repeated per row: the honesty rule is about the user knowing, not about the
+ * sentence appearing N times.
+ */
+
+const STATUS_STYLE: Record<
+  AutomationListItem["status"],
+  { dot: string; label: string; row?: string }
+> = {
+  ok: { dot: "text-green-600 dark:text-green-500", label: "Healthy" },
+  warning: {
+    dot: "text-amber-600 dark:text-amber-500",
+    label: "Needs attention",
+    row: "bg-amber-50/40 dark:bg-amber-950/10",
+  },
+  failing: {
+    dot: "text-destructive",
+    label: "Failing",
+    row: "bg-destructive/5",
+  },
+  paused: {
+    dot: "text-amber-600 dark:text-amber-500",
+    label: "Paused",
+    row: "bg-amber-50/40 dark:bg-amber-950/10",
+  },
+  idle: { dot: "text-muted-foreground", label: "Idle" },
+};
+
+type AutomationsTableProps = {
+  automations: AutomationListItem[];
+  runningId: string | null;
+  onOpen: (automationId: string) => void;
+  onRunNow: (automationId: string) => void;
+  onToggleEnabled: (automation: AutomationListItem) => void;
+  onResume: (automationId: string) => void;
+};
+
+export function AutomationsTable({
+  automations,
+  runningId,
+  onOpen,
+  onRunNow,
+  onToggleEnabled,
+  onResume,
+}: AutomationsTableProps) {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <table className="w-full text-xs">
+        <thead className="sticky top-0 z-10 bg-muted text-left text-[11px] uppercase text-muted-foreground">
+          <tr>
+            <th className="w-8 px-3 py-2">
+              <span className="sr-only">Status</span>
+            </th>
+            <th className="px-3 py-2">Automation</th>
+            <th className="px-3 py-2">Type</th>
+            <th className="px-3 py-2">Schedule</th>
+            <th className="px-3 py-2">Last run</th>
+            <th className="px-3 py-2">Next run</th>
+            <th className="w-px px-3 py-2 text-right">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {automations.map((automation) => {
+            const style = STATUS_STYLE[automation.status];
+            const mode = executionModeCopy(automation.executionMode);
+            const paused = Boolean(automation.autoPausedAt);
+            const busy = automation.running || runningId === automation.id;
+            // Only a row in trouble earns a second line; a healthy one says all
+            // it needs to on the first. Keyed off the pause reason as well as
+            // the derived status, so a reason can never be present and unshown.
+            const needsExplanation =
+              automation.status === "failing" ||
+              automation.status === "paused" ||
+              Boolean(automation.autoPauseReason);
+
+            return (
+              <tr
+                key={automation.id}
+                className={cn("border-t border-border/60 align-top", style.row)}
+                data-testid="automation-row"
+              >
+                <td className="px-3 py-2">
+                  {busy ? (
+                    <Loader2 className="size-3.5 animate-spin text-muted-foreground" aria-label="Running" />
+                  ) : (
+                    <CircleDot className={cn("size-3.5", style.dot)} aria-label={style.label} />
+                  )}
+                </td>
+
+                <td className="px-3 py-2">
+                  <button
+                    type="button"
+                    className="font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => onOpen(automation.id)}
+                  >
+                    {automation.name}
+                  </button>
+                  {!automation.enabled && !paused && (
+                    <span className="ml-2 text-muted-foreground">Off</span>
+                  )}
+                  {needsExplanation && (
+                    <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+                      <AlertTriangle className="mt-px size-3 shrink-0 text-amber-600 dark:text-amber-500" aria-hidden />
+                      <span>{automation.autoPauseReason ?? automation.statusSummary}</span>
+                    </p>
+                  )}
+                </td>
+
+                <td className="px-3 py-2 whitespace-nowrap text-muted-foreground">
+                  {automation.typeLabel}
+                </td>
+
+                <td className="px-3 py-2 whitespace-nowrap">
+                  {automation.scheduleLabel}
+                  <span className="text-muted-foreground"> · </span>
+                  {/* The mode is the one thing people get wrong about an
+                      automation, so it stays on the row — with the full
+                      explanation a hover away rather than repeated in prose. */}
+                  <span className="cursor-help underline decoration-dotted" title={mode.detail}>
+                    {automation.executionMode === "server" ? "Server" : "Browser only"}
+                  </span>
+                </td>
+
+                <td className="px-3 py-2">
+                  {automation.lastRunAt ? (
+                    <span title={formatDateTime(automation.lastRunAt)}>
+                      {relativeTime(automation.lastRunAt)}
+                      {automation.lastRun?.rollup?.message && (
+                        <span className="text-muted-foreground">
+                          {" · "}
+                          {automation.lastRun.rollup.message}
+                        </span>
+                      )}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">Never</span>
+                  )}
+                </td>
+
+                <td className="px-3 py-2 whitespace-nowrap" title={formatDateTime(automation.nextRunAt)}>
+                  {automation.enabled && !paused ? (
+                    relativeTime(automation.nextRunAt)
+                  ) : (
+                    <span className="text-muted-foreground">Not scheduled</span>
+                  )}
+                </td>
+
+                <td className="px-3 py-2">
+                  <div className="flex items-center justify-end gap-1.5">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => onRunNow(automation.id)}
+                      aria-label={`Run ${automation.name} now`}
+                    >
+                      {busy ? <Loader2 className="animate-spin" aria-hidden /> : <Play aria-hidden />}
+                      Run now
+                    </Button>
+
+                    {paused ? (
+                      <Button variant="outline" size="sm" onClick={() => onResume(automation.id)}>
+                        Resume
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onToggleEnabled(automation)}
+                        aria-label={
+                          automation.enabled
+                            ? `Pause ${automation.name}`
+                            : `Enable ${automation.name}`
+                        }
+                      >
+                        {automation.enabled ? <Pause aria-hidden /> : <Play aria-hidden />}
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/automations/components/AutomationsTable.tsx
+++ b/src/features/automations/components/AutomationsTable.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { AlertTriangle, CircleDot, Loader2, Pause, Play } from "lucide-react";
+import {
+  AlertTriangle,
+  CircleCheck,
+  CircleDot,
+  CirclePause,
+  CircleX,
+  Loader2,
+  Pause,
+  Play,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { executionModeCopy, formatDateTime, relativeTime } from "../lib/presentation";
@@ -28,27 +38,39 @@ import type { AutomationListItem } from "../lib/automationsApi";
  * sentence appearing N times.
  */
 
+/**
+ * Status is carried by a word, an icon shape and a colour — in that order of
+ * importance.
+ *
+ * Colour alone cannot say "failing": it is invisible to anyone who cannot
+ * distinguish the hues, and it disappears entirely in a screenshot pasted into
+ * a bug report. The shapes differ too, so the three signals degrade
+ * independently.
+ */
 const STATUS_STYLE: Record<
   AutomationListItem["status"],
-  { dot: string; label: string; row?: string }
+  { icon: LucideIcon; tone: string; label: string; row?: string }
 > = {
-  ok: { dot: "text-green-600 dark:text-green-500", label: "Healthy" },
+  ok: { icon: CircleCheck, tone: "text-green-600 dark:text-green-500", label: "Healthy" },
   warning: {
-    dot: "text-amber-600 dark:text-amber-500",
-    label: "Needs attention",
+    icon: AlertTriangle,
+    tone: "text-amber-600 dark:text-amber-500",
+    label: "Attention",
     row: "bg-amber-50/40 dark:bg-amber-950/10",
   },
   failing: {
-    dot: "text-destructive",
+    icon: CircleX,
+    tone: "text-destructive",
     label: "Failing",
     row: "bg-destructive/5",
   },
   paused: {
-    dot: "text-amber-600 dark:text-amber-500",
+    icon: CirclePause,
+    tone: "text-amber-600 dark:text-amber-500",
     label: "Paused",
     row: "bg-amber-50/40 dark:bg-amber-950/10",
   },
-  idle: { dot: "text-muted-foreground", label: "Idle" },
+  idle: { icon: CircleDot, tone: "text-muted-foreground", label: "Idle" },
 };
 
 type AutomationsTableProps = {
@@ -73,9 +95,7 @@ export function AutomationsTable({
       <table className="w-full text-xs">
         <thead className="sticky top-0 z-10 bg-muted text-left text-[11px] uppercase text-muted-foreground">
           <tr>
-            <th className="w-8 px-3 py-2">
-              <span className="sr-only">Status</span>
-            </th>
+            <th className="px-3 py-2">Status</th>
             <th className="px-3 py-2">Automation</th>
             <th className="px-3 py-2">Type</th>
             <th className="px-3 py-2">Schedule</th>
@@ -89,6 +109,7 @@ export function AutomationsTable({
         <tbody>
           {automations.map((automation) => {
             const style = STATUS_STYLE[automation.status];
+            const StatusIcon = style.icon;
             const mode = executionModeCopy(automation.executionMode);
             const paused = Boolean(automation.autoPausedAt);
             const busy = automation.running || runningId === automation.id;
@@ -106,11 +127,17 @@ export function AutomationsTable({
                 className={cn("border-t border-border/60 align-top", style.row)}
                 data-testid="automation-row"
               >
-                <td className="px-3 py-2">
+                <td className="px-3 py-2 whitespace-nowrap">
                   {busy ? (
-                    <Loader2 className="size-3.5 animate-spin text-muted-foreground" aria-label="Running" />
+                    <span className="flex items-center gap-1.5 text-muted-foreground">
+                      <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                      Running
+                    </span>
                   ) : (
-                    <CircleDot className={cn("size-3.5", style.dot)} aria-label={style.label} />
+                    <span className={cn("flex items-center gap-1.5", style.tone)}>
+                      <StatusIcon className="size-3.5" aria-hidden />
+                      {style.label}
+                    </span>
                   )}
                 </td>
 

--- a/src/features/automations/components/AutomationsView.test.tsx
+++ b/src/features/automations/components/AutomationsView.test.tsx
@@ -170,7 +170,8 @@ describe("AutomationsView", () => {
 
     renderView();
 
-    expect(await screen.findByLabelText("Running")).toBeInTheDocument();
+    // Status is readable as a word, not just a colour.
+    expect(await screen.findByText("Running")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /run .* now/i })).toBeDisabled();
   });
 
@@ -326,5 +327,29 @@ describe("AutomationsView", () => {
     releaseRefresh();
     await waitFor(() => expect(refresh).not.toBeDisabled());
     expect(refresh.querySelector("svg")).not.toHaveClass("animate-spin");
+  });
+
+  it("states each status in words, not only in colour", async () => {
+    mockedApi.listAutomations.mockResolvedValue({
+      automations: [
+        automation({ id: "a", name: "Healthy one" }),
+        automation({
+          id: "b",
+          name: "Broken one",
+          status: "failing",
+          statusSummary: "Last 3 attempts failed: provider unreachable",
+          consecutiveFailures: 3,
+        }),
+      ],
+      jobTypes: [],
+    });
+
+    renderView();
+
+    // Anyone who cannot distinguish the hues — or who pastes a screenshot into
+    // a bug report — still learns which row is in trouble.
+    expect(await screen.findByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByText("Failing")).toBeInTheDocument();
+    expect(screen.getByText(/provider unreachable/)).toBeInTheDocument();
   });
 });

--- a/src/features/automations/components/AutomationsView.test.tsx
+++ b/src/features/automations/components/AutomationsView.test.tsx
@@ -44,6 +44,9 @@ function automation(overrides: Partial<AutomationListItem> = {}): AutomationList
     scheduleLabel: "Every 30 minutes",
     running: false,
     lastRun: run(),
+    typeLabel: "Budget File Sync",
+    status: "ok",
+    statusSummary: "Last run finished successfully.",
     ...overrides,
   };
 }
@@ -95,8 +98,10 @@ describe("AutomationsView", () => {
 
     expect(await screen.findByText("Household → Joint")).toBeInTheDocument();
     expect(screen.getByText(/Every 30 minutes/)).toBeInTheDocument();
-    expect(screen.getByText("Succeeded")).toBeInTheDocument();
-    expect(screen.getByText("3 added")).toBeInTheDocument();
+    // The job type is named rather than inferred: "Household → Joint" says
+    // nothing about what kind of automation it is once bank sync exists.
+    expect(screen.getByText("Budget File Sync")).toBeInTheDocument();
+    expect(screen.getByText(/3 added/)).toBeInTheDocument();
   });
 
   it("states on every row whether the automation runs with Bench closed", async () => {
@@ -110,15 +115,19 @@ describe("AutomationsView", () => {
 
     renderView();
 
-    expect(await screen.findByText(/even with Actual Bench closed/i)).toBeInTheDocument();
-    // The browser-mode row must say so on the row itself, not in docs somewhere.
-    expect(screen.getByText(/only runs while Actual Bench is open/i)).toBeInTheDocument();
+    // Stated once for the page...
+    expect(await screen.findByText(/run on a schedule even with Actual Bench closed/i)).toBeInTheDocument();
+    // ...and per row, where a browser-only automation cannot be mistaken for an
+    // unattended one. The full explanation is on the control itself.
+    const browserCell = screen.getByText("Browser only");
+    expect(browserCell).toHaveAttribute("title", expect.stringMatching(/only runs while Actual Bench is open/i));
+    expect(screen.getAllByText("Server").length).toBeGreaterThan(0);
   });
 
   it("runs an automation on demand", async () => {
     renderView();
 
-    fireEvent.click(await screen.findByRole("button", { name: /run now/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /run .* now/i }));
 
     // react-query passes its own context as a second argument; assert on the id.
     await waitFor(() => expect(mockedApi.runAutomationNow).toHaveBeenCalled());
@@ -144,7 +153,7 @@ describe("AutomationsView", () => {
     renderView();
     await screen.findByText("Second automation");
 
-    const buttons = screen.getAllByRole("button", { name: /run now/i });
+    const buttons = screen.getAllByRole("button", { name: /run .* now/i });
     fireEvent.click(buttons[0]);
 
     await waitFor(() => expect(buttons[0]).toBeDisabled());
@@ -161,8 +170,8 @@ describe("AutomationsView", () => {
 
     renderView();
 
-    expect(await screen.findByText("Running")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+    expect(await screen.findByLabelText("Running")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /run .* now/i })).toBeDisabled();
   });
 
   it("surfaces the pause reason and offers Resume rather than a bare toggle", async () => {
@@ -173,6 +182,8 @@ describe("AutomationsView", () => {
           autoPausedAt: "2026-08-25T09:00:00.000Z",
           autoPauseReason: "Paused after 5 consecutive failures: provider unreachable",
           consecutiveFailures: 5,
+          status: "paused",
+          statusSummary: "Paused after 5 consecutive failures: provider unreachable",
         }),
       ],
       jobTypes: [],
@@ -180,8 +191,8 @@ describe("AutomationsView", () => {
 
     renderView();
 
-    expect(await screen.findByText("Auto-paused")).toBeInTheDocument();
-    expect(screen.getByText(/provider unreachable/)).toBeInTheDocument();
+    // A row in trouble earns the extra line that explains it.
+    expect(await screen.findByText(/provider unreachable/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /resume/i }));
     await waitFor(() => expect(mockedApi.patchAutomation).toHaveBeenCalledWith("auto-1", { resume: true }));
@@ -206,7 +217,11 @@ describe("AutomationsView", () => {
     renderView();
 
     expect(await screen.findByText(/No automations yet/i)).toBeInTheDocument();
-    expect(screen.getByText(/becomes an automation automatically/i)).toBeInTheDocument();
+    // The empty page must explain *why* it is empty: which flows qualify, and
+    // that a just-enrolled one is not missing, only not picked up yet.
+    expect(screen.getByText(/Auto-sync on a server schedule/i)).toBeInTheDocument();
+    expect(screen.getByText(/stays out of here on purpose/i)).toBeInTheDocument();
+    expect(screen.getByText(/appears as soon as you refresh this page/i)).toBeInTheDocument();
   });
 
   it("opens run history with the job type's own result rendering", async () => {
@@ -258,7 +273,7 @@ describe("AutomationsView", () => {
     });
 
     renderView();
-    fireEvent.click(await screen.findByRole("button", { name: /run now/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /run .* now/i }));
 
     // A run that happened answers 200 whatever it concluded, so the toast has
     // to read the outcome rather than the HTTP status.
@@ -274,11 +289,42 @@ describe("AutomationsView", () => {
     });
 
     renderView();
-    fireEvent.click(await screen.findByRole("button", { name: /run now/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /run .* now/i }));
 
     await waitFor(() =>
       expect(toast.warning).toHaveBeenCalledWith("A run is already in progress")
     );
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("animates the refresh control only while a requested refresh is running", async () => {
+    let releaseRefresh: () => void = () => {};
+    mockedApi.listAutomations
+      .mockResolvedValueOnce({ automations: [automation()], jobTypes: [] })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseRefresh = () => resolve({ automations: [automation()], jobTypes: [] });
+          })
+      );
+
+    renderView();
+    await screen.findByText("Household → Joint");
+
+    const refresh = screen.getByRole("button", { name: /refresh automations/i });
+    const icon = refresh.querySelector("svg");
+
+    // At rest it must not spin: the page polls on its own, and an icon that is
+    // always moving tells the user nothing about their click.
+    expect(icon).not.toHaveClass("animate-spin");
+
+    fireEvent.click(refresh);
+
+    await waitFor(() => expect(refresh).toBeDisabled());
+    expect(refresh.querySelector("svg")).toHaveClass("animate-spin");
+
+    releaseRefresh();
+    await waitFor(() => expect(refresh).not.toBeDisabled());
+    expect(refresh.querySelector("svg")).not.toHaveClass("animate-spin");
   });
 });

--- a/src/features/automations/components/AutomationsView.tsx
+++ b/src/features/automations/components/AutomationsView.tsx
@@ -2,27 +2,22 @@
 
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Info, Loader2, Pause, Play, RefreshCw } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
+import { cn } from "@/lib/utils";
 import Link from "next/link";
 import {
   listAutomations,
   listReviewQueue,
   patchAutomation,
   runAutomationNow,
-  type AutomationListItem,
 } from "../lib/automationsApi";
-import {
-  executionModeCopy,
-  formatDateTime,
-  relativeTime,
-  runStatusLabel,
-  runStatusTone,
-} from "../lib/presentation";
+
 import { AutomationDetail } from "./AutomationDetail";
+import { AutomationsTable } from "./AutomationsTable";
+import { describeAutomationsSummary } from "../lib/presentation";
 
 /**
  * The Automations workspace (RD-079 / PR-043d).
@@ -36,35 +31,6 @@ import { AutomationDetail } from "./AutomationDetail";
  * Budget's experimental Budget Automations (RD-047) are a different thing that
  * Bench does not drive; nothing here should read as that feature.
  */
-
-const TONE_VARIANT = {
-  ok: "status-active",
-  warn: "status-warning",
-  bad: "destructive",
-  muted: "secondary",
-} as const;
-
-function LastRunBadge({ automation }: { automation: AutomationListItem }) {
-  if (automation.running) {
-    return (
-      <Badge variant="secondary">
-        <Loader2 className="animate-spin" aria-hidden />
-        Running
-      </Badge>
-    );
-  }
-  if (!automation.lastRun) return <span className="text-muted-foreground">Never run</span>;
-
-  const status = automation.lastRun.status;
-  return (
-    <span className="flex items-center gap-2">
-      <Badge variant={TONE_VARIANT[runStatusTone(status)]}>{runStatusLabel(status)}</Badge>
-      <span className="text-muted-foreground" title={formatDateTime(automation.lastRunAt)}>
-        {relativeTime(automation.lastRunAt)}
-      </span>
-    </span>
-  );
-}
 
 export function AutomationsView() {
   const queryClient = useQueryClient();
@@ -126,6 +92,24 @@ export function AutomationsView() {
     refetchInterval: 30_000,
   });
 
+  /**
+   * Spins for a refresh someone asked for, and only that.
+   *
+   * Keying the animation off `isFetching` would spin every 15 seconds as the
+   * background poll runs, which reads as activity when nothing is happening —
+   * and would leave a user unable to tell whether their click did anything.
+   */
+  const [refreshing, setRefreshing] = useState(false);
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    try {
+      await Promise.all([automationsQuery.refetch(), reviewQueueQuery.refetch()]);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
   const automations = automationsQuery.data?.automations ?? [];
   const reviewQueue = reviewQueueQuery.data ?? [];
   const selected = automations.find((automation) => automation.id === selectedId) ?? null;
@@ -133,7 +117,8 @@ export function AutomationsView() {
   return (
     <PageLayout
       title="Automations"
-      count={automations.length > 0 ? `${automations.length} automation${automations.length === 1 ? "" : "s"}` : undefined}
+      count={describeAutomationsSummary(automations)}
+      scrollManaged
       isLoading={automationsQuery.isLoading}
       isError={automationsQuery.isError}
       error={automationsQuery.error}
@@ -142,10 +127,11 @@ export function AutomationsView() {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => void automationsQuery.refetch()}
+          onClick={() => void handleRefresh()}
+          disabled={refreshing}
           aria-label="Refresh automations"
         >
-          <RefreshCw aria-hidden />
+          <RefreshCw className={cn(refreshing && "animate-spin")} aria-hidden />
           Refresh
         </Button>
       }
@@ -154,17 +140,29 @@ export function AutomationsView() {
           <div className="mx-auto max-w-lg px-6 py-16 text-center">
             <h2 className="text-sm font-semibold">No automations yet</h2>
             <p className="mt-2 text-sm text-muted-foreground">
-              Scheduled work shows up here. A Budget File Sync flow set to run unattended becomes an
-              automation automatically, so you can see when it last ran and what it did.
+              A Budget File Sync flow becomes an automation when its review policy is{" "}
+              <strong className="font-medium">Auto-sync on a server schedule (unattended)</strong> — a
+              flow set to manual review, or to sync while Bench is open, stays out of here on purpose.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              A flow you just enrolled appears as soon as you refresh this page.
             </p>
           </div>
         ) : undefined
       }
     >
-      <div className="flex flex-col gap-3 p-4">
+      <div className="flex min-h-0 flex-1 flex-col">
+        {/* Stated once for the page instead of on every row: the rule is that
+            the user knows where automations run, not that the sentence repeats. */}
+        <p className="border-b border-border px-4 py-2 text-xs text-muted-foreground">
+          Automations marked <strong className="font-medium">Server</strong> run on a schedule even
+          with Actual Bench closed. One server instance runs them — Bench does not coordinate across
+          several.
+        </p>
+
         {reviewQueue.length > 0 && (
           <section
-            className="rounded-md border border-amber-400/30 bg-amber-50 p-4 dark:bg-amber-950/20"
+            className="border-b border-amber-400/30 bg-amber-50 px-4 py-3 dark:bg-amber-950/20"
             aria-labelledby="review-queue-heading"
           >
             <h2 id="review-queue-heading" className="text-sm font-semibold text-amber-900 dark:text-amber-200">
@@ -184,106 +182,16 @@ export function AutomationsView() {
           </section>
         )}
 
-        {automations.map((automation) => {
-          const mode = executionModeCopy(automation.executionMode);
-          const paused = Boolean(automation.autoPausedAt);
-          const isStarting = runNow.isPending && runNow.variables === automation.id;
-
-          return (
-            <div
-              key={automation.id}
-              className="rounded-md border border-border bg-card p-4 text-sm"
-              data-testid="automation-card"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <button
-                      type="button"
-                      className="truncate font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      onClick={() => setSelectedId(automation.id)}
-                    >
-                      {automation.name}
-                    </button>
-                    {paused && <Badge variant="status-warning">Auto-paused</Badge>}
-                    {!automation.enabled && !paused && <Badge variant="status-inactive">Off</Badge>}
-                  </div>
-
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {automation.scheduleLabel} · {mode.label}
-                  </p>
-                </div>
-
-                <div className="flex shrink-0 items-center gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    // Scoped to *this* automation: `isPending` alone claimed
-                    // every row was running whenever any one of them was.
-                    disabled={automation.running || isStarting}
-                    onClick={() => runNow.mutate(automation.id)}
-                  >
-                    {automation.running || isStarting ? (
-                      <Loader2 className="animate-spin" aria-hidden />
-                    ) : (
-                      <Play aria-hidden />
-                    )}
-                    Run now
-                  </Button>
-
-                  {paused ? (
-                    <Button variant="outline" size="sm" onClick={() => resume.mutate(automation.id)}>
-                      Resume
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setEnabled.mutate({ id: automation.id, enabled: !automation.enabled })}
-                      aria-label={automation.enabled ? "Pause automation" : "Enable automation"}
-                    >
-                      {automation.enabled ? <Pause aria-hidden /> : <Play aria-hidden />}
-                      {automation.enabled ? "Pause" : "Enable"}
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 text-xs sm:grid-cols-3">
-                <div>
-                  <dt className="text-muted-foreground">Last run</dt>
-                  <dd className="mt-0.5">
-                    <LastRunBadge automation={automation} />
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-muted-foreground">Next run</dt>
-                  <dd className="mt-0.5" title={formatDateTime(automation.nextRunAt)}>
-                    {automation.enabled && !paused ? relativeTime(automation.nextRunAt) : "Not scheduled"}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-muted-foreground">Result</dt>
-                  <dd className="mt-0.5 truncate" title={automation.lastRun?.rollup?.message ?? undefined}>
-                    {automation.lastRun?.rollup?.message ?? "—"}
-                  </dd>
-                </div>
-              </dl>
-
-              {paused && automation.autoPauseReason && (
-                <p className="mt-3 flex items-start gap-2 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
-                  <AlertTriangle className="mt-px size-3.5 shrink-0" aria-hidden />
-                  <span>{automation.autoPauseReason}</span>
-                </p>
-              )}
-
-              <p className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
-                <Info className="mt-px size-3.5 shrink-0" aria-hidden />
-                <span>{mode.detail}</span>
-              </p>
-            </div>
-          );
-        })}
+        <AutomationsTable
+          automations={automations}
+          runningId={runNow.isPending ? (runNow.variables ?? null) : null}
+          onOpen={setSelectedId}
+          onRunNow={(id) => runNow.mutate(id)}
+          onToggleEnabled={(automation) =>
+            setEnabled.mutate({ id: automation.id, enabled: !automation.enabled })
+          }
+          onResume={(id) => resume.mutate(id)}
+        />
       </div>
 
       {selected && <AutomationDetail automation={selected} onClose={() => setSelectedId(null)} />}

--- a/src/features/automations/lib/automationsApi.ts
+++ b/src/features/automations/lib/automationsApi.ts
@@ -6,6 +6,11 @@ export type AutomationListItem = AutomationDefinition & {
   scheduleLabel: string;
   running: boolean;
   lastRun: AutomationRun | null;
+  /** Human name of the job type — "Budget File Sync", "Bank sync". */
+  typeLabel: string;
+  status: "ok" | "warning" | "failing" | "paused" | "idle";
+  /** One sentence a person can act on, from the health module. */
+  statusSummary: string;
 };
 
 export type AutomationJobTypeSummary = {

--- a/src/features/automations/lib/presentation.test.ts
+++ b/src/features/automations/lib/presentation.test.ts
@@ -1,4 +1,12 @@
-import { executionModeCopy, relativeTime, runStatusLabel, runStatusTone, runDuration, triggerLabel } from "./presentation";
+import {
+  describeAutomationsSummary,
+  executionModeCopy,
+  relativeTime,
+  runDuration,
+  runStatusLabel,
+  runStatusTone,
+  triggerLabel,
+} from "./presentation";
 import type { AutomationRun } from "@/lib/app-db/types";
 
 function run(overrides: Partial<AutomationRun> = {}): AutomationRun {
@@ -70,5 +78,46 @@ describe("run detail formatting", () => {
     expect(relativeTime("2026-08-25T11:00:00Z", now)).toMatch(/hour ago/);
     expect(relativeTime("2026-08-25T12:30:00Z", now)).toMatch(/in 30 minutes/);
     expect(relativeTime(null, now)).toBe("—");
+  });
+});
+
+describe("the page summary line", () => {
+  const now = Date.parse("2026-08-26T12:00:00Z");
+  const base = { status: "ok" as const, enabled: true, autoPausedAt: null, nextRunAt: null };
+
+  it("answers whether the page can be closed again, not just how many rows it has", () => {
+    expect(
+      describeAutomationsSummary(
+        [
+          { ...base, nextRunAt: "2026-08-26T12:05:00.000Z" },
+          { ...base, nextRunAt: "2026-08-26T12:30:00.000Z" },
+        ],
+        now
+      )
+    ).toBe("2 automations · all healthy · next run in 5 minutes");
+  });
+
+  it("leads with trouble, because silence about it reads as reassurance", () => {
+    const summary = describeAutomationsSummary(
+      [
+        { ...base, status: "failing" },
+        { ...base, status: "paused", enabled: false, autoPausedAt: "2026-08-26T09:00:00.000Z" },
+        { ...base, nextRunAt: "2026-08-26T12:05:00.000Z" },
+      ],
+      now
+    );
+
+    expect(summary).toBe("3 automations · 1 failing, 1 paused · next run in 5 minutes");
+    expect(summary).not.toMatch(/all healthy/);
+  });
+
+  it("does not promise a next run when nothing is scheduled", () => {
+    expect(describeAutomationsSummary([{ ...base, enabled: false }], now)).toBe(
+      "1 automation · all healthy"
+    );
+  });
+
+  it("says nothing at all when there are no automations", () => {
+    expect(describeAutomationsSummary([], now)).toBeUndefined();
   });
 });

--- a/src/features/automations/lib/presentation.ts
+++ b/src/features/automations/lib/presentation.ts
@@ -124,3 +124,46 @@ export function triggerLabel(run: AutomationRun): string {
       return "Scheduled";
   }
 }
+
+/**
+ * The one line at the top of the page: how many automations, whether anything
+ * needs attention, and when the next one runs.
+ *
+ * "2 automations" alone answers a question nobody asked. What someone opening
+ * this page wants to know is whether they can close it again.
+ */
+export function describeAutomationsSummary(
+  automations: {
+    status: "ok" | "warning" | "failing" | "paused" | "idle";
+    enabled: boolean;
+    autoPausedAt: string | null;
+    nextRunAt: string | null;
+  }[],
+  nowMs = Date.now()
+): string | undefined {
+  if (automations.length === 0) return undefined;
+
+  const count = `${automations.length} automation${automations.length === 1 ? "" : "s"}`;
+  const failing = automations.filter((automation) => automation.status === "failing").length;
+  const paused = automations.filter((automation) => automation.status === "paused").length;
+  const warning = automations.filter((automation) => automation.status === "warning").length;
+
+  const trouble = [
+    failing > 0 ? `${failing} failing` : null,
+    paused > 0 ? `${paused} paused` : null,
+    warning > 0 ? `${warning} need attention` : null,
+  ].filter((part): part is string => part !== null);
+
+  const upcoming = automations
+    .filter((automation) => automation.enabled && !automation.autoPausedAt && automation.nextRunAt)
+    .map((automation) => Date.parse(automation.nextRunAt as string))
+    .filter((ms) => !Number.isNaN(ms))
+    .sort((a, b) => a - b)[0];
+
+  const next = upcoming === undefined ? null : `next run ${relativeTime(new Date(upcoming).toISOString(), nowMs)}`;
+
+  // Silence about trouble would read as reassurance, so it comes first.
+  const parts = [count, ...(trouble.length > 0 ? [trouble.join(", ")] : ["all healthy"])];
+  if (next) parts.push(next);
+  return parts.join(" · ");
+}

--- a/src/lib/app-db/automationRepository.test.ts
+++ b/src/lib/app-db/automationRepository.test.ts
@@ -223,4 +223,20 @@ describe("automation repository", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("never reports a run in progress when the claim column is absent", () => {
+    const { root, db } = tempDb();
+    try {
+      const created = createAutomation(db, baseInput);
+      expect(created.runningSince).toBeNull();
+
+      // A row read from a database whose `running_since` column is missing
+      // yields `undefined`, and callers ask "is this running?" by comparing
+      // against null. Undefined must not answer yes: that is how a schema fault
+      // surfaced as an automation stuck on "Running" rather than as an error.
+      expect(created.runningSince !== null).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/lib/app-db/automationRepository.test.ts
+++ b/src/lib/app-db/automationRepository.test.ts
@@ -227,14 +227,23 @@ describe("automation repository", () => {
   it("never reports a run in progress when the claim column is absent", () => {
     const { root, db } = tempDb();
     try {
-      const created = createAutomation(db, baseInput);
-      expect(created.runningSince).toBeNull();
+      createAutomation(db, baseInput);
 
-      // A row read from a database whose `running_since` column is missing
-      // yields `undefined`, and callers ask "is this running?" by comparing
-      // against null. Undefined must not answer yes: that is how a schema fault
-      // surfaced as an automation stuck on "Running" rather than as an error.
-      expect(created.runningSince !== null).toBe(false);
+      // Reproduce the real fault rather than asserting around it: a database
+      // that reached v18 from an intermediate build has no `running_since`, and
+      // its schema_version already reads 19-or-later on a later boot, so the
+      // repair does not re-run. Dropping the column reproduces exactly that row
+      // shape.
+      db.exec("ALTER TABLE automation_definitions DROP COLUMN running_since");
+
+      const [automation] = listAutomations(db);
+
+      // `row.running_since` is now `undefined`, and every caller asks "is this
+      // running?" by comparing against null. Undefined must not answer yes —
+      // that is how a schema fault disguised itself as an automation stuck on
+      // "Running" instead of surfacing as the error it was.
+      expect(automation.runningSince).toBeNull();
+      expect(automation.runningSince !== null).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/lib/app-db/automationRepository.ts
+++ b/src/lib/app-db/automationRepository.ts
@@ -216,7 +216,12 @@ function rowToDefinition(row: AutomationDefinitionRow): AutomationDefinition {
     lastRunAt: row.last_run_at,
     lastSuccessAt: row.last_success_at,
     nextRunAt: row.next_run_at,
-    runningSince: row.running_since,
+    // `?? null` rather than a bare read: a database whose `running_since`
+    // column is missing yields `undefined`, and every downstream check for
+    // "is this running?" compares against null. Undefined would then read as
+    // *running*, which is how a broken schema showed up as an automation stuck
+    // on "Running" instead of as the error it was.
+    runningSince: row.running_since ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/lib/app-db/migrationUpgrade.test.ts
+++ b/src/lib/app-db/migrationUpgrade.test.ts
@@ -13,7 +13,12 @@ import {
   createPayeeCleanupSuppression,
   listPayeeCleanupSuppressions,
 } from "./payeeCleanupSuppressionRepository";
-import { createAutomation, listAutomations } from "./automationRepository";
+import {
+  claimAutomation,
+  createAutomation,
+  getAutomation,
+  listAutomations,
+} from "./automationRepository";
 import { createAutomationRun, listAutomationRuns } from "./automationRunRepository";
 
 /**
@@ -285,6 +290,86 @@ describe("upgrading an existing database", () => {
 
       // The pre-existing reconciliation work is untouched.
       expect(getReconciliationSession(db, "sess-old")).not.toBeNull();
+    } finally {
+      resetAppDbForTests();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs a database that reached v18 from an intermediate branch build", () => {
+    // The exact shape a dev server ended up in: v18 recorded, but the
+    // automation tables created before `running_since` was added to them. Every
+    // engine tick then failed with "no such column: running_since".
+    const root = mkdtempSync(join(tmpdir(), "actual-bench-upgrade-v18-partial-"));
+    const path = join(root, "metadata.sqlite");
+
+    const seed = new Database(path);
+    seed.exec(`
+      CREATE TABLE app_meta (key text PRIMARY KEY, value text NOT NULL, updated_at text NOT NULL);
+      CREATE TABLE automation_definitions (
+        id text PRIMARY KEY,
+        type text NOT NULL,
+        name text NOT NULL,
+        enabled integer NOT NULL DEFAULT 1,
+        execution_mode text NOT NULL DEFAULT 'server',
+        schedule_kind text NOT NULL DEFAULT 'interval',
+        interval_minutes integer,
+        cron_expression text,
+        timezone text NOT NULL DEFAULT 'UTC',
+        target_ref_json text NOT NULL,
+        credential_ref text,
+        config_json text NOT NULL,
+        failure_policy_json text,
+        consecutive_failures integer NOT NULL DEFAULT 0,
+        auto_paused_at text,
+        auto_pause_reason text,
+        last_run_at text,
+        last_success_at text,
+        next_run_at text,
+        created_at text NOT NULL,
+        updated_at text NOT NULL
+      );
+      CREATE TABLE automation_runs (
+        id text PRIMARY KEY,
+        automation_id text REFERENCES automation_definitions(id) ON DELETE CASCADE,
+        type text NOT NULL,
+        status text NOT NULL,
+        started_at text NOT NULL,
+        finished_at text,
+        trigger text NOT NULL DEFAULT 'schedule',
+        attempt integer NOT NULL DEFAULT 1,
+        execution_mode text NOT NULL DEFAULT 'server',
+        result_json text,
+        rollup_json text,
+        error_json text
+      );
+    `);
+    seed.prepare("INSERT INTO app_meta (key, value, updated_at) VALUES (?, ?, ?)").run(
+      "schema_version",
+      "18",
+      "2026-08-25T18:30:55.405Z"
+    );
+    seed
+      .prepare(
+        `INSERT INTO automation_definitions
+           (id, type, name, target_ref_json, config_json, created_at, updated_at)
+         VALUES ('auto-1', 'budget-file-sync', 'Test 2', '{"version":1,"data":{}}',
+                 '{"version":1,"data":{"flowId":"flow-1"}}', '2026-08-25T18:30:55.405Z',
+                 '2026-08-25T18:30:55.405Z')`
+      )
+      .run();
+    seed.close();
+
+    try {
+      const db = getAppDb(path);
+
+      // The automation survives the repair, and the claim now works instead of
+      // throwing on every tick.
+      const [automation] = listAutomations(db);
+      expect(automation.name).toBe("Test 2");
+      expect(automation.runningSince).toBeNull();
+      expect(claimAutomation(db, "auto-1", "2026-08-26T18:00:00.000Z")).toBe(true);
+      expect(getAutomation(db, "auto-1")?.runningSince).toBe("2026-08-26T18:00:00.000Z");
     } finally {
       resetAppDbForTests();
       rmSync(root, { recursive: true, force: true });

--- a/src/lib/app-db/migrations.ts
+++ b/src/lib/app-db/migrations.ts
@@ -33,7 +33,7 @@ import {
 import { KDF_VERSION_META_KEY, SALT_META_KEY, VERIFIER_META_KEY } from "./vaultMetaKeys";
 import { AppDbUnavailableError } from "./errors";
 
-export const LATEST_SCHEMA_VERSION = 18;
+export const LATEST_SCHEMA_VERSION = 19;
 
 type Migration = {
   version: number;
@@ -232,7 +232,28 @@ const MIGRATIONS: readonly Migration[] = [
       ...AUTOMATION_INDEX_SQL,
     ],
   },
+  {
+    version: 19,
+    // Repair for a database that reached v18 from an *intermediate* build of the
+    // automation branch.
+    //
+    // `running_since` was added to the v18 table definition during review, while
+    // v18 was still unreleased — which is safe for anyone who had never run the
+    // branch, and wrong for anyone who had. A database migrated by the earlier
+    // build records schema_version 18, so the corrected v18 is skipped and the
+    // column never appears: every engine tick then fails with "no such column:
+    // running_since", and no automation runs at all.
+    //
+    // `CREATE TABLE IF NOT EXISTS` cannot fix this — the table already exists —
+    // so the column is added on its own, guarded, and is a no-op on a database
+    // that got the corrected v18.
+    apply: applyAutomationClaimColumn,
+  },
 ];
+
+function applyAutomationClaimColumn(db: SqliteDatabase): void {
+  addColumnIfMissing(db, "automation_definitions", "running_since", "text");
+}
 
 /**
  * RD-072: statement rows, saved profiles and apply configs move to the

--- a/src/lib/automation/engine.test.ts
+++ b/src/lib/automation/engine.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
-import { createAutomation, getAutomation } from "@/lib/app-db/automationRepository";
+import { createAutomation, getAutomation, listAutomations } from "@/lib/app-db/automationRepository";
 import { listAutomationRuns } from "@/lib/app-db/automationRunRepository";
 import { upsertSyncCredential } from "@/lib/app-db/syncCredentialRepository";
 import {
@@ -610,6 +610,64 @@ describe("automation engine", () => {
       const [run] = listAutomationRuns(db, { automationId: id });
       expect(JSON.stringify(run)).not.toContain("abcd1234efgh5678");
       expect(String(run.error?.data.message)).toContain("[redacted]");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets a job type pick up work enrolled since the last tick", async () => {
+    const { root, db } = tempDb();
+    try {
+      let created = false;
+      registerAutomationJobType(
+        testJobType({
+          reconcile: (database) => {
+            // Stands in for a sync flow switched to unattended while the server
+            // was already running: without a per-tick reconcile it would not
+            // exist as an automation until the next restart.
+            if (created) return;
+            createAutomation(database, {
+              type: "test-job",
+              name: "Enrolled after boot",
+              scheduleKind: "interval",
+              intervalMinutes: 30,
+              targetRef: { version: 1, data: {} },
+              config: { version: 1, data: { label: "late" } },
+            });
+            created = true;
+          },
+        })
+      );
+
+      const summary = await runEngineTick(db, { nowMs: Date.parse("2026-08-26T10:00:00Z") });
+
+      expect(listAutomations(db)).toHaveLength(1);
+      // And it is not merely registered: it ran on the very same tick.
+      expect(summary.ran).toHaveLength(1);
+      expect(summary.ran[0].status).toBe("succeeded");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps running automations when a job type's reconcile throws", async () => {
+    const { root, db } = tempDb();
+    try {
+      registerAutomationJobType(
+        testJobType({
+          reconcile: () => {
+            throw new Error("reconcile exploded");
+          },
+        })
+      );
+      const id = definition(db);
+
+      const summary = await runEngineTick(db, { nowMs: Date.parse("2026-08-26T10:00:00Z") });
+
+      // A reconciliation problem is not a reason to stop work that is already
+      // configured and due.
+      expect(summary.ran).toHaveLength(1);
+      expect(listAutomationRuns(db, { automationId: id })).toHaveLength(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/lib/automation/engine.ts
+++ b/src/lib/automation/engine.ts
@@ -16,7 +16,7 @@ import {
 import { getSyncCredential, hasSyncCredential } from "@/lib/app-db/syncCredentialRepository";
 import { vaultEnabled } from "@/lib/sync/vault";
 import { logger } from "@/lib/logger";
-import { getAutomationJobType } from "./registry";
+import { getAutomationJobType, listAutomationJobTypes } from "./registry";
 import { createRunLogger, redactSecrets } from "./runLogger";
 import { effectiveNextRunAt, isDue } from "./schedule";
 import type { AutomationCredentials, AutomationJobType } from "./registry";
@@ -412,6 +412,13 @@ export async function runEngineTick(
 ): Promise<TickSummary> {
   const nowMs = options.nowMs ?? Date.now();
   const at = new Date(nowMs).toISOString();
+
+  // Let each job type reconcile its definitions with its own configuration
+  // first, so an automation enrolled since the last tick is picked up now
+  // rather than at the next server restart. The engine stays ignorant of what
+  // any of this means; it just gives every type the chance.
+  await reconcileJobTypes(db);
+
   const due = selectDueAutomations(db, nowMs);
   const ran: EngineRunOutcome[] = [];
 
@@ -428,6 +435,31 @@ export async function runEngineTick(
   }
 
   return { at, due: due.length, ran };
+}
+
+/**
+ * Give every registered job type a chance to reconcile.
+ *
+ * Called at the top of every tick, and again by the read paths that show
+ * automations to a person: polling for a change someone just made is how a page
+ * ends up telling them their new sync flow does not exist. It is idempotent and
+ * costs two queries, so doing it on read buys correctness cheaply.
+ *
+ * One failing type must not stop anything: the others still have work to do,
+ * and a reconciliation problem is not a reason to stop running automations that
+ * are already configured, nor to fail a read.
+ */
+export async function reconcileJobTypes(db: SqliteDatabase): Promise<void> {
+  for (const jobType of listAutomationJobTypes()) {
+    if (!jobType.reconcile) continue;
+    try {
+      await jobType.reconcile(db);
+    } catch (error) {
+      logger.warn(
+        `[automation] ${jobType.type} could not reconcile: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
 }
 
 /** Request cancellation of an in-flight run. */

--- a/src/lib/automation/jobs/budgetFileSync.test.ts
+++ b/src/lib/automation/jobs/budgetFileSync.test.ts
@@ -5,7 +5,13 @@ import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
 import { createSyncFlow, updateSyncFlow, getSyncFlow } from "@/lib/app-db/syncFlowRepository";
 import { listAutomations, updateAutomation } from "@/lib/app-db/automationRepository";
 import { createSyncFlowRun } from "@/lib/app-db/syncRunRepository";
-import { budgetFileSyncJobType } from "./budgetFileSync";
+import {
+  __resetBudgetFileSyncRegistrationForTests,
+  budgetFileSyncJobType,
+  registerBudgetFileSyncJobType,
+} from "./budgetFileSync";
+import { __resetEngineStateForTests, runEngineTick } from "../engine";
+import { __resetAutomationRegistryForTests } from "../registry";
 import { migrateSyncFlowsToAutomations } from "./budgetFileSyncMigration";
 import { MIN_INTERVAL_MINUTES } from "../schedule";
 import type { SqliteDatabase } from "@/lib/app-db/types";
@@ -329,6 +335,41 @@ describe("migrating sync flows onto the engine", () => {
       const effective = Math.max(automation.intervalMinutes ?? 0, MIN_INTERVAL_MINUTES);
       expect(effective).toBeGreaterThanOrEqual(MIN_INTERVAL_MINUTES);
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("enrols a flow created while the server is already running", async () => {
+    const { root, db } = tempDb();
+    try {
+      registerBudgetFileSyncJobType();
+
+      // Boot-time sweep: nothing to do yet.
+      await runEngineTick(db, { nowMs: Date.parse("2026-08-26T10:00:00Z") });
+      expect(listAutomations(db)).toHaveLength(0);
+
+      // The user creates an unattended flow in the Sync UI.
+      unattendedFlow(db, "Created after boot");
+
+      // The very next tick picks it up — no restart required. This was the bug:
+      // the sweep only ran at startup, so a flow enrolled afterwards silently
+      // never appeared and never ran.
+      await runEngineTick(db, { nowMs: Date.parse("2026-08-26T10:01:00Z") });
+
+      const [automation] = listAutomations(db);
+      expect(automation?.name).toBe("Created after boot");
+      expect(automation?.config.data.flowId).toBeDefined();
+
+      // With no vault configured in this environment the engine then fails
+      // closed on the very same tick — which is the point: the flow is now
+      // visible with a reason a person can act on, instead of being absent and
+      // silently never running.
+      expect(automation?.enabled).toBe(false);
+      expect(automation?.autoPauseReason).toMatch(/vault is disabled/);
+    } finally {
+      __resetEngineStateForTests();
+      __resetAutomationRegistryForTests();
+      __resetBudgetFileSyncRegistrationForTests();
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/src/lib/automation/jobs/budgetFileSync.ts
+++ b/src/lib/automation/jobs/budgetFileSync.ts
@@ -2,6 +2,8 @@ import { getAppDb } from "@/lib/app-db/connection";
 import { classifySafeSyncOutcome } from "@/features/sync/lib/flowHealth";
 import { isServerSafeSyncBlocked, runServerSafeSync } from "@/lib/sync/serverSafeSync";
 import { registerAutomationJobType } from "../registry";
+import { migrateSyncFlowsToAutomations } from "./budgetFileSyncMigration";
+import { BUDGET_FILE_SYNC_JOB_TYPE } from "./budgetFileSyncType";
 import type { AutomationJobType, AutomationRunContext } from "../registry";
 import type { ServerSafeSyncResult } from "@/lib/sync/serverSafeSync";
 import type { AutomationRunRollup, JsonEnvelope } from "@/lib/app-db/types";
@@ -23,7 +25,8 @@ import type { AutomationRunRollup, JsonEnvelope } from "@/lib/app-db/types";
  * automation run can link straight to the sync run it produced.
  */
 
-export const BUDGET_FILE_SYNC_JOB_TYPE = "budget-file-sync";
+// Re-exported so existing callers keep one import site.
+export { BUDGET_FILE_SYNC_JOB_TYPE } from "./budgetFileSyncType";
 
 export type BudgetFileSyncConfig = {
   flowId: string;
@@ -171,6 +174,15 @@ export const budgetFileSyncJobType: AutomationJobType<BudgetFileSyncConfig, Budg
         message: result.message ?? null,
       },
     };
+  },
+
+  /**
+   * Flows are created and switched to unattended in the Sync UI at any time, so
+   * the enrolment sweep runs every tick rather than only at boot. It is
+   * idempotent and keyed on the flow id, so repeating it costs two reads.
+   */
+  reconcile(db) {
+    migrateSyncFlowsToAutomations(db);
   },
 
   // Budget File Sync constructs writes through Bench, so it does take part in

--- a/src/lib/automation/jobs/budgetFileSyncMigration.ts
+++ b/src/lib/automation/jobs/budgetFileSyncMigration.ts
@@ -4,7 +4,7 @@ import { createAutomation, listAutomations, updateAutomation } from "@/lib/app-d
 import { decodeFlowPlanConfig } from "@/lib/sync/flowConfig";
 import { logger } from "@/lib/logger";
 import { MIN_INTERVAL_MINUTES } from "../schedule";
-import { BUDGET_FILE_SYNC_JOB_TYPE } from "./budgetFileSync";
+import { BUDGET_FILE_SYNC_JOB_TYPE } from "./budgetFileSyncType";
 import type { AutomationDefinition, SqliteDatabase } from "@/lib/app-db/types";
 
 /**

--- a/src/lib/automation/jobs/budgetFileSyncType.ts
+++ b/src/lib/automation/jobs/budgetFileSyncType.ts
@@ -1,0 +1,10 @@
+/**
+ * The Budget File Sync job type's identifier, alone in its own module.
+ *
+ * The job type needs its enrolment sweep and the sweep needs the identifier,
+ * which is a cycle if the constant lives with either of them. Cycles like that
+ * happen to work under Jest's CommonJS and can fail under a bundler's module
+ * initialization order, so the shared value sits where neither side has to
+ * import the other.
+ */
+export const BUDGET_FILE_SYNC_JOB_TYPE = "budget-file-sync";

--- a/src/lib/automation/registry.ts
+++ b/src/lib/automation/registry.ts
@@ -2,6 +2,7 @@ import type {
   AutomationDefinition,
   AutomationRunRollup,
   JsonEnvelope,
+  SqliteDatabase,
 } from "@/lib/app-db/types";
 
 /**
@@ -107,6 +108,21 @@ export type AutomationJobType<TConfig = unknown, TResult = unknown> = {
    * payload keeps its full detail while the roll-up stays small. */
   serializeResult(result: TResult): JsonEnvelope;
   classification?: AutomationClassificationSupport;
+  /**
+   * Bring this type's automations in line with the feature's own configuration.
+   *
+   * Called on every engine tick, before anything is selected to run. It exists
+   * because a feature's configuration lives outside the engine and changes
+   * while the server is up: Budget File Sync flows are created and switched to
+   * unattended from the Sync UI at any time, and running the reconciliation
+   * only at boot meant a flow enrolled after startup silently never ran until
+   * the next restart.
+   *
+   * Must be idempotent and cheap — it runs once a minute. Errors are logged and
+   * swallowed; a type that cannot reconcile must not stop other automations
+   * from running.
+   */
+  reconcile?(db: SqliteDatabase): void | Promise<void>;
 };
 
 const registry = new Map<string, AutomationJobType<never, never>>();


### PR DESCRIPTION
Three faults found by using the feature rather than reading it, and a layout rework the second one made obvious.

## 1. The engine is dead on some existing databases

**Symptom:** `warn: [automation] tick failed: no such column: running_since`, once a minute, forever. No automation runs.

`running_since` was added to the v18 automation table during review, while v18 was still unreleased. That is safe for a database that had never seen v18 and wrong for one that had — including any dev server that ran the branch. Migrations are keyed by version, so a database already recording 18 skips the corrected definition and never gets the column.

v19 adds the column if it is absent and does nothing otherwise. `CREATE TABLE IF NOT EXISTS` could not have repaired it, because the table exists. The test seeds a database in exactly that shape and asserts it survives and can claim afterwards.

The same fault also **presented itself as an automation stuck on "Running"**: a missing column reads as `undefined`, and the check was `!== null`. Now read as `?? null`, so a schema fault can never disguise itself as a run in progress again.

## 2. A newly enrolled flow never appeared

The enrolment sweep ran only at server boot, so a flow enrolled for unattended sync afterwards silently never became an automation — no row, no run, no error, and a page saying "No automations yet" to someone looking at the flow they had just created.

A job type can now declare `reconcile(db)`; the engine calls it each tick, and the read paths call it before listing. That keeps the engine ignorant of what reconciliation means and gives future job types the same ability — bank sync will have the same problem with accounts linked after the fact.

Reconciling on read is what makes the page structurally unable to lie: whatever created the flow, opening or refreshing shows it. Idempotent, two queries, failures swallowed so it can never break a read.

## 3. The page wasted space and never said what an automation *was*

About eleven lines per automation for five facts — the execution-mode paragraph repeated per card, labels stacked above values, run status and result saying the same thing twice — and nothing naming the job type, so "Test 2" told you nothing. Once bank sync sits beside budget file sync, a name cannot distinguish them at all.

Now a table, one line each, matching the rest of Bench's list pages:

- a **Type** column names the job type
- **space in proportion to trouble**: healthy rows stay one line; a failing or paused row grows a second carrying the reason
- the mode stays per row as **Server** / **Browser only**, with the full explanation on the control instead of repeated beneath every card
- the header answers whether the page can be closed again, and leads with trouble when there is any
- Refresh animates only for a refresh someone asked for, not the 15-second poll

## Deployment note

This build is what un-wedges an installation currently logging `no such column: running_since`. Until it is deployed, the engine on such a database does nothing at all.

## Validation

`npx tsc --noEmit` clean · `npm run lint` clean for changed files · **240 suites / 2846 tests** · `npm run build` compiles (schema migration).