### PR TITLE
Sync your banks on a schedule

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -69,6 +69,7 @@ One place for everything Actual Bench runs on a schedule, on a shared engine rat
 - **Fail closed on credentials**: an automation that names a credential it cannot resolve (vault disabled, key rotated, credential withdrawn) does not run at all and pauses with that reason.
 - **Overdue is a warning**, not a silent success: an automation well past its next run is flagged even though nothing failed.
 - **Shared review queue**: work an automation left for a person, linking into the job type's own review screen. Job types that only trigger Actual's own work construct nothing reviewable and are absent from the queue rather than shown empty.
+- **Scheduled bank sync**: ask Actual to pull from your connected banks (SimpleFIN / GoCardless) on a schedule with nothing open. Per-account results, one bank's failure never hiding the others, accounts with no bank link reported as such rather than counted as synced, and a transaction count only where Bench could measure one. A partly-failed run does not auto-pause the automation; a wholly failed one counts towards it.
 - Not in scope: an external job runner, message queue, or multi-process workers; notification channels (email/webhook/push); coordinating automations across more than one Bench instance; and making Direct mode unattended.
 
 See `docs/AUTOMATIONS.md`.

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -94,6 +94,32 @@ page under **"Waiting for you to decide"**, linking into the sync workspace wher
 review them. Job types that only trigger Actual's own work — rather than constructing writes
 themselves — have nothing to review and do not appear there at all.
 
+## Bank sync
+
+**Schedule bank sync** on the Automations page asks Actual to pull from the banks you connected *in
+Actual* (SimpleFIN / GoCardless), on a schedule, with nothing open. Bench triggers Actual's own
+import — it does not create the transactions and does not change how Actual handles duplicates.
+
+It needs a connection whose credentials are enrolled in the vault, because that is what lets it run
+unattended; without one the dialog says so rather than creating an automation that could only pause.
+
+What a run reports, per account:
+
+- **Synced** or **Sync started**, depending on whether the connection tells Bench the import
+  finished. Over the HTTP API the server answers "started", so Bench says the sync began instead of
+  quoting a number it cannot verify.
+- **Failed**, with the provider's reason, for that account only. Accounts are synced one at a time,
+  so one bank with expired consent cannot hide the rest — and a run where some accounts worked is
+  reported as partly done rather than as a failure.
+- **No bank link**, for an account Actual would silently skip. It is never counted as synced.
+
+A partial run does **not** count towards the failure streak that auto-pauses an automation: one
+unreachable bank is an ordinary outcome, and pausing would stop the accounts that do work. A run
+where *every* account failed does count.
+
+Bank sync contributes nothing to the review queue. It constructs nothing for you to review — Actual's
+importer owns what arrives.
+
 ## External cron
 
 If you would rather drive the schedule yourself, `POST /api/sync/scheduler/tick` runs one pass.

--- a/src/app/api/automations/bank-sync-accounts/route.ts
+++ b/src/app/api/automations/bank-sync-accounts/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { getSyncCredential } from "@/lib/app-db/syncCredentialRepository";
+import { listAccountsForBankSync, isBankLinked } from "@/lib/actual/bankSyncAccounts";
+import { vaultEnabled } from "@/lib/sync/vault";
+import type { HttpApiConnection } from "@/store/connection";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Which accounts a scheduled bank sync would actually pull (RD-080 / PR-045).
+ *
+ * The browser cannot answer this: the connection's credentials live in the
+ * server-side vault, and the budget in question is often not the one currently
+ * open. Without it the create dialog can only assert "every linked account is
+ * synced" and hope — including when the honest answer is "none of them are
+ * linked, so this automation would do nothing".
+ *
+ * Read-only, and returns account names and link state only — never any part of
+ * the credential it used to ask.
+ */
+export async function GET(request: Request) {
+  try {
+    const fingerprint = new URL(request.url).searchParams.get("connection");
+    if (!fingerprint) {
+      return NextResponse.json({ error: "A connection is required." }, { status: 400 });
+    }
+    if (!vaultEnabled()) {
+      return NextResponse.json({ error: "The credential vault is disabled." }, { status: 400 });
+    }
+
+    const credential = getSyncCredential(getAppDb(), fingerprint);
+    if (!credential) {
+      return NextResponse.json(
+        { error: "That connection has no stored credentials." },
+        { status: 404 }
+      );
+    }
+
+    const connection: HttpApiConnection = {
+      id: credential.connectionFingerprint,
+      label: credential.label || credential.baseUrl,
+      mode: "http-api",
+      baseUrl: credential.baseUrl,
+      apiKey: credential.secret.apiKey,
+      budgetSyncId: credential.budgetSyncId,
+      ...(credential.secret.encryptionPassword
+        ? { encryptionPassword: credential.secret.encryptionPassword }
+        : {}),
+    };
+
+    const accounts = await listAccountsForBankSync(connection);
+
+    return NextResponse.json({
+      accounts: accounts
+        .filter((account) => !account.closed)
+        .map((account) => ({
+          id: account.id,
+          name: account.name,
+          linked: isBankLinked(account),
+          syncSource: account.syncSource,
+          lastSync: account.lastSync,
+        })),
+    });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/automations/bank-sync-accounts/route.ts
+++ b/src/app/api/automations/bank-sync-accounts/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { getAppDb } from "@/lib/app-db/connection";
 import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { AppDbUnavailableError, AppDbValidationError } from "@/lib/app-db/errors";
+import { sanitizeBankSyncError } from "@/lib/actual/bankSync";
 import { getSyncCredential } from "@/lib/app-db/syncCredentialRepository";
 import { listAccountsForBankSync, isBankLinked } from "@/lib/actual/bankSyncAccounts";
 import { vaultEnabled } from "@/lib/sync/vault";
@@ -65,6 +67,15 @@ export async function GET(request: Request) {
         })),
     });
   } catch (error) {
-    return appDbErrorResponse(error);
+    // Upstream error text is forwarded verbatim by the proxy and can carry the
+    // API key it was called with — a URL with credentials in it, or a server
+    // echoing the header back. This route talks to actual-http-api with a vault
+    // secret, so nothing from that side reaches the browser unsanitized.
+    return appDbErrorResponse(sanitizeUpstreamError(error));
   }
+}
+
+function sanitizeUpstreamError(error: unknown): unknown {
+  if (error instanceof AppDbValidationError || error instanceof AppDbUnavailableError) return error;
+  return new Error(sanitizeBankSyncError(error));
 }

--- a/src/features/automations/components/AutomationsView.tsx
+++ b/src/features/automations/components/AutomationsView.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { RefreshCw } from "lucide-react";
+import { Plus, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
@@ -17,6 +17,7 @@ import {
 
 import { AutomationDetail } from "./AutomationDetail";
 import { AutomationsTable } from "./AutomationsTable";
+import { NewBankSyncDialog } from "./NewBankSyncDialog";
 import { describeAutomationsSummary } from "../lib/presentation";
 
 /**
@@ -35,6 +36,7 @@ import { describeAutomationsSummary } from "../lib/presentation";
 export function AutomationsView() {
   const queryClient = useQueryClient();
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
 
   const automationsQuery = useQuery({
     queryKey: ["automations"],
@@ -124,16 +126,22 @@ export function AutomationsView() {
       error={automationsQuery.error}
       onRetry={() => void automationsQuery.refetch()}
       actions={
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => void handleRefresh()}
-          disabled={refreshing}
-          aria-label="Refresh automations"
-        >
-          <RefreshCw className={cn(refreshing && "animate-spin")} aria-hidden />
-          Refresh
-        </Button>
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void handleRefresh()}
+            disabled={refreshing}
+            aria-label="Refresh automations"
+          >
+            <RefreshCw className={cn(refreshing && "animate-spin")} aria-hidden />
+            Refresh
+          </Button>
+          <Button size="sm" onClick={() => setCreating(true)}>
+            <Plus aria-hidden />
+            Schedule bank sync
+          </Button>
+        </>
       }
       emptyState={
         automations.length === 0 ? (
@@ -193,6 +201,8 @@ export function AutomationsView() {
           onResume={(id) => resume.mutate(id)}
         />
       </div>
+
+      <NewBankSyncDialog open={creating} onOpenChange={setCreating} onCreated={invalidate} />
 
       {selected && <AutomationDetail automation={selected} onClose={() => setSelectedId(null)} />}
     </PageLayout>

--- a/src/features/automations/components/NewBankSyncDialog.test.tsx
+++ b/src/features/automations/components/NewBankSyncDialog.test.tsx
@@ -71,7 +71,8 @@ describe("scheduling a bank sync", () => {
 
   it("says when the first run will happen, not just how often", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     // Someone choosing a schedule should see the consequence of choosing it.
     expect(screen.getByText(/First run/)).toBeInTheDocument();
@@ -79,7 +80,8 @@ describe("scheduling a bank sync", () => {
 
   it("offers plain cadences, keeping cron out of the way", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     const cadence = screen.getByLabelText("How often");
     expect(screen.queryByLabelText("Cron expression")).not.toBeInTheDocument();
@@ -98,7 +100,8 @@ describe("scheduling a bank sync", () => {
 
   it("keeps cron available for the person who wants weekdays only", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     fireEvent.change(screen.getByLabelText("How often"), { target: { value: "cron" } });
     fireEvent.change(screen.getByLabelText("Cron expression"), { target: { value: "@daily" } });
@@ -114,7 +117,8 @@ describe("scheduling a bank sync", () => {
 
   it("never schedules runs closer together than the unattended floor", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     fireEvent.change(screen.getByLabelText("Hours between runs"), { target: { value: "0.1" } });
     fireEvent.click(screen.getByRole("button", { name: /schedule sync/i }));
@@ -125,7 +129,8 @@ describe("scheduling a bank sync", () => {
 
   it("does not ask which budget when there is only one", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     // A picker with one option is a question with one answer.
     expect(screen.queryByText("Budget")).not.toBeInTheDocument();
@@ -135,7 +140,8 @@ describe("scheduling a bank sync", () => {
 
   it("picks a time zone from a list, and only when the schedule has a clock", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     // "Every 6 hours" means the same thing everywhere, so asking would be
     // asking a question whose answer cannot matter.
@@ -160,7 +166,8 @@ describe("scheduling a bank sync", () => {
 
   it("does not schedule midnight when the time is cleared", async () => {
     renderDialog();
-    await screen.findByText("Checking");
+    // Wait for the account list to have loaded, not for any one name in it.
+    await screen.findByText(/accounts will sync/);
 
     fireEvent.change(screen.getByLabelText("How often"), { target: { value: "daily" } });
     fireEvent.change(screen.getByLabelText("Time of day"), { target: { value: "" } });

--- a/src/features/automations/components/NewBankSyncDialog.test.tsx
+++ b/src/features/automations/components/NewBankSyncDialog.test.tsx
@@ -157,4 +157,17 @@ describe("scheduling a bank sync", () => {
     await waitFor(() => expect(mockedApi.createAutomation).toHaveBeenCalled());
     expect(mockedApi.createAutomation.mock.calls[0][0].timezone).toBe("UTC");
   });
+
+  it("does not schedule midnight when the time is cleared", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    fireEvent.change(screen.getByLabelText("How often"), { target: { value: "daily" } });
+    fireEvent.change(screen.getByLabelText("Time of day"), { target: { value: "" } });
+
+    // An empty time used to become `0 0 * * *` — a schedule nobody chose.
+    expect(screen.getByText(/Enter a time of day/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /schedule sync/i })).toBeDisabled();
+    expect(mockedApi.createAutomation).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/automations/components/NewBankSyncDialog.test.tsx
+++ b/src/features/automations/components/NewBankSyncDialog.test.tsx
@@ -1,0 +1,160 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NewBankSyncDialog } from "./NewBankSyncDialog";
+import * as api from "../lib/automationsApi";
+import type { BankSyncAccountPreview } from "../lib/automationsApi";
+
+jest.mock("../lib/automationsApi");
+jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn() } }));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <NewBankSyncDialog open onOpenChange={() => {}} onCreated={() => {}} />
+    </QueryClientProvider>
+  );
+}
+
+const connection = {
+  connectionFingerprint: "srv-1",
+  label: "Household",
+  baseUrl: "https://budget.example.com",
+  budgetSyncId: "budget-1",
+};
+
+function account(overrides: Partial<BankSyncAccountPreview> = {}): BankSyncAccountPreview {
+  return { id: "a", name: "Checking", linked: true, syncSource: "simpleFin", lastSync: null, ...overrides };
+}
+
+describe("scheduling a bank sync", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.listVaultConnections.mockResolvedValue({ enabled: true, credentials: [connection] });
+    mockedApi.listBankSyncAccounts.mockResolvedValue([
+      account(),
+      account({ id: "b", name: "Savings" }),
+      account({ id: "c", name: "Cash", linked: false, syncSource: null }),
+    ]);
+    mockedApi.createAutomation.mockResolvedValue({} as never);
+  });
+
+  it("shows which accounts will sync instead of asking for faith", async () => {
+    renderDialog();
+
+    // The centre of the dialog: what this will actually do, by name.
+    expect(await screen.findByText("Checking")).toBeInTheDocument();
+    expect(screen.getByText("Savings")).toBeInTheDocument();
+    expect(screen.getByText(/2 of 3 accounts will sync/)).toBeInTheDocument();
+    // And what it will not do, so an unlinked account is never a silent skip.
+    expect(screen.getByText(/not connected to a bank — skipped/)).toBeInTheDocument();
+  });
+
+  it("refuses to schedule work that could never import anything", async () => {
+    mockedApi.listBankSyncAccounts.mockResolvedValue([account({ linked: false, syncSource: null })]);
+
+    renderDialog();
+
+    // `getByText` inside `waitFor` re-queries the live DOM each attempt: the
+    // dialog swaps its content node as it mounts, and `findByText` can resolve
+    // with the node that was replaced.
+    await waitFor(() =>
+      expect(
+        screen.getByText(/None of the accounts in this budget are connected to a bank/)
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByRole("button", { name: /schedule sync/i })).toBeDisabled();
+    expect(mockedApi.createAutomation).not.toHaveBeenCalled();
+  });
+
+  it("says when the first run will happen, not just how often", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    // Someone choosing a schedule should see the consequence of choosing it.
+    expect(screen.getByText(/First run/)).toBeInTheDocument();
+  });
+
+  it("offers plain cadences, keeping cron out of the way", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    const cadence = screen.getByLabelText("How often");
+    expect(screen.queryByLabelText("Cron expression")).not.toBeInTheDocument();
+
+    fireEvent.change(cadence, { target: { value: "daily" } });
+    fireEvent.change(screen.getByLabelText("Time of day"), { target: { value: "07:30" } });
+    fireEvent.click(screen.getByRole("button", { name: /schedule sync/i }));
+
+    await waitFor(() => expect(mockedApi.createAutomation).toHaveBeenCalled());
+    const payload = mockedApi.createAutomation.mock.calls[0][0];
+    // "Once a day at 07:30" is stored as a schedule the engine understands,
+    // without anyone having typed a cron expression.
+    expect(payload.cronExpression).toBe("30 7 * * *");
+    expect(payload.credentialRef).toBe("srv-1");
+  });
+
+  it("keeps cron available for the person who wants weekdays only", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    fireEvent.change(screen.getByLabelText("How often"), { target: { value: "cron" } });
+    fireEvent.change(screen.getByLabelText("Cron expression"), { target: { value: "@daily" } });
+
+    expect(screen.getByText(/Five fields/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /schedule sync/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Cron expression"), { target: { value: "0 7 * * 1-5" } });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /schedule sync/i })).not.toBeDisabled()
+    );
+  });
+
+  it("never schedules runs closer together than the unattended floor", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    fireEvent.change(screen.getByLabelText("Hours between runs"), { target: { value: "0.1" } });
+    fireEvent.click(screen.getByRole("button", { name: /schedule sync/i }));
+
+    await waitFor(() => expect(mockedApi.createAutomation).toHaveBeenCalled());
+    expect(mockedApi.createAutomation.mock.calls[0][0].intervalMinutes).toBe(15);
+  });
+
+  it("does not ask which budget when there is only one", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    // A picker with one option is a question with one answer.
+    expect(screen.queryByText("Budget")).not.toBeInTheDocument();
+    // And no server URL is shown to someone who does not administer servers.
+    expect(screen.queryByText(/https:\/\//)).not.toBeInTheDocument();
+  });
+
+  it("picks a time zone from a list, and only when the schedule has a clock", async () => {
+    renderDialog();
+    await screen.findByText("Checking");
+
+    // "Every 6 hours" means the same thing everywhere, so asking would be
+    // asking a question whose answer cannot matter.
+    expect(screen.queryByLabelText("Time zone")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("How often"), { target: { value: "daily" } });
+
+    const zone = screen.getByLabelText("Time zone");
+    // A mistyped zone is a schedule that silently runs at the wrong hour, so it
+    // is chosen, never typed.
+    expect(zone.tagName).toBe("SELECT");
+    // Labelled the way every other time-zone picker does, and the way the tz
+    // database's own tables do — an IANA path alone is not an answer to "when".
+    expect(zone.textContent).toMatch(/\(UTC[+-]\d{2}:\d{2}\)/);
+
+    fireEvent.change(zone, { target: { value: "UTC" } });
+    fireEvent.click(screen.getByRole("button", { name: /schedule sync/i }));
+
+    await waitFor(() => expect(mockedApi.createAutomation).toHaveBeenCalled());
+    expect(mockedApi.createAutomation.mock.calls[0][0].timezone).toBe("UTC");
+  });
+});

--- a/src/features/automations/components/NewBankSyncDialog.tsx
+++ b/src/features/automations/components/NewBankSyncDialog.tsx
@@ -97,21 +97,30 @@ function AccountRow({ account }: { account: BankSyncAccountPreview }) {
 export function NewBankSyncDialog({ open, onOpenChange, onCreated }: NewBankSyncDialogProps) {
   const vault = useQuery({ queryKey: ["vault-connections"], queryFn: listVaultConnections, enabled: open });
 
-  const [connectionFingerprint, setConnectionFingerprint] = useState("");
+  const [chosenConnection, setChosenConnection] = useState("");
   const [cadence, setCadence] = useState<Cadence>("hours");
   const [hours, setHours] = useState("6");
   const [dailyTime, setDailyTime] = useState("06:00");
   const [cron, setCron] = useState("0 6 * * 1-5");
   const [timezone, setTimezone] = useState(() => browserTimezone());
 
-  const timezones = useMemo(() => timezoneOptions(), []);
-  const connections = vault.data?.credentials ?? [];
+  // A clock read during render is impure; snapshot it, and refresh it while the
+  // dialog is open so "first run in 3 minutes" does not quietly go stale.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    if (!open) return;
+    const timer = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(timer);
+  }, [open]);
+
+  const timezones = useMemo(() => timezoneOptions(new Date(nowMs)), [nowMs]);
+  const connections = useMemo(() => vault.data?.credentials ?? [], [vault.data]);
   const vaultEnabled = vault.data?.enabled ?? false;
 
-  useEffect(() => {
-    if (!open || connections.length === 0 || connectionFingerprint) return;
-    setConnectionFingerprint(connections[0].connectionFingerprint);
-  }, [open, connections, connectionFingerprint]);
+  // Derived rather than written from an effect: the first enrolled connection
+  // is the default until someone picks another, which needs no render pass to
+  // settle and cannot cascade.
+  const connectionFingerprint = chosenConnection || connections[0]?.connectionFingerprint || "";
 
   const accountsQuery = useQuery({
     queryKey: ["bank-sync-accounts", connectionFingerprint],
@@ -140,10 +149,10 @@ export function NewBankSyncDialog({ open, onOpenChange, onCreated }: NewBankSync
         failurePolicy: { backoffMinutes: 5, backoffCeilingMinutes: 60, pauseAfterConsecutiveFailures: 5 },
       },
       lastRunAtMs: null,
-      nowMs: Date.now(),
+      nowMs,
     });
     return ms === null ? null : new Date(ms).toISOString();
-  }, [cronInvalid, schedule.scheduleKind, schedule.intervalMinutes, schedule.cronExpression, timezone]);
+  }, [cronInvalid, schedule.scheduleKind, schedule.intervalMinutes, schedule.cronExpression, timezone, nowMs]);
 
   const create = useMutation({
     mutationFn: async () => {
@@ -201,7 +210,7 @@ export function NewBankSyncDialog({ open, onOpenChange, onCreated }: NewBankSync
                   <select
                     className={`${selectClass} w-full`}
                     value={connectionFingerprint}
-                    onChange={(event) => setConnectionFingerprint(event.target.value)}
+                    onChange={(event) => setChosenConnection(event.target.value)}
                   >
                     {connections.map((connection) => (
                       <option key={connection.connectionFingerprint} value={connection.connectionFingerprint}>

--- a/src/features/automations/components/NewBankSyncDialog.tsx
+++ b/src/features/automations/components/NewBankSyncDialog.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Check, Loader2, Minus } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isValidCronExpression } from "@/lib/automation/cron";
+import { nextRunAt } from "@/lib/automation/schedule";
+import {
+  createAutomation,
+  listBankSyncAccounts,
+  listVaultConnections,
+  type BankSyncAccountPreview,
+} from "../lib/automationsApi";
+import { formatDateTime, relativeTime } from "../lib/presentation";
+import { browserTimezone, timezoneOptions } from "../lib/timezones";
+
+/**
+ * Scheduling a bank sync (RD-080 / PR-045).
+ *
+ * Built around the three things a person actually decides — what gets synced,
+ * how often, and when it starts — rather than around the fields the record
+ * happens to have.
+ *
+ * The account list is the centre of it. Without it this dialog can only assert
+ * "every linked account is synced" and hope; with it, someone can see that two
+ * of their four accounts are connected to a bank, and that scheduling this when
+ * none are would create an automation that does nothing forever.
+ *
+ * Cron is still available, because someone will want "weekdays at 07:00" — but
+ * it lives under Custom, not beside "every few hours" as an equal choice. A
+ * personal-finance app should not ask anybody to write `0 6 * * *`.
+ */
+
+const inputClass = "h-8 rounded-md px-2 text-xs md:text-xs";
+const selectClass = "h-8 rounded-md border border-input bg-background px-2 text-xs";
+
+type Cadence = "hours" | "daily" | "cron";
+
+type NewBankSyncDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+};
+
+function scheduleFor(
+  cadence: Cadence,
+  hours: string,
+  dailyTime: string,
+  cron: string
+): { scheduleKind: "interval" | "cron"; intervalMinutes?: number; cronExpression?: string } {
+  if (cadence === "hours") {
+    const parsed = Number(hours);
+    const minutes = Number.isFinite(parsed) ? Math.round(parsed * 60) : 360;
+    // The unattended floor: below it, each run spends its time reopening the
+    // budget rather than syncing.
+    return { scheduleKind: "interval", intervalMinutes: Math.max(minutes, 15) };
+  }
+  if (cadence === "daily") {
+    const [hour = "6", minute = "0"] = dailyTime.split(":");
+    return { scheduleKind: "cron", cronExpression: `${Number(minute)} ${Number(hour)} * * *` };
+  }
+  return { scheduleKind: "cron", cronExpression: cron.trim() };
+}
+
+function AccountRow({ account }: { account: BankSyncAccountPreview }) {
+  return (
+    <li className="flex items-baseline gap-2 py-0.5">
+      {account.linked ? (
+        <Check className="size-3 shrink-0 translate-y-0.5 text-green-600 dark:text-green-500" aria-hidden />
+      ) : (
+        <Minus className="size-3 shrink-0 translate-y-0.5 text-muted-foreground" aria-hidden />
+      )}
+      <span className={account.linked ? undefined : "text-muted-foreground"}>{account.name}</span>
+      {account.linked ? (
+        account.lastSync && (
+          <span className="text-muted-foreground" title={formatDateTime(account.lastSync)}>
+            last synced {relativeTime(account.lastSync)}
+          </span>
+        )
+      ) : (
+        <span className="text-muted-foreground">not connected to a bank — skipped</span>
+      )}
+    </li>
+  );
+}
+
+export function NewBankSyncDialog({ open, onOpenChange, onCreated }: NewBankSyncDialogProps) {
+  const vault = useQuery({ queryKey: ["vault-connections"], queryFn: listVaultConnections, enabled: open });
+
+  const [connectionFingerprint, setConnectionFingerprint] = useState("");
+  const [cadence, setCadence] = useState<Cadence>("hours");
+  const [hours, setHours] = useState("6");
+  const [dailyTime, setDailyTime] = useState("06:00");
+  const [cron, setCron] = useState("0 6 * * 1-5");
+  const [timezone, setTimezone] = useState(() => browserTimezone());
+
+  const timezones = useMemo(() => timezoneOptions(), []);
+  const connections = vault.data?.credentials ?? [];
+  const vaultEnabled = vault.data?.enabled ?? false;
+
+  useEffect(() => {
+    if (!open || connections.length === 0 || connectionFingerprint) return;
+    setConnectionFingerprint(connections[0].connectionFingerprint);
+  }, [open, connections, connectionFingerprint]);
+
+  const accountsQuery = useQuery({
+    queryKey: ["bank-sync-accounts", connectionFingerprint],
+    queryFn: () => listBankSyncAccounts(connectionFingerprint),
+    enabled: open && Boolean(connectionFingerprint),
+  });
+
+  const accounts = accountsQuery.data ?? [];
+  const linked = accounts.filter((account) => account.linked);
+  const schedule = scheduleFor(cadence, hours, dailyTime, cron);
+  const cronInvalid = schedule.scheduleKind === "cron" && !isValidCronExpression(schedule.cronExpression ?? "");
+
+  // Show the consequence, not just the setting: someone choosing "once a day at
+  // 06:00" should see whether that means this morning or tomorrow.
+  const firstRun = useMemo(() => {
+    if (cronInvalid) return null;
+    const ms = nextRunAt({
+      definition: {
+        scheduleKind: schedule.scheduleKind,
+        intervalMinutes: schedule.intervalMinutes ?? null,
+        cronExpression: schedule.cronExpression ?? null,
+        timezone,
+        enabled: true,
+        autoPausedAt: null,
+        consecutiveFailures: 0,
+        failurePolicy: { backoffMinutes: 5, backoffCeilingMinutes: 60, pauseAfterConsecutiveFailures: 5 },
+      },
+      lastRunAtMs: null,
+      nowMs: Date.now(),
+    });
+    return ms === null ? null : new Date(ms).toISOString();
+  }, [cronInvalid, schedule.scheduleKind, schedule.intervalMinutes, schedule.cronExpression, timezone]);
+
+  const create = useMutation({
+    mutationFn: async () => {
+      const connection = connections.find((entry) => entry.connectionFingerprint === connectionFingerprint);
+      return createAutomation({
+        type: "bank-sync",
+        name: `Bank sync — ${connection?.label || "budget"}`,
+        executionMode: "server",
+        ...schedule,
+        timezone,
+        credentialRef: connectionFingerprint,
+        targetRef: { version: 1, data: { connectionFingerprint } },
+        config: { version: 1, data: { connectionFingerprint, accountIds: [] } },
+      });
+    },
+    onSuccess: () => {
+      toast.success("Bank sync scheduled");
+      onCreated();
+      onOpenChange(false);
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const blocked = !vaultEnabled || connections.length === 0 || linked.length === 0;
+  const canSubmit = !blocked && !cronInvalid && !create.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Schedule a bank sync</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 px-4 pb-2 text-xs">
+          <p className="text-muted-foreground">
+            Pull new transactions from the banks you connected in Actual, on a schedule, without
+            keeping Actual Bench open.
+          </p>
+
+          {!vaultEnabled ? (
+            <p className="rounded-md bg-amber-50 px-3 py-2 text-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
+              This needs the credential vault. Set <code>SYNC_VAULT_KEY</code> on the server and
+              restart to enable unattended automations.
+            </p>
+          ) : connections.length === 0 ? (
+            <p className="rounded-md bg-amber-50 px-3 py-2 text-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
+              No budget has stored credentials yet. Enrol one from Budget File Sync first — without
+              it a scheduled sync could only pause.
+            </p>
+          ) : (
+            <>
+              {connections.length > 1 && (
+                <label className="block">
+                  <span className="mb-1 block font-medium">Budget</span>
+                  <select
+                    className={`${selectClass} w-full`}
+                    value={connectionFingerprint}
+                    onChange={(event) => setConnectionFingerprint(event.target.value)}
+                  >
+                    {connections.map((connection) => (
+                      <option key={connection.connectionFingerprint} value={connection.connectionFingerprint}>
+                        {connection.label || connection.baseUrl}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
+              <section>
+                <h3 className="mb-1 font-medium">What will sync</h3>
+
+                {accountsQuery.isLoading ? (
+                  <p className="flex items-center gap-2 text-muted-foreground">
+                    <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                    Checking which accounts are connected to a bank…
+                  </p>
+                ) : accountsQuery.isError ? (
+                  <p className="text-destructive">{(accountsQuery.error as Error).message}</p>
+                ) : linked.length === 0 ? (
+                  <p className="flex items-start gap-2 rounded-md bg-amber-50 px-3 py-2 text-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
+                    <AlertTriangle className="mt-px size-3.5 shrink-0" aria-hidden />
+                    <span>
+                      None of the accounts in this budget are connected to a bank, so this would
+                      never import anything. Connect an account to SimpleFIN or GoCardless in Actual
+                      first.
+                    </span>
+                  </p>
+                ) : (
+                  <>
+                    <ul className="rounded-md border border-border px-3 py-2">
+                      {accounts.map((account) => (
+                        <AccountRow key={account.id} account={account} />
+                      ))}
+                    </ul>
+                    <p className="mt-1 text-muted-foreground">
+                      {linked.length} of {accounts.length} account{accounts.length === 1 ? "" : "s"} will
+                      sync. Each is synced separately, so one bank failing does not stop the others.
+                    </p>
+                  </>
+                )}
+              </section>
+
+              <section>
+                <h3 className="mb-1 font-medium">How often</h3>
+                <div className="flex flex-wrap items-center gap-2">
+                  <select
+                    className={selectClass}
+                    value={cadence}
+                    onChange={(event) => setCadence(event.target.value as Cadence)}
+                    aria-label="How often"
+                  >
+                    <option value="hours">Every few hours</option>
+                    <option value="daily">Once a day</option>
+                    <option value="cron">Custom…</option>
+                  </select>
+
+                  {cadence === "hours" && (
+                    <label className="flex items-center gap-1.5">
+                      <Input
+                        className={`${inputClass} w-16`}
+                        type="number"
+                        min={1}
+                        max={24}
+                        value={hours}
+                        onChange={(event) => setHours(event.target.value)}
+                        aria-label="Hours between runs"
+                      />
+                      <span className="text-muted-foreground">hours apart</span>
+                    </label>
+                  )}
+
+                  {cadence === "daily" && (
+                    <label className="flex items-center gap-1.5">
+                      <span className="text-muted-foreground">at</span>
+                      <Input
+                        className={`${inputClass} w-24`}
+                        type="time"
+                        value={dailyTime}
+                        onChange={(event) => setDailyTime(event.target.value)}
+                        aria-label="Time of day"
+                      />
+                    </label>
+                  )}
+
+                  {cadence === "cron" && (
+                    <label className="flex flex-1 items-center gap-1.5">
+                      <Input
+                        className={`${inputClass} flex-1`}
+                        value={cron}
+                        onChange={(event) => setCron(event.target.value)}
+                        aria-label="Cron expression"
+                        aria-invalid={cronInvalid}
+                      />
+                    </label>
+                  )}
+                </div>
+
+                {cadence === "cron" && cronInvalid && (
+                  <p className="mt-1 text-destructive">
+                    Five fields, e.g. <code>0 6 * * 1-5</code> for weekdays at 06:00.
+                  </p>
+                )}
+
+                {/* A time zone only changes anything for a clock-based
+                    schedule. Asking for it beside "every 6 hours" would be
+                    asking a question whose answer cannot matter. */}
+                {cadence !== "hours" && (
+                  <label className="mt-2 flex flex-wrap items-center gap-1.5">
+                    <span className="text-muted-foreground">Time zone</span>
+                    <select
+                      className={selectClass}
+                      value={timezone}
+                      onChange={(event) => setTimezone(event.target.value)}
+                      aria-label="Time zone"
+                    >
+                      {timezones.map((zone) => (
+                        <option key={zone.value} value={zone.value}>
+                          {zone.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+
+                <p className="mt-1.5 text-muted-foreground">
+                  {firstRun ? (
+                    <>
+                      First run {relativeTime(firstRun)} — {formatDateTime(firstRun)}
+                    </>
+                  ) : (
+                    "That schedule never comes around."
+                  )}
+                </p>
+              </section>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" disabled={!canSubmit} onClick={() => create.mutate()}>
+            {create.isPending ? "Scheduling…" : "Schedule sync"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/automations/components/NewBankSyncDialog.tsx
+++ b/src/features/automations/components/NewBankSyncDialog.tsx
@@ -66,8 +66,18 @@ function scheduleFor(
     return { scheduleKind: "interval", intervalMinutes: Math.max(minutes, 15) };
   }
   if (cadence === "daily") {
-    const [hour = "6", minute = "0"] = dailyTime.split(":");
-    return { scheduleKind: "cron", cronExpression: `${Number(minute)} ${Number(hour)} * * *` };
+    // A cleared time input is "" — and destructuring defaults only cover
+    // `undefined`, so this used to become `0 0 * * *` and quietly schedule
+    // midnight. An incomplete time is not a schedule; it fails validation
+    // instead.
+    const match = /^(\d{1,2}):(\d{2})$/.exec(dailyTime.trim());
+    if (!match) return { scheduleKind: "cron", cronExpression: "" };
+
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    if (hour > 23 || minute > 59) return { scheduleKind: "cron", cronExpression: "" };
+
+    return { scheduleKind: "cron", cronExpression: `${minute} ${hour} * * *` };
   }
   return { scheduleKind: "cron", cronExpression: cron.trim() };
 }
@@ -309,6 +319,10 @@ export function NewBankSyncDialog({ open, onOpenChange, onCreated }: NewBankSync
                     </label>
                   )}
                 </div>
+
+                {cadence === "daily" && cronInvalid && (
+                  <p className="mt-1 text-destructive">Enter a time of day, such as 06:00.</p>
+                )}
 
                 {cadence === "cron" && cronInvalid && (
                   <p className="mt-1 text-destructive">

--- a/src/features/automations/components/resultRenderers.test.tsx
+++ b/src/features/automations/components/resultRenderers.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { AutomationResult } from "./resultRenderers";
+import type { AutomationRun } from "@/lib/app-db/types";
+
+function run(type: string, data: Record<string, unknown>): AutomationRun {
+  return {
+    id: "run-1",
+    automationId: "auto-1",
+    type,
+    status: "succeeded",
+    startedAt: "2026-08-27T06:00:00.000Z",
+    finishedAt: "2026-08-27T06:00:20.000Z",
+    trigger: "schedule",
+    attempt: 1,
+    executionMode: "server",
+    result: { version: 1, data: data as never },
+    rollup: null,
+    error: null,
+  };
+}
+
+describe("bank sync run results", () => {
+  it("shows what happened per account, in this job type's own terms", () => {
+    render(
+      <AutomationResult
+        run={run("bank-sync", {
+          countsObserved: true,
+          accounts: [
+            { accountId: "a", accountName: "Checking", status: "synced", message: null, observedNewTransactions: 4 },
+            { accountId: "b", accountName: "Savings", status: "failed", message: "consent expired", observedNewTransactions: null },
+            { accountId: "c", accountName: "Cash", status: "not-linked", message: null, observedNewTransactions: null },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByText("Checking")).toBeInTheDocument();
+    expect(screen.getByText("4 new", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("consent expired", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("No bank link")).toBeInTheDocument();
+  });
+
+  it("says Bench cannot know the count when the server only accepted the request", () => {
+    render(
+      <AutomationResult
+        run={run("bank-sync", {
+          countsObserved: false,
+          accounts: [{ accountId: "a", accountName: "Checking", status: "accepted", message: null, observedNewTransactions: null }],
+        })}
+      />
+    );
+
+    expect(screen.getByText(/cannot say how many transactions arrived/)).toBeInTheDocument();
+  });
+
+  it("survives a payload whose shape is not what this version expects", () => {
+    // The engine stores a job type's result without inspecting it, and an older
+    // version of the feature may have written something else. Putting that
+    // straight into React took down the whole run-history panel once already.
+    render(
+      <AutomationResult
+        run={run("bank-sync", {
+          countsObserved: true,
+          accounts: [
+            { accountId: "a", accountName: { nested: "object" }, status: 42, observedNewTransactions: "many" },
+            "not even an object",
+            { accountName: "no id at all" },
+            { accountId: "b", accountName: "Valid", status: "synced" },
+          ],
+        })}
+      />
+    );
+
+    // The unreadable rows are dropped rather than crashing the panel, and the
+    // readable one still renders.
+    expect(screen.getByText("Valid")).toBeInTheDocument();
+    expect(screen.getByText("a")).toBeInTheDocument();
+  });
+
+  it("falls back to a readable rendering for a job type with no renderer", () => {
+    render(<AutomationResult run={run("some-future-type", { widgets: 3, mode: "fast" })} />);
+
+    expect(screen.getByText("widgets")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+});

--- a/src/features/automations/components/resultRenderers.tsx
+++ b/src/features/automations/components/resultRenderers.tsx
@@ -90,8 +90,72 @@ function GenericResult({ result }: AutomationResultRendererProps) {
   );
 }
 
+type BankSyncAccountRow = {
+  accountId: string;
+  accountName: string | null;
+  status: string;
+  message: string | null;
+  observedNewTransactions: number | null;
+};
+
+const ACCOUNT_STATUS_LABEL: Record<string, string> = {
+  synced: "Synced",
+  accepted: "Sync started",
+  failed: "Failed",
+  "not-linked": "No bank link",
+};
+
+/** Bank sync: what happened per account, in this type's own terms. */
+function BankSyncResult({ result }: AutomationResultRendererProps) {
+  const accounts = Array.isArray(result.accounts) ? (result.accounts as unknown as BankSyncAccountRow[]) : [];
+  const countsObserved = result.countsObserved === true;
+
+  if (accounts.length === 0) {
+    return <p className="text-xs text-muted-foreground">No accounts were synced.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-1 text-xs">
+        {accounts.map((account) => (
+          <li key={account.accountId} className="flex flex-wrap items-baseline gap-x-2">
+            <span className="font-medium">{account.accountName ?? account.accountId}</span>
+            <span
+              className={
+                account.status === "failed"
+                  ? "text-destructive"
+                  : account.status === "not-linked"
+                    ? "text-muted-foreground"
+                    : undefined
+              }
+            >
+              {ACCOUNT_STATUS_LABEL[account.status] ?? account.status}
+            </span>
+            {typeof account.observedNewTransactions === "number" && (
+              <span className="text-muted-foreground">
+                · {account.observedNewTransactions} new
+              </span>
+            )}
+            {account.message && <span className="text-muted-foreground">· {account.message}</span>}
+          </li>
+        ))}
+      </ul>
+
+      {!countsObserved && (
+        // The distinction the whole feature rests on: a server that answered
+        // "started" has not told us what arrived, and inventing a zero here
+        // would be the one thing this must never do.
+        <p className="text-[11px] text-muted-foreground">
+          Actual imports in the background, so Bench cannot say how many transactions arrived.
+        </p>
+      )}
+    </div>
+  );
+}
+
 const RENDERERS: Record<string, (props: AutomationResultRendererProps) => React.ReactElement> = {
   "budget-file-sync": BudgetFileSyncResult,
+  "bank-sync": BankSyncResult,
 };
 
 export function AutomationResult({ run }: { run: AutomationRun }) {

--- a/src/features/automations/components/resultRenderers.tsx
+++ b/src/features/automations/components/resultRenderers.tsx
@@ -106,8 +106,37 @@ const ACCOUNT_STATUS_LABEL: Record<string, string> = {
 };
 
 /** Bank sync: what happened per account, in this type's own terms. */
+/**
+ * Read one account row defensively.
+ *
+ * The payload is a job type's own JSON, which the engine stores without
+ * inspecting and which may have been written by an older version of this
+ * feature. A cast would put whatever it finds straight into React — and an
+ * object where a string was expected takes down the whole run-history panel,
+ * which is exactly how a non-string log line broke it once already.
+ */
+function readAccountRow(value: JsonValue): BankSyncAccountRow | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (typeof row.accountId !== "string") return null;
+
+  return {
+    accountId: row.accountId,
+    accountName: typeof row.accountName === "string" ? row.accountName : null,
+    status: typeof row.status === "string" ? row.status : "unknown",
+    message: typeof row.message === "string" ? row.message : null,
+    observedNewTransactions:
+      typeof row.observedNewTransactions === "number" ? row.observedNewTransactions : null,
+  };
+}
+
 function BankSyncResult({ result }: AutomationResultRendererProps) {
-  const accounts = Array.isArray(result.accounts) ? (result.accounts as unknown as BankSyncAccountRow[]) : [];
+  const accounts = Array.isArray(result.accounts)
+    ? result.accounts.flatMap((entry) => {
+        const row = readAccountRow(entry);
+        return row ? [row] : [];
+      })
+    : [];
   const countsObserved = result.countsObserved === true;
 
   if (accounts.length === 0) {

--- a/src/features/automations/lib/automationsApi.ts
+++ b/src/features/automations/lib/automationsApi.ts
@@ -100,3 +100,60 @@ export async function listReviewQueue(): Promise<ReviewQueueEntry[]> {
   return ((await response.json()) as { entries: ReviewQueueEntry[] }).entries;
 }
 
+export type VaultConnection = {
+  connectionFingerprint: string;
+  label: string;
+  baseUrl: string;
+  budgetSyncId: string;
+};
+
+/**
+ * Connections with credentials stored for unattended use.
+ *
+ * The set an automation can actually be built on: a connection without an
+ * enrolled credential produces an automation that can only fail closed.
+ */
+export async function listVaultConnections(): Promise<{
+  enabled: boolean;
+  credentials: VaultConnection[];
+}> {
+  const response = await fetch("/api/sync-credentials", { cache: "no-store" });
+  if (!response.ok) return readError(response);
+  return (await response.json()) as { enabled: boolean; credentials: VaultConnection[] };
+}
+
+export async function createAutomation(input: Record<string, unknown>): Promise<AutomationDefinition> {
+  const response = await fetch("/api/automations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) return readError(response);
+  return ((await response.json()) as { automation: AutomationDefinition }).automation;
+}
+
+export type BankSyncAccountPreview = {
+  id: string;
+  name: string;
+  linked: boolean;
+  syncSource: string | null;
+  lastSync: string | null;
+};
+
+/**
+ * What a scheduled bank sync would actually pull.
+ *
+ * Server-side, because the vault credential is not the browser's to hold and
+ * the budget in question is often not the one currently open.
+ */
+export async function listBankSyncAccounts(
+  connectionFingerprint: string
+): Promise<BankSyncAccountPreview[]> {
+  const response = await fetch(
+    `/api/automations/bank-sync-accounts?connection=${encodeURIComponent(connectionFingerprint)}`,
+    { cache: "no-store" }
+  );
+  if (!response.ok) return readError(response);
+  return ((await response.json()) as { accounts: BankSyncAccountPreview[] }).accounts;
+}
+

--- a/src/features/automations/lib/timezones.test.ts
+++ b/src/features/automations/lib/timezones.test.ts
@@ -1,0 +1,61 @@
+import {
+  browserTimezone,
+  formatOffset,
+  timezoneOptions,
+  zoneCity,
+  zoneOffsetMinutes,
+} from "./timezones";
+
+describe("time zone choices", () => {
+  it("labels offsets the way the tz database does", () => {
+    expect(formatOffset(0)).toBe("UTC+00:00");
+    expect(formatOffset(240)).toBe("UTC+04:00");
+    expect(formatOffset(-300)).toBe("UTC-05:00");
+    // Half- and quarter-hour zones are real places, not rounding errors.
+    expect(formatOffset(330)).toBe("UTC+05:30");
+    expect(formatOffset(345)).toBe("UTC+05:45");
+  });
+
+  it("reads the offset that is actually in force, not a tabulated one", () => {
+    // New York is UTC-5 in January and UTC-4 in July. A fixed table would be
+    // wrong for half the year, which is why this is computed.
+    expect(zoneOffsetMinutes("America/New_York", new Date("2026-01-15T12:00:00Z"))).toBe(-300);
+    expect(zoneOffsetMinutes("America/New_York", new Date("2026-07-15T12:00:00Z"))).toBe(-240);
+    // Dubai does not observe daylight saving.
+    expect(zoneOffsetMinutes("Asia/Dubai", new Date("2026-01-15T12:00:00Z"))).toBe(240);
+    expect(zoneOffsetMinutes("Asia/Dubai", new Date("2026-07-15T12:00:00Z"))).toBe(240);
+    expect(zoneOffsetMinutes("UTC", new Date("2026-07-15T12:00:00Z"))).toBe(0);
+  });
+
+  it("refuses a zone the platform cannot resolve rather than inventing one", () => {
+    expect(zoneOffsetMinutes("Mars/Olympus")).toBeNull();
+  });
+
+  it("names the place, not the path", () => {
+    expect(zoneCity("Asia/Dubai")).toBe("Dubai");
+    expect(zoneCity("America/Argentina/Buenos_Aires")).toBe("Buenos Aires");
+    expect(zoneCity("UTC")).toBe("UTC");
+  });
+
+  it("offers the user's own zone first, then UTC", () => {
+    const options = timezoneOptions(new Date("2026-07-15T12:00:00Z"));
+
+    expect(options[0].value).toBe(browserTimezone());
+    expect(options.map((option) => option.value)).toContain("UTC");
+    if (browserTimezone() !== "UTC") expect(options[1].value).toBe("UTC");
+  });
+
+  it("orders the rest west to east, so scanning has a direction", () => {
+    const rest = timezoneOptions(new Date("2026-07-15T12:00:00Z")).slice(2);
+    const offsets = rest.map((option) => option.offsetMinutes);
+
+    expect(offsets).toEqual([...offsets].sort((a, b) => a - b));
+    expect(rest[0].label).toMatch(/^\(UTC[+-]\d{2}:\d{2}\) /);
+  });
+
+  it("never offers a zone it could not resolve", () => {
+    const options = timezoneOptions();
+    expect(options.every((option) => Number.isFinite(option.offsetMinutes))).toBe(true);
+    expect(new Set(options.map((option) => option.value)).size).toBe(options.length);
+  });
+});

--- a/src/features/automations/lib/timezones.ts
+++ b/src/features/automations/lib/timezones.ts
@@ -1,0 +1,131 @@
+/**
+ * Time-zone choices for a schedule (RD-080 / PR-045).
+ *
+ * The presentation follows the convention people already recognise from every
+ * other time-zone picker — `(UTC+04:00) Dubai`, ordered west to east — because
+ * an IANA identifier alone ("Asia/Dubai") is a developer's answer to "when
+ * should this run".
+ *
+ * Offsets are labelled **UTC**, matching the tz database's own tables. `Intl`
+ * reports them as "GMT+04:00"; the two are the same number, and UTC is the term
+ * the underlying zone data uses.
+ *
+ * The offsets are computed from `Intl` at call time rather than tabulated. A
+ * fixed table is wrong for half the year in every zone that observes daylight
+ * saving: "(GMT-08:00) Pacific Time" reads as a fact and is false in July.
+ */
+
+export type TimezoneOption = {
+  /** IANA identifier — what actually gets stored and scheduled. */
+  value: string;
+  /** e.g. "(UTC+04:00) Dubai" */
+  label: string;
+  offsetMinutes: number;
+};
+
+const FALLBACK_ZONES = [
+  "UTC",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Moscow",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Sao_Paulo",
+];
+
+export function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/** Current offset in minutes, DST included, or null if the zone is unusable. */
+export function zoneOffsetMinutes(zone: string, at: Date = new Date()): number | null {
+  try {
+    const formatted = new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      timeZoneName: "longOffset",
+    }).format(at);
+
+    const match = /GMT([+-])(\d{2}):(\d{2})/.exec(formatted);
+    // A zone sitting exactly on zero is rendered as plain "GMT" by Intl.
+    if (!match) return /GMT/.test(formatted) ? 0 : null;
+
+    const sign = match[1] === "-" ? -1 : 1;
+    return sign * (Number(match[2]) * 60 + Number(match[3]));
+  } catch {
+    return null;
+  }
+}
+
+export function formatOffset(minutes: number): string {
+  if (minutes === 0) return "UTC+00:00";
+  const sign = minutes < 0 ? "-" : "+";
+  const absolute = Math.abs(minutes);
+  const hours = String(Math.floor(absolute / 60)).padStart(2, "0");
+  const rest = String(absolute % 60).padStart(2, "0");
+  return `UTC${sign}${hours}:${rest}`;
+}
+
+/** "America/Argentina/Buenos_Aires" → "Buenos Aires" */
+export function zoneCity(zone: string): string {
+  const segments = zone.split("/");
+  return (segments[segments.length - 1] ?? zone).replace(/_/g, " ");
+}
+
+function availableZones(): string[] {
+  const supported = (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf;
+  if (typeof supported !== "function") return FALLBACK_ZONES;
+  try {
+    const zones = supported("timeZone");
+    return zones.length > 0 ? zones : FALLBACK_ZONES;
+  } catch {
+    return FALLBACK_ZONES;
+  }
+}
+
+/**
+ * Every selectable zone, ordered west to east, with the user's own zone and UTC
+ * pinned first — the two answers most people want, without scrolling a list of
+ * four hundred.
+ */
+export function timezoneOptions(at: Date = new Date()): TimezoneOption[] {
+  const own = browserTimezone();
+
+  const zones = new Set<string>(availableZones());
+  // Neither is guaranteed to be in the platform list, and both must be offered.
+  zones.add("UTC");
+  zones.add(own);
+
+  const options: TimezoneOption[] = [];
+  for (const zone of zones) {
+    const offsetMinutes = zoneOffsetMinutes(zone, at);
+    if (offsetMinutes === null) continue;
+    options.push({
+      value: zone,
+      label: `(${formatOffset(offsetMinutes)}) ${zoneCity(zone)}`,
+      offsetMinutes,
+    });
+  }
+
+  options.sort(
+    (a, b) => a.offsetMinutes - b.offsetMinutes || a.label.localeCompare(b.label)
+  );
+
+  const pinned = options.filter((option) => option.value === own || option.value === "UTC");
+  const rest = options.filter((option) => option.value !== own && option.value !== "UTC");
+  // The user's own zone leads, because it is the right answer far more often
+  // than any other single entry.
+  pinned.sort((a, b) => (a.value === own ? -1 : b.value === own ? 1 : 0));
+
+  return [...pinned, ...rest];
+}

--- a/src/lib/actual/browserApiTransport.ts
+++ b/src/lib/actual/browserApiTransport.ts
@@ -397,7 +397,8 @@ async function runBrowserQuery<T>(
  */
 async function runBrowserBankSync(
   connection: BrowserApiConnection,
-  accountId?: string
+  accountId?: string,
+  signal?: AbortSignal
 ): Promise<BankSyncOutcome> {
   const api = await getBrowserApiRuntime(connection);
   const trigger = api.runBankSync?.bind(api);
@@ -426,6 +427,7 @@ async function runBrowserBankSync(
   return runBankSyncForAccounts({
     loadAccounts: () => listAccountsForBankSync(connection),
     accountId,
+    signal,
     trigger: async (id) => {
       await trigger({ accountId: id });
     },
@@ -1249,7 +1251,7 @@ export function createBrowserApiTransport(
     },
 
     getSyncCapabilities: () => getBudgetFileSyncCapabilities(connection),
-    runBankSync: (input) => runBrowserBankSync(connection, input?.accountId),
+    runBankSync: (input) => runBrowserBankSync(connection, input?.accountId, input?.signal),
     canRunBankSync: async () => {
       // The runtime is already open on any page that could offer this, so this
       // resolves from cache rather than loading a budget to answer a question.

--- a/src/lib/actual/httpApiTransport.ts
+++ b/src/lib/actual/httpApiTransport.ts
@@ -185,6 +185,7 @@ export function createHttpApiTransport(
       runBankSyncForAccounts({
         loadAccounts: () => listAccountsForBankSync(connection),
         accountId: input?.accountId,
+        signal: input?.signal,
         trigger: (accountId) => triggerAccountBankSync(connection, accountId),
         // The endpoint answers "Bank sync started". Until that is verified
         // against a live server, treat it as accepted rather than finished —

--- a/src/lib/actual/runBankSync.test.ts
+++ b/src/lib/actual/runBankSync.test.ts
@@ -239,4 +239,47 @@ describe("summarizing", () => {
     expect(outcome.countsObserved).toBe(false);
     expect(outcome.status).toBe("ok");
   });
+
+  it("stops between accounts when the run is cancelled", async () => {
+    const loadAccounts = withAccounts([
+      account({ id: "a" }),
+      account({ id: "b" }),
+      account({ id: "c" }),
+    ]);
+    const controller = new AbortController();
+    const triggered: string[] = [];
+
+    const outcome = await runBankSyncForAccounts({
+      loadAccounts,
+      synchronous: true,
+      signal: controller.signal,
+      trigger: async (id) => {
+        triggered.push(id);
+        // Someone presses stop while the first account is syncing.
+        if (id === "a") controller.abort();
+      },
+    });
+
+    // The remaining banks are not contacted, and the account that did sync is
+    // still reported rather than the whole run being discarded.
+    expect(triggered).toEqual(["a"]);
+    expect(outcome.results.map((result) => result.accountId)).toEqual(["a"]);
+  });
+
+  it("does not start at all when cancelled before the first account", async () => {
+    const loadAccounts = withAccounts([account({ id: "a" })]);
+    const controller = new AbortController();
+    controller.abort();
+
+    const outcome = await runBankSyncForAccounts({
+      loadAccounts,
+      synchronous: true,
+      signal: controller.signal,
+      trigger: async () => {
+        throw new Error("should not be called");
+      },
+    });
+
+    expect(outcome.results).toHaveLength(0);
+  });
 });

--- a/src/lib/actual/runBankSync.ts
+++ b/src/lib/actual/runBankSync.ts
@@ -34,6 +34,15 @@ export type RunBankSyncOptions = {
   /** Count transactions in an account, when the transport can. */
   countTransactions?: (accountId: string) => Promise<number>;
   accountId?: string;
+  /**
+   * Stops the run between accounts.
+   *
+   * Checked here rather than by callers because this is the only place that
+   * knows where one account ends and the next begins — a caller that syncs
+   * "every account" hands over a single call and could not otherwise interrupt
+   * it at all.
+   */
+  signal?: AbortSignal;
 };
 
 function accountResult(
@@ -58,6 +67,10 @@ export async function runBankSyncForAccounts(
   );
 
   for (const account of targets) {
+    // A cancelled run stops here, with the accounts already synced reported
+    // honestly rather than the whole run discarded.
+    if (options.signal?.aborted) break;
+
     // Counting is only meaningful when the trigger is synchronous *and* the
     // transport can read transactions; otherwise the number is reported as
     // unknown rather than as zero.

--- a/src/lib/actual/transport.ts
+++ b/src/lib/actual/transport.ts
@@ -365,7 +365,7 @@ export interface ActualBenchTransport {
    * Optional: a transport that cannot do this omits it, and the capability
    * report says so, rather than the operation silently doing nothing.
    */
-  runBankSync?(input?: { accountId?: string }): Promise<BankSyncOutcome>;
+  runBankSync?(input?: { accountId?: string; signal?: AbortSignal }): Promise<BankSyncOutcome>;
   /**
    * Whether this connection can actually run a bank sync right now.
    *

--- a/src/lib/automation/bootstrap.ts
+++ b/src/lib/automation/bootstrap.ts
@@ -1,3 +1,4 @@
+import { registerBankSyncJobType } from "./jobs/bankSync";
 import { registerBudgetFileSyncJobType } from "./jobs/budgetFileSync";
 
 /**
@@ -11,4 +12,5 @@ import { registerBudgetFileSyncJobType } from "./jobs/budgetFileSync";
  */
 export function ensureAutomationJobTypesRegistered(): void {
   registerBudgetFileSyncJobType();
+  registerBankSyncJobType();
 }

--- a/src/lib/automation/engine.test.ts
+++ b/src/lib/automation/engine.test.ts
@@ -15,6 +15,11 @@ import {
   selectDueAutomations,
 } from "./engine";
 import { claimAutomation, releaseAutomationClaim } from "@/lib/app-db/automationRepository";
+import { __resetBankSyncRegistrationForTests, registerBankSyncJobType } from "./jobs/bankSync";
+import {
+  __resetBudgetFileSyncRegistrationForTests,
+  registerBudgetFileSyncJobType,
+} from "./jobs/budgetFileSync";
 import {
   __resetAutomationRegistryForTests,
   registerAutomationJobType,
@@ -669,6 +674,43 @@ describe("automation engine", () => {
       expect(summary.ran).toHaveLength(1);
       expect(listAutomationRuns(db, { automationId: id })).toHaveLength(1);
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("registers a second real job type without the engine knowing anything about it", async () => {
+    const { root, db } = tempDb();
+    try {
+      // The claim the whole engine exists to support, tested with the real
+      // second type rather than a stand-in: registering it touches no engine
+      // file, and the engine runs it without understanding what a bank is.
+      registerBudgetFileSyncJobType();
+      registerBankSyncJobType();
+
+      const id = createAutomation(db, {
+        type: "bank-sync",
+        name: "Pull from banks",
+        scheduleKind: "cron",
+        cronExpression: "0 6 * * *",
+        timezone: "UTC",
+        targetRef: { version: 1, data: {} },
+        // The vault reference the engine checks, and the same fingerprint in
+        // the type's own config: the engine fails closed on `credentialRef`
+        // without knowing what the config means.
+        credentialRef: "srv-1",
+        config: { version: 1, data: { connectionFingerprint: "srv-1" } },
+      }).id;
+
+      // No vault credential exists, so the engine fails closed — which is
+      // itself the engine treating an unfamiliar type exactly like a familiar
+      // one, with no branch anywhere that names "bank-sync".
+      const outcome = await executeAutomation(db, id, { trigger: "manual" });
+
+      expect(outcome.status).toBe("skipped");
+      expect(getAutomation(db, id)?.autoPauseReason).toMatch(/vault is disabled|stored credential/);
+    } finally {
+      __resetBudgetFileSyncRegistrationForTests();
+      __resetBankSyncRegistrationForTests();
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/src/lib/automation/jobs/bankSync.test.ts
+++ b/src/lib/automation/jobs/bankSync.test.ts
@@ -1,0 +1,143 @@
+import { bankSyncJobType } from "./bankSync";
+import { BANK_SYNC_JOB_TYPE } from "./bankSyncType";
+import type { BankSyncOutcome } from "@/lib/actual/bankSync";
+
+function outcome(overrides: Partial<BankSyncOutcome> = {}): BankSyncOutcome {
+  return { status: "ok", results: [], countsObserved: true, ...overrides };
+}
+
+describe("bank sync job type", () => {
+  it("contributes nothing to the review queue, because it constructs nothing", () => {
+    // The case the optional `classification` field exists for: this type asks
+    // Actual to run its own import, so there is no staged work to review and it
+    // must be absent from the queue rather than listed with a zero.
+    expect(bankSyncJobType.classification).toBeUndefined();
+    expect(bankSyncJobType.type).toBe(BANK_SYNC_JOB_TYPE);
+  });
+
+  it("refuses a configuration with no connection, in words a person can act on", () => {
+    expect(() => bankSyncJobType.validateConfig({ version: 1, data: {} })).toThrow(
+      /no connection to sync/
+    );
+  });
+
+  it("stores 'every linked account' rather than a snapshot of account ids", () => {
+    // An empty selection means all, so an account linked next month is included
+    // without anyone remembering to edit the automation.
+    expect(
+      bankSyncJobType.validateConfig({ version: 1, data: { connectionFingerprint: "srv-1" } })
+    ).toEqual({ connectionFingerprint: "srv-1", accountIds: [] });
+
+    expect(
+      bankSyncJobType.validateConfig({
+        version: 1,
+        data: { connectionFingerprint: " srv-1 ", accountIds: ["a", 7, "b"] },
+      })
+    ).toEqual({ connectionFingerprint: "srv-1", accountIds: ["a", "b"] });
+  });
+
+  it("does not let one unreachable bank count against the automation's health", () => {
+    const rollup = bankSyncJobType.summarize(
+      outcome({
+        status: "partial",
+        results: [
+          { accountId: "a", accountName: "Checking", status: "synced", observedNewTransactions: 4 },
+          { accountId: "b", accountName: "Savings", status: "failed", message: "consent expired" },
+        ],
+      })
+    );
+
+    expect(rollup.outcome).toBe("partial");
+    // Budget File Sync makes the opposite choice, because a partial *apply*
+    // there means writes failed. Here it means a bank was unreachable, and
+    // pausing the automation would stop the accounts that do work.
+    expect(rollup.countsAsFailure).toBeUndefined();
+    expect(rollup.message).toMatch(/4 new transactions in 1 account/);
+    expect(rollup.message).toMatch(/1 failed/);
+  });
+
+  it("reports every account failing as a failure", () => {
+    const rollup = bankSyncJobType.summarize(
+      outcome({
+        status: "failed",
+        results: [
+          { accountId: "a", status: "failed", message: "unreachable" },
+          { accountId: "b", status: "failed", message: "unreachable" },
+        ],
+      })
+    );
+
+    expect(rollup.outcome).toBe("failed");
+    expect(rollup.itemCount).toBe(2);
+  });
+
+  it("says nothing is linked rather than claiming a clean run", () => {
+    const rollup = bankSyncJobType.summarize(
+      outcome({ results: [{ accountId: "a", accountName: "Cash", status: "not-linked" }] })
+    );
+
+    expect(rollup.outcome).toBe("no_changes");
+    expect(rollup.message).toMatch(/No accounts are linked to a bank/);
+  });
+
+  it("never quotes a transaction count the transport did not measure", () => {
+    const rollup = bankSyncJobType.summarize(
+      outcome({
+        countsObserved: false,
+        results: [
+          { accountId: "a", status: "accepted", observedNewTransactions: null },
+          { accountId: "b", status: "accepted", observedNewTransactions: null },
+        ],
+      })
+    );
+
+    expect(rollup.message).toBe("Sync started for 2 accounts");
+    expect(rollup.message).not.toMatch(/new transaction/);
+    expect(rollup.message).not.toMatch(/\b0\b/);
+  });
+
+  it("distinguishes a measured zero from an unmeasured one", () => {
+    const rollup = bankSyncJobType.summarize(
+      outcome({
+        countsObserved: true,
+        results: [{ accountId: "a", status: "synced", observedNewTransactions: 0 }],
+      })
+    );
+
+    expect(rollup.message).toBe("No new transactions in 1 account");
+  });
+
+  it("keeps per-account detail in its own result payload", () => {
+    const serialized = bankSyncJobType.serializeResult(
+      outcome({
+        status: "partial",
+        countsObserved: true,
+        results: [
+          { accountId: "a", accountName: "Checking", status: "synced", observedNewTransactions: 4 },
+          { accountId: "b", accountName: "Savings", status: "failed", message: "consent expired" },
+        ],
+      })
+    );
+
+    const accounts = serialized.data.accounts as unknown as { accountId: string; status: string }[];
+    expect(accounts).toHaveLength(2);
+    expect(accounts[1]).toEqual({
+      accountId: "b",
+      accountName: "Savings",
+      status: "failed",
+      message: "consent expired",
+      observedNewTransactions: null,
+    });
+    // Nothing here borrows Budget File Sync's vocabulary.
+    expect(Object.keys(serialized.data)).not.toContain("applied");
+  });
+
+  it("reports an unavailable transport as a failure, not as an empty success", () => {
+    const rollup = bankSyncJobType.summarize(
+      outcome({ status: "unsupported", results: [], countsObserved: false, message: "not available" })
+    );
+
+    expect(rollup.outcome).toBe("failed");
+    expect(rollup.message).toBe("not available");
+  });
+});

--- a/src/lib/automation/jobs/bankSync.test.ts
+++ b/src/lib/automation/jobs/bankSync.test.ts
@@ -1,4 +1,6 @@
 import { bankSyncJobType } from "./bankSync";
+import type { AutomationRunContext } from "../registry";
+import type { BankSyncConfig } from "./bankSync";
 import { BANK_SYNC_JOB_TYPE } from "./bankSyncType";
 import type { BankSyncOutcome } from "@/lib/actual/bankSync";
 
@@ -139,5 +141,40 @@ describe("bank sync job type", () => {
 
     expect(rollup.outcome).toBe("failed");
     expect(rollup.message).toBe("not available");
+  });
+
+  it("refuses a config naming a different connection than the credential the engine checked", async () => {
+    // The engine fails closed on `definition.credentialRef`. Reading the vault
+    // by the fingerprint in this type's own config would use a credential that
+    // was never checked, so the two are required to agree.
+    const ctx = {
+      config: { connectionFingerprint: "srv-OTHER", accountIds: [] } as BankSyncConfig,
+      credentials: {
+        status: "resolved" as const,
+        serverFingerprint: "srv-1",
+        reveal: () => ({ apiKey: "should-not-be-used" }),
+      },
+      definition: {} as never,
+      attempt: 1,
+      signal: new AbortController().signal,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      reportProgress: () => {},
+    } as unknown as AutomationRunContext<BankSyncConfig>;
+
+    await expect(bankSyncJobType.run(ctx)).rejects.toThrow(/does not match the credential/);
+  });
+
+  it("refuses to run without a resolved credential", async () => {
+    const ctx = {
+      config: { connectionFingerprint: "srv-1", accountIds: [] } as BankSyncConfig,
+      credentials: { status: "unavailable" as const, reason: "vault disabled" },
+      definition: {} as never,
+      attempt: 1,
+      signal: new AbortController().signal,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      reportProgress: () => {},
+    } as unknown as AutomationRunContext<BankSyncConfig>;
+
+    await expect(bankSyncJobType.run(ctx)).rejects.toThrow(/no usable credential/);
   });
 });

--- a/src/lib/automation/jobs/bankSync.ts
+++ b/src/lib/automation/jobs/bankSync.ts
@@ -1,0 +1,214 @@
+import { createHttpApiTransport } from "@/lib/actual/httpApiTransport";
+import { getSyncCredential } from "@/lib/app-db/syncCredentialRepository";
+import { getAppDb } from "@/lib/app-db/connection";
+import { registerAutomationJobType } from "../registry";
+import { BANK_SYNC_JOB_TYPE } from "./bankSyncType";
+import type { AutomationJobType, AutomationRunContext } from "../registry";
+import type { BankSyncAccountResult, BankSyncOutcome } from "@/lib/actual/bankSync";
+import type { AutomationRunRollup, JsonEnvelope } from "@/lib/app-db/types";
+import type { HttpApiConnection } from "@/store/connection";
+
+/**
+ * Automatic Bank Sync as an automation job type (RD-080 / PR-045).
+ *
+ * Bench asks Actual to pull from the connected banks on a schedule. It does not
+ * construct the transactions and does not second-guess Actual's duplicate
+ * handling — what it owns is *when* the pull happens and *what happened*.
+ *
+ * Two contract choices distinguish this from Budget File Sync, and they are the
+ * reason the engine's registry has the shape it does:
+ *
+ *   * **No `classification`.** This type triggers Actual's own import path and
+ *     constructs nothing, so it has nothing for the shared review queue and is
+ *     absent from it rather than listed with a zero.
+ *   * **A partial run does not count against health.** One unreachable bank out
+ *     of twelve is a normal Tuesday; auto-pausing the whole automation over it
+ *     would be wrong. Budget File Sync makes the opposite choice, because a
+ *     partial *apply* there means writes failed.
+ */
+
+export type BankSyncConfig = {
+  /** Vault fingerprint of the connection whose banks are pulled. */
+  connectionFingerprint: string;
+  /**
+   * Accounts to sync. Empty means every linked account — stored as "all"
+   * rather than a snapshot of ids, so an account linked later is included
+   * without anyone editing the automation.
+   */
+  accountIds: string[];
+};
+
+export type BankSyncJobResult = BankSyncOutcome;
+
+function readConfig(raw: JsonEnvelope): BankSyncConfig {
+  const fingerprint = raw.data.connectionFingerprint;
+  if (typeof fingerprint !== "string" || !fingerprint.trim()) {
+    throw new Error("This automation has no connection to sync (connectionFingerprint is missing).");
+  }
+
+  const accountIds = Array.isArray(raw.data.accountIds)
+    ? raw.data.accountIds.filter((value): value is string => typeof value === "string")
+    : [];
+
+  return { connectionFingerprint: fingerprint.trim(), accountIds };
+}
+
+function connectionFromVault(fingerprint: string): HttpApiConnection {
+  const credential = getSyncCredential(getAppDb(), fingerprint);
+  if (!credential) {
+    // The engine fails closed before reaching here, so this is the narrow race
+    // where the credential was withdrawn mid-run.
+    throw new Error("The stored credential for this connection is no longer available.");
+  }
+
+  return {
+    id: credential.connectionFingerprint,
+    label: credential.label || credential.baseUrl,
+    mode: "http-api",
+    baseUrl: credential.baseUrl,
+    apiKey: credential.secret.apiKey,
+    budgetSyncId: credential.budgetSyncId,
+    ...(credential.secret.encryptionPassword
+      ? { encryptionPassword: credential.secret.encryptionPassword }
+      : {}),
+  };
+}
+
+function describe(results: BankSyncAccountResult[], countsObserved: boolean): string {
+  const synced = results.filter((result) => result.status === "synced" || result.status === "accepted");
+  const failed = results.filter((result) => result.status === "failed");
+  const skipped = results.filter((result) => result.status === "not-linked");
+
+  const parts: string[] = [];
+
+  if (countsObserved) {
+    const counted = synced.filter(
+      (result): result is BankSyncAccountResult & { observedNewTransactions: number } =>
+        typeof result.observedNewTransactions === "number"
+    );
+    const total = counted.reduce((sum, result) => sum + result.observedNewTransactions, 0);
+    parts.push(
+      total === 0
+        ? `No new transactions in ${synced.length} account${synced.length === 1 ? "" : "s"}`
+        : `${total} new transaction${total === 1 ? "" : "s"} in ${synced.length} account${synced.length === 1 ? "" : "s"}`
+    );
+  } else if (synced.length > 0) {
+    // The server accepted the request without saying what arrived; claiming a
+    // count here would be inventing one.
+    parts.push(`Sync started for ${synced.length} account${synced.length === 1 ? "" : "s"}`);
+  }
+
+  if (failed.length > 0) parts.push(`${failed.length} failed`);
+  if (skipped.length > 0) parts.push(`${skipped.length} not linked to a bank`);
+
+  return parts.join(", ") || "Nothing to sync";
+}
+
+export const bankSyncJobType: AutomationJobType<BankSyncConfig, BankSyncJobResult> = {
+  type: BANK_SYNC_JOB_TYPE,
+  label: "Bank sync",
+
+  validateConfig: readConfig,
+
+  async run(ctx: AutomationRunContext<BankSyncConfig>): Promise<BankSyncJobResult> {
+    const connection = connectionFromVault(ctx.config.connectionFingerprint);
+    const transport = createHttpApiTransport(connection);
+
+    if (!transport.runBankSync) {
+      return {
+        status: "unsupported",
+        results: [],
+        countsObserved: false,
+        message: "This connection cannot trigger a bank sync.",
+      };
+    }
+
+    ctx.logger.info(
+      ctx.config.accountIds.length > 0
+        ? `Syncing ${ctx.config.accountIds.length} selected account(s)`
+        : "Syncing every account linked to a bank"
+    );
+
+    // One call per selected account so a cancelled run stops between accounts
+    // rather than after every bank has been contacted.
+    if (ctx.config.accountIds.length > 0) {
+      const results: BankSyncAccountResult[] = [];
+      for (const accountId of ctx.config.accountIds) {
+        if (ctx.signal.aborted) break;
+        const outcome = await transport.runBankSync({ accountId });
+        results.push(...outcome.results);
+      }
+      return {
+        status: rollupStatus(results),
+        results,
+        countsObserved: false,
+      };
+    }
+
+    return transport.runBankSync();
+  },
+
+  summarize(result: BankSyncJobResult): AutomationRunRollup {
+    const attempted = result.results.filter((entry) => entry.status !== "not-linked");
+    const message = describe(result.results, result.countsObserved);
+
+    if (result.status === "unsupported") {
+      return { outcome: "failed", itemCount: 0, message: result.message ?? "Bank sync is unavailable." };
+    }
+    if (attempted.length === 0) {
+      return { outcome: "no_changes", itemCount: 0, message: "No accounts are linked to a bank." };
+    }
+    if (result.status === "failed") {
+      return { outcome: "failed", itemCount: attempted.length, message };
+    }
+    if (result.status === "partial") {
+      // Deliberately not `countsAsFailure`: some banks being unreachable is an
+      // ordinary outcome, and pausing the automation over it would stop the
+      // accounts that do work from syncing.
+      return { outcome: "partial", itemCount: attempted.length, message };
+    }
+    return { outcome: "ok", itemCount: attempted.length, message };
+  },
+
+  serializeResult(result: BankSyncJobResult): JsonEnvelope {
+    return {
+      version: 1,
+      data: {
+        status: result.status,
+        countsObserved: result.countsObserved,
+        accounts: result.results.map((entry) => ({
+          accountId: entry.accountId,
+          accountName: entry.accountName ?? null,
+          status: entry.status,
+          message: entry.message ?? null,
+          observedNewTransactions: entry.observedNewTransactions ?? null,
+        })),
+      },
+    };
+  },
+
+  // No `classification`: this type constructs nothing, so it contributes
+  // nothing to the shared review queue.
+};
+
+function rollupStatus(results: BankSyncAccountResult[]): BankSyncOutcome["status"] {
+  const attempted = results.filter((result) => result.status !== "not-linked");
+  const failed = attempted.filter((result) => result.status === "failed");
+  if (attempted.length === 0) return "ok";
+  if (failed.length === 0) return "ok";
+  return failed.length === attempted.length ? "failed" : "partial";
+}
+
+let registered = false;
+
+/** Idempotent: the boot path and tests can both call it. */
+export function registerBankSyncJobType(): void {
+  if (registered) return;
+  registerAutomationJobType(bankSyncJobType);
+  registered = true;
+}
+
+/** Test-only: allow re-registration after the registry is reset. */
+export function __resetBankSyncRegistrationForTests(): void {
+  registered = false;
+}

--- a/src/lib/automation/jobs/bankSync.ts
+++ b/src/lib/automation/jobs/bankSync.ts
@@ -129,23 +129,24 @@ export const bankSyncJobType: AutomationJobType<BankSyncConfig, BankSyncJobResul
         : "Syncing every account linked to a bank"
     );
 
-    // One call per selected account so a cancelled run stops between accounts
-    // rather than after every bank has been contacted.
+    // Cancellation is honoured between accounts on both paths: the transport
+    // checks the signal inside its own loop, which is the only place that knows
+    // where one account ends and the next begins.
     if (ctx.config.accountIds.length > 0) {
       const results: BankSyncAccountResult[] = [];
+      let countsObserved = false;
+
       for (const accountId of ctx.config.accountIds) {
         if (ctx.signal.aborted) break;
-        const outcome = await transport.runBankSync({ accountId });
+        const outcome = await transport.runBankSync({ accountId, signal: ctx.signal });
         results.push(...outcome.results);
+        countsObserved = countsObserved || outcome.countsObserved;
       }
-      return {
-        status: rollupStatus(results),
-        results,
-        countsObserved: false,
-      };
+
+      return { status: rollupStatus(results), results, countsObserved };
     }
 
-    return transport.runBankSync();
+    return transport.runBankSync({ signal: ctx.signal });
   },
 
   summarize(result: BankSyncJobResult): AutomationRunRollup {

--- a/src/lib/automation/jobs/bankSync.ts
+++ b/src/lib/automation/jobs/bankSync.ts
@@ -1,9 +1,9 @@
 import { createHttpApiTransport } from "@/lib/actual/httpApiTransport";
-import { getSyncCredential } from "@/lib/app-db/syncCredentialRepository";
+import { listSyncCredentialMeta } from "@/lib/app-db/syncCredentialRepository";
 import { getAppDb } from "@/lib/app-db/connection";
 import { registerAutomationJobType } from "../registry";
 import { BANK_SYNC_JOB_TYPE } from "./bankSyncType";
-import type { AutomationJobType, AutomationRunContext } from "../registry";
+import type { AutomationCredentials, AutomationJobType, AutomationRunContext } from "../registry";
 import type { BankSyncAccountResult, BankSyncOutcome } from "@/lib/actual/bankSync";
 import type { AutomationRunRollup, JsonEnvelope } from "@/lib/app-db/types";
 import type { HttpApiConnection } from "@/store/connection";
@@ -53,24 +53,52 @@ function readConfig(raw: JsonEnvelope): BankSyncConfig {
   return { connectionFingerprint: fingerprint.trim(), accountIds };
 }
 
-function connectionFromVault(fingerprint: string): HttpApiConnection {
-  const credential = getSyncCredential(getAppDb(), fingerprint);
-  if (!credential) {
-    // The engine fails closed before reaching here, so this is the narrow race
-    // where the credential was withdrawn mid-run.
+/**
+ * Build the connection from the credential the **engine** validated.
+ *
+ * Reading the vault directly by the fingerprint in this type's own config would
+ * sidestep the engine's fail-closed check: the engine guards
+ * `definition.credentialRef`, so a config naming a different connection would be
+ * used without ever having been checked. The two are required to agree, and the
+ * secret comes from `ctx.credentials.reveal()` — which is also what registers it
+ * for redaction, so a provider error echoing the key cannot reach a log, a
+ * stored error, or the pause reason.
+ *
+ * Only the non-secret metadata (URL, budget, label) is read from the vault here,
+ * through the accessor that never decrypts.
+ */
+function connectionFromCredentials(
+  credentials: AutomationCredentials,
+  configFingerprint: string
+): HttpApiConnection {
+  if (credentials.status !== "resolved") {
+    throw new Error("This automation has no usable credential. Re-enrol the connection to run it.");
+  }
+  if (configFingerprint && configFingerprint !== credentials.serverFingerprint) {
+    throw new Error(
+      "This automation's connection does not match the credential it was set up with. Recreate it to continue."
+    );
+  }
+
+  const meta = listSyncCredentialMeta(getAppDb()).find(
+    (entry) => entry.connectionFingerprint === credentials.serverFingerprint
+  );
+  if (!meta) {
+    // The narrow race where the credential was withdrawn after the engine
+    // checked it and before the run reached here.
     throw new Error("The stored credential for this connection is no longer available.");
   }
 
+  const secret = credentials.reveal();
+
   return {
-    id: credential.connectionFingerprint,
-    label: credential.label || credential.baseUrl,
+    id: meta.connectionFingerprint,
+    label: meta.label || meta.baseUrl,
     mode: "http-api",
-    baseUrl: credential.baseUrl,
-    apiKey: credential.secret.apiKey,
-    budgetSyncId: credential.budgetSyncId,
-    ...(credential.secret.encryptionPassword
-      ? { encryptionPassword: credential.secret.encryptionPassword }
-      : {}),
+    baseUrl: meta.baseUrl,
+    apiKey: secret.apiKey,
+    budgetSyncId: meta.budgetSyncId,
+    ...(secret.encryptionPassword ? { encryptionPassword: secret.encryptionPassword } : {}),
   };
 }
 
@@ -111,7 +139,7 @@ export const bankSyncJobType: AutomationJobType<BankSyncConfig, BankSyncJobResul
   validateConfig: readConfig,
 
   async run(ctx: AutomationRunContext<BankSyncConfig>): Promise<BankSyncJobResult> {
-    const connection = connectionFromVault(ctx.config.connectionFingerprint);
+    const connection = connectionFromCredentials(ctx.credentials, ctx.config.connectionFingerprint);
     const transport = createHttpApiTransport(connection);
 
     if (!transport.runBankSync) {

--- a/src/lib/automation/jobs/bankSyncType.ts
+++ b/src/lib/automation/jobs/bankSyncType.ts
@@ -1,0 +1,8 @@
+/**
+ * The Bank Sync job type's identifier, alone in its own module.
+ *
+ * Same reason as `budgetFileSyncType`: the job type and anything that needs to
+ * name it would otherwise import each other, and such cycles work under Jest's
+ * CommonJS while failing under a bundler's module initialization order.
+ */
+export const BANK_SYNC_JOB_TYPE = "bank-sync";


### PR DESCRIPTION
Actual can pull transactions from SimpleFIN and GoCardless. Bench could already trigger that by hand; this runs it on a schedule, with nothing open.

## What it does

**Tools → Automations → Schedule bank sync.** Pick a budget, see which of its accounts are actually connected to a bank, choose how often, and it runs on the server.

Per run, per account: **synced** (with a count where Bench could measure one), **sync started** (where the server only says it accepted the request), **failed** with the provider's reason, or **not connected to a bank** — never counted as synced, because Actual silently skips those and reporting them as successes would be a lie.

A partly-failed run does **not** count towards the failure streak that auto-pauses an automation: one unreachable bank is an ordinary outcome, and pausing would stop the accounts that do work. A wholly failed run does count.

## It is also the engine's exam

RD-079's central claim was that a second job type could be registered **without touching scheduler internals**. Under `src/lib/automation/`, this branch changes `bootstrap.ts` (one line) and `engine.test.ts` (a new test). No scheduling, locking, run-handling or health code moved to teach the engine what a bank is — and a test drives a bank-sync automation through the engine to prove it, rather than asserting it in prose.

The two contract choices that differ from Budget File Sync are the reason the registry has the shape it does:

- **no `classification`** — this type constructs nothing, so it contributes nothing to the review queue and is absent from it rather than listed with a zero;
- **`countsAsFailure` stays false** for a partial run, the opposite of sync's choice, because "some items failed" means a broken write path there and an unreachable bank here.

## The dialog

Built around what a person decides rather than the fields the record has.

The account list needed a small read-only server route: the browser cannot see which accounts are bank-connected, because the credentials are in the server-side vault and the budget is often not the one open. Without it the dialog could only assert "every linked account is synced" and hope — including when the honest answer is "none are", which now blocks scheduling instead of creating a job that could never import anything.

Cadence is plain — every few hours, or once a day at a time — with cron kept under **Custom** for "weekdays at 07:00". The first run is shown as a real date and a relative time, so choosing 06:00 tells you whether that means this morning or tomorrow. Time zones are picked from a list labelled the way the tz database labels them, `(UTC+04:00) Dubai`, ordered west to east, with your own zone and UTC first — and only asked for when the schedule has a clock in it, since "every 6 hours" means the same thing everywhere. Offsets are computed rather than tabulated, because a fixed table is wrong for half the year in every zone that observes daylight saving.

## Still open, and handled conservatively

No bank-connected account was available to test against, so two questions from the transport work remain: whether the HTTP endpoint's `200` means *finished* (treated as merely accepted, so no count is claimed), and whether a per-account call handles a SimpleFIN account correctly. Both are recorded for verification when an account exists; neither can produce a wrong number in the meantime, only a missing one.

## Validation

`npx tsc --noEmit` clean · `npm run lint` clean for changed files · **246 suites / 2902 tests** · `npm run build` compiles.