### PR TITLE
Verified backups: storage, destinations, verification and retention

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -74,6 +74,24 @@ One place for everything Actual Bench runs on a schedule, on a shared engine rat
 
 See `docs/AUTOMATIONS.md`.
 
+## Backups
+
+Verified copies of your budget and of Bench's own settings, taken on a schedule, kept in as many places as you like, and checked by **opening them** rather than by assuming. Open it from **Tools → Backups**.
+
+- **A readiness statement, deliberately pessimistic** — one sentence saying what you would get back and how old it is. A copy Bench has never opened, a destination that failed last night, or every copy sitting in one place all pull it down, with the reasons listed underneath.
+- **Destinations**: a folder on the server (any mounted volume or NAS share) and **S3-compatible** buckets — AWS, MinIO, Backblaze B2, Cloudflare R2, Wasabi, Garage. Paths are checked while you type them; every save tests the destination by writing real bytes, reading them back and comparing checksums. Keys are sealed with `SYNC_VAULT_KEY` and never stored in readable form.
+- **Verification, at three depths** — a valid archive; opened, integrity-checked and counted (the default); or the full Budget File Health suite. Always on the plaintext, **before** encryption. A copy that fails is still stored and clearly marked, because a backup Bench distrusts beats no backup as long as nobody believes it is fine.
+- **Weekly re-checking (scrub)** — storage rots quietly, so Bench re-reads the newest copies in each destination, re-computes checksums, and opens the newest one properly, decrypting first where it holds the passphrase so an encrypted backup is proved **decryptable** rather than merely present. Also available on demand.
+- **Retention written as refusals** — never a pin, never a protected copy, never anything under the minimum age, never a backup you took by hand, and **never the newest verified copy**. No combination of settings can empty a destination. The prune preview is produced by the code that does the pruning, not an approximation of it.
+- **Optional encryption**, off by default: AES-256-GCM with scrypt, parameters carried in the file itself so a copy can be decrypted with nothing but the passphrase. Bench cannot recover one without it, and neither can anyone else.
+- **Recovery points before risky changes** — a copy taken before a batch of deletions or payee merges, debounced across a session, protected rather than pinned so it expires on its own. If one cannot be taken, Bench asks before continuing instead of silently dropping the safety net.
+- **Look inside without restoring** — accounts, payees, transactions and date range, so you can tell whether this is the copy you want.
+- **Restore that does not depend on Bench** — download the ZIP and use Actual's own **Import file → Actual**, which creates a *new* budget and never touches the one you are using. Bench does not import for you: Actual's HTTP API has no import endpoint, and a half-worked restore is worse than a deliberate one.
+- **Survives losing Bench** — every copy is written with a manifest beside it, so **Find backups** rebuilds the whole inventory from a bare destination, and the **recovery sheet** (Markdown, no secrets in it) documents the paths, keys, commands and encrypted file format for restoring with `unzip`, `sqlite3` and `node` alone.
+- Not in scope: restoring into an existing budget in place, continuous or point-in-time backup, backing up an Actual server's own database or its other budgets, and notification channels.
+
+See `docs/BACKUPS.md`.
+
 ## Budget File Sync
 
 A workspace for syncing data between budget files as saved one-way flows. One unified engine covers every data type — **transactions, payees, and categories** — so preview, apply, run history, the review queue, and the whole safe-only automation layer work identically for each. It is **preview-first** and conservative by default (**create-only**), with opt-in advanced modes (update, delete, grouped splits, same-budget) that never write silently. Every data type - transactions, payees, and categories - syncs in **both Direct and HTTP API Server mode**, in any combination (Direct-to-HTTP, HTTP-to-Direct, and same-mode).

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -70,6 +70,7 @@ export default defineConfig({
 						{ label: 'ActualQL', link: '/user-guide/actualql/' },
 						{ label: 'FX Rates', link: '/user-guide/fx-rates/' },
 						{ label: 'Bundle Export / Import', link: '/user-guide/bundle-export-import/' },
+						{ label: 'Backups', link: '/user-guide/backups/' },
 					],
 				},
 				{

--- a/docs-site/src/content/docs/user-guide/backups.mdx
+++ b/docs-site/src/content/docs/user-guide/backups.mdx
@@ -1,0 +1,147 @@
+---
+title: Backups
+description: Keep verified copies of your budget on a schedule, in more than one place, and know exactly what you would get back if you needed it.
+sidebar:
+  order: 12
+---
+
+A ZIP you exported once is not a backup. You do not know whether it still opens, whether it is
+complete, or how old it is — and you find out on the day it matters.
+
+**Backups** in Actual Bench takes copies on a schedule, **opens each one to check it is readable**,
+stores it in as many places as you like, and keeps the inventory honest about what actually exists.
+Open it from **Tools → Backups**.
+
+## The line at the top
+
+Everything on the page is evidence for one sentence: *if this budget disappeared right now, what
+would I get back, and how old would it be?*
+
+It is deliberately pessimistic. A copy Bench has never opened, a destination that failed last night,
+or every copy sitting in one place all pull it down — and the reasons are listed underneath. A
+backup screen that reassures you is worse than no backup screen at all.
+
+## Destinations
+
+Two kinds, matching the two situations people are actually in:
+
+- **A folder on this server** — any absolute path the server can write to: a mounted volume, a NAS
+  share, a second disk. Bench creates it if it does not exist.
+- **An S3-compatible bucket** — AWS, but equally MinIO on a NAS, Backblaze B2, Cloudflare R2, Wasabi
+  or Garage. Access keys are encrypted with your server's `SYNC_VAULT_KEY` and never stored in
+  readable form.
+
+Bench checks a folder path while you are typing it rather than at 3am when the backup runs. It will
+tell you the directory does not exist and create it, that it cannot write there, that the volume is
+nearly full, or that the folder is on the same disk as Bench's own data — that last one is a warning,
+not a refusal, because `/data/backups` is a perfectly sensible arrangement that simply is not
+off-site.
+
+Adding or editing a destination always tests it by **using** it: Bench writes real bytes, reads them
+back, compares checksums and deletes the test file. A test that only checked credentials would pass
+on a read-only volume, which is exactly the configuration people get wrong.
+
+A bucket that accepts writes but refuses deletes is a warning rather than an error. Immutable buckets
+are a real choice; backups still work, and only retention is affected.
+
+## Backup rules
+
+A rule says what to copy, where to put it, how often, and how long to keep it.
+
+- **What** — the budget, Bench's own settings, or both. Bench's settings are your sync flows and
+  mappings, reconciliation sessions, automations, saved queries and payee-cleanup decisions:
+  everything you have taught Bench, which lives nowhere else.
+- **Which budget** — an **enrolled** connection. A scheduled backup runs with your browser closed, so
+  it needs credentials the server can use on its own. If nothing is enrolled, Bench says so instead
+  of quietly offering you an empty list.
+- **When** — every day at a time you pick, every few hours, or a cron expression with an explicit
+  time zone.
+- **Encryption** — off by default, because for most self-hosted setups the copy lands on a volume you
+  already control and encryption mainly adds a way to lose the data permanently. Turn it on when a
+  copy goes somewhere you do not control. **Bench cannot recover an encrypted backup without the
+  passphrase, and neither can anyone else.**
+
+Rules run on Bench's automation engine, so they appear on the **Automations** page with their run
+history, health and backoff like everything else scheduled.
+
+## Verified, not just stored
+
+Every copy is checked before it is trusted, at one of three depths:
+
+| Level | What it does |
+|---|---|
+| Quick | Confirms it is a real archive containing what an Actual export contains. |
+| Normal | Opens the database, runs SQLite's integrity check, and counts what is inside. **The default.** |
+| Thorough | The full Budget File Health check, including relationship checks. |
+
+Verification runs on the plaintext, **before** encryption. Verifying afterwards would only prove
+bytes survived a round trip, which is the least interesting thing that can go wrong.
+
+A copy that fails verification is still stored, and clearly marked. A backup Bench distrusts is more
+useful than no backup — as long as nobody is allowed to believe it is fine.
+
+### Weekly re-checking
+
+Storage rots quietly. A full volume truncates a file, a failing disk flips a bit, somebody tidies a
+bucket, and nothing announces any of it. Once a week Bench re-reads the newest few copies in every
+destination, re-computes their checksums, and opens the newest one properly — decrypting it first
+where it has the passphrase, so an encrypted backup is proved to be **decryptable** rather than
+merely present.
+
+**Verify now** does the same thing on demand.
+
+## Retention
+
+Retention keeps a sensible spread — so many daily, weekly, monthly and yearly copies — but it is
+written as a set of refusals first:
+
+1. A **pinned** copy is never deleted.
+2. A **protected** copy is never deleted while protected.
+3. Nothing **newer than the minimum age** is deleted, whatever the rules say.
+4. The **newest verified copy always survives**. If none has verified, the newest copy survives
+   instead.
+5. A backup you took **by hand** is never expired on your behalf.
+
+There is no combination of settings that empties a destination.
+
+**Retention** on a rule shows exactly what would be removed and why, before anything happens — and
+that preview is produced by the same code that does the pruning, so it is what will happen rather
+than an approximation of it.
+
+## Recovery points before risky changes
+
+Before Bench saves a batch of deletions or payee merges, it copies the budget first, so there is
+something from five minutes ago rather than only from last night. Several changes in one session
+share a recovery point, and these expire on their own instead of piling up forever.
+
+If a recovery point cannot be taken, Bench **asks** rather than deciding for you: your changes stay
+unsaved, the reason is shown, and you can save anyway.
+
+Turn it off from the checkbox under the rules if you would rather it did not.
+
+## Getting a backup back
+
+**Look inside** opens a copy and tells you what is in it — accounts, payees, transactions and the
+date range — without restoring anything. That is usually the real question: not "is this file
+intact" but "is *this* the one".
+
+**Download** hands you the file. Put it into Actual Budget with **Import file → Actual**: it creates
+a **new** budget from the copy, and the budget you are using is untouched.
+
+Bench does not import for you. Actual's HTTP API has no import endpoint, and a restore that
+half-worked would be worse than one you did deliberately.
+
+### If Bench itself is gone
+
+Every backup is written with a **manifest** beside it describing what it is, when it was taken, its
+checksum and whether it is encrypted. So:
+
+- **Find backups** rebuilds the inventory by reading those manifests. Restore Bench onto a fresh
+  machine, point it at the same bucket, and your backup history comes back.
+- **Recovery sheet** is a page of Markdown to print or keep with your passwords. It names the real
+  paths and object keys, gives commands that work with `unzip`, `sqlite3` and `node`, and documents
+  the encrypted file format byte by byte. It contains no secret, so it is safe to keep where you keep
+  such things.
+
+The downloaded ZIP is exactly what Actual's own export produces. It opens whether or not Bench still
+exists — which is the entire point.

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -1,7 +1,7 @@
 # Automations
 
-Actual Bench runs scheduled work — today that means Budget File Sync, with more job types to
-follow — through one **automation engine**. The Automations page (Tools → Automations) is where you
+Actual Bench runs scheduled work — Budget File Sync, scheduled bank sync, and backups — through one
+**automation engine**. The Automations page (Tools → Automations) is where you
 see what runs, when it last ran, what it did, and what needs your attention.
 
 > **This is not Actual Budget's "Budget Automations".** That is an experimental feature inside
@@ -130,3 +130,7 @@ crons keep working.
 ## Related
 
 - [`UNATTENDED_SYNC.md`](UNATTENDED_SYNC.md) — enrolling credentials and the vault.
+
+## Related
+
+- Backups and their `backup` / `backup-scrub` job types: `docs/BACKUPS.md`.

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,0 +1,219 @@
+# Backups
+
+Actual Bench takes verified copies of your budget — and of its own metadata database — on a
+schedule, stores them in one or more destinations, and re-checks them so you find out about a bad
+backup before you need it rather than after.
+
+This document is the operator's view: how it behaves, what it refuses to do, and what to check when
+something looks wrong. The user-facing guide is at `docs-site/src/content/docs/user-guide/backups.mdx`.
+
+## What a backup is here
+
+An **artifact** is one thing that was backed up — a budget export, or a copy of Bench's own
+`actual-bench.sqlite`. A **location** is one copy of that artifact in one destination. An artifact in
+two destinations is one artifact in two places, and a failure in one of them is not a failure of the
+other.
+
+Every artifact is written with a **manifest** (`<object-key>.manifest.json`) beside it, carrying
+everything needed to understand the file with no Bench database available: identity, source budget,
+content summary, checksums, encryption parameters, retention tier and the Bench version that wrote
+it. The index in the app database is a cache of those manifests, not the record of truth — a
+catalogue that lives inside the thing being backed up has a circular dependency at exactly the wrong
+moment.
+
+Object keys are human-navigable on purpose:
+
+```
+budget/household-budget/2026/2026-08-27T020000-3f9c1ab2.zip
+budget/household-budget/2026/2026-08-27T020000-3f9c1ab2.zip.manifest.json
+app-db/actual-bench/2026/2026-08-27T020000-77b41e05.sqlite
+```
+
+The day someone is browsing a destination by hand is the day Bench is not available to help.
+
+## Requirements
+
+| Requirement | Why |
+|---|---|
+| **HTTP API mode** for the source budget | A scheduled backup runs with no browser. Direct mode's engine lives in the browser, so there is nothing on the server to export from. |
+| **An enrolled connection** | The backup uses the same vault credentials unattended sync uses. Enrolment is where the operator granted unattended access. |
+| **`SYNC_VAULT_KEY`** | Needed for enrolled credentials, for S3 access keys, and for a stored encryption passphrase. Without it Bench refuses to store any of them rather than writing them in the clear. |
+| A writable destination | A folder path on the server, or an S3-compatible bucket. |
+
+Backing up **only** Bench's own settings (`contents: app-db`) needs none of the above beyond a
+destination — it is a local `VACUUM INTO`.
+
+## Destinations
+
+### Local path
+
+Any absolute path the server can write to. Bench creates it if missing, and grades its checks:
+
+- **Refused**: a relative path, a path that is a file, a path it cannot write to, and the directory
+  holding Bench's own database (backups must not intermingle with it).
+- **Warned**: the same device as Bench's data (good against mistakes, useless against losing the
+  disk), and a volume low on space.
+
+Writes go to a temporary file and are renamed into place, so a partly-written archive never looks
+like a complete one.
+
+### S3-compatible
+
+Signature V4 is implemented directly over `fetch`; there is no AWS SDK in the image. Verified against
+AWS's published GET Object test vector.
+
+- A custom `endpoint` implies **path-style** addressing, which is what MinIO, Garage and most
+  self-hosted providers need. Virtual-host style needs wildcard DNS almost nobody configures.
+- Works with AWS, MinIO, Backblaze B2, Cloudflare R2, Wasabi and Garage.
+- Access keys live in `backup_credentials`, sealed with AES-256-GCM under `SYNC_VAULT_KEY`. Nothing
+  outside that module decrypts them, and a destination whose credentials cannot be resolved **fails
+  closed** — it never falls back to an unauthenticated attempt, which would surface as 403s that look
+  like a broken bucket.
+
+Every save tests the destination by writing real bytes, reading them back, comparing checksums and
+deleting the probe. A bucket that refuses deletes is a **warning**: backups still work, only
+retention cannot prune.
+
+## The run
+
+1. **Export** the budget from the Actual server, through the same per-server request queue the proxy
+   uses. That is not politeness — Actual opens the budget file to serve an export, and a sync
+   applying changes at that moment is how a backup gets taken mid-write.
+2. **Verify the plaintext**, before anything else touches it.
+3. **Encrypt**, if the rule says so.
+4. **Fan out** to every destination independently, recording each result on its own.
+
+A run that stored nothing is a failure. A run that stored somewhere but not everywhere, or stored
+something that did not verify, is **partial** — reported honestly, but it does **not** count towards
+the automation's failure streak. Auto-pausing a backup because one of two destinations is unreachable
+would stop the copies that were still working.
+
+Bench's own database is copied with `VACUUM INTO`, which takes SQLite's read lock: the copy is
+consistent even if a sync is writing, and there is no WAL to reunite later.
+
+## Verification
+
+Bench reuses Budget Diagnostics' machinery — the same code that powers Budget File Health — pointed
+at an artifact instead of a live budget.
+
+| Level | Cost | What it proves |
+|---|---|---|
+| `archive` | cheap | It is a real ZIP containing what an Actual export contains. |
+| `data` | moderate | The database opens, `PRAGMA integrity_check` passes, and the contents can be counted. **Default.** |
+| `deep` | slow | The full diagnostic suite, including relationship checks. |
+
+Verification always runs **before** encryption. Verifying ciphertext proves only that bytes survived
+a round trip.
+
+### Scrub
+
+Weekly (`backup-scrub`, Sundays at 04:00 by default), Bench re-reads the newest three copies per
+destination: presence, size, checksum, and a full open of the newest one — decrypting first where the
+policy's passphrase is stored, so an encrypted backup is proved decryptable rather than merely
+present.
+
+A scrub that finds damage **is** a failure and does count towards the streak. The reasoning is the
+mirror image of a backup run: a failed backup means today's copy is missing and tomorrow's run may
+fix it; a failed scrub means copies that already exist are bad, and repeating the scrub will not
+improve them.
+
+A copy that has disappeared is recorded as **missing**, not deleted — the distinction decides whether
+to suspect retention or a disk.
+
+## Retention
+
+Refusals first, schedule second. In precedence order:
+
+1. Pinned copies are never pruned.
+2. Protected copies are never pruned while protected (this is what automatic recovery points use).
+3. Nothing younger than `minimumAgeHours` is pruned.
+4. The newest **verified** copy of each artifact kind, per rule, always survives; if none verified,
+   the newest copy survives.
+5. Manual backups are never expired automatically.
+
+Then grandfather-father-son: the newest copy of each of the last N days, weeks, months and years. The
+surviving copy from rule 4 occupies its own day/week/month/year slot, so "keep 7 daily" keeps seven
+rather than eight.
+
+If a copy cannot be deleted, the artifact **keeps its row**. Removing Bench's record of a file that is
+still in a destination would turn a transient error into an orphan nobody knows about.
+
+`POST /api/backups/policies/:id/prune` previews by default; `{"apply": true}` performs it. The
+preview is produced by the same function that performs the prune.
+
+## Safety recovery points
+
+Before Bench saves a batch containing deletions or payee merges (or 25+ staged items), it takes a
+budget-only backup tagged with what you were about to do. These are `tier: auto`, protected for
+`autoProtectionDays` or while they are among the newest `autoProtectionCount`, and then expire
+normally — they are not pins.
+
+Debounced (30 minutes by default) so one working session shares a recovery point. On by default;
+switch it off from the Recovery Center. If one cannot be taken, the UI asks before continuing rather
+than silently dropping the safety net.
+
+## Restore
+
+Bench deliberately does not import for you. Actual's HTTP API has no import endpoint, and Actual's
+own **Import file → Actual** always creates a *new* budget file, so "never overwrite the source" is
+free.
+
+To restore:
+
+1. Download the artifact (decrypt it first if it ends in `.enc`).
+2. Check `sha256sum` against `checksumSha256` in the manifest — or `plaintextChecksumSha256` when it
+   was encrypted.
+3. Import it into Actual.
+
+**Look inside** (`POST /api/backups/artifacts/:id/inspect`) opens a copy server-side and reports its
+contents without restoring anything. An inspection counts as a verification.
+
+## Encryption format
+
+Optional, per rule, off by default. AES-256-GCM with a scrypt-derived key (N=32768, r=8, p=1). The
+file is self-describing so it can be decrypted with nothing but itself and the passphrase:
+
+```
+bytes  0..7    magic 'BENCHBK1'
+byte   8       format version (1)
+byte   9       salt length (16)
+byte   10      IV length (12)
+byte   11      auth tag length (16)
+then           salt, IV, auth tag, then ciphertext
+```
+
+The passphrase and derived key are never written anywhere — not in the manifest, not in the app
+database beyond the sealed vault entry, not in the recovery sheet.
+
+## Recovering from losing Bench
+
+1. Stand up Bench on a new server with the **same `SYNC_VAULT_KEY`** (a different key gives you back
+   every rule but no stored credentials).
+2. Add the destination again.
+3. **Find backups** (`POST /api/backups/discover`) reads the manifests and rebuilds the inventory —
+   verification state, retention tier and source budget intact. Discovery adds; it never overwrites a
+   record Bench already has, and never deletes.
+4. Restore Bench's own metadata database, if you have a copy, by stopping Bench, placing the file at
+   `ACTUAL_BENCH_DB_PATH` (default `/data/actual-bench.sqlite`), and starting it again.
+
+The **recovery sheet** (`GET /api/backups/recovery-sheet`) is a Markdown page documenting all of the
+above against your actual paths and keys. It contains no secrets and is meant to be printed or kept
+with your passwords.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| "has no stored credentials. Re-enter its access key" | The destination's sealed credential is missing. Fails closed by design. |
+| "Could not unseal credentials … SYNC_VAULT_KEY" | The vault key changed since the credential was stored. |
+| "not enrolled for unattended use" | The source connection has no vault credential; enrol it in Budget File Sync. |
+| Backup stored but "could not confirm it is readable" | Verification failed. Open the copy's detail for the findings — usually a truncated or non-Actual archive. |
+| Scrub reports "Size changed" | The stored object is not the size it was written at: a truncated upload or a full volume. |
+| Scrub reports "bytes have changed" | Checksum mismatch — bit rot, or something rewrote the object. |
+| Destination test passes but backups fail | Check free space; the probe is 64 bytes and a real export is not. |
+
+## Not in scope
+
+Restoring into an existing budget in place; continuous or point-in-time backup; backing up an Actual
+server's own database or its other budget files; notification channels; and coordinating backups
+across more than one Bench instance.

--- a/src/app/(app)/backups/page.tsx
+++ b/src/app/(app)/backups/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { BackupsView } from "@/features/backups/components/BackupsView";
+
+export const metadata: Metadata = {
+  title: "Backups - Actual Bench",
+};
+
+export default function BackupsPage() {
+  return <BackupsView />;
+}

--- a/src/app/api/backups/artifacts/[artifactId]/download/route.ts
+++ b/src/app/api/backups/artifacts/[artifactId]/download/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import {
+  getBackupArtifact,
+  getBackupDestination,
+  listArtifactLocations,
+} from "@/lib/app-db/backupRepository";
+import { createDestinationAdapter } from "@/lib/backup/destinations";
+
+type RouteContext = { params: Promise<{ artifactId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Hand the file back to the user.
+ *
+ * The most important restore path there is, and the one least likely to break:
+ * a downloaded ZIP goes into Actual's own "Import file" without Bench being
+ * involved at all. Every cleverer path in this feature is a convenience on top
+ * of this one, so it stays simple and always available.
+ *
+ * Encrypted artifacts are served as stored — Bench does not silently decrypt a
+ * file on its way out of the server, where the plaintext would then be sitting
+ * in a downloads folder.
+ */
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const { artifactId } = await context.params;
+    const db = getAppDb();
+
+    const artifact = getBackupArtifact(db, artifactId);
+    if (!artifact) return NextResponse.json({ error: "Backup not found" }, { status: 404 });
+
+    const location = listArtifactLocations(db, artifactId).find(
+      (entry) => entry.status === "stored" && entry.destinationId
+    );
+    if (!location?.destinationId) {
+      return NextResponse.json({ error: "Bench has no stored copy of this backup." }, { status: 404 });
+    }
+
+    const destination = getBackupDestination(db, location.destinationId);
+    if (!destination) {
+      return NextResponse.json({ error: "The destination holding it has been removed." }, { status: 404 });
+    }
+
+    const bytes = await createDestinationAdapter(db, destination).get(location.objectKey);
+    const filename = location.objectKey.split("/").pop() ?? "backup.zip";
+
+    return new NextResponse(new Uint8Array(bytes), {
+      headers: {
+        "Content-Type": artifact.encrypted
+          ? "application/octet-stream"
+          : artifact.kind === "budget"
+            ? "application/zip"
+            : "application/vnd.sqlite3",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Content-Length": String(bytes.byteLength),
+      },
+    });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/artifacts/[artifactId]/inspect/route.ts
+++ b/src/app/api/backups/artifacts/[artifactId]/inspect/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { getAppDb } from "@/lib/app-db/connection";
+import { inspectArtifact } from "@/lib/backup/inspect";
+
+type RouteContext = { params: Promise<{ artifactId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+/**
+ * Open a backup and report what is inside it, without restoring anything.
+ *
+ * The question in front of a list of backups is rarely "is this file intact"
+ * but "is this the one" — does it still have the account, does it stop before
+ * the bad import. Answering it by restoring would mean creating a budget,
+ * looking, and cleaning up.
+ */
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { artifactId } = await context.params;
+    const body = (await readJsonBody(request).catch(() => ({}))) as { passphrase?: string };
+
+    const result = await inspectArtifact(getAppDb(), artifactId, {
+      passphrase: typeof body?.passphrase === "string" && body.passphrase ? body.passphrase : undefined,
+    });
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/artifacts/[artifactId]/route.ts
+++ b/src/app/api/backups/artifacts/[artifactId]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  deleteBackupArtifact,
+  getBackupArtifact,
+  getBackupDestination,
+  listArtifactLocations,
+  recordArtifactLocation,
+  setArtifactPinned,
+} from "@/lib/app-db/backupRepository";
+import { createDestinationAdapter } from "@/lib/backup/destinations";
+import { manifestKeyFor } from "@/lib/backup/manifest";
+
+type RouteContext = { params: Promise<{ artifactId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const { artifactId } = await context.params;
+    const body = (await readJsonBody(request)) as { pinned?: boolean };
+    if (typeof body?.pinned !== "boolean") {
+      return NextResponse.json({ error: "Nothing to change." }, { status: 400 });
+    }
+
+    const artifact = setArtifactPinned(getAppDb(), artifactId, body.pinned);
+    if (!artifact) return NextResponse.json({ error: "Backup not found" }, { status: 404 });
+    return NextResponse.json({ artifact });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+/**
+ * Delete one backup, everywhere it is stored.
+ *
+ * The user asked for this one specifically, so a pin does not block it — a pin
+ * protects a backup from *retention*, not from its owner. What does block it is
+ * a copy Bench cannot delete: the row stays, so the file does not become an
+ * orphan nobody has a record of.
+ */
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const { artifactId } = await context.params;
+    const db = getAppDb();
+
+    const artifact = getBackupArtifact(db, artifactId);
+    if (!artifact) return NextResponse.json({ error: "Backup not found" }, { status: 404 });
+
+    const failures: string[] = [];
+    for (const location of listArtifactLocations(db, artifactId)) {
+      if (location.status !== "stored" || !location.destinationId) continue;
+      const destination = getBackupDestination(db, location.destinationId);
+      if (!destination) continue;
+
+      try {
+        const adapter = createDestinationAdapter(db, destination);
+        await adapter.remove(location.objectKey);
+        await adapter.remove(manifestKeyFor(location.objectKey));
+        recordArtifactLocation(db, {
+          artifactId,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "deleted",
+        });
+      } catch (error) {
+        failures.push(
+          `${destination.name}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      return NextResponse.json(
+        {
+          error: `Bench could not delete every copy, so it kept its record of this backup: ${failures.join("; ")}`,
+        },
+        { status: 502 }
+      );
+    }
+
+    deleteBackupArtifact(db, artifactId);
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/destinations/[destinationId]/route.ts
+++ b/src/app/api/backups/destinations/[destinationId]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  deleteBackupDestination,
+  getBackupDestination,
+  listBackupPolicies,
+  listDestinationLocations,
+  updateBackupDestination,
+} from "@/lib/app-db/backupRepository";
+import { deleteBackupCredential, upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+
+type RouteContext = { params: Promise<{ destinationId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const { destinationId } = await context.params;
+    const body = await readJsonBody(request);
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json({ error: "Destination payload must be an object" }, { status: 400 });
+    }
+
+    const payload = body as Record<string, unknown>;
+    const credentials = payload.credentials as
+      | { accessKeyId?: string; secretAccessKey?: string; sessionToken?: string }
+      | undefined;
+    delete payload.credentials;
+
+    const db = getAppDb();
+    if (credentials?.accessKeyId && credentials?.secretAccessKey) {
+      upsertBackupCredential(db, {
+        ref: destinationId,
+        kind: "s3",
+        secret: {
+          accessKeyId: credentials.accessKeyId,
+          secretAccessKey: credentials.secretAccessKey,
+          ...(credentials.sessionToken ? { sessionToken: credentials.sessionToken } : {}),
+        },
+      });
+      payload.credentialRef = destinationId;
+    }
+
+    const destination = updateBackupDestination(db, destinationId, payload);
+    if (!destination) return NextResponse.json({ error: "Destination not found" }, { status: 404 });
+    return NextResponse.json({ destination });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+/**
+ * Removing a destination removes Bench's ability to reach it — never the copies
+ * inside it. Those are still real files, and deleting someone's backups because
+ * they tidied up a configuration entry would be indefensible; the response says
+ * what was left behind so the UI can say it too.
+ */
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const { destinationId } = await context.params;
+    const db = getAppDb();
+
+    const destination = getBackupDestination(db, destinationId);
+    if (!destination) return NextResponse.json({ error: "Destination not found" }, { status: 404 });
+
+    const inUse = listBackupPolicies(db).filter((policy) => policy.destinationIds.includes(destinationId));
+    if (inUse.length > 0) {
+      return NextResponse.json(
+        {
+          error: `${inUse.map((policy) => `"${policy.name}"`).join(", ")} still ${
+            inUse.length === 1 ? "writes" : "write"
+          } here. Remove it from ${inUse.length === 1 ? "that rule" : "those rules"} first.`,
+        },
+        { status: 409 }
+      );
+    }
+
+    const orphanedCopies = listDestinationLocations(db, destinationId, { limit: 500 }).filter(
+      (location) => location.status === "stored"
+    ).length;
+
+    deleteBackupDestination(db, destinationId);
+    deleteBackupCredential(db, destinationId);
+
+    return NextResponse.json({ deleted: true, orphanedCopies });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/destinations/[destinationId]/test/route.ts
+++ b/src/app/api/backups/destinations/[destinationId]/test/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { getBackupDestination, recordDestinationOutcome } from "@/lib/app-db/backupRepository";
+import { createDestinationAdapter } from "@/lib/backup/destinations";
+
+type RouteContext = { params: Promise<{ destinationId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Test a destination by using it: write real bytes, read them back, compare
+ * checksums, delete. A test that only checks credentials would pass on a
+ * read-only volume, which is precisely the configuration people get wrong.
+ */
+export async function POST(_request: Request, context: RouteContext) {
+  try {
+    const { destinationId } = await context.params;
+    const db = getAppDb();
+    const destination = getBackupDestination(db, destinationId);
+    if (!destination) return NextResponse.json({ error: "Destination not found" }, { status: 404 });
+
+    const at = new Date().toISOString();
+    try {
+      const result = await createDestinationAdapter(db, destination).test();
+      recordDestinationOutcome(db, destinationId, {
+        success: result.ok,
+        at,
+        reason: result.ok ? undefined : result.checks.find((check) => check.status === "fail")?.detail,
+      });
+      return NextResponse.json({ result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      recordDestinationOutcome(db, destinationId, { success: false, at, reason: message });
+      return NextResponse.json({
+        result: { ok: false, checks: [{ name: "Connect", status: "fail", detail: message }], facts: { location: "" } },
+      });
+    }
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/destinations/inspect/route.ts
+++ b/src/app/api/backups/destinations/inspect/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { inspectLocalPath } from "@/lib/backup/destinations";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Check a folder path while the user is still typing it, rather than at 3am
+ * when the backup runs. Creates the directory if it is missing, since asking
+ * someone to mkdir by hand inside a container is a good way to end up with a
+ * destination that never gets configured.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = (await readJsonBody(request)) as { path?: unknown };
+    const path = typeof body?.path === "string" ? body.path : "";
+    return NextResponse.json(await inspectLocalPath(path));
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/destinations/route.ts
+++ b/src/app/api/backups/destinations/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { createBackupDestination, listBackupDestinations, updateBackupDestination } from "@/lib/app-db/backupRepository";
+import { upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import { vaultEnabled } from "@/lib/sync/vault";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return NextResponse.json({ destinations: listBackupDestinations(getAppDb()) });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+/**
+ * Create a destination, sealing its credentials in the same request.
+ *
+ * The secret never becomes part of the destination row: it goes to the sealed
+ * store and the row keeps a reference. Refusing up front when the vault is off
+ * is the honest failure — accepting the keys and dropping them would leave a
+ * destination that looks configured and fails every night at 2am.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await readJsonBody(request);
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json({ error: "Destination payload must be an object" }, { status: 400 });
+    }
+    const payload = body as Record<string, unknown>;
+    const credentials = payload.credentials as
+      | { accessKeyId?: string; secretAccessKey?: string; sessionToken?: string }
+      | undefined;
+    delete payload.credentials;
+
+    if (payload.kind === "s3") {
+      if (!credentials?.accessKeyId || !credentials?.secretAccessKey) {
+        return NextResponse.json(
+          { error: "An access key and secret are required for an S3-compatible destination." },
+          { status: 400 }
+        );
+      }
+      if (!vaultEnabled()) {
+        return NextResponse.json(
+          {
+            error:
+              "Set SYNC_VAULT_KEY on the server before adding a bucket. Bench will not store an access key it cannot encrypt.",
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    const db = getAppDb();
+    const destination = createBackupDestination(db, payload);
+
+    if (payload.kind === "s3" && credentials?.accessKeyId && credentials?.secretAccessKey) {
+      upsertBackupCredential(db, {
+        ref: destination.id,
+        kind: "s3",
+        label: destination.name,
+        secret: {
+          accessKeyId: credentials.accessKeyId,
+          secretAccessKey: credentials.secretAccessKey,
+          ...(credentials.sessionToken ? { sessionToken: credentials.sessionToken } : {}),
+        },
+      });
+      // The reference is the destination's own id: one destination, one secret,
+      // and deleting the destination has an obvious thing to delete.
+      updateBackupDestination(db, destination.id, { credentialRef: destination.id });
+    }
+
+    return NextResponse.json({ destination: { ...destination, credentialRef: destination.id } }, { status: 201 });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/discover/route.ts
+++ b/src/app/api/backups/discover/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { getBackupDestination, listBackupDestinations } from "@/lib/app-db/backupRepository";
+import { discoverBackups, type DiscoveryResult } from "@/lib/backup/discover";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Rebuild the inventory from the manifests in a destination.
+ *
+ * For the case this whole design anticipates: the server died, the volume was
+ * recreated, Bench was restored onto a fresh machine — and the bucket is still
+ * full of backups. Discovery adds; it never overwrites what Bench already knows
+ * and never deletes.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = (await readJsonBody(request).catch(() => ({}))) as { destinationId?: string };
+    const db = getAppDb();
+
+    const destinations = body?.destinationId
+      ? [getBackupDestination(db, body.destinationId)].filter((entry) => entry !== null)
+      : listBackupDestinations(db).filter((destination) => destination.enabled);
+
+    if (destinations.length === 0) {
+      return NextResponse.json({ error: "There is no destination to scan." }, { status: 404 });
+    }
+
+    const results: DiscoveryResult[] = [];
+    for (const destination of destinations) {
+      try {
+        results.push(await discoverBackups(db, destination));
+      } catch (error) {
+        results.push({
+          destinationId: destination.id,
+          destinationName: destination.name,
+          scanned: 0,
+          imported: 0,
+          alreadyKnown: 0,
+          unreadable: 0,
+          notes: [error instanceof Error ? error.message : String(error)],
+        });
+      }
+    }
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/policies/[policyId]/prune/route.ts
+++ b/src/app/api/backups/policies/[policyId]/prune/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { getBackupPolicy, listBackupArtifacts } from "@/lib/app-db/backupRepository";
+import { prune } from "@/lib/backup/prune";
+
+type RouteContext = { params: Promise<{ policyId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Apply retention, or preview it.
+ *
+ * Defaults to a preview. Deleting backups is the one thing here that cannot be
+ * undone, so the destructive reading of an ambiguous request is the wrong
+ * default — the caller has to ask for it explicitly.
+ */
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { policyId } = await context.params;
+    const body = (await readJsonBody(request).catch(() => ({}))) as { apply?: boolean };
+
+    const db = getAppDb();
+    const policy = getBackupPolicy(db, policyId);
+    if (!policy) return NextResponse.json({ error: "Backup rule not found" }, { status: 404 });
+
+    const result = await prune(db, {
+      artifacts: listBackupArtifacts(db, { policyId, limit: 500 }),
+      retention: policy.retention,
+      dryRun: body?.apply !== true,
+    });
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/policies/[policyId]/route.ts
+++ b/src/app/api/backups/policies/[policyId]/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  deleteBackupPolicy,
+  getBackupPolicy,
+  listBackupArtifacts,
+  listBackupPolicies,
+  updateBackupPolicy,
+} from "@/lib/app-db/backupRepository";
+import { deleteBackupCredential, upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import { reconcileBackupAutomations } from "@/lib/automation/jobs/backupReconcile";
+
+type RouteContext = { params: Promise<{ policyId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function PATCH(request: Request, context: RouteContext) {
+  try {
+    const { policyId } = await context.params;
+    const body = await readJsonBody(request);
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json({ error: "Backup rule payload must be an object" }, { status: 400 });
+    }
+    const payload = body as Record<string, unknown>;
+    const passphrase = typeof payload.passphrase === "string" ? payload.passphrase : null;
+    delete payload.passphrase;
+
+    const db = getAppDb();
+    if (passphrase) {
+      upsertBackupCredential(db, { ref: policyId, kind: "passphrase", secret: { passphrase } });
+      payload.encryptionCredentialRef = policyId;
+    }
+
+    const policy = updateBackupPolicy(db, policyId, payload);
+    if (!policy) return NextResponse.json({ error: "Backup rule not found" }, { status: 404 });
+
+    reconcileBackupAutomations(db, listBackupPolicies(db));
+    return NextResponse.json({ policy });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+/**
+ * Deleting a rule stops it running. It never deletes the copies it took: those
+ * are backups, they are still restorable, and the reason to keep the artifact
+ * rows is that a stored copy nobody has a record of is the worst of both worlds.
+ * They stay in the inventory, unowned, and retention will not touch them
+ * because they no longer belong to a rule with rules.
+ */
+export async function DELETE(_request: Request, context: RouteContext) {
+  try {
+    const { policyId } = await context.params;
+    const db = getAppDb();
+    if (!getBackupPolicy(db, policyId)) {
+      return NextResponse.json({ error: "Backup rule not found" }, { status: 404 });
+    }
+
+    const keptArtifacts = listBackupArtifacts(db, { policyId, limit: 500 }).length;
+    deleteBackupPolicy(db, policyId);
+    deleteBackupCredential(db, policyId);
+    reconcileBackupAutomations(db, listBackupPolicies(db));
+
+    return NextResponse.json({ deleted: true, keptArtifacts });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/policies/[policyId]/run/route.ts
+++ b/src/app/api/backups/policies/[policyId]/run/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { getBackupPolicy } from "@/lib/app-db/backupRepository";
+import { runBackup } from "@/lib/backup/runBackup";
+
+type RouteContext = { params: Promise<{ policyId: string }> };
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+// A large budget takes a while to export, verify and upload to two places.
+export const maxDuration = 300;
+
+/**
+ * Back up now.
+ *
+ * A run that happened answers 200 whatever it concluded — a backup that failed
+ * is a result, not a transport error, and the caller needs the detail to say
+ * which destination refused it.
+ */
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { policyId } = await context.params;
+    const body = await readJsonBody(request).catch(() => ({}));
+    const options = (body ?? {}) as { takenBefore?: string; notes?: string };
+
+    const db = getAppDb();
+    const policy = getBackupPolicy(db, policyId);
+    if (!policy) return NextResponse.json({ error: "Backup rule not found" }, { status: 404 });
+
+    const result = await runBackup(db, policy, {
+      trigger: "manual",
+      tier: "manual",
+      takenBefore: options.takenBefore ?? null,
+      notes: options.notes ?? null,
+    });
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/policies/route.ts
+++ b/src/app/api/backups/policies/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import {
+  createBackupPolicy,
+  listBackupPolicies,
+  updateBackupPolicy,
+} from "@/lib/app-db/backupRepository";
+import { upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import { reconcileBackupAutomations } from "@/lib/automation/jobs/backupReconcile";
+import { vaultEnabled } from "@/lib/sync/vault";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return NextResponse.json({ policies: listBackupPolicies(getAppDb()) });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await readJsonBody(request);
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json({ error: "Backup rule payload must be an object" }, { status: 400 });
+    }
+    const payload = body as Record<string, unknown>;
+    const passphrase = typeof payload.passphrase === "string" ? payload.passphrase : null;
+    delete payload.passphrase;
+
+    if (payload.encryption === "passphrase" && !passphrase) {
+      return NextResponse.json(
+        { error: "A passphrase is required to encrypt backups." },
+        { status: 400 }
+      );
+    }
+    if (passphrase && !vaultEnabled()) {
+      return NextResponse.json(
+        {
+          error:
+            "Set SYNC_VAULT_KEY on the server before encrypting backups. Bench will not store a passphrase it cannot encrypt.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const db = getAppDb();
+    const policy = createBackupPolicy(db, payload);
+
+    if (passphrase) {
+      upsertBackupCredential(db, {
+        ref: policy.id,
+        kind: "passphrase",
+        label: policy.name,
+        secret: { passphrase },
+      });
+      updateBackupPolicy(db, policy.id, { encryptionCredentialRef: policy.id });
+    }
+
+    // Give it its automation now rather than waiting for the next tick, so the
+    // schedule the user just chose is visible on the Automations page
+    // immediately instead of appearing a minute later.
+    reconcileBackupAutomations(db, listBackupPolicies(db));
+
+    return NextResponse.json({ policy: { ...policy, encryptionCredentialRef: passphrase ? policy.id : null } }, { status: 201 });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/recovery-sheet/route.ts
+++ b/src/app/api/backups/recovery-sheet/route.ts
@@ -1,0 +1,26 @@
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import { buildRecoverySheet } from "@/lib/backup/recoverySheet";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * The recovery sheet, as Markdown to print or keep with your passwords.
+ *
+ * Served as a file rather than rendered in the app on purpose: its whole value
+ * is being readable when this app is not running.
+ */
+export async function GET() {
+  try {
+    const sheet = buildRecoverySheet(getAppDb());
+    return new Response(sheet, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Content-Disposition": `attachment; filename="actual-bench-recovery-sheet.md"`,
+      },
+    });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/route.ts
+++ b/src/app/api/backups/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse } from "@/lib/app-db/routeResponses";
+import {
+  listArtifactLocations,
+  listBackupArtifacts,
+  listBackupDestinations,
+  listBackupPolicies,
+} from "@/lib/app-db/backupRepository";
+import { listSyncCredentialMeta } from "@/lib/app-db/syncCredentialRepository";
+import { buildBackupReadiness } from "@/lib/backup/readiness";
+import { vaultEnabled } from "@/lib/sync/vault";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Everything the Recovery Center needs, in one request.
+ *
+ * Deliberately one call rather than five: the page is a single answer to "what
+ * would I get back if I needed it", and assembling that from separate requests
+ * would let it render half-answered — a readiness line contradicting the
+ * inventory below it for a second is worse than waiting.
+ */
+export async function GET() {
+  try {
+    const db = getAppDb();
+
+    const destinations = listBackupDestinations(db);
+    const artifacts = listBackupArtifacts(db, { limit: 200 }).map((artifact) => ({
+      ...artifact,
+      locations: listArtifactLocations(db, artifact.id).map((location) => ({
+        ...location,
+        destinationName:
+          destinations.find((destination) => destination.id === location.destinationId)?.name ?? null,
+      })),
+    }));
+
+    return NextResponse.json({
+      readiness: buildBackupReadiness(db),
+      destinations,
+      policies: listBackupPolicies(db),
+      artifacts,
+      // Which budgets can be backed up unattended, and why some cannot.
+      sources: listSyncCredentialMeta(db).map((credential) => ({
+        connectionFingerprint: credential.connectionFingerprint,
+        label: credential.label || credential.baseUrl,
+        baseUrl: credential.baseUrl,
+        budgetSyncId: credential.budgetSyncId,
+      })),
+      vaultEnabled: vaultEnabled(),
+    });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/safety-point/route.ts
+++ b/src/app/api/backups/safety-point/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { takeSafetyRecoveryPoint } from "@/lib/backup/safetyPoint";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Take a recovery point before something risky.
+ *
+ * Always answers 200 with an outcome, never an error status: the caller is
+ * mid-action, and a rejected request would make "the backup did not happen"
+ * indistinguishable from "your change cannot proceed". The caller decides what
+ * to do about a failure — which, in the UI, is to ask.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = (await readJsonBody(request).catch(() => ({}))) as {
+      reason?: string;
+      force?: boolean;
+    };
+
+    const outcome = await takeSafetyRecoveryPoint(getAppDb(), {
+      reason: typeof body?.reason === "string" && body.reason ? body.reason.slice(0, 200) : "a change in Bench",
+      force: body?.force === true,
+    });
+
+    return NextResponse.json({ outcome });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/scrub/route.ts
+++ b/src/app/api/backups/scrub/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { listBackupDestinations } from "@/lib/app-db/backupRepository";
+import { scrubAll } from "@/lib/backup/scrub";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/** Verify stored copies on demand — the same work the weekly scrub does. */
+export async function POST(request: Request) {
+  try {
+    const body = (await readJsonBody(request).catch(() => ({}))) as {
+      destinationIds?: string[];
+      newest?: number;
+      deepest?: number;
+    };
+
+    const db = getAppDb();
+    const ids =
+      Array.isArray(body?.destinationIds) && body.destinationIds.length > 0
+        ? body.destinationIds
+        : listBackupDestinations(db)
+            .filter((destination) => destination.enabled)
+            .map((destination) => destination.id);
+
+    const results = await scrubAll(db, ids, {
+      newest: typeof body?.newest === "number" ? body.newest : 3,
+      deepest: typeof body?.deepest === "number" ? body.deepest : 1,
+    });
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/backups/settings/route.ts
+++ b/src/app/api/backups/settings/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/lib/app-db/connection";
+import { appDbErrorResponse, readJsonBody } from "@/lib/app-db/routeResponses";
+import { readSafetySettings, writeSafetySettings } from "@/lib/backup/safetyPoint";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return NextResponse.json({ safetyPoints: readSafetySettings(getAppDb()) });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const body = (await readJsonBody(request)) as {
+      enabled?: boolean;
+      debounceMinutes?: number;
+    };
+    const settings = writeSafetySettings(getAppDb(), {
+      enabled: typeof body?.enabled === "boolean" ? body.enabled : undefined,
+      debounceMinutes: typeof body?.debounceMinutes === "number" ? body.debounceMinutes : undefined,
+    });
+    return NextResponse.json({ safetyPoints: settings });
+  } catch (error) {
+    return appDbErrorResponse(error);
+  }
+}

--- a/src/app/api/proxy/serverQueue.ts
+++ b/src/app/api/proxy/serverQueue.ts
@@ -63,11 +63,11 @@ type QueueConnection = Pick<HttpProxyConnection, "baseUrl" | "budgetSyncId" | "a
  * response promise. On 5xx or rejection, attempts a best-effort budget close
  * before releasing the queue.
  */
-export function queueServerRequest(
+export function queueServerRequest<T extends { status: number } = NextResponse>(
   connection: QueueConnection,
   reqId: string,
-  operation: () => Promise<NextResponse>
-): Promise<NextResponse> {
+  operation: () => Promise<T>
+): Promise<T> {
   const serverKey = normalizeBaseUrl(connection.baseUrl);
   const prev = serverQueueTails.get(serverKey) ?? Promise.resolve();
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -37,6 +37,7 @@ import {
   ClipboardCheck,
   Sparkles,
   Timer,
+  DatabaseBackup,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/store/connection";
@@ -123,6 +124,9 @@ export const SIDEBAR_SECTIONS: SidebarSection[] = [
         // experimental Budget Automations (RD-047) are a different feature Bench
         // does not drive, so the label must not read as that.
         { id: "automations", label: "Automations", href: "/automations", icon: Timer },
+        // Sits with the tools rather than in the footer: a backup is about a
+        // budget's data, not about the app's own configuration.
+        { id: "backups", label: "Backups", href: "/backups", icon: DatabaseBackup },
         { id: "fx-rates", label: "FX Rates", href: "/fx-rates", icon: Banknote },
         { id: "query", label: "ActualQL Queries", href: "/query", icon: Terminal },
         { id: "data-browser", label: "Data Browser", href: "/data-browser", icon: Database },

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -44,6 +44,11 @@ import {
 import { useBudgetEditsStore } from "@/store/budgetEdits";
 import { useBudgetSavePipeline } from "./useBudgetSavePipeline";
 import { useBudgetSave } from "@/features/budget-management/hooks/useBudgetSave";
+import {
+  describeRiskyChange,
+  shouldTakeRecoveryPoint,
+  takeRecoveryPoint,
+} from "@/features/backups/lib/safetyPoint";
 import { BudgetSaveProgressDialog } from "@/features/budget-management/components/BudgetSaveProgressDialog";
 import { BudgetSaveReviewDialog } from "@/features/budget-management/components/BudgetSaveReviewDialog";
 import {
@@ -103,6 +108,10 @@ export function TopBar() {
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  // Set when a recovery point could not be taken before a risky save, so the
+  // user can decide whether to go ahead without one.
+  const [recoveryPointWarning, setRecoveryPointWarning] = useState<string | null>(null);
+  const [takingRecoveryPoint, setTakingRecoveryPoint] = useState(false);
   const [budgetSaveReviewSkipped, setBudgetSaveReviewSkipped] = useState(
     () => readBudgetSaveReviewSkip()
   );
@@ -138,6 +147,21 @@ export function TopBar() {
   const stagedDiscardAll = useStagedStore((s) => s.discardAll);
   const clearHistory = useStagedStore((s) => s.clearHistory);
   const { saveAll, isSaving: isEntitySaving } = useBudgetSavePipeline();
+  // What is about to be written, so the risk rule has something to judge. A
+  // merge or a deletion is worth a recovery point whatever its count; a big
+  // batch is worth one on size alone.
+  const pendingPayeeMerges = useStagedStore((s) => s.pendingPayeeMerges);
+  const stagedCounts = useStagedStore((s) => {
+    let itemCount = 0;
+    let deleteCount = 0;
+    for (const slice of [s.accounts, s.payees, s.categoryGroups, s.categories, s.rules, s.schedules, s.tags]) {
+      for (const entry of Object.values(slice)) {
+        if (entry.isNew || entry.isUpdated || entry.isDeleted) itemCount += 1;
+        if (entry.isDeleted) deleteCount += 1;
+      }
+    }
+    return { itemCount, deleteCount };
+  });
 
   // Budget page store (always called — hooks cannot be conditional)
   const budgetHasChanges = useBudgetEditsStore(
@@ -239,25 +263,50 @@ export function TopBar() {
       setBudgetSaveReviewEdits(editSnapshot);
       setBudgetSaveReviewHolds(holdSnapshot);
     } else {
-      try {
-        const { totalSucceeded, totalFailed } = await saveAll();
-        clearHistory();
-        if (totalFailed === 0) {
-          toast.success(
-            `Saved ${totalSucceeded} item${totalSucceeded !== 1 ? "s" : ""} successfully.`
-          );
-        } else {
-          toast.error(`${totalSucceeded} saved, ${totalFailed} failed.`);
+      const change = {
+        itemCount: stagedCounts.itemCount,
+        deleteCount: stagedCounts.deleteCount,
+        mergeCount: pendingPayeeMerges.length,
+      };
+
+      // A recovery point before the change, not after it — the whole point is
+      // to have something from five minutes ago rather than from last night.
+      if (shouldTakeRecoveryPoint(change)) {
+        setTakingRecoveryPoint(true);
+        const outcome = await takeRecoveryPoint(describeRiskyChange(change)).finally(() =>
+          setTakingRecoveryPoint(false)
+        );
+        if (outcome.status === "taken") toast.success(outcome.message);
+        if (outcome.status === "failed") {
+          // Ask rather than decide. Proceeding silently would remove the safety
+          // net the user thinks they have; refusing outright would hold their
+          // work hostage to a backup problem they may already know about.
+          setRecoveryPointWarning(outcome.message);
+          return;
         }
-      } catch (err) {
-        const msg =
-          err instanceof Error
-            ? err.message
-            : typeof err === "object" && err !== null && "message" in err
+      }
+
+      await performSave();
+    }
+  }
+
+  async function performSave() {
+    try {
+      const { totalSucceeded, totalFailed } = await saveAll();
+      clearHistory();
+      if (totalFailed === 0) {
+        toast.success(`Saved ${totalSucceeded} item${totalSucceeded !== 1 ? "s" : ""} successfully.`);
+      } else {
+        toast.error(`${totalSucceeded} saved, ${totalFailed} failed.`);
+      }
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : typeof err === "object" && err !== null && "message" in err
             ? String((err as { message: unknown }).message)
             : "Save failed.";
-        toast.error(msg);
-      }
+      toast.error(msg);
     }
   }
 
@@ -472,7 +521,7 @@ export function TopBar() {
             title={isOffline ? "Cannot save - server is unreachable" : undefined}
           >
             <Save className="mr-1 h-3.5 w-3.5" />
-            {isSaving ? "Saving…" : "Save"}
+            {takingRecoveryPoint ? "Backing up…" : isSaving ? "Saving…" : "Save"}
           </Button>
         </div>
       </header>
@@ -508,6 +557,38 @@ export function TopBar() {
           }}
         />
       )}
+
+      {/* Asked, not assumed: the user decides whether to change their budget
+          without the recovery point they were expecting. */}
+      <Dialog
+        open={recoveryPointWarning !== null}
+        onOpenChange={(open) => {
+          if (!open) setRecoveryPointWarning(null);
+        }}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Bench could not take a recovery point</DialogTitle>
+            <DialogDescription>
+              {recoveryPointWarning} Your changes have not been saved yet. You can save anyway, or
+              fix the backup problem first and try again.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRecoveryPointWarning(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                setRecoveryPointWarning(null);
+                void performSave();
+              }}
+            >
+              Save anyway
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={pendingAction !== null} onOpenChange={(open) => { if (!open) setPendingAction(null); }}>
         <DialogContent showCloseButton={false}>

--- a/src/features/backups/components/BackupDetail.tsx
+++ b/src/features/backups/components/BackupDetail.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Download, Loader2, Pin, PinOff, Search, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  deleteArtifact,
+  downloadUrl,
+  inspectBackup,
+  setPinned,
+  type ArtifactWithLocations,
+} from "../lib/backupsApi";
+import { COPY_STATE_COPY, copyState, formatBytes, formatDateTime } from "../lib/presentation";
+import type { InspectionResult } from "@/lib/backup/inspect";
+
+/**
+ * One backup, in detail (RD-077 / PR-047e).
+ *
+ * The actions are ordered by how often they are the right one. **Look inside**
+ * comes first because the real question in front of a list of backups is "is
+ * this the one" — does it still have the account I deleted, does it stop before
+ * the import that went wrong — and answering that by restoring means creating a
+ * budget, opening it, checking, and cleaning up.
+ *
+ * **Download** is second and is the restore path that always works: the ZIP
+ * goes into Actual's own "Import file", with Bench uninvolved. Everything
+ * cleverer in this feature is a convenience on top of that one, which is why it
+ * is offered plainly rather than buried.
+ */
+
+export function BackupDetail({
+  artifact,
+  onClose,
+  onChanged,
+}: {
+  artifact: ArtifactWithLocations;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [passphrase, setPassphrase] = useState("");
+  const [inspection, setInspection] = useState<InspectionResult | null>(null);
+  const state = copyState(artifact);
+
+  const inspect = useMutation({
+    mutationFn: () => inspectBackup(artifact.id, passphrase || undefined),
+    onSuccess: (result) => {
+      setInspection(result);
+      if (result.opened && result.verification?.status === "passed") toast.success(result.message);
+      else if (!result.opened) toast.warning(result.message);
+      else toast.error(result.message);
+      onChanged();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const pin = useMutation({
+    mutationFn: () => setPinned(artifact.id, !artifact.pinned),
+    onSuccess: () => {
+      toast.success(artifact.pinned ? "Unpinned" : "Pinned — retention will never delete this copy");
+      onChanged();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const remove = useMutation({
+    mutationFn: () => deleteArtifact(artifact.id),
+    onSuccess: () => {
+      toast.success("Backup deleted everywhere it was stored");
+      onChanged();
+      onClose();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const findings = (artifact.verification?.data.findings ?? []) as string[];
+  const contents = (artifact.verification?.data.content ?? {}) as Record<string, number | string>;
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>
+            {artifact.kind === "budget" ? artifact.sourceBudgetName ?? "Budget" : "Bench settings"}
+          </SheetTitle>
+          <SheetDescription>{formatDateTime(artifact.createdAt)}</SheetDescription>
+        </SheetHeader>
+
+        <div className="space-y-4 px-4 pb-6 text-xs">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={state === "verified" ? "status-active" : state === "unverified" ? "secondary" : "destructive"}>
+              {COPY_STATE_COPY[state].label}
+            </Badge>
+            {artifact.encrypted && <Badge variant="secondary">Encrypted</Badge>}
+            {artifact.pinned && <Badge variant="secondary">Pinned</Badge>}
+            <span className="text-muted-foreground">{formatBytes(artifact.sizeBytes)}</span>
+          </div>
+
+          <p className="text-muted-foreground">{COPY_STATE_COPY[state].detail}</p>
+
+          <section className="space-y-1">
+            <h3 className="font-medium">Where it is</h3>
+            {artifact.locations.length === 0 ? (
+              <p className="text-muted-foreground">Nowhere. Bench has no stored copy of this backup.</p>
+            ) : (
+              <ul className="space-y-1">
+                {artifact.locations.map((location) => (
+                  <li key={location.id} className="rounded border border-border p-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium">{location.destinationName ?? "Removed destination"}</span>
+                      <span className="text-muted-foreground">{location.status}</span>
+                    </div>
+                    <code className="mt-0.5 block break-all text-muted-foreground">{location.objectKey}</code>
+                    {location.lastError && <p className="mt-1 text-destructive">{location.lastError}</p>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {(Object.keys(contents).length > 0 || inspection?.verification) && (
+            <section className="space-y-1">
+              <h3 className="font-medium">What is inside</h3>
+              <dl className="grid grid-cols-2 gap-x-3 gap-y-1">
+                {Object.entries(inspection?.verification?.content ?? contents).map(([key, value]) =>
+                  value === null || value === undefined ? null : (
+                    <div key={key} className="contents">
+                      <dt className="text-muted-foreground capitalize">
+                        {key.replace(/([A-Z])/g, " $1").toLowerCase()}
+                      </dt>
+                      <dd>{String(value)}</dd>
+                    </div>
+                  )
+                )}
+              </dl>
+            </section>
+          )}
+
+          {findings.length > 0 && (
+            <section className="space-y-1">
+              <h3 className="font-medium text-destructive">What Bench found</h3>
+              <ul className="space-y-1">
+                {findings.slice(0, 8).map((finding) => (
+                  <li key={finding} className="text-destructive">
+                    {finding}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {artifact.encrypted && (
+            <label className="block space-y-1">
+              <span className="font-medium">Passphrase</span>
+              <Input
+                className="h-8 rounded-md px-2 text-xs md:text-xs"
+                type="password"
+                value={passphrase}
+                onChange={(event) => setPassphrase(event.target.value)}
+                placeholder="only needed if Bench has not stored it"
+                autoComplete="new-password"
+              />
+            </label>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" onClick={() => inspect.mutate()} disabled={inspect.isPending}>
+              {inspect.isPending ? <Loader2 className="animate-spin" aria-hidden /> : <Search aria-hidden />}
+              Look inside
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => window.open(downloadUrl(artifact.id), "_blank")}>
+              <Download aria-hidden />
+              Download
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => pin.mutate()} disabled={pin.isPending}>
+              {artifact.pinned ? <PinOff aria-hidden /> : <Pin aria-hidden />}
+              {artifact.pinned ? "Unpin" : "Pin"}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="text-destructive"
+              onClick={() => remove.mutate()}
+              disabled={remove.isPending}
+            >
+              {remove.isPending ? <Loader2 className="animate-spin" aria-hidden /> : <Trash2 aria-hidden />}
+              Delete
+            </Button>
+          </div>
+
+          <section className="space-y-1 border-t border-border pt-3 text-muted-foreground">
+            <h3 className="font-medium text-foreground">Restoring this</h3>
+            <p>
+              Download the file and use <strong className="font-medium">Import file → Actual</strong>{" "}
+              in Actual Budget. It creates a <em>new</em> budget from the copy; the budget you are
+              using now is not touched.
+            </p>
+            <p>
+              Bench does not import for you: Actual&rsquo;s HTTP API has no import endpoint, and a
+              restore that half-worked would be worse than one you did deliberately.
+            </p>
+            {artifact.plaintextChecksumSha256 && (
+              <p className="break-all">
+                SHA-256 of the archive:{" "}
+                <code>{artifact.plaintextChecksumSha256 ?? artifact.checksumSha256}</code>
+              </p>
+            )}
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/features/backups/components/BackupRuleDialog.tsx
+++ b/src/features/backups/components/BackupRuleDialog.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isValidCronExpression } from "@/lib/automation/cron";
+import { browserTimezone, timezoneOptions } from "@/features/automations/lib/timezones";
+import { createPolicy, patchPolicy, type BackupSource } from "../lib/backupsApi";
+import type { BackupDestination, BackupPolicy } from "@/lib/app-db/backupRepository";
+
+/**
+ * A backup rule (RD-077 / PR-047e).
+ *
+ * Built around the four things a person decides — what to copy, where to put
+ * it, how often, and how long to keep it — rather than around the columns the
+ * record happens to have. Everything else has a defensible default and stays
+ * out of the way under **More options**.
+ *
+ * Two decisions show up directly in this form:
+ *
+ *   * **The source is an enrolled connection**, not a URL. A scheduled backup
+ *     has no browser to borrow, so it needs credentials the server can use
+ *     unattended, and enrolment is where the operator already granted that. A
+ *     budget that has not been enrolled is offered as an explanation rather
+ *     than silently missing from the list.
+ *   * **Encryption is off by default.** For most self-hosters the copy lands on
+ *     a volume they already control, and encryption mainly adds a way to lose
+ *     the data permanently. It matters the moment a copy goes somewhere they do
+ *     not control, and the wording says exactly that rather than nudging.
+ */
+
+const inputClass = "h-8 rounded-md px-2 text-xs md:text-xs";
+const selectClass = "h-8 w-full rounded-md border border-input bg-background px-2 text-xs";
+
+type Cadence = "daily" | "hours" | "cron";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  destinations: BackupDestination[];
+  sources: BackupSource[];
+  vaultEnabled: boolean;
+  existing?: BackupPolicy | null;
+  onSaved: () => void;
+};
+
+function initialCadence(policy: BackupPolicy | null | undefined): Cadence {
+  if (!policy) return "daily";
+  if (policy.scheduleKind === "interval") return "hours";
+  return /^0 \d{1,2} \* \* \*$/.test(policy.cronExpression ?? "") ? "daily" : "cron";
+}
+
+export function BackupRuleDialog({
+  open,
+  onOpenChange,
+  destinations,
+  sources,
+  vaultEnabled,
+  existing,
+  onSaved,
+}: Props) {
+  const editing = Boolean(existing);
+  const [name, setName] = useState(existing?.name ?? "Nightly backup");
+  const [source, setSource] = useState(
+    String(existing?.sourceRef.data.connectionFingerprint ?? sources[0]?.connectionFingerprint ?? "")
+  );
+  const [contents, setContents] = useState<BackupPolicy["contents"]>(existing?.contents ?? "both");
+  const [destinationIds, setDestinationIds] = useState<string[]>(
+    existing?.destinationIds ?? destinations.map((destination) => destination.id)
+  );
+
+  const [cadence, setCadence] = useState<Cadence>(initialCadence(existing));
+  const [hour, setHour] = useState(() => {
+    const match = /^0 (\d{1,2}) \* \* \*$/.exec(existing?.cronExpression ?? "0 2 * * *");
+    return match ? Number(match[1]) : 2;
+  });
+  const [everyHours, setEveryHours] = useState(
+    existing?.intervalMinutes ? Math.max(1, Math.round(existing.intervalMinutes / 60)) : 6
+  );
+  const [cron, setCron] = useState(existing?.cronExpression ?? "0 2 * * *");
+  const [timezone, setTimezone] = useState(existing?.timezone ?? browserTimezone());
+
+  const [verificationLevel, setVerificationLevel] = useState(existing?.verificationLevel ?? "data");
+  const [encrypt, setEncrypt] = useState(existing?.encryption === "passphrase");
+  const [passphrase, setPassphrase] = useState("");
+  const [scrubEnabled, setScrubEnabled] = useState(existing?.scrubEnabled ?? true);
+  const [showMore, setShowMore] = useState(false);
+
+  const [retention, setRetention] = useState(
+    existing?.retention ?? {
+      daily: 7,
+      weekly: 4,
+      monthly: 12,
+      yearly: 3,
+      minimumAgeHours: 24,
+      autoProtectionDays: 14,
+      autoProtectionCount: 10,
+    }
+  );
+
+  const schedule =
+    cadence === "hours"
+      ? { scheduleKind: "interval" as const, intervalMinutes: everyHours * 60, cronExpression: null }
+      : {
+          scheduleKind: "cron" as const,
+          cronExpression: cadence === "daily" ? `0 ${hour} * * *` : cron.trim(),
+          intervalMinutes: null,
+        };
+
+  const cronValid = cadence !== "cron" || isValidCronExpression(cron.trim());
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        name: name.trim(),
+        contents,
+        sourceRef: { version: 1, data: { connectionFingerprint: source } },
+        destinationIds,
+        verificationLevel,
+        encryption: encrypt ? "passphrase" : "none",
+        retention,
+        scrubEnabled,
+        timezone,
+        ...schedule,
+        ...(encrypt && passphrase ? { passphrase } : {}),
+      };
+      return existing ? patchPolicy(existing.id, payload) : createPolicy(payload);
+    },
+    onSuccess: () => {
+      toast.success(editing ? "Backup rule updated" : "Backup rule created");
+      onSaved();
+      onOpenChange(false);
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const needsSource = contents !== "app-db";
+  const canSave =
+    name.trim().length > 0 &&
+    destinationIds.length > 0 &&
+    (!needsSource || source.length > 0) &&
+    (!encrypt || editing || passphrase.length >= 8) &&
+    cronValid;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit backup rule" : "New backup rule"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="max-h-[65vh] space-y-3 overflow-y-auto pr-1 text-xs">
+          <label className="block space-y-1">
+            <span className="font-medium">Name</span>
+            <Input className={inputClass} value={name} onChange={(event) => setName(event.target.value)} />
+          </label>
+
+          <label className="block space-y-1">
+            <span className="font-medium">What to copy</span>
+            <select
+              className={selectClass}
+              value={contents}
+              onChange={(event) => setContents(event.target.value as BackupPolicy["contents"])}
+            >
+              <option value="both">The budget and Bench&rsquo;s own settings</option>
+              <option value="budget">Just the budget</option>
+              <option value="app-db">Just Bench&rsquo;s settings</option>
+            </select>
+            <span className="block text-muted-foreground">
+              Bench&rsquo;s settings are your sync rules, mappings, reconciliation sessions and
+              automations — everything you have taught it, which lives nowhere else.
+            </span>
+          </label>
+
+          {needsSource && (
+            <label className="block space-y-1">
+              <span className="font-medium">Budget</span>
+              {sources.length === 0 ? (
+                <span className="block rounded-md border border-amber-400/40 bg-amber-50 p-2 text-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
+                  No budget is enrolled for unattended use yet. A scheduled backup runs with the
+                  browser closed, so it needs credentials the server can use on its own — enrol a
+                  connection in Budget File Sync first.
+                </span>
+              ) : (
+                <select
+                  className={selectClass}
+                  value={source}
+                  onChange={(event) => setSource(event.target.value)}
+                >
+                  {sources.map((entry) => (
+                    <option key={entry.connectionFingerprint} value={entry.connectionFingerprint}>
+                      {entry.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </label>
+          )}
+
+          <fieldset className="space-y-1">
+            <legend className="font-medium">Where to put it</legend>
+            {destinations.length === 0 ? (
+              <p className="text-muted-foreground">Add a destination first.</p>
+            ) : (
+              destinations.map((destination) => (
+                <label key={destination.id} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={destinationIds.includes(destination.id)}
+                    onChange={(event) =>
+                      setDestinationIds((current) =>
+                        event.target.checked
+                          ? [...current, destination.id]
+                          : current.filter((id) => id !== destination.id)
+                      )
+                    }
+                  />
+                  <span>{destination.name}</span>
+                  <span className="text-muted-foreground">
+                    {destination.kind === "local" ? "folder" : "bucket"}
+                  </span>
+                </label>
+              ))
+            )}
+            {destinationIds.length === 1 && destinations.length > 1 && (
+              <p className="text-muted-foreground">
+                One destination protects you from mistakes. Two protect you from losing the machine.
+              </p>
+            )}
+          </fieldset>
+
+          <div className="space-y-1">
+            <span className="font-medium">When</span>
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                className={selectClass + " w-auto"}
+                value={cadence}
+                onChange={(event) => setCadence(event.target.value as Cadence)}
+              >
+                <option value="daily">Every day</option>
+                <option value="hours">Every few hours</option>
+                <option value="cron">Custom</option>
+              </select>
+
+              {cadence === "daily" && (
+                <>
+                  <span className="text-muted-foreground">at</span>
+                  <select
+                    className={selectClass + " w-auto"}
+                    value={hour}
+                    onChange={(event) => setHour(Number(event.target.value))}
+                  >
+                    {Array.from({ length: 24 }, (_, index) => (
+                      <option key={index} value={index}>
+                        {String(index).padStart(2, "0")}:00
+                      </option>
+                    ))}
+                  </select>
+                </>
+              )}
+
+              {cadence === "hours" && (
+                <>
+                  <span className="text-muted-foreground">every</span>
+                  <Input
+                    className={inputClass + " w-16"}
+                    type="number"
+                    min={1}
+                    max={24}
+                    value={everyHours}
+                    onChange={(event) => setEveryHours(Math.max(1, Number(event.target.value)))}
+                  />
+                  <span className="text-muted-foreground">hours</span>
+                </>
+              )}
+
+              {cadence === "cron" && (
+                <Input
+                  className={inputClass + " w-40 font-mono"}
+                  value={cron}
+                  onChange={(event) => setCron(event.target.value)}
+                  aria-invalid={!cronValid}
+                />
+              )}
+            </div>
+            {cadence === "cron" && !cronValid && (
+              <p className="text-destructive">That is not a valid five-field cron expression.</p>
+            )}
+            {cadence !== "hours" && (
+              <select
+                className={selectClass}
+                value={timezone}
+                onChange={(event) => setTimezone(event.target.value)}
+              >
+                {timezoneOptions().map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={encrypt}
+              disabled={!vaultEnabled}
+              onChange={(event) => setEncrypt(event.target.checked)}
+            />
+            <span>
+              <span className="font-medium">Encrypt these backups</span>
+              <span className="block text-muted-foreground">
+                {vaultEnabled
+                  ? "Worth it when a copy goes somewhere you do not control. Bench cannot recover an encrypted backup without the passphrase — nobody can."
+                  : "Set SYNC_VAULT_KEY on the server to enable encryption."}
+              </span>
+            </span>
+          </label>
+
+          {encrypt && (
+            <label className="block space-y-1">
+              <span className="font-medium">Passphrase</span>
+              <Input
+                className={inputClass}
+                type="password"
+                value={passphrase}
+                onChange={(event) => setPassphrase(event.target.value)}
+                placeholder={editing ? "unchanged" : "at least 8 characters"}
+                autoComplete="new-password"
+              />
+              <span className="block text-muted-foreground">
+                Write this down somewhere that is not on this server. It is the single point of
+                failure in the whole arrangement.
+              </span>
+            </label>
+          )}
+
+          <button
+            type="button"
+            className="text-muted-foreground underline-offset-4 hover:underline"
+            onClick={() => setShowMore((current) => !current)}
+          >
+            {showMore ? "Fewer options" : "More options"}
+          </button>
+
+          {showMore && (
+            <div className="space-y-3 rounded-md border border-border p-2">
+              <label className="block space-y-1">
+                <span className="font-medium">How thoroughly to check each copy</span>
+                <select
+                  className={selectClass}
+                  value={verificationLevel}
+                  onChange={(event) =>
+                    setVerificationLevel(event.target.value as BackupPolicy["verificationLevel"])
+                  }
+                >
+                  <option value="archive">Quick — it is a valid archive</option>
+                  <option value="data">Normal — open the database and count what is inside</option>
+                  <option value="deep">Thorough — the full Budget File Health check</option>
+                </select>
+              </label>
+
+              <fieldset className="space-y-1">
+                <legend className="font-medium">How many to keep</legend>
+                <div className="grid grid-cols-4 gap-2">
+                  {(["daily", "weekly", "monthly", "yearly"] as const).map((tier) => (
+                    <label key={tier} className="space-y-1">
+                      <span className="block capitalize text-muted-foreground">{tier}</span>
+                      <Input
+                        className={inputClass}
+                        type="number"
+                        min={0}
+                        value={retention[tier]}
+                        onChange={(event) =>
+                          setRetention((current) => ({
+                            ...current,
+                            [tier]: Math.max(0, Number(event.target.value)),
+                          }))
+                        }
+                      />
+                    </label>
+                  ))}
+                </div>
+                <p className="text-muted-foreground">
+                  Bench never deletes a pinned copy, anything newer than{" "}
+                  {retention.minimumAgeHours}h, or the newest verified copy — whatever these numbers
+                  say.
+                </p>
+              </fieldset>
+
+              <label className="flex items-start gap-2">
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={scrubEnabled}
+                  onChange={(event) => setScrubEnabled(event.target.checked)}
+                />
+                <span>
+                  <span className="font-medium">Re-check stored copies weekly</span>
+                  <span className="block text-muted-foreground">
+                    Storage rots quietly. This re-reads the newest few copies and tells you if one
+                    has stopped being readable.
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={() => save.mutate()} disabled={!canSave || save.isPending}>
+            {save.isPending ? <Loader2 className="animate-spin" aria-hidden /> : null}
+            {editing ? "Save" : "Create rule"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/backups/components/BackupsTable.tsx
+++ b/src/features/backups/components/BackupsTable.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { CircleCheck, CircleHelp, CircleX, Lock, Pin, Server } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  COPY_STATE_COPY,
+  copyState,
+  formatBytes,
+  formatDateTime,
+  relativeTime,
+  type CopyState,
+} from "../lib/presentation";
+import type { ArtifactWithLocations } from "../lib/backupsApi";
+
+/**
+ * The inventory (RD-077 / PR-047e).
+ *
+ * One line per backup, because the task is scanning: *which copy do I want, and
+ * can I trust it?* The columns are chosen to answer exactly that and nothing
+ * else — when it was taken, what it holds, whether Bench has read it, and where
+ * it lives. Everything further is in the side sheet.
+ *
+ * The same layout rules as the Automations table: space in proportion to
+ * trouble (a healthy copy gets one line; a damaged one gets a second carrying
+ * the reason), and status carried by word, shape and colour together so it
+ * survives a screenshot and a colour-blind reader.
+ */
+
+const STATE_STYLE: Record<CopyState, { icon: LucideIcon; tone: string; row?: string }> = {
+  verified: { icon: CircleCheck, tone: "text-green-600 dark:text-green-500" },
+  unverified: { icon: CircleHelp, tone: "text-muted-foreground" },
+  damaged: { icon: CircleX, tone: "text-destructive", row: "bg-destructive/5" },
+  gone: { icon: CircleX, tone: "text-destructive", row: "bg-destructive/5" },
+};
+
+type Props = {
+  artifacts: ArtifactWithLocations[];
+  selectedId: string | null;
+  onOpen: (artifactId: string) => void;
+};
+
+export function BackupsTable({ artifacts, selectedId, onOpen }: Props) {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead className="sticky top-0 z-10 bg-background">
+          <tr className="border-b border-border text-left text-xs text-muted-foreground">
+            <th scope="col" className="px-4 py-2 font-medium">Taken</th>
+            <th scope="col" className="px-4 py-2 font-medium">Contents</th>
+            <th scope="col" className="px-4 py-2 font-medium">State</th>
+            <th scope="col" className="px-4 py-2 font-medium">Size</th>
+            <th scope="col" className="px-4 py-2 font-medium">Stored in</th>
+            <th scope="col" className="px-4 py-2 font-medium">Keep</th>
+          </tr>
+        </thead>
+        <tbody>
+          {artifacts.map((artifact) => {
+            const state = copyState(artifact);
+            const style = STATE_STYLE[state];
+            const Icon = style.icon;
+            const stored = artifact.locations.filter((location) => location.status === "stored");
+            const troubled = state === "damaged" || state === "gone";
+
+            return (
+              <tr
+                key={artifact.id}
+                onClick={() => onOpen(artifact.id)}
+                className={cn(
+                  "cursor-pointer border-b border-border/60 align-top hover:bg-muted/50",
+                  style.row,
+                  selectedId === artifact.id && "bg-muted"
+                )}
+              >
+                <td className="px-4 py-2 whitespace-nowrap">
+                  <div className="font-medium">{relativeTime(artifact.createdAt)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatDateTime(artifact.createdAt)}
+                  </div>
+                </td>
+
+                <td className="px-4 py-2">
+                  <div className="flex items-center gap-1.5">
+                    {artifact.kind === "app-db" ? (
+                      <Server className="size-3.5 text-muted-foreground" aria-hidden />
+                    ) : null}
+                    <span>
+                      {artifact.kind === "budget"
+                        ? artifact.sourceBudgetName ?? "Budget"
+                        : "Bench settings"}
+                    </span>
+                    {artifact.encrypted && (
+                      <Lock className="size-3.5 text-muted-foreground" aria-label="Encrypted" />
+                    )}
+                  </div>
+                  {artifact.takenBefore && (
+                    <div className="text-xs text-muted-foreground">
+                      Taken before {artifact.takenBefore}
+                    </div>
+                  )}
+                </td>
+
+                <td className="px-4 py-2">
+                  <div className={cn("flex items-center gap-1.5 whitespace-nowrap", style.tone)}>
+                    <Icon className="size-4" aria-hidden />
+                    <span className="font-medium">{COPY_STATE_COPY[state].label}</span>
+                  </div>
+                  {troubled && (
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      {COPY_STATE_COPY[state].detail}
+                    </div>
+                  )}
+                </td>
+
+                <td className="px-4 py-2 whitespace-nowrap text-muted-foreground">
+                  {formatBytes(artifact.sizeBytes)}
+                </td>
+
+                <td className="px-4 py-2">
+                  {stored.length === 0 ? (
+                    <span className="text-muted-foreground">nowhere</span>
+                  ) : (
+                    <div className="flex flex-wrap gap-1">
+                      {stored.map((location) => (
+                        <span
+                          key={location.id}
+                          className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+                        >
+                          {location.destinationName ?? "removed destination"}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </td>
+
+                <td className="px-4 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                  {artifact.pinned ? (
+                    <span className="flex items-center gap-1 text-foreground">
+                      <Pin className="size-3.5" aria-hidden /> Pinned
+                    </span>
+                  ) : artifact.protectedUntil && new Date(artifact.protectedUntil) > new Date() ? (
+                    `Protected until ${artifact.protectedUntil.slice(0, 10)}`
+                  ) : (
+                    tierLabel(artifact.tier)
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function tierLabel(tier: string): string {
+  switch (tier) {
+    case "manual":
+      return "Kept (taken by hand)";
+    case "auto":
+      return "Recovery point";
+    case "daily":
+      return "Daily";
+    case "weekly":
+      return "Weekly";
+    case "monthly":
+      return "Monthly";
+    case "yearly":
+      return "Yearly";
+    default:
+      return tier;
+  }
+}

--- a/src/features/backups/components/BackupsView.test.tsx
+++ b/src/features/backups/components/BackupsView.test.tsx
@@ -263,6 +263,7 @@ describe("the Recovery Center", () => {
         passed: 2,
         failed: 1,
         missing: 0,
+        skipped: 0,
         artifacts: [],
       },
     ]);

--- a/src/features/backups/components/BackupsView.test.tsx
+++ b/src/features/backups/components/BackupsView.test.tsx
@@ -1,0 +1,280 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { BackupsView } from "./BackupsView";
+import * as api from "../lib/backupsApi";
+import type { ArtifactWithLocations, RecoveryCenterData } from "../lib/backupsApi";
+
+jest.mock("../lib/backupsApi");
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+function artifact(overrides: Partial<ArtifactWithLocations> = {}): ArtifactWithLocations {
+  return {
+    id: "art-1",
+    policyId: "pol-1",
+    kind: "budget",
+    createdAt: "2026-08-27T02:00:00.000Z",
+    sourceBudgetId: "budget-1",
+    sourceBudgetName: "Household",
+    sizeBytes: 2_400_000,
+    checksumSha256: "a".repeat(64),
+    plaintextChecksumSha256: null,
+    encrypted: false,
+    encryption: null,
+    tier: "daily",
+    pinned: false,
+    protectedUntil: null,
+    takenBefore: null,
+    verificationLevel: "data",
+    verificationStatus: "passed",
+    verifiedAt: "2026-08-27T02:00:10.000Z",
+    verification: null,
+    manifestVersion: 1,
+    benchVersion: null,
+    notes: null,
+    locations: [
+      {
+        id: "loc-1",
+        artifactId: "art-1",
+        destinationId: "dest-1",
+        destinationName: "NAS volume",
+        objectKey: "budget/household/2026/2026-08-27T020000-art1.zip",
+        status: "stored",
+        uploadedAt: "2026-08-27T02:00:20.000Z",
+        lastVerifiedAt: "2026-08-27T02:00:20.000Z",
+        lastError: null,
+        createdAt: "2026-08-27T02:00:20.000Z",
+        updatedAt: "2026-08-27T02:00:20.000Z",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function data(overrides: Partial<RecoveryCenterData> = {}): RecoveryCenterData {
+  return {
+    readiness: {
+      status: "protected",
+      headline: "You could restore a verified backup from 3 hours ago.",
+      detail: "1 stored copy across 1 destination.",
+      newestVerified: {
+        artifactId: "art-1",
+        createdAt: "2026-08-27T02:00:00.000Z",
+        ageHours: 3,
+        budgetName: "Household",
+      },
+      totalCopies: 1,
+      destinationCount: 1,
+      redundant: false,
+      issues: [],
+    },
+    destinations: [
+      {
+        id: "dest-1",
+        name: "NAS volume",
+        kind: "local",
+        enabled: true,
+        config: { version: 1, data: { path: "/mnt/backups" } },
+        credentialRef: null,
+        lastSuccessAt: "2026-08-27T02:00:20.000Z",
+        lastFailureAt: null,
+        lastFailureReason: null,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-27T02:00:20.000Z",
+      },
+    ],
+    policies: [
+      {
+        id: "pol-1",
+        name: "Nightly",
+        enabled: true,
+        contents: "both",
+        sourceRef: { version: 1, data: { connectionFingerprint: "conn-1" } },
+        destinationIds: ["dest-1"],
+        verificationLevel: "data",
+        encryption: "none",
+        encryptionCredentialRef: null,
+        retention: {
+          daily: 7,
+          weekly: 4,
+          monthly: 12,
+          yearly: 3,
+          minimumAgeHours: 24,
+          autoProtectionDays: 14,
+          autoProtectionCount: 10,
+        },
+        scheduleKind: "cron",
+        cronExpression: "0 2 * * *",
+        intervalMinutes: null,
+        timezone: "UTC",
+        scrubEnabled: true,
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      },
+    ],
+    artifacts: [artifact()],
+    sources: [
+      {
+        connectionFingerprint: "conn-1",
+        label: "Household",
+        baseUrl: "https://actual.example.com",
+        budgetSyncId: "budget-1",
+      },
+    ],
+    vaultEnabled: true,
+    ...overrides,
+  };
+}
+
+function renderView() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <BackupsView />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedApi.fetchRecoveryCenter.mockResolvedValue(data());
+});
+
+describe("the Recovery Center", () => {
+  it("leads with what you would actually get back", async () => {
+    renderView();
+    expect(
+      await screen.findByText("You could restore a verified backup from 3 hours ago.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows each copy's state in words, not only in colour", async () => {
+    renderView();
+    expect(await screen.findByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText("Household")).toBeInTheDocument();
+    expect(screen.getByText("NAS volume", { selector: "span.rounded" })).toBeInTheDocument();
+  });
+
+  it("says a backup with no surviving copy is gone, whatever it once verified as", async () => {
+    // The single most misleading thing this page could do is show a verified
+    // badge on a backup that is not there any more.
+    mockedApi.fetchRecoveryCenter.mockResolvedValue(
+      data({
+        artifacts: [
+          artifact({
+            verificationStatus: "passed",
+            locations: [
+              {
+                ...artifact().locations[0],
+                status: "missing",
+              },
+            ],
+          }),
+        ],
+      })
+    );
+
+    renderView();
+    expect(await screen.findByText("No copy")).toBeInTheDocument();
+    expect(screen.queryByText("Verified")).not.toBeInTheDocument();
+  });
+
+  it("reports a failed manual backup as a failure rather than as finished", async () => {
+    mockedApi.backUpNow.mockResolvedValue({
+      policyId: "pol-1",
+      trigger: "manual",
+      startedAt: "2026-08-27T09:00:00.000Z",
+      finishedAt: "2026-08-27T09:00:05.000Z",
+      artifacts: [],
+      stored: false,
+      verified: false,
+      message: "No enabled destination",
+    });
+
+    renderView();
+    fireEvent.click(await screen.findByRole("button", { name: /back up now/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("No enabled destination"));
+  });
+
+  it("warns rather than congratulates when a copy stored but did not verify", async () => {
+    mockedApi.backUpNow.mockResolvedValue({
+      policyId: "pol-1",
+      trigger: "manual",
+      startedAt: "2026-08-27T09:00:00.000Z",
+      finishedAt: "2026-08-27T09:00:05.000Z",
+      artifacts: [],
+      stored: true,
+      verified: false,
+      message: "Stored, but Bench could not confirm the copy is readable.",
+    });
+
+    renderView();
+    fireEvent.click(await screen.findByRole("button", { name: /back up now/i }));
+
+    await waitFor(() =>
+      expect(toast.warning).toHaveBeenCalledWith("Stored, but Bench could not confirm the copy is readable.")
+    );
+  });
+
+  it("tells you when a destination is broken, on the destination", async () => {
+    mockedApi.fetchRecoveryCenter.mockResolvedValue(
+      data({
+        destinations: [
+          {
+            ...data().destinations[0],
+            // After the last success: a destination that failed and then
+            // succeeded is working, and must not be shown as broken.
+            lastFailureAt: "2026-08-27T06:00:00.000Z",
+            lastFailureReason: "No space left on device",
+          },
+        ],
+      })
+    );
+
+    renderView();
+    // The reason sits inline with the destination name, so it spans nodes.
+    await screen.findByText("NAS volume", { selector: "span.font-medium" });
+    await waitFor(() =>
+      expect(document.body.textContent).toContain("No space left on device")
+    );
+  });
+
+  it("explains the empty state instead of showing a blank page", async () => {
+    mockedApi.fetchRecoveryCenter.mockResolvedValue(
+      data({ artifacts: [], policies: [], destinations: [] })
+    );
+
+    renderView();
+    expect(await screen.findByText("No copies yet")).toBeInTheDocument();
+    expect(screen.getByText(/Nowhere to put a backup yet/)).toBeInTheDocument();
+  });
+
+  it("reports damage found by a manual verify as an error", async () => {
+    mockedApi.scrubNow.mockResolvedValue([
+      {
+        destinationId: "dest-1",
+        destinationName: "NAS volume",
+        checked: 3,
+        passed: 2,
+        failed: 1,
+        missing: 0,
+        artifacts: [],
+      },
+    ]);
+
+    renderView();
+    // Wait for the inventory: "Verify now" is disabled until there is something
+    // to verify, and clicking a disabled button proves nothing.
+    await screen.findByText("Verified");
+    fireEvent.click(screen.getByRole("button", { name: /verify now/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("1 of 3 copies are damaged or missing")
+    );
+  });
+});

--- a/src/features/backups/components/BackupsView.tsx
+++ b/src/features/backups/components/BackupsView.tsx
@@ -35,6 +35,7 @@ import {
   relativeTime,
   sortArtifacts,
 } from "../lib/presentation";
+import { fetchSafetySettings, patchSafetySettings } from "../lib/safetyPoint";
 import { BackupDetail } from "./BackupDetail";
 import { BackupRuleDialog } from "./BackupRuleDialog";
 import { BackupsTable } from "./BackupsTable";
@@ -72,6 +73,24 @@ export function BackupsView() {
     null
   );
   const [refreshing, setRefreshing] = useState(false);
+
+  const settingsQuery = useQuery({
+    queryKey: ["backup-settings"],
+    queryFn: fetchSafetySettings,
+  });
+
+  const setSafetyPoints = useMutation({
+    mutationFn: (enabled: boolean) => patchSafetySettings({ enabled }),
+    onSuccess: (settings) => {
+      toast.success(
+        settings.enabled
+          ? "Bench will take a recovery point before risky changes"
+          : "Recovery points before risky changes are off"
+      );
+      void queryClient.invalidateQueries({ queryKey: ["backup-settings"] });
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
 
   const query = useQuery({
     queryKey: ["backups"],
@@ -389,6 +408,24 @@ export function BackupsView() {
               ))}
             </ul>
           )}
+          <label className="mt-2 flex items-start gap-2 border-t border-border pt-2 text-xs">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={settingsQuery.data?.enabled ?? true}
+              disabled={setSafetyPoints.isPending || settingsQuery.isLoading}
+              onChange={(event) => setSafetyPoints.mutate(event.target.checked)}
+            />
+            <span>
+              <span className="font-medium">Take a recovery point before risky changes</span>
+              <span className="block text-muted-foreground">
+                Before Bench saves a batch of deletions or payee merges, it copies the budget first —
+                so there is something from five minutes ago, not just from last night. Several
+                changes in one session share a recovery point, and these expire on their own instead
+                of piling up.
+              </span>
+            </span>
+          </label>
         </section>
 
         {artifacts.length === 0 ? (

--- a/src/features/backups/components/BackupsView.tsx
+++ b/src/features/backups/components/BackupsView.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  FileText,
+  HardDrive,
+  Loader2,
+  Play,
+  Plus,
+  RefreshCw,
+  ScanSearch,
+  ShieldCheck,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { cn } from "@/lib/utils";
+import {
+  backUpNow,
+  deleteDestination,
+  deletePolicy,
+  discoverBackups,
+  fetchRecoveryCenter,
+  previewRetention,
+  scrubNow,
+  testDestination,
+} from "../lib/backupsApi";
+import {
+  describeContents,
+  describeRetention,
+  describeSchedule,
+  formatBytes,
+  relativeTime,
+  sortArtifacts,
+} from "../lib/presentation";
+import { BackupDetail } from "./BackupDetail";
+import { BackupRuleDialog } from "./BackupRuleDialog";
+import { BackupsTable } from "./BackupsTable";
+import { DestinationDialog } from "./DestinationDialog";
+import { ReadinessBanner } from "./ReadinessBanner";
+import { RetentionPreviewDialog } from "./RetentionPreviewDialog";
+import type { BackupDestination, BackupPolicy } from "@/lib/app-db/backupRepository";
+import type { PruneResult } from "@/lib/backup/prune";
+
+/**
+ * The Recovery Center (RD-077 / PR-047e).
+ *
+ * Ordered by the questions people arrive with, most urgent first: *am I covered
+ * right now* (the readiness statement), *where do copies go and are those
+ * places working* (destinations), *what is scheduled* (rules), and *which copy
+ * do I want* (the inventory).
+ *
+ * The inventory gets the remaining height because it is the part you scan; the
+ * two configuration strips above it are one line per item and stay out of the
+ * way. A backup screen that spends its space on the rules rather than on the
+ * backups has its priorities the wrong way round — the rules are read twice a
+ * year, the copies are read on the worst day of it.
+ */
+
+export function BackupsView() {
+  const queryClient = useQueryClient();
+  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
+  const [destinationDialog, setDestinationDialog] = useState<
+    { open: boolean; existing: BackupDestination | null } | null
+  >(null);
+  const [ruleDialog, setRuleDialog] = useState<{ open: boolean; existing: BackupPolicy | null } | null>(
+    null
+  );
+  const [prunePreview, setPrunePreview] = useState<{ policy: BackupPolicy; result: PruneResult } | null>(
+    null
+  );
+  const [refreshing, setRefreshing] = useState(false);
+
+  const query = useQuery({
+    queryKey: ["backups"],
+    queryFn: fetchRecoveryCenter,
+    // Runs finish while the page is open — a scheduled backup at 2am, a scrub, a
+    // manual run in another tab.
+    refetchInterval: 30_000,
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["backups"] });
+  };
+
+  const runNow = useMutation({
+    mutationFn: backUpNow,
+    onSuccess: (result) => {
+      // Say what happened. A backup that stored nothing comes back as a 200 with
+      // a failed result, and calling that "Backup finished" hides exactly what
+      // the user pressed the button to find out.
+      if (!result.stored) toast.error(result.message ?? "Nothing could be stored");
+      else if (!result.verified) toast.warning(result.message ?? "Stored, but Bench could not read it back");
+      else toast.success(result.message ?? "Backed up and verified");
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const verify = useMutation({
+    mutationFn: () => scrubNow(),
+    onSuccess: (results) => {
+      const checked = results.reduce((total, entry) => total + entry.checked, 0);
+      const bad = results.reduce((total, entry) => total + entry.failed + entry.missing, 0);
+      if (bad > 0) toast.error(`${bad} of ${checked} copies are damaged or missing`);
+      else if (checked === 0) toast.info("There are no stored copies to verify yet");
+      else toast.success(`${checked} copies verified`);
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const discover = useMutation({
+    mutationFn: () => discoverBackups(),
+    onSuccess: (results) => {
+      const imported = results.reduce((total, entry) => total + entry.imported, 0);
+      const notes = results.flatMap((entry) => entry.notes);
+      if (imported > 0) toast.success(`Found ${imported} backup(s) not in the inventory`);
+      else toast.info(notes[0] ?? "Nothing new — the inventory already matches what is stored");
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const test = useMutation({
+    mutationFn: testDestination,
+    onSuccess: (result) => {
+      const failure = result.checks.find((check) => check.status === "fail");
+      if (result.ok) toast.success("Wrote a test file and read it back");
+      else toast.error(failure?.detail ?? "The destination test failed");
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const removeDestination = useMutation({
+    mutationFn: deleteDestination,
+    onSuccess: ({ orphanedCopies }) => {
+      toast.success(
+        orphanedCopies > 0
+          ? `Destination removed. ${orphanedCopies} stored copy(ies) are still there — Bench just no longer manages them.`
+          : "Destination removed"
+      );
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const removeRule = useMutation({
+    mutationFn: deletePolicy,
+    onSuccess: ({ keptArtifacts }) => {
+      toast.success(
+        keptArtifacts > 0
+          ? `Rule deleted. Its ${keptArtifacts} backup(s) are kept — deleting a rule never deletes backups.`
+          : "Rule deleted"
+      );
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const preview = useMutation({
+    mutationFn: (policy: BackupPolicy) =>
+      previewRetention(policy.id).then((result) => ({ policy, result })),
+    onSuccess: (value) => setPrunePreview(value),
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    try {
+      await query.refetch();
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  const data = query.data;
+  const artifacts = sortArtifacts(data?.artifacts ?? []);
+  const selected = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
+
+  return (
+    <PageLayout
+      title="Backups"
+      count={
+        data ? `${artifacts.length} ${artifacts.length === 1 ? "copy" : "copies"}` : undefined
+      }
+      scrollManaged
+      isLoading={query.isLoading}
+      isError={query.isError}
+      error={query.error}
+      onRetry={() => void query.refetch()}
+      actions={
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void handleRefresh()}
+            disabled={refreshing}
+            aria-label="Refresh backups"
+          >
+            <RefreshCw className={cn(refreshing && "animate-spin")} aria-hidden />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => verify.mutate()}
+            disabled={verify.isPending || artifacts.length === 0}
+          >
+            {verify.isPending ? <Loader2 className="animate-spin" aria-hidden /> : <ShieldCheck aria-hidden />}
+            Verify now
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => window.open("/api/backups/recovery-sheet", "_blank")}
+          >
+            <FileText aria-hidden />
+            Recovery sheet
+          </Button>
+          <Button size="sm" onClick={() => setRuleDialog({ open: true, existing: null })}>
+            <Plus aria-hidden />
+            New backup rule
+          </Button>
+        </>
+      }
+    >
+      <div className="flex min-h-0 flex-1 flex-col">
+        {data && <ReadinessBanner readiness={data.readiness} />}
+
+        {/* Destinations: one line each. Health lives here because a destination
+            fails independently of whichever rule discovered it. */}
+        <section className="border-b border-border px-4 py-2" aria-labelledby="destinations-heading">
+          <div className="flex items-center justify-between gap-2">
+            <h2 id="destinations-heading" className="text-xs font-semibold">
+              Destinations
+            </h2>
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => discover.mutate()}
+                disabled={discover.isPending || (data?.destinations.length ?? 0) === 0}
+              >
+                {discover.isPending ? <Loader2 className="animate-spin" aria-hidden /> : <ScanSearch aria-hidden />}
+                Find backups
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => setDestinationDialog({ open: true, existing: null })}
+              >
+                <Plus aria-hidden />
+                Add
+              </Button>
+            </div>
+          </div>
+
+          {(data?.destinations.length ?? 0) === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Nowhere to put a backup yet. Add a folder on this server, or an S3-compatible bucket.
+            </p>
+          ) : (
+            <ul className="mt-1 space-y-1">
+              {data?.destinations.map((destination) => {
+                const broken =
+                  destination.lastFailureAt &&
+                  (!destination.lastSuccessAt || destination.lastFailureAt > destination.lastSuccessAt);
+                return (
+                  <li
+                    key={destination.id}
+                    className="flex flex-wrap items-center gap-2 text-xs"
+                  >
+                    <HardDrive
+                      className={cn("size-3.5", broken ? "text-destructive" : "text-muted-foreground")}
+                      aria-hidden
+                    />
+                    <span className="font-medium">{destination.name}</span>
+                    <span className="text-muted-foreground">
+                      {destination.kind === "local"
+                        ? String(destination.config.data.path ?? "")
+                        : `${String(destination.config.data.bucket ?? "")}${
+                            destination.config.data.prefix ? `/${String(destination.config.data.prefix)}` : ""
+                          }`}
+                    </span>
+                    {broken ? (
+                      <span className="text-destructive">
+                        failed {relativeTime(destination.lastFailureAt)}: {destination.lastFailureReason}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        last wrote {relativeTime(destination.lastSuccessAt)}
+                      </span>
+                    )}
+                    <span className="flex-1" />
+                    <button
+                      type="button"
+                      className="text-muted-foreground underline-offset-4 hover:underline"
+                      onClick={() => test.mutate(destination.id)}
+                    >
+                      Test
+                    </button>
+                    <button
+                      type="button"
+                      className="text-muted-foreground underline-offset-4 hover:underline"
+                      onClick={() => setDestinationDialog({ open: true, existing: destination })}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="text-muted-foreground underline-offset-4 hover:underline"
+                      onClick={() => removeDestination.mutate(destination.id)}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
+        {/* Rules: also one line each, with the two actions that matter on them. */}
+        <section className="border-b border-border px-4 py-2" aria-labelledby="rules-heading">
+          <h2 id="rules-heading" className="text-xs font-semibold">
+            Backup rules
+          </h2>
+          {(data?.policies.length ?? 0) === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              No rule yet, so nothing is being copied on a schedule.
+            </p>
+          ) : (
+            <ul className="mt-1 space-y-1">
+              {data?.policies.map((policy) => (
+                <li key={policy.id} className="flex flex-wrap items-center gap-2 text-xs">
+                  <span className={cn("font-medium", !policy.enabled && "text-muted-foreground")}>
+                    {policy.name}
+                  </span>
+                  {!policy.enabled && <span className="text-muted-foreground">(paused)</span>}
+                  <span className="text-muted-foreground">{describeContents(policy)}</span>
+                  <span className="text-muted-foreground">· {describeSchedule(policy)}</span>
+                  <span className="text-muted-foreground">· {describeRetention(policy)}</span>
+                  {policy.encryption === "passphrase" && (
+                    <span className="text-muted-foreground">· encrypted</span>
+                  )}
+                  <span className="flex-1" />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-xs"
+                    onClick={() => runNow.mutate(policy.id)}
+                    disabled={runNow.isPending}
+                  >
+                    {runNow.isPending && runNow.variables === policy.id ? (
+                      <Loader2 className="animate-spin" aria-hidden />
+                    ) : (
+                      <Play aria-hidden />
+                    )}
+                    Back up now
+                  </Button>
+                  <button
+                    type="button"
+                    className="text-muted-foreground underline-offset-4 hover:underline"
+                    onClick={() => preview.mutate(policy)}
+                  >
+                    Retention
+                  </button>
+                  <button
+                    type="button"
+                    className="text-muted-foreground underline-offset-4 hover:underline"
+                    onClick={() => setRuleDialog({ open: true, existing: policy })}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="text-muted-foreground underline-offset-4 hover:underline"
+                    onClick={() => removeRule.mutate(policy.id)}
+                  >
+                    <Trash2 className="inline size-3" aria-hidden /> Delete
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {artifacts.length === 0 ? (
+          <div className="mx-auto max-w-lg px-6 py-16 text-center">
+            <h2 className="text-sm font-semibold">No copies yet</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Once a rule runs, every copy it takes appears here with what Bench found inside it. If
+              you already have Bench backups in a destination, use{" "}
+              <strong className="font-medium">Find backups</strong> to read them back into the
+              inventory.
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="border-b border-border px-4 py-1.5 text-xs text-muted-foreground">
+              Total stored: {formatBytes(artifacts.reduce((total, entry) => total + entry.sizeBytes, 0))}.
+              Bench never deletes a pinned copy or the newest verified one.
+            </p>
+            <BackupsTable
+              artifacts={artifacts}
+              selectedId={selectedArtifactId}
+              onOpen={setSelectedArtifactId}
+            />
+          </>
+        )}
+      </div>
+
+      {destinationDialog && (
+        <DestinationDialog
+          open={destinationDialog.open}
+          onOpenChange={(open) => setDestinationDialog(open ? destinationDialog : null)}
+          existing={destinationDialog.existing}
+          onSaved={invalidate}
+        />
+      )}
+
+      {ruleDialog && data && (
+        <BackupRuleDialog
+          open={ruleDialog.open}
+          onOpenChange={(open) => setRuleDialog(open ? ruleDialog : null)}
+          destinations={data.destinations}
+          sources={data.sources}
+          vaultEnabled={data.vaultEnabled}
+          existing={ruleDialog.existing}
+          onSaved={invalidate}
+        />
+      )}
+
+      {prunePreview && (
+        <RetentionPreviewDialog
+          policy={prunePreview.policy}
+          result={prunePreview.result}
+          onClose={() => setPrunePreview(null)}
+          onApplied={() => {
+            setPrunePreview(null);
+            invalidate();
+          }}
+        />
+      )}
+
+      {selected && (
+        <BackupDetail
+          artifact={selected}
+          onClose={() => setSelectedArtifactId(null)}
+          onChanged={invalidate}
+        />
+      )}
+    </PageLayout>
+  );
+}

--- a/src/features/backups/components/DestinationDialog.tsx
+++ b/src/features/backups/components/DestinationDialog.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { AlertTriangle, Check, Loader2, Minus } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { createDestination, inspectPath, patchDestination, testDestination } from "../lib/backupsApi";
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import type { DestinationCheck } from "@/lib/backup/destinations/types";
+
+/**
+ * Adding a place for backups to go (RD-077 / PR-047e).
+ *
+ * Two kinds, presented as the two situations people are actually in rather than
+ * as a list of storage technologies: a folder on this server (which covers
+ * every mounted volume and NAS share), or a bucket somewhere else.
+ *
+ * The dialog checks the path *while it is being typed*, not when the backup
+ * runs at 3am. That is most of its value: it will tell you the directory does
+ * not exist and offer to create it, that Bench cannot write there, that the
+ * volume is nearly full, or that this folder is on the same disk as Bench's own
+ * data — which is a warning rather than a refusal, because `/data/backups` is a
+ * legitimate and common arrangement that simply is not off-site.
+ */
+
+const inputClass = "h-8 rounded-md px-2 text-xs md:text-xs";
+const selectClass = "h-8 w-full rounded-md border border-input bg-background px-2 text-xs";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existing?: BackupDestination | null;
+  onSaved: () => void;
+};
+
+export function DestinationDialog({ open, onOpenChange, existing, onSaved }: Props) {
+  const editing = Boolean(existing);
+  const [kind, setKind] = useState<"local" | "s3">(existing?.kind ?? "local");
+  const [name, setName] = useState(existing?.name ?? "");
+
+  const config = (existing?.config.data ?? {}) as Record<string, unknown>;
+  const [path, setPath] = useState(String(config.path ?? "/data/backups"));
+  const [bucket, setBucket] = useState(String(config.bucket ?? ""));
+  const [region, setRegion] = useState(String(config.region ?? "us-east-1"));
+  const [endpoint, setEndpoint] = useState(String(config.endpoint ?? ""));
+  const [prefix, setPrefix] = useState(String(config.prefix ?? "actual-bench"));
+  const [accessKeyId, setAccessKeyId] = useState("");
+  const [secretAccessKey, setSecretAccessKey] = useState("");
+
+  const [checks, setChecks] = useState<DestinationCheck[] | null>(null);
+
+  const check = useMutation({
+    mutationFn: () => inspectPath(path),
+    onSuccess: (result) => setChecks(result.checks),
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const payload =
+        kind === "local"
+          ? { name, kind, config: { version: 1, data: { path: path.trim() } } }
+          : {
+              name,
+              kind,
+              config: {
+                version: 1,
+                data: {
+                  bucket: bucket.trim(),
+                  region: region.trim(),
+                  endpoint: endpoint.trim() || null,
+                  prefix: prefix.trim(),
+                },
+              },
+              ...(accessKeyId && secretAccessKey
+                ? { credentials: { accessKeyId, secretAccessKey } }
+                : {}),
+            };
+
+      const destination = existing
+        ? await patchDestination(existing.id, payload)
+        : await createDestination(payload);
+
+      // Test on save, always. A destination that has never been written to is a
+      // guess, and the moment to find that out is now rather than at 2am.
+      const result = await testDestination(destination.id);
+      return { destination, result };
+    },
+    onSuccess: ({ result }) => {
+      setChecks(result.checks);
+      if (result.ok) {
+        toast.success(
+          editing ? "Destination updated and tested" : "Destination added — Bench wrote a test file and read it back"
+        );
+        onSaved();
+        onOpenChange(false);
+      } else {
+        // Saved, but not working. Keep the dialog open with the reason: closing
+        // it would leave a destination that looks configured and is not.
+        toast.warning("Saved, but the test failed. See the checks below.");
+        onSaved();
+      }
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const canSave =
+    name.trim().length > 0 &&
+    (kind === "local"
+      ? path.trim().length > 0
+      : bucket.trim().length > 0 && (editing || (accessKeyId && secretAccessKey)));
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit destination" : "Add a destination"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 text-xs">
+          <Field label="Name">
+            <Input
+              className={inputClass}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={kind === "local" ? "NAS volume" : "Off-site bucket"}
+            />
+          </Field>
+
+          {!editing && (
+            <Field label="Kind">
+              <select
+                className={selectClass}
+                value={kind}
+                onChange={(event) => setKind(event.target.value as "local" | "s3")}
+              >
+                <option value="local">A folder on this server</option>
+                <option value="s3">An S3-compatible bucket</option>
+              </select>
+            </Field>
+          )}
+
+          {kind === "local" ? (
+            <>
+              <Field label="Folder">
+                <div className="flex gap-2">
+                  <Input
+                    className={inputClass}
+                    value={path}
+                    onChange={(event) => {
+                      setPath(event.target.value);
+                      setChecks(null);
+                    }}
+                    placeholder="/data/backups"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => check.mutate()}
+                    disabled={check.isPending || !path.trim()}
+                  >
+                    {check.isPending ? <Loader2 className="animate-spin" aria-hidden /> : null}
+                    Check
+                  </Button>
+                </div>
+              </Field>
+              <p className="text-muted-foreground">
+                Any absolute path the server can write to — a mounted volume, a NAS share, a second
+                disk. Bench creates it if it does not exist.
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Bucket">
+                  <Input className={inputClass} value={bucket} onChange={(e) => setBucket(e.target.value)} />
+                </Field>
+                <Field label="Region">
+                  <Input className={inputClass} value={region} onChange={(e) => setRegion(e.target.value)} />
+                </Field>
+              </div>
+              <Field label="Endpoint (leave blank for AWS)">
+                <Input
+                  className={inputClass}
+                  value={endpoint}
+                  onChange={(e) => setEndpoint(e.target.value)}
+                  placeholder="https://minio.lan:9000"
+                />
+              </Field>
+              <Field label="Prefix">
+                <Input className={inputClass} value={prefix} onChange={(e) => setPrefix(e.target.value)} />
+              </Field>
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Access key ID">
+                  <Input
+                    className={inputClass}
+                    value={accessKeyId}
+                    onChange={(e) => setAccessKeyId(e.target.value)}
+                    placeholder={editing ? "unchanged" : ""}
+                    autoComplete="off"
+                  />
+                </Field>
+                <Field label="Secret access key">
+                  <Input
+                    className={inputClass}
+                    type="password"
+                    value={secretAccessKey}
+                    onChange={(e) => setSecretAccessKey(e.target.value)}
+                    placeholder={editing ? "unchanged" : ""}
+                    autoComplete="new-password"
+                  />
+                </Field>
+              </div>
+              <p className="text-muted-foreground">
+                Works with MinIO, Backblaze B2, Cloudflare R2, Wasabi and Garage as well as AWS. Keys
+                are encrypted with your server&rsquo;s <code>SYNC_VAULT_KEY</code> and never stored in
+                readable form.
+              </p>
+            </>
+          )}
+
+          {checks && checks.length > 0 && <ChecksList checks={checks} />}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={() => save.mutate()} disabled={!canSave || save.isPending}>
+            {save.isPending ? <Loader2 className="animate-spin" aria-hidden /> : null}
+            {editing ? "Save and test" : "Add and test"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+/** Checks are shown in full, pass and fail alike: a list of only problems makes
+ * it impossible to tell "nothing was checked" from "everything was fine". */
+function ChecksList({ checks }: { checks: DestinationCheck[] }) {
+  return (
+    <ul className="space-y-1 rounded-md border border-border p-2">
+      {checks.map((check) => (
+        <li key={check.name} className="flex items-start gap-2">
+          {check.status === "pass" ? (
+            <Check className="mt-0.5 size-3.5 shrink-0 text-green-600 dark:text-green-500" aria-hidden />
+          ) : check.status === "warn" ? (
+            <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500" aria-hidden />
+          ) : (
+            <Minus className="mt-0.5 size-3.5 shrink-0 text-destructive" aria-hidden />
+          )}
+          <span
+            className={cn(
+              "min-w-0",
+              check.status === "fail" && "text-destructive",
+              check.status === "warn" && "text-amber-700 dark:text-amber-400"
+            )}
+          >
+            <span className="font-medium">{check.name}: </span>
+            {check.detail}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/backups/components/ReadinessBanner.tsx
+++ b/src/features/backups/components/ReadinessBanner.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { AlertTriangle, ShieldAlert, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { BackupReadiness } from "@/lib/backup/readiness";
+
+/**
+ * The readiness statement (RD-077 / PR-047e).
+ *
+ * The first thing on the page, and the only sentence most people will read:
+ * *if this budget disappeared right now, what would I get back, and how old
+ * would it be?* Everything below is evidence for it.
+ *
+ * It is deliberately pessimistic. A backup screen that reassures you is worse
+ * than no backup screen, so anything Bench cannot presently prove pulls this
+ * line down rather than being rounded up — and the issues that pulled it down
+ * are listed underneath rather than left for the user to hunt for.
+ */
+
+const TONE = {
+  protected: {
+    icon: ShieldCheck,
+    wrapper: "border-green-500/30 bg-green-50 dark:bg-green-950/20",
+    accent: "text-green-700 dark:text-green-400",
+  },
+  "at-risk": {
+    icon: AlertTriangle,
+    wrapper: "border-amber-400/40 bg-amber-50 dark:bg-amber-950/20",
+    accent: "text-amber-800 dark:text-amber-300",
+  },
+  unprotected: {
+    icon: ShieldAlert,
+    wrapper: "border-destructive/30 bg-destructive/5",
+    accent: "text-destructive",
+  },
+} as const;
+
+export function ReadinessBanner({ readiness }: { readiness: BackupReadiness }) {
+  const tone = TONE[readiness.status];
+  const Icon = tone.icon;
+
+  return (
+    <section
+      className={cn("border-b px-4 py-3", tone.wrapper)}
+      aria-labelledby="backup-readiness-heading"
+    >
+      <div className="flex items-start gap-3">
+        <Icon className={cn("mt-0.5 size-5 shrink-0", tone.accent)} aria-hidden />
+        <div className="min-w-0 flex-1">
+          <h2 id="backup-readiness-heading" className={cn("text-sm font-semibold", tone.accent)}>
+            {readiness.headline}
+          </h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">{readiness.detail}</p>
+
+          {readiness.issues.length > 0 && (
+            <ul className="mt-2 space-y-1">
+              {readiness.issues.map((issue) => (
+                <li key={issue} className="flex items-start gap-1.5 text-xs text-muted-foreground">
+                  <span aria-hidden className="mt-1.5 size-1 shrink-0 rounded-full bg-current" />
+                  <span>{issue}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/backups/components/RetentionPreviewDialog.tsx
+++ b/src/features/backups/components/RetentionPreviewDialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { previewRetention } from "../lib/backupsApi";
+import { formatBytes, formatDateTime } from "../lib/presentation";
+import type { BackupPolicy } from "@/lib/app-db/backupRepository";
+import type { PruneResult } from "@/lib/backup/prune";
+
+/**
+ * What retention would do, before it does it (RD-077 / PR-047e).
+ *
+ * The preview is produced by the same function that performs the prune, not by
+ * a second implementation that agrees with it most of the time — so this list
+ * *is* what will happen, and every line carries the reason that decided it.
+ * Deleting backups is the one action in this feature that cannot be undone, so
+ * it is the one that gets shown in full first.
+ */
+export function RetentionPreviewDialog({
+  policy,
+  result,
+  onClose,
+  onApplied,
+}: {
+  policy: BackupPolicy;
+  result: PruneResult;
+  onClose: () => void;
+  onApplied: () => void;
+}) {
+  const apply = useMutation({
+    mutationFn: () => previewRetention(policy.id, true),
+    onSuccess: (applied) => {
+      const removed = applied.pruned.filter((entry) => entry.removed).length;
+      if (applied.failed > 0) {
+        toast.warning(
+          `Removed ${removed}; ${applied.failed} copy(ies) could not be deleted and were kept in the inventory.`
+        );
+      } else if (removed === 0) {
+        toast.info("Nothing was eligible to remove.");
+      } else {
+        toast.success(`Removed ${removed} copy(ies), freeing ${formatBytes(applied.freedBytes)}.`);
+      }
+      onApplied();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Retention for &ldquo;{policy.name}&rdquo;</DialogTitle>
+        </DialogHeader>
+
+        <div className="max-h-[55vh] space-y-2 overflow-y-auto text-xs">
+          <p className="text-muted-foreground">
+            Keeping {result.kept} {result.kept === 1 ? "copy" : "copies"}.{" "}
+            {result.pruned.length === 0
+              ? "Nothing is eligible to be removed."
+              : `${result.pruned.length} would be removed, freeing ${formatBytes(result.freedBytes)}.`}
+          </p>
+
+          {result.pruned.length > 0 && (
+            <ul className="space-y-1">
+              {result.pruned.map((entry) => (
+                <li key={entry.artifactId} className="rounded border border-border p-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-medium">{formatDateTime(entry.createdAt)}</span>
+                    <span className="text-muted-foreground">{formatBytes(entry.sizeBytes)}</span>
+                  </div>
+                  <p className="text-muted-foreground">{entry.reason}</p>
+                  {entry.locations.length > 0 && (
+                    <p className="mt-0.5 break-all text-muted-foreground">
+                      {entry.locations.map((location) => location.destinationName).join(", ")}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={onClose}>
+            Close
+          </Button>
+          {result.pruned.length > 0 && (
+            <Button
+              size="sm"
+              className="text-destructive-foreground"
+              variant="destructive"
+              onClick={() => apply.mutate()}
+              disabled={apply.isPending}
+            >
+              {apply.isPending ? <Loader2 className="animate-spin" aria-hidden /> : null}
+              Remove {result.pruned.length}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/backups/lib/backupsApi.ts
+++ b/src/features/backups/lib/backupsApi.ts
@@ -1,0 +1,216 @@
+import type {
+  BackupArtifact,
+  BackupArtifactLocation,
+  BackupDestination,
+  BackupPolicy,
+} from "@/lib/app-db/backupRepository";
+import type { DestinationCheck, DestinationFacts } from "@/lib/backup/destinations/types";
+import type { BackupReadiness } from "@/lib/backup/readiness";
+import type { BackupRunResult } from "@/lib/backup/runBackup";
+import type { PruneResult } from "@/lib/backup/prune";
+import type { ScrubResult } from "@/lib/backup/scrub";
+import type { DiscoveryResult } from "@/lib/backup/discover";
+import type { InspectionResult } from "@/lib/backup/inspect";
+
+/** Client for the backup routes (RD-077 / PR-047e). */
+
+export type ArtifactWithLocations = BackupArtifact & {
+  locations: (BackupArtifactLocation & { destinationName: string | null })[];
+};
+
+export type BackupSource = {
+  connectionFingerprint: string;
+  label: string;
+  baseUrl: string;
+  budgetSyncId: string;
+};
+
+export type RecoveryCenterData = {
+  readiness: BackupReadiness;
+  destinations: BackupDestination[];
+  policies: BackupPolicy[];
+  artifacts: ArtifactWithLocations[];
+  sources: BackupSource[];
+  vaultEnabled: boolean;
+};
+
+async function readError(response: Response): Promise<never> {
+  let message = `Request failed (${response.status})`;
+  try {
+    const body = (await response.json()) as { error?: string };
+    if (body.error) message = body.error;
+  } catch {
+    // Keep the status-code message.
+  }
+  throw new Error(message);
+}
+
+async function json<T>(response: Response): Promise<T> {
+  if (!response.ok) return readError(response);
+  return (await response.json()) as T;
+}
+
+export async function fetchRecoveryCenter(): Promise<RecoveryCenterData> {
+  return json<RecoveryCenterData>(await fetch("/api/backups", { cache: "no-store" }));
+}
+
+// ── destinations ─────────────────────────────────────────────────────────────
+
+export type DestinationTestResponse = {
+  result: { ok: boolean; checks: DestinationCheck[]; facts: DestinationFacts };
+};
+
+export async function inspectPath(path: string): Promise<{ checks: DestinationCheck[]; facts: DestinationFacts }> {
+  return json(
+    await fetch("/api/backups/destinations/inspect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path }),
+    })
+  );
+}
+
+export async function createDestination(input: Record<string, unknown>): Promise<BackupDestination> {
+  const body = await json<{ destination: BackupDestination }>(
+    await fetch("/api/backups/destinations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    })
+  );
+  return body.destination;
+}
+
+export async function patchDestination(
+  id: string,
+  input: Record<string, unknown>
+): Promise<BackupDestination> {
+  const body = await json<{ destination: BackupDestination }>(
+    await fetch(`/api/backups/destinations/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    })
+  );
+  return body.destination;
+}
+
+export async function deleteDestination(id: string): Promise<{ orphanedCopies: number }> {
+  return json(await fetch(`/api/backups/destinations/${id}`, { method: "DELETE" }));
+}
+
+export async function testDestination(id: string): Promise<DestinationTestResponse["result"]> {
+  const body = await json<DestinationTestResponse>(
+    await fetch(`/api/backups/destinations/${id}/test`, { method: "POST" })
+  );
+  return body.result;
+}
+
+// ── rules ────────────────────────────────────────────────────────────────────
+
+export async function createPolicy(input: Record<string, unknown>): Promise<BackupPolicy> {
+  const body = await json<{ policy: BackupPolicy }>(
+    await fetch("/api/backups/policies", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    })
+  );
+  return body.policy;
+}
+
+export async function patchPolicy(id: string, input: Record<string, unknown>): Promise<BackupPolicy> {
+  const body = await json<{ policy: BackupPolicy }>(
+    await fetch(`/api/backups/policies/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    })
+  );
+  return body.policy;
+}
+
+export async function deletePolicy(id: string): Promise<{ keptArtifacts: number }> {
+  return json(await fetch(`/api/backups/policies/${id}`, { method: "DELETE" }));
+}
+
+/** Runs are slow and their result is the point, so it is returned in full. */
+export async function backUpNow(policyId: string): Promise<BackupRunResult> {
+  const body = await json<{ result: BackupRunResult }>(
+    await fetch(`/api/backups/policies/${policyId}/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+  );
+  return body.result;
+}
+
+export async function previewRetention(policyId: string, apply = false): Promise<PruneResult> {
+  const body = await json<{ result: PruneResult }>(
+    await fetch(`/api/backups/policies/${policyId}/prune`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apply }),
+    })
+  );
+  return body.result;
+}
+
+// ── copies ───────────────────────────────────────────────────────────────────
+
+export async function setPinned(artifactId: string, pinned: boolean): Promise<BackupArtifact> {
+  const body = await json<{ artifact: BackupArtifact }>(
+    await fetch(`/api/backups/artifacts/${artifactId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned }),
+    })
+  );
+  return body.artifact;
+}
+
+export async function deleteArtifact(artifactId: string): Promise<void> {
+  const response = await fetch(`/api/backups/artifacts/${artifactId}`, { method: "DELETE" });
+  if (!response.ok) await readError(response);
+}
+
+export async function inspectBackup(
+  artifactId: string,
+  passphrase?: string
+): Promise<InspectionResult> {
+  const body = await json<{ result: InspectionResult }>(
+    await fetch(`/api/backups/artifacts/${artifactId}/inspect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(passphrase ? { passphrase } : {}),
+    })
+  );
+  return body.result;
+}
+
+export function downloadUrl(artifactId: string): string {
+  return `/api/backups/artifacts/${artifactId}/download`;
+}
+
+export async function scrubNow(destinationIds?: string[]): Promise<ScrubResult[]> {
+  const body = await json<{ results: ScrubResult[] }>(
+    await fetch("/api/backups/scrub", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(destinationIds ? { destinationIds } : {}),
+    })
+  );
+  return body.results;
+}
+
+export async function discoverBackups(destinationId?: string): Promise<DiscoveryResult[]> {
+  const body = await json<{ results: DiscoveryResult[] }>(
+    await fetch("/api/backups/discover", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(destinationId ? { destinationId } : {}),
+    })
+  );
+  return body.results;
+}

--- a/src/features/backups/lib/presentation.ts
+++ b/src/features/backups/lib/presentation.ts
@@ -1,0 +1,125 @@
+import type { ArtifactWithLocations } from "./backupsApi";
+import type { BackupPolicy } from "@/lib/app-db/backupRepository";
+
+/**
+ * Turning backup state into words (RD-077 / PR-047e).
+ *
+ * Kept out of the components because these are judgements, not formatting:
+ * whether a copy counts as verified, what a retention rule adds up to in plain
+ * English, how old is too old. Two implementations of any of those would
+ * eventually disagree with each other on the same screen.
+ */
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+export function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function relativeTime(iso: string | null, now: Date = new Date()): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "never";
+  const minutes = Math.round((now.getTime() - then) / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  return months < 12 ? `${months}mo ago` : `${Math.round(months / 12)}y ago`;
+}
+
+export type CopyState = "verified" | "unverified" | "damaged" | "gone";
+
+/**
+ * What a copy is worth, in one word.
+ *
+ * "Gone" outranks everything: a backup with no surviving copy is not a backup
+ * whatever its verification once said, and showing it as verified would be the
+ * single most misleading thing this page could do.
+ */
+export function copyState(artifact: ArtifactWithLocations): CopyState {
+  const stored = artifact.locations.filter((location) => location.status === "stored");
+  if (stored.length === 0) return "gone";
+  if (artifact.verificationStatus === "failed") return "damaged";
+  if (artifact.verificationStatus === "passed") return "verified";
+  return "unverified";
+}
+
+export const COPY_STATE_COPY: Record<CopyState, { label: string; detail: string }> = {
+  verified: { label: "Verified", detail: "Bench opened this copy and read it." },
+  unverified: {
+    label: "Not checked",
+    detail: "Stored, but Bench has not opened it. It might restore and it might not.",
+  },
+  damaged: {
+    label: "Damaged",
+    detail: "Bench could not read this copy. Do not rely on it.",
+  },
+  gone: {
+    label: "No copy",
+    detail: "Bench has a record of this backup but no surviving copy of it.",
+  },
+};
+
+export function describeRetention(policy: BackupPolicy): string {
+  const { retention } = policy;
+  const parts: string[] = [];
+  if (retention.daily > 0) parts.push(`${retention.daily} daily`);
+  if (retention.weekly > 0) parts.push(`${retention.weekly} weekly`);
+  if (retention.monthly > 0) parts.push(`${retention.monthly} monthly`);
+  if (retention.yearly > 0) parts.push(`${retention.yearly} yearly`);
+  if (parts.length === 0) return "Keeps only the newest verified copy";
+  return `Keeps ${parts.join(", ")}`;
+}
+
+export function describeSchedule(policy: BackupPolicy): string {
+  if (policy.scheduleKind === "interval") {
+    const minutes = policy.intervalMinutes ?? 1440;
+    if (minutes % 1440 === 0) return `Every ${minutes / 1440} day(s)`;
+    if (minutes % 60 === 0) return `Every ${minutes / 60} hour(s)`;
+    return `Every ${minutes} minutes`;
+  }
+  const cron = policy.cronExpression ?? "0 2 * * *";
+  const known: Record<string, string> = {
+    "0 2 * * *": "Daily at 02:00",
+    "0 3 * * *": "Daily at 03:00",
+    "0 4 * * *": "Daily at 04:00",
+    "0 2 * * 0": "Weekly on Sunday at 02:00",
+    "0 2 1 * *": "Monthly on the 1st at 02:00",
+  };
+  const label = known[cron] ?? `Cron: ${cron}`;
+  return policy.timezone && policy.timezone !== "UTC" ? `${label} (${policy.timezone})` : label;
+}
+
+export function describeContents(policy: BackupPolicy): string {
+  if (policy.contents === "budget") return "Budget";
+  if (policy.contents === "app-db") return "Bench settings";
+  return "Budget + Bench settings";
+}
+
+/** Which copies are worth showing first: trouble, then recency. */
+export function sortArtifacts(artifacts: ArtifactWithLocations[]): ArtifactWithLocations[] {
+  return [...artifacts].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}

--- a/src/features/backups/lib/safetyPoint.test.ts
+++ b/src/features/backups/lib/safetyPoint.test.ts
@@ -1,0 +1,28 @@
+import { describeRiskyChange, shouldTakeRecoveryPoint } from "./safetyPoint";
+
+describe("which changes are worth a recovery point", () => {
+  it("does not export a whole budget to rename one payee", () => {
+    expect(shouldTakeRecoveryPoint({ itemCount: 1 })).toBe(false);
+    expect(shouldTakeRecoveryPoint({ itemCount: 10 })).toBe(false);
+  });
+
+  it("always takes one before a payee merge, however small", () => {
+    // Merges are irreversible in Actual: undo does not bring the payee back.
+    expect(shouldTakeRecoveryPoint({ itemCount: 2, mergeCount: 1 })).toBe(true);
+  });
+
+  it("always takes one before a deletion", () => {
+    expect(shouldTakeRecoveryPoint({ itemCount: 1, deleteCount: 1 })).toBe(true);
+  });
+
+  it("takes one for a large batch on size alone", () => {
+    expect(shouldTakeRecoveryPoint({ itemCount: 24 })).toBe(false);
+    expect(shouldTakeRecoveryPoint({ itemCount: 25 })).toBe(true);
+  });
+
+  it("describes the change in the words the user would use", () => {
+    expect(describeRiskyChange({ itemCount: 40, mergeCount: 3 })).toBe("saving 3 payee merges");
+    expect(describeRiskyChange({ itemCount: 5, deleteCount: 1 })).toBe("saving 1 deletion");
+    expect(describeRiskyChange({ itemCount: 30 })).toBe("saving 30 changes");
+  });
+});

--- a/src/features/backups/lib/safetyPoint.ts
+++ b/src/features/backups/lib/safetyPoint.ts
@@ -1,0 +1,74 @@
+import type { SafetyPointOutcome, SafetyPointSettings } from "@/lib/backup/safetyPoint";
+
+/**
+ * Asking for a recovery point before a risky change (RD-077 / PR-047f).
+ *
+ * Client side of the shared action. The important part is `shouldTakeRecoveryPoint`:
+ * a rule about *which* changes are worth a full export, kept in one place so
+ * every risky screen agrees. Renaming one payee does not warrant it; merging
+ * forty does, and so does anything that deletes.
+ */
+
+export type RiskyChange = {
+  /** Total staged items about to be written. */
+  itemCount: number;
+  /** Items that remove something, which is what makes a change hard to undo. */
+  deleteCount?: number;
+  /** Payee merges are irreversible in Actual, whatever their count. */
+  mergeCount?: number;
+};
+
+/** Batches at or above this size are worth a copy on their own. */
+export const RISKY_ITEM_THRESHOLD = 25;
+
+export function shouldTakeRecoveryPoint(change: RiskyChange): boolean {
+  if ((change.mergeCount ?? 0) > 0) return true;
+  if ((change.deleteCount ?? 0) > 0) return true;
+  return change.itemCount >= RISKY_ITEM_THRESHOLD;
+}
+
+export function describeRiskyChange(change: RiskyChange): string {
+  const parts: string[] = [];
+  if (change.mergeCount) parts.push(`${change.mergeCount} payee merge${change.mergeCount === 1 ? "" : "s"}`);
+  if (change.deleteCount) parts.push(`${change.deleteCount} deletion${change.deleteCount === 1 ? "" : "s"}`);
+  if (parts.length === 0) parts.push(`${change.itemCount} changes`);
+  return `saving ${parts.join(" and ")}`;
+}
+
+export async function takeRecoveryPoint(reason: string): Promise<SafetyPointOutcome> {
+  try {
+    const response = await fetch("/api/backups/safety-point", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason }),
+    });
+    if (!response.ok) {
+      return { status: "failed", message: `Bench could not take a recovery point (${response.status}).` };
+    }
+    const body = (await response.json()) as { outcome: SafetyPointOutcome };
+    return body.outcome;
+  } catch (error) {
+    return {
+      status: "failed",
+      message: error instanceof Error ? error.message : "Bench could not take a recovery point.",
+    };
+  }
+}
+
+export async function fetchSafetySettings(): Promise<SafetyPointSettings> {
+  const response = await fetch("/api/backups/settings", { cache: "no-store" });
+  if (!response.ok) throw new Error(`Request failed (${response.status})`);
+  return ((await response.json()) as { safetyPoints: SafetyPointSettings }).safetyPoints;
+}
+
+export async function patchSafetySettings(
+  input: Partial<SafetyPointSettings>
+): Promise<SafetyPointSettings> {
+  const response = await fetch("/api/backups/settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) throw new Error(`Request failed (${response.status})`);
+  return ((await response.json()) as { safetyPoints: SafetyPointSettings }).safetyPoints;
+}

--- a/src/features/budget-diagnostics/lib/bundleIsolation.test.ts
+++ b/src/features/budget-diagnostics/lib/bundleIsolation.test.ts
@@ -10,7 +10,16 @@ const SRC_DIR = join(ROOT, "src");
 const SQLITE_IMPORTS = ["@sqlite.org/sqlite-wasm"] as const;
 const FFLATE_IMPORTS = ["fflate"] as const;
 const SQLITE_ALLOWED_PREFIXES = ["src/features/budget-diagnostics/"];
-const FFLATE_ALLOWED_PREFIXES = ["src/features/budget-diagnostics/", "src/features/bundle/"];
+// `src/lib/backup/` is server-only by construction — every module in it imports
+// node:crypto or better-sqlite3 — so its ZIP parsing runs in Node and never
+// reaches a client bundle. That is the property this guard exists to protect,
+// and the reason the backup verifier can reuse the diagnostics ZIP handling
+// rather than growing a second copy of it.
+const FFLATE_ALLOWED_PREFIXES = [
+  "src/features/budget-diagnostics/",
+  "src/features/bundle/",
+  "src/lib/backup/",
+];
 const ALLOWED_TYPE_DECLARATIONS = new Set(["src/types/sqlite-wasm.d.ts"]);
 
 function listSourceFiles(dir: string): string[] {

--- a/src/lib/app-db/backupCredentialRepository.test.ts
+++ b/src/lib/app-db/backupCredentialRepository.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getAppDb, resetAppDbForTests } from "./connection";
+import {
+  deleteBackupCredential,
+  getBackupCredential,
+  getBackupCredentialMeta,
+  hasBackupCredential,
+  listBackupCredentialMeta,
+  upsertBackupCredential,
+} from "./backupCredentialRepository";
+import type { SqliteDatabase } from "./types";
+
+function tempDb(): { root: string; db: SqliteDatabase } {
+  const root = mkdtempSync(join(tmpdir(), "actual-bench-backup-vault-"));
+  return { root, db: getAppDb(join(root, "metadata.sqlite")) };
+}
+
+describe("backup credentials", () => {
+  let root: string;
+  let db: SqliteDatabase;
+  const previousKey = process.env.SYNC_VAULT_KEY;
+
+  beforeEach(() => {
+    process.env.SYNC_VAULT_KEY = "test-vault-key";
+    ({ root, db } = tempDb());
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+    if (previousKey === undefined) delete process.env.SYNC_VAULT_KEY;
+    else process.env.SYNC_VAULT_KEY = previousKey;
+  });
+
+  it("round-trips an S3 secret", () => {
+    upsertBackupCredential(db, {
+      ref: "dest-1",
+      kind: "s3",
+      label: "Off-site",
+      secret: { accessKeyId: "AKIA", secretAccessKey: "shh", sessionToken: "temp" },
+    });
+
+    expect(getBackupCredential(db, "dest-1")).toEqual({
+      accessKeyId: "AKIA",
+      secretAccessKey: "shh",
+      sessionToken: "temp",
+    });
+  });
+
+  it("never stores the secret in readable form", () => {
+    upsertBackupCredential(db, {
+      ref: "dest-1",
+      kind: "s3",
+      secret: { accessKeyId: "AKIA", secretAccessKey: "super-secret-value" },
+    });
+
+    const row = db
+      .prepare("SELECT * FROM backup_credentials WHERE ref = ?")
+      .get<Record<string, string>>("dest-1");
+    expect(JSON.stringify(row)).not.toContain("super-secret-value");
+    expect(JSON.stringify(row)).not.toContain("AKIA");
+  });
+
+  it("returns metadata without the secret, so it is safe to send to the browser", () => {
+    upsertBackupCredential(db, {
+      ref: "pol-1",
+      kind: "passphrase",
+      label: "Nightly encryption",
+      secret: { passphrase: "correct horse" },
+    });
+
+    const meta = getBackupCredentialMeta(db, "pol-1");
+    expect(meta).toMatchObject({ ref: "pol-1", kind: "passphrase", label: "Nightly encryption" });
+    expect(JSON.stringify(meta)).not.toContain("correct horse");
+    expect(listBackupCredentialMeta(db)).toHaveLength(1);
+  });
+
+  it("replaces a secret in place when it is re-entered", () => {
+    upsertBackupCredential(db, { ref: "dest-1", kind: "s3", secret: { accessKeyId: "old", secretAccessKey: "old" } });
+    upsertBackupCredential(db, { ref: "dest-1", kind: "s3", secret: { accessKeyId: "new", secretAccessKey: "new" } });
+
+    expect(getBackupCredential(db, "dest-1")).toEqual({ accessKeyId: "new", secretAccessKey: "new" });
+    expect(listBackupCredentialMeta(db)).toHaveLength(1);
+  });
+
+  it("reports absence rather than inventing an empty secret", () => {
+    expect(hasBackupCredential(db, "missing")).toBe(false);
+    expect(getBackupCredential(db, "missing")).toBeNull();
+    expect(getBackupCredentialMeta(db, "missing")).toBeNull();
+  });
+
+  it("forgets a secret when its destination is deleted", () => {
+    upsertBackupCredential(db, { ref: "dest-1", kind: "s3", secret: { accessKeyId: "a", secretAccessKey: "b" } });
+    deleteBackupCredential(db, "dest-1");
+    expect(hasBackupCredential(db, "dest-1")).toBe(false);
+  });
+
+  it("refuses to store anything when the vault key is not configured", () => {
+    // Fail closed: writing a credential in the clear because the operator
+    // forgot an env var would be the worst possible fallback.
+    delete process.env.SYNC_VAULT_KEY;
+    expect(() =>
+      upsertBackupCredential(db, { ref: "dest-2", kind: "s3", secret: { accessKeyId: "a", secretAccessKey: "b" } })
+    ).toThrow();
+  });
+
+  it("cannot open a secret sealed under a different key", () => {
+    upsertBackupCredential(db, { ref: "dest-1", kind: "s3", secret: { accessKeyId: "a", secretAccessKey: "b" } });
+    process.env.SYNC_VAULT_KEY = "a-different-key";
+    expect(() => getBackupCredential(db, "dest-1")).toThrow();
+  });
+});

--- a/src/lib/app-db/backupCredentialRepository.ts
+++ b/src/lib/app-db/backupCredentialRepository.ts
@@ -1,0 +1,122 @@
+import { openSecret, sealSecret } from "@/lib/sync/vault";
+import { AppDbValidationError } from "./errors";
+import type { SqliteDatabase } from "./types";
+
+/**
+ * Sealed secrets for backups (RD-077 / PR-047b).
+ *
+ * Destination credentials and backup passphrases, encrypted at rest under
+ * `SYNC_VAULT_KEY` exactly as the sync vault does. Kept in their own table
+ * because they answer a different question — what Bench needs to *write a copy*
+ * rather than what it needs to reach a budget — and because a destination's
+ * keys should not be entangled with a connection's lifecycle.
+ *
+ * Only this module decrypts. Everything else works with a `ref`.
+ */
+
+export type BackupCredentialKind = "s3" | "passphrase";
+
+export type S3Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Some providers (temporary credentials) need this too. */
+  sessionToken?: string;
+};
+
+export type PassphraseCredential = { passphrase: string };
+
+export type BackupSecret = S3Credentials | PassphraseCredential;
+
+export type BackupCredentialMeta = {
+  ref: string;
+  kind: BackupCredentialKind;
+  label: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type Row = {
+  ref: string;
+  kind: string;
+  label: string;
+  ciphertext: string;
+  iv: string;
+  auth_tag: string;
+  created_at: string;
+  updated_at: string;
+};
+
+function toMeta(row: Row): BackupCredentialMeta {
+  return {
+    ref: row.ref,
+    kind: row.kind as BackupCredentialKind,
+    label: row.label,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** Seal and store. Requires an enabled vault; fails closed if there is none. */
+export function upsertBackupCredential(
+  db: SqliteDatabase,
+  input: { ref: string; kind: BackupCredentialKind; label?: string; secret: BackupSecret }
+): BackupCredentialMeta {
+  if (!input.ref.trim()) throw new AppDbValidationError("ref is required");
+  const now = new Date().toISOString();
+  const sealed = sealSecret(JSON.stringify(input.secret));
+
+  db.prepare(
+    `INSERT INTO backup_credentials (ref, kind, label, ciphertext, iv, auth_tag, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(ref) DO UPDATE SET
+       kind = excluded.kind,
+       label = excluded.label,
+       ciphertext = excluded.ciphertext,
+       iv = excluded.iv,
+       auth_tag = excluded.auth_tag,
+       updated_at = excluded.updated_at`
+  ).run(
+    input.ref.trim(),
+    input.kind,
+    input.label ?? "",
+    sealed.ciphertext,
+    sealed.iv,
+    sealed.authTag,
+    now,
+    now
+  );
+
+  const meta = getBackupCredentialMeta(db, input.ref.trim());
+  if (!meta) throw new AppDbValidationError("Failed to store backup credential");
+  return meta;
+}
+
+/** Read + decrypt (server-only). Null when absent; throws if the vault cannot open it. */
+export function getBackupCredential(db: SqliteDatabase, ref: string): BackupSecret | null {
+  const row = db.prepare("SELECT * FROM backup_credentials WHERE ref = ?").get<Row>(ref);
+  if (!row) return null;
+  return JSON.parse(
+    openSecret({ ciphertext: row.ciphertext, iv: row.iv, authTag: row.auth_tag })
+  ) as BackupSecret;
+}
+
+/** Non-secret metadata — safe to return to the browser. */
+export function getBackupCredentialMeta(db: SqliteDatabase, ref: string): BackupCredentialMeta | null {
+  const row = db.prepare("SELECT * FROM backup_credentials WHERE ref = ?").get<Row>(ref);
+  return row ? toMeta(row) : null;
+}
+
+export function hasBackupCredential(db: SqliteDatabase, ref: string): boolean {
+  return !!db.prepare("SELECT 1 AS ok FROM backup_credentials WHERE ref = ?").get<{ ok: number }>(ref);
+}
+
+export function listBackupCredentialMeta(db: SqliteDatabase): BackupCredentialMeta[] {
+  return db
+    .prepare("SELECT * FROM backup_credentials ORDER BY updated_at DESC")
+    .all<Row>()
+    .map(toMeta);
+}
+
+export function deleteBackupCredential(db: SqliteDatabase, ref: string): void {
+  db.prepare("DELETE FROM backup_credentials WHERE ref = ?").run(ref);
+}

--- a/src/lib/app-db/backupRepository.test.ts
+++ b/src/lib/app-db/backupRepository.test.ts
@@ -1,0 +1,397 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getAppDb, resetAppDbForTests } from "./connection";
+import {
+  DEFAULT_RETENTION,
+  createBackupArtifact,
+  createBackupDestination,
+  createBackupPolicy,
+  deleteBackupArtifact,
+  deleteBackupDestination,
+  getBackupArtifact,
+  getBackupDestination,
+  listArtifactLocations,
+  listBackupArtifacts,
+  listBackupDestinations,
+  listDestinationLocations,
+  recordArtifactLocation,
+  recordArtifactVerification,
+  recordDestinationOutcome,
+  setArtifactPinned,
+  updateBackupDestination,
+  updateBackupPolicy,
+} from "./backupRepository";
+import type { SqliteDatabase } from "./types";
+
+function tempDb(): { root: string; db: SqliteDatabase } {
+  const root = mkdtempSync(join(tmpdir(), "actual-bench-backup-db-"));
+  return { root, db: getAppDb(join(root, "metadata.sqlite")) };
+}
+
+function artifactInput(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "budget",
+    checksumSha256: "a".repeat(64),
+    sizeBytes: 2048,
+    sourceBudgetId: "budget-1",
+    sourceBudgetName: "Household",
+    ...overrides,
+  };
+}
+
+describe("backup destinations", () => {
+  afterEach(() => resetAppDbForTests());
+
+  it("stores a local path and an S3 bucket without holding a secret", () => {
+    const { root, db } = tempDb();
+    try {
+      const local = createBackupDestination(db, {
+        name: "NAS volume",
+        kind: "local",
+        config: { version: 1, data: { path: "/mnt/backups/actual" } },
+      });
+      const s3 = createBackupDestination(db, {
+        name: "Off-site",
+        kind: "s3",
+        config: { version: 1, data: { bucket: "bench-backups", region: "eu-central-1", prefix: "prod/" } },
+        // The credentials themselves live in the vault; this is the reference.
+        credentialRef: "s3-fingerprint-1",
+      });
+
+      expect(local.kind).toBe("local");
+      expect(local.config.data.path).toBe("/mnt/backups/actual");
+      expect(s3.credentialRef).toBe("s3-fingerprint-1");
+      expect(listBackupDestinations(db)).toHaveLength(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to put an access key in the config", () => {
+    const { root, db } = tempDb();
+    try {
+      expect(() =>
+        createBackupDestination(db, {
+          name: "Careless",
+          kind: "s3",
+          config: { version: 1, data: { bucket: "b", secretAccessKey: "AKIA-not-here" } },
+        })
+      ).toThrow(/cannot store credential field/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("remembers its own health, separately from any run that used it", () => {
+    const { root, db } = tempDb();
+    try {
+      const destination = createBackupDestination(db, { name: "Off-site", kind: "s3" });
+
+      recordDestinationOutcome(db, destination.id, {
+        success: false,
+        at: "2026-08-27T01:00:00.000Z",
+        reason: "403 from bucket",
+      });
+      let current = getBackupDestination(db, destination.id);
+      expect(current?.lastFailureReason).toBe("403 from bucket");
+
+      recordDestinationOutcome(db, destination.id, { success: true, at: "2026-08-27T02:00:00.000Z" });
+      current = getBackupDestination(db, destination.id);
+      expect(current?.lastSuccessAt).toBe("2026-08-27T02:00:00.000Z");
+      // A success clears the standing reason; the failure timestamp remains as
+      // history rather than being erased.
+      expect(current?.lastFailureReason).toBeNull();
+      expect(current?.lastFailureAt).toBe("2026-08-27T01:00:00.000Z");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("updates and deletes", () => {
+    const { root, db } = tempDb();
+    try {
+      const destination = createBackupDestination(db, { name: "Local", kind: "local" });
+      const updated = updateBackupDestination(db, destination.id, { name: "Renamed", enabled: false });
+      expect(updated?.name).toBe("Renamed");
+      expect(updated?.enabled).toBe(false);
+      expect(deleteBackupDestination(db, destination.id)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("backup policies", () => {
+  afterEach(() => resetAppDbForTests());
+
+  it("defaults to verified, unencrypted, tiered retention", () => {
+    const { root, db } = tempDb();
+    try {
+      const policy = createBackupPolicy(db, {
+        name: "Nightly",
+        sourceRef: { version: 1, data: { connectionFingerprint: "srv-1" } },
+        destinationIds: ["dest-1", "dest-2"],
+      });
+
+      expect(policy.contents).toBe("both");
+      // Verification defaults to opening the file, not to trusting the bytes.
+      expect(policy.verificationLevel).toBe("data");
+      expect(policy.encryption).toBe("none");
+      expect(policy.retention).toEqual(DEFAULT_RETENTION);
+      expect(policy.destinationIds).toEqual(["dest-1", "dest-2"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps partial retention edits from erasing the rules not being edited", () => {
+    const { root, db } = tempDb();
+    try {
+      const policy = createBackupPolicy(db, { name: "Nightly", retention: { daily: 30 } });
+      expect(policy.retention.daily).toBe(30);
+      expect(policy.retention.monthly).toBe(DEFAULT_RETENTION.monthly);
+      expect(policy.retention.minimumAgeHours).toBe(DEFAULT_RETENTION.minimumAgeHours);
+
+      const updated = updateBackupPolicy(db, policy.id, { retention: { yearly: 7 } });
+      expect(updated?.retention.yearly).toBe(7);
+      expect(updated?.retention.daily).toBe(DEFAULT_RETENTION.daily);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a retention rule that is not a count", () => {
+    const { root, db } = tempDb();
+    try {
+      expect(() => createBackupPolicy(db, { name: "Bad", retention: { daily: -1 } })).toThrow(
+        /must be zero or a positive integer/
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stores a passphrase as a vault reference, never as a passphrase", () => {
+    const { root, db } = tempDb();
+    try {
+      const policy = createBackupPolicy(db, {
+        name: "Encrypted",
+        encryption: "passphrase",
+        encryptionCredentialRef: "backup-passphrase-1",
+      });
+      expect(policy.encryption).toBe("passphrase");
+      expect(policy.encryptionCredentialRef).toBe("backup-passphrase-1");
+
+      expect(() =>
+        createBackupPolicy(db, {
+          name: "Careless",
+          sourceRef: { version: 1, data: { passphrase: "hunter2" } },
+        })
+      ).toThrow(/cannot store credential field/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("artifacts and their copies", () => {
+  afterEach(() => resetAppDbForTests());
+
+  it("records one artifact stored in two destinations", () => {
+    const { root, db } = tempDb();
+    try {
+      const local = createBackupDestination(db, { name: "Local", kind: "local" });
+      const offsite = createBackupDestination(db, { name: "Off-site", kind: "s3" });
+      const artifact = createBackupArtifact(db, artifactInput());
+
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: local.id,
+        objectKey: "/mnt/backups/household-2026-08-27.zip",
+        uploadedAt: "2026-08-27T02:00:00.000Z",
+      });
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: offsite.id,
+        objectKey: "prod/household-2026-08-27.zip",
+        status: "failed",
+        lastError: "timed out",
+      });
+
+      const locations = listArtifactLocations(db, artifact.id);
+      expect(locations).toHaveLength(2);
+
+      // The point of the separate table: one copy failing is not the artifact
+      // failing, and each destination carries its own truth.
+      const failed = locations.find((entry) => entry.destinationId === offsite.id);
+      expect(failed?.status).toBe("failed");
+      expect(failed?.lastError).toBe("timed out");
+      expect(locations.find((entry) => entry.destinationId === local.id)?.status).toBe("stored");
+      expect(listDestinationLocations(db, offsite.id)).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("updates a copy on retry instead of inventing a second one", () => {
+    const { root, db } = tempDb();
+    try {
+      const destination = createBackupDestination(db, { name: "Off-site", kind: "s3" });
+      const artifact = createBackupArtifact(db, artifactInput());
+      const key = "prod/household-2026-08-27.zip";
+
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey: key,
+        status: "failed",
+        lastError: "timed out",
+      });
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey: key,
+        status: "stored",
+        uploadedAt: "2026-08-27T02:05:00.000Z",
+      });
+
+      const locations = listArtifactLocations(db, artifact.id);
+      expect(locations).toHaveLength(1);
+      expect(locations[0].status).toBe("stored");
+      expect(locations[0].lastError).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("is unverified until something verifies it", () => {
+    const { root, db } = tempDb();
+    try {
+      const artifact = createBackupArtifact(db, artifactInput());
+      // Bytes arriving is not verification; that distinction is the feature.
+      expect(artifact.verificationStatus).toBe("unverified");
+      expect(artifact.verificationLevel).toBeNull();
+
+      const verified = recordArtifactVerification(db, artifact.id, {
+        level: "data",
+        status: "passed",
+        at: "2026-08-27T02:01:00.000Z",
+        findings: { version: 1, data: { accounts: 14, transactions: 8431, integrityCheck: "ok" } },
+      });
+
+      expect(verified?.verificationStatus).toBe("passed");
+      expect(verified?.verificationLevel).toBe("data");
+      expect(verified?.verification?.data.transactions).toBe(8431);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an artifact whose policy was deleted", () => {
+    const { root, db } = tempDb();
+    try {
+      const policy = createBackupPolicy(db, { name: "Nightly" });
+      const artifact = createBackupArtifact(db, artifactInput({ policyId: policy.id }));
+
+      db.prepare("DELETE FROM backup_policies WHERE id = ?").run(policy.id);
+
+      // The file still exists and is still restorable, which is the whole point
+      // — deleting a policy must not erase the record of what it produced.
+      const kept = getBackupArtifact(db, artifact.id);
+      expect(kept).not.toBeNull();
+      expect(kept?.policyId).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes an artifact's copies with it", () => {
+    const { root, db } = tempDb();
+    try {
+      const destination = createBackupDestination(db, { name: "Local", kind: "local" });
+      const artifact = createBackupArtifact(db, artifactInput());
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey: "/mnt/backups/a.zip",
+      });
+
+      expect(deleteBackupArtifact(db, artifact.id)).toBe(true);
+      expect(listArtifactLocations(db, artifact.id)).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("pins and unpins, and lists newest first", () => {
+    const { root, db } = tempDb();
+    try {
+      createBackupArtifact(db, artifactInput({ createdAt: "2026-08-25T00:00:00.000Z" }));
+      const newer = createBackupArtifact(db, artifactInput({ createdAt: "2026-08-27T00:00:00.000Z" }));
+      createBackupArtifact(db, artifactInput({ kind: "app-db", createdAt: "2026-08-26T00:00:00.000Z" }));
+
+      expect(listBackupArtifacts(db)[0].id).toBe(newer.id);
+      expect(listBackupArtifacts(db, { kind: "app-db" })).toHaveLength(1);
+
+      expect(setArtifactPinned(db, newer.id, true)?.pinned).toBe(true);
+      expect(setArtifactPinned(db, newer.id, false)?.pinned).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("carries encryption parameters without a key, and an automatic point's protection window", () => {
+    const { root, db } = tempDb();
+    try {
+      const artifact = createBackupArtifact(
+        db,
+        artifactInput({
+          encrypted: true,
+          encryption: { version: 1, data: { algorithm: "aes-256-gcm", salt: "c2FsdA==", iv: "aXY=" } },
+          plaintextChecksumSha256: "b".repeat(64),
+          tier: "auto",
+          protectedUntil: "2026-09-10T00:00:00.000Z",
+          takenBefore: "Payee Cleanup apply",
+        })
+      );
+
+      expect(artifact.encrypted).toBe(true);
+      expect(artifact.encryption?.data.salt).toBe("c2FsdA==");
+      expect(artifact.tier).toBe("auto");
+      // Protected rather than pinned: exempt for a window, then prunes normally.
+      expect(artifact.pinned).toBe(false);
+      expect(artifact.protectedUntil).toBe("2026-09-10T00:00:00.000Z");
+      expect(artifact.takenBefore).toBe("Payee Cleanup apply");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("knows the vocabulary this feature actually uses for secrets", () => {
+    const { root, db } = tempDb();
+    try {
+      // Each of these walked past the original guard, which only knew about
+      // apiKey / password / token / credential.
+      for (const field of ["secretAccessKey", "passphrase", "accessKey", "privateKey"]) {
+        expect(() =>
+          createBackupDestination(db, {
+            name: `Careless ${field}`,
+            kind: "s3",
+            config: { version: 1, data: { bucket: "b", [field]: "should-not-be-stored" } },
+          })
+        ).toThrow(/cannot store credential field/);
+      }
+
+      // And a legitimate setting is still allowed through.
+      const fine = createBackupDestination(db, {
+        name: "Fine",
+        kind: "s3",
+        config: { version: 1, data: { bucket: "b", region: "eu-central-1", pathStyle: true } },
+      });
+      expect(fine.config.data.region).toBe("eu-central-1");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/app-db/backupRepository.ts
+++ b/src/lib/app-db/backupRepository.ts
@@ -1,0 +1,784 @@
+import { generateId } from "@/lib/uuid";
+import { AppDbValidationError } from "./errors";
+import {
+  EMPTY_ENVELOPE,
+  isRecord,
+  normalizeEnvelope as normalizeSharedEnvelope,
+  parseEnvelope as parseSharedEnvelope,
+} from "./jsonEnvelope";
+import type { JsonEnvelope, SqliteDatabase } from "./types";
+import type {
+  BackupArtifactKind,
+  BackupRetentionTier,
+  BackupVerificationLevel,
+  BackupVerificationStatus,
+} from "@/lib/backup/manifest";
+
+/**
+ * Storage for verified backups (RD-077 / PR-047a).
+ *
+ * Destinations, policies, artifacts and the copies of an artifact that live in
+ * each destination. Storage only — nothing here writes a file, exports a
+ * budget, or decides what to prune.
+ *
+ * The one rule the schema enforces rather than trusts: no row may hold a
+ * secret. A destination's credentials and a backup passphrase are vault
+ * references, and the config envelopes are checked for credential-shaped fields
+ * on the way in, the same as sync flow metadata.
+ */
+
+export type BackupDestinationKind = "local" | "s3";
+
+export type BackupDestination = {
+  id: string;
+  name: string;
+  kind: BackupDestinationKind;
+  enabled: boolean;
+  config: JsonEnvelope;
+  /** Vault fingerprint. Never a secret. */
+  credentialRef: string | null;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastFailureReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BackupRetention = {
+  /** Copies to keep per tier. Zero disables a tier. */
+  daily: number;
+  weekly: number;
+  monthly: number;
+  yearly: number;
+  /** Nothing younger than this prunes, whatever the rules say. */
+  minimumAgeHours: number;
+  /** How long an automatic safety point is exempt from tier retention. */
+  autoProtectionDays: number;
+  /** …or the newest N automatic points, whichever protects more. */
+  autoProtectionCount: number;
+};
+
+export const DEFAULT_RETENTION: BackupRetention = {
+  daily: 7,
+  weekly: 4,
+  monthly: 12,
+  yearly: 3,
+  minimumAgeHours: 24,
+  autoProtectionDays: 14,
+  autoProtectionCount: 10,
+};
+
+export type BackupPolicyContents = "budget" | "app-db" | "both";
+export type BackupEncryptionMode = "none" | "passphrase";
+
+export type BackupPolicy = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  contents: BackupPolicyContents;
+  sourceRef: JsonEnvelope;
+  destinationIds: string[];
+  verificationLevel: BackupVerificationLevel;
+  encryption: BackupEncryptionMode;
+  encryptionCredentialRef: string | null;
+  retention: BackupRetention;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BackupArtifact = {
+  id: string;
+  policyId: string | null;
+  kind: BackupArtifactKind;
+  createdAt: string;
+  sourceBudgetId: string | null;
+  sourceBudgetName: string | null;
+  sizeBytes: number;
+  checksumSha256: string;
+  plaintextChecksumSha256: string | null;
+  encrypted: boolean;
+  encryption: JsonEnvelope | null;
+  tier: BackupRetentionTier;
+  pinned: boolean;
+  protectedUntil: string | null;
+  takenBefore: string | null;
+  verificationLevel: BackupVerificationLevel | null;
+  verificationStatus: BackupVerificationStatus;
+  verifiedAt: string | null;
+  verification: JsonEnvelope | null;
+  manifestVersion: number;
+  benchVersion: string | null;
+  notes: string | null;
+};
+
+export type BackupLocationStatus = "stored" | "failed" | "missing" | "deleted";
+
+export type BackupArtifactLocation = {
+  id: string;
+  artifactId: string;
+  destinationId: string | null;
+  objectKey: string;
+  status: BackupLocationStatus;
+  uploadedAt: string | null;
+  lastVerifiedAt: string | null;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+/** Destination and policy settings are user input, so credential-shaped fields
+ * are refused: the secret belongs in the vault, referenced by fingerprint. */
+function normalizeEnvelope(value: unknown, label: string): JsonEnvelope {
+  return normalizeSharedEnvelope(value, label, { rejectSecrets: true });
+}
+
+function parseEnvelope(raw: string, label: string): JsonEnvelope {
+  return parseSharedEnvelope(raw, label, { rejectSecrets: true });
+}
+
+function text(value: unknown, label: string, maxLength = 400): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new AppDbValidationError(`${label} is required`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) throw new AppDbValidationError(`${label} is too long`);
+  return trimmed;
+}
+
+function optionalText(value: unknown, label: string, maxLength = 2000): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw new AppDbValidationError(`${label} must be a string`);
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > maxLength) throw new AppDbValidationError(`${label} is too long`);
+  return trimmed;
+}
+
+function oneOf<T extends string>(value: unknown, allowed: readonly T[], label: string, fallback: T): T {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new AppDbValidationError(`${label} must be one of: ${allowed.join(", ")}`);
+  }
+  return value as T;
+}
+
+function count(value: unknown, label: string, fallback: number): number {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new AppDbValidationError(`${label} must be zero or a positive integer`);
+  }
+  return value;
+}
+
+const DESTINATION_KINDS: BackupDestinationKind[] = ["local", "s3"];
+const CONTENTS: BackupPolicyContents[] = ["budget", "app-db", "both"];
+const LEVELS: BackupVerificationLevel[] = ["archive", "data", "deep"];
+const STATUSES: BackupVerificationStatus[] = ["unverified", "passed", "failed"];
+const TIERS: BackupRetentionTier[] = ["manual", "auto", "daily", "weekly", "monthly", "yearly"];
+const LOCATION_STATUSES: BackupLocationStatus[] = ["stored", "failed", "missing", "deleted"];
+
+// ── destinations ─────────────────────────────────────────────────────────────
+
+type DestinationRow = {
+  id: string;
+  name: string;
+  kind: string;
+  enabled: number;
+  config_json: string;
+  credential_ref: string | null;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+  last_failure_reason: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function rowToDestination(row: DestinationRow): BackupDestination {
+  return {
+    id: row.id,
+    name: row.name,
+    kind: row.kind as BackupDestinationKind,
+    enabled: row.enabled === 1,
+    config: parseEnvelope(row.config_json, "config"),
+    credentialRef: row.credential_ref,
+    lastSuccessAt: row.last_success_at,
+    lastFailureAt: row.last_failure_at,
+    lastFailureReason: row.last_failure_reason,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function listBackupDestinations(db: SqliteDatabase): BackupDestination[] {
+  return db
+    .prepare("SELECT * FROM backup_destinations ORDER BY created_at")
+    .all<DestinationRow>()
+    .map(rowToDestination);
+}
+
+export function getBackupDestination(db: SqliteDatabase, id: string): BackupDestination | null {
+  const row = db.prepare("SELECT * FROM backup_destinations WHERE id = ?").get<DestinationRow>(id);
+  return row ? rowToDestination(row) : null;
+}
+
+export function createBackupDestination(db: SqliteDatabase, input: unknown): BackupDestination {
+  if (!isRecord(input)) throw new AppDbValidationError("Destination payload must be an object");
+
+  const now = new Date().toISOString();
+  const id = input.id === undefined ? generateId() : text(input.id, "id", 64);
+
+  db.prepare(
+    `INSERT INTO backup_destinations
+       (id, name, kind, enabled, config_json, credential_ref, last_success_at,
+        last_failure_at, last_failure_reason, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)`
+  ).run(
+    id,
+    text(input.name, "name", 120),
+    oneOf(input.kind, DESTINATION_KINDS, "kind", "local"),
+    input.enabled === false ? 0 : 1,
+    JSON.stringify(
+      input.config === undefined ? EMPTY_ENVELOPE : normalizeEnvelope(input.config, "config")
+    ),
+    optionalText(input.credentialRef, "credentialRef", 200),
+    now,
+    now
+  );
+
+  const created = getBackupDestination(db, id);
+  if (!created) throw new AppDbValidationError("Failed to create destination");
+  return created;
+}
+
+export function updateBackupDestination(
+  db: SqliteDatabase,
+  id: string,
+  input: unknown
+): BackupDestination | null {
+  if (!isRecord(input)) throw new AppDbValidationError("Destination payload must be an object");
+  const existing = getBackupDestination(db, id);
+  if (!existing) return null;
+
+  const assignments: string[] = [];
+  const params: unknown[] = [];
+  const set = (column: string, value: unknown) => {
+    assignments.push(`${column} = ?`);
+    params.push(value);
+  };
+
+  if (input.name !== undefined) set("name", text(input.name, "name", 120));
+  if (input.enabled !== undefined) set("enabled", input.enabled === false ? 0 : 1);
+  if (input.config !== undefined) {
+    set("config_json", JSON.stringify(normalizeEnvelope(input.config, "config")));
+  }
+  if (input.credentialRef !== undefined) {
+    set("credential_ref", optionalText(input.credentialRef, "credentialRef", 200));
+  }
+  if (assignments.length === 0) return existing;
+
+  set("updated_at", new Date().toISOString());
+  params.push(id);
+  db.prepare(`UPDATE backup_destinations SET ${assignments.join(", ")} WHERE id = ?`).run(...params);
+  return getBackupDestination(db, id);
+}
+
+/**
+ * Record what a destination just did.
+ *
+ * Health lives on the destination rather than on the run, because a bucket that
+ * rejects writes is broken independently of whichever policy discovered it.
+ */
+export function recordDestinationOutcome(
+  db: SqliteDatabase,
+  id: string,
+  outcome: { success: boolean; at: string; reason?: string }
+): BackupDestination | null {
+  const existing = getBackupDestination(db, id);
+  if (!existing) return null;
+
+  if (outcome.success) {
+    db.prepare(
+      "UPDATE backup_destinations SET last_success_at = ?, last_failure_reason = NULL, updated_at = ? WHERE id = ?"
+    ).run(outcome.at, new Date().toISOString(), id);
+  } else {
+    db.prepare(
+      "UPDATE backup_destinations SET last_failure_at = ?, last_failure_reason = ?, updated_at = ? WHERE id = ?"
+    ).run(outcome.at, optionalText(outcome.reason, "reason", 500), new Date().toISOString(), id);
+  }
+
+  return getBackupDestination(db, id);
+}
+
+export function deleteBackupDestination(db: SqliteDatabase, id: string): boolean {
+  return db.prepare("DELETE FROM backup_destinations WHERE id = ?").run(id).changes > 0;
+}
+
+// ── policies ─────────────────────────────────────────────────────────────────
+
+type PolicyRow = {
+  id: string;
+  name: string;
+  enabled: number;
+  contents: string;
+  source_ref_json: string;
+  destination_ids_json: string;
+  verification_level: string;
+  encryption: string;
+  encryption_credential_ref: string | null;
+  retention_json: string;
+  created_at: string;
+  updated_at: string;
+};
+
+function normalizeRetention(value: unknown): BackupRetention {
+  if (value === undefined || value === null) return DEFAULT_RETENTION;
+  if (!isRecord(value)) throw new AppDbValidationError("retention must be an object");
+
+  return {
+    daily: count(value.daily, "retention.daily", DEFAULT_RETENTION.daily),
+    weekly: count(value.weekly, "retention.weekly", DEFAULT_RETENTION.weekly),
+    monthly: count(value.monthly, "retention.monthly", DEFAULT_RETENTION.monthly),
+    yearly: count(value.yearly, "retention.yearly", DEFAULT_RETENTION.yearly),
+    minimumAgeHours: count(
+      value.minimumAgeHours,
+      "retention.minimumAgeHours",
+      DEFAULT_RETENTION.minimumAgeHours
+    ),
+    autoProtectionDays: count(
+      value.autoProtectionDays,
+      "retention.autoProtectionDays",
+      DEFAULT_RETENTION.autoProtectionDays
+    ),
+    autoProtectionCount: count(
+      value.autoProtectionCount,
+      "retention.autoProtectionCount",
+      DEFAULT_RETENTION.autoProtectionCount
+    ),
+  };
+}
+
+function parseRetention(raw: string): BackupRetention {
+  try {
+    return normalizeRetention(JSON.parse(raw) as unknown);
+  } catch (error) {
+    if (error instanceof AppDbValidationError) throw error;
+    throw new AppDbValidationError("retention contains invalid JSON");
+  }
+}
+
+function parseDestinationIds(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : [];
+  } catch {
+    throw new AppDbValidationError("destinationIds contains invalid JSON");
+  }
+}
+
+function rowToPolicy(row: PolicyRow): BackupPolicy {
+  return {
+    id: row.id,
+    name: row.name,
+    enabled: row.enabled === 1,
+    contents: row.contents as BackupPolicyContents,
+    sourceRef: parseEnvelope(row.source_ref_json, "sourceRef"),
+    destinationIds: parseDestinationIds(row.destination_ids_json),
+    verificationLevel: row.verification_level as BackupVerificationLevel,
+    encryption: row.encryption as BackupEncryptionMode,
+    encryptionCredentialRef: row.encryption_credential_ref,
+    retention: parseRetention(row.retention_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function listBackupPolicies(db: SqliteDatabase): BackupPolicy[] {
+  return db
+    .prepare("SELECT * FROM backup_policies ORDER BY created_at")
+    .all<PolicyRow>()
+    .map(rowToPolicy);
+}
+
+export function getBackupPolicy(db: SqliteDatabase, id: string): BackupPolicy | null {
+  const row = db.prepare("SELECT * FROM backup_policies WHERE id = ?").get<PolicyRow>(id);
+  return row ? rowToPolicy(row) : null;
+}
+
+export function createBackupPolicy(db: SqliteDatabase, input: unknown): BackupPolicy {
+  if (!isRecord(input)) throw new AppDbValidationError("Policy payload must be an object");
+
+  const now = new Date().toISOString();
+  const id = input.id === undefined ? generateId() : text(input.id, "id", 64);
+  const destinationIds = Array.isArray(input.destinationIds)
+    ? input.destinationIds.filter((entry): entry is string => typeof entry === "string")
+    : [];
+
+  const encryption = oneOf(input.encryption, ["none", "passphrase"] as const, "encryption", "none");
+
+  db.prepare(
+    `INSERT INTO backup_policies
+       (id, name, enabled, contents, source_ref_json, destination_ids_json,
+        verification_level, encryption, encryption_credential_ref, retention_json,
+        created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    text(input.name, "name", 120),
+    input.enabled === false ? 0 : 1,
+    oneOf(input.contents, CONTENTS, "contents", "both"),
+    JSON.stringify(
+      input.sourceRef === undefined ? EMPTY_ENVELOPE : normalizeEnvelope(input.sourceRef, "sourceRef")
+    ),
+    JSON.stringify(destinationIds),
+    oneOf(input.verificationLevel, LEVELS, "verificationLevel", "data"),
+    encryption,
+    optionalText(input.encryptionCredentialRef, "encryptionCredentialRef", 200),
+    JSON.stringify(normalizeRetention(input.retention)),
+    now,
+    now
+  );
+
+  const created = getBackupPolicy(db, id);
+  if (!created) throw new AppDbValidationError("Failed to create policy");
+  return created;
+}
+
+export function updateBackupPolicy(db: SqliteDatabase, id: string, input: unknown): BackupPolicy | null {
+  if (!isRecord(input)) throw new AppDbValidationError("Policy payload must be an object");
+  const existing = getBackupPolicy(db, id);
+  if (!existing) return null;
+
+  const assignments: string[] = [];
+  const params: unknown[] = [];
+  const set = (column: string, value: unknown) => {
+    assignments.push(`${column} = ?`);
+    params.push(value);
+  };
+
+  if (input.name !== undefined) set("name", text(input.name, "name", 120));
+  if (input.enabled !== undefined) set("enabled", input.enabled === false ? 0 : 1);
+  if (input.contents !== undefined) set("contents", oneOf(input.contents, CONTENTS, "contents", "both"));
+  if (input.sourceRef !== undefined) {
+    set("source_ref_json", JSON.stringify(normalizeEnvelope(input.sourceRef, "sourceRef")));
+  }
+  if (input.destinationIds !== undefined) {
+    const ids = Array.isArray(input.destinationIds)
+      ? input.destinationIds.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    set("destination_ids_json", JSON.stringify(ids));
+  }
+  if (input.verificationLevel !== undefined) {
+    set("verification_level", oneOf(input.verificationLevel, LEVELS, "verificationLevel", "data"));
+  }
+  if (input.encryption !== undefined) {
+    set("encryption", oneOf(input.encryption, ["none", "passphrase"] as const, "encryption", "none"));
+  }
+  if (input.encryptionCredentialRef !== undefined) {
+    set(
+      "encryption_credential_ref",
+      optionalText(input.encryptionCredentialRef, "encryptionCredentialRef", 200)
+    );
+  }
+  if (input.retention !== undefined) {
+    set("retention_json", JSON.stringify(normalizeRetention(input.retention)));
+  }
+  if (assignments.length === 0) return existing;
+
+  set("updated_at", new Date().toISOString());
+  params.push(id);
+  db.prepare(`UPDATE backup_policies SET ${assignments.join(", ")} WHERE id = ?`).run(...params);
+  return getBackupPolicy(db, id);
+}
+
+export function deleteBackupPolicy(db: SqliteDatabase, id: string): boolean {
+  return db.prepare("DELETE FROM backup_policies WHERE id = ?").run(id).changes > 0;
+}
+
+// ── artifacts and their copies ───────────────────────────────────────────────
+
+type ArtifactRow = {
+  id: string;
+  policy_id: string | null;
+  kind: string;
+  created_at: string;
+  source_budget_id: string | null;
+  source_budget_name: string | null;
+  size_bytes: number;
+  checksum_sha256: string;
+  plaintext_checksum_sha256: string | null;
+  encrypted: number;
+  encryption_json: string | null;
+  tier: string;
+  pinned: number;
+  protected_until: string | null;
+  taken_before: string | null;
+  verification_level: string | null;
+  verification_status: string;
+  verified_at: string | null;
+  verification_json: string | null;
+  manifest_version: number;
+  bench_version: string | null;
+  notes: string | null;
+};
+
+function rowToArtifact(row: ArtifactRow): BackupArtifact {
+  return {
+    id: row.id,
+    policyId: row.policy_id,
+    kind: row.kind as BackupArtifactKind,
+    createdAt: row.created_at,
+    sourceBudgetId: row.source_budget_id,
+    sourceBudgetName: row.source_budget_name,
+    sizeBytes: row.size_bytes,
+    checksumSha256: row.checksum_sha256,
+    plaintextChecksumSha256: row.plaintext_checksum_sha256,
+    encrypted: row.encrypted === 1,
+    // Encryption parameters are not user input and hold no secret, so they are
+    // read plainly rather than through the credential guard.
+    encryption: row.encryption_json ? (JSON.parse(row.encryption_json) as JsonEnvelope) : null,
+    tier: row.tier as BackupRetentionTier,
+    pinned: row.pinned === 1,
+    protectedUntil: row.protected_until,
+    takenBefore: row.taken_before,
+    verificationLevel: (row.verification_level as BackupVerificationLevel | null) ?? null,
+    verificationStatus: row.verification_status as BackupVerificationStatus,
+    verifiedAt: row.verified_at,
+    verification: row.verification_json ? (JSON.parse(row.verification_json) as JsonEnvelope) : null,
+    manifestVersion: row.manifest_version,
+    benchVersion: row.bench_version,
+    notes: row.notes,
+  };
+}
+
+export function createBackupArtifact(db: SqliteDatabase, input: unknown): BackupArtifact {
+  if (!isRecord(input)) throw new AppDbValidationError("Artifact payload must be an object");
+
+  const id = input.id === undefined ? generateId() : text(input.id, "id", 64);
+
+  db.prepare(
+    `INSERT INTO backup_artifacts
+       (id, policy_id, kind, created_at, source_budget_id, source_budget_name, size_bytes,
+        checksum_sha256, plaintext_checksum_sha256, encrypted, encryption_json, tier, pinned,
+        protected_until, taken_before, verification_level, verification_status, verified_at,
+        verification_json, manifest_version, bench_version, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    optionalText(input.policyId, "policyId", 64),
+    oneOf(input.kind, ["budget", "app-db"] as const, "kind", "budget"),
+    optionalText(input.createdAt, "createdAt", 40) ?? new Date().toISOString(),
+    optionalText(input.sourceBudgetId, "sourceBudgetId", 200),
+    optionalText(input.sourceBudgetName, "sourceBudgetName", 200),
+    count(input.sizeBytes, "sizeBytes", 0),
+    text(input.checksumSha256, "checksumSha256", 128),
+    optionalText(input.plaintextChecksumSha256, "plaintextChecksumSha256", 128),
+    input.encrypted === true ? 1 : 0,
+    input.encryption === undefined || input.encryption === null
+      ? null
+      : JSON.stringify(input.encryption),
+    oneOf(input.tier, TIERS, "tier", "manual"),
+    input.pinned === true ? 1 : 0,
+    optionalText(input.protectedUntil, "protectedUntil", 40),
+    optionalText(input.takenBefore, "takenBefore", 300),
+    input.verificationLevel === undefined || input.verificationLevel === null
+      ? null
+      : oneOf(input.verificationLevel, LEVELS, "verificationLevel", "data"),
+    oneOf(input.verificationStatus, STATUSES, "verificationStatus", "unverified"),
+    optionalText(input.verifiedAt, "verifiedAt", 40),
+    input.verification === undefined || input.verification === null
+      ? null
+      : JSON.stringify(input.verification),
+    count(input.manifestVersion, "manifestVersion", 1),
+    optionalText(input.benchVersion, "benchVersion", 60),
+    optionalText(input.notes, "notes", 2000)
+  );
+
+  const created = getBackupArtifact(db, id);
+  if (!created) throw new AppDbValidationError("Failed to create artifact");
+  return created;
+}
+
+export function getBackupArtifact(db: SqliteDatabase, id: string): BackupArtifact | null {
+  const row = db.prepare("SELECT * FROM backup_artifacts WHERE id = ?").get<ArtifactRow>(id);
+  return row ? rowToArtifact(row) : null;
+}
+
+export function listBackupArtifacts(
+  db: SqliteDatabase,
+  options: { policyId?: string; kind?: BackupArtifactKind; limit?: number } = {}
+): BackupArtifact[] {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+  if (options.policyId) {
+    clauses.push("policy_id = ?");
+    params.push(options.policyId);
+  }
+  if (options.kind) {
+    clauses.push("kind = ?");
+    params.push(options.kind);
+  }
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+  const limit = options.limit && options.limit > 0 ? Math.min(options.limit, 500) : 200;
+
+  return db
+    .prepare(`SELECT * FROM backup_artifacts ${where} ORDER BY created_at DESC LIMIT ?`)
+    .all<ArtifactRow>(...params, limit)
+    .map(rowToArtifact);
+}
+
+/** Record a verification result against an artifact. */
+export function recordArtifactVerification(
+  db: SqliteDatabase,
+  id: string,
+  input: {
+    level: BackupVerificationLevel;
+    status: BackupVerificationStatus;
+    at: string;
+    findings?: JsonEnvelope | null;
+  }
+): BackupArtifact | null {
+  const existing = getBackupArtifact(db, id);
+  if (!existing) return null;
+
+  db.prepare(
+    `UPDATE backup_artifacts
+        SET verification_level = ?, verification_status = ?, verified_at = ?, verification_json = ?
+      WHERE id = ?`
+  ).run(
+    oneOf(input.level, LEVELS, "level", "data"),
+    oneOf(input.status, STATUSES, "status", "unverified"),
+    input.at,
+    input.findings ? JSON.stringify(input.findings) : null,
+    id
+  );
+
+  return getBackupArtifact(db, id);
+}
+
+/** Pin or unpin. A pin is permanent and outranks every retention rule. */
+export function setArtifactPinned(db: SqliteDatabase, id: string, pinned: boolean): BackupArtifact | null {
+  if (!getBackupArtifact(db, id)) return null;
+  db.prepare("UPDATE backup_artifacts SET pinned = ? WHERE id = ?").run(pinned ? 1 : 0, id);
+  return getBackupArtifact(db, id);
+}
+
+export function deleteBackupArtifact(db: SqliteDatabase, id: string): boolean {
+  return db.prepare("DELETE FROM backup_artifacts WHERE id = ?").run(id).changes > 0;
+}
+
+type LocationRow = {
+  id: string;
+  artifact_id: string;
+  destination_id: string | null;
+  object_key: string;
+  status: string;
+  uploaded_at: string | null;
+  last_verified_at: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function rowToLocation(row: LocationRow): BackupArtifactLocation {
+  return {
+    id: row.id,
+    artifactId: row.artifact_id,
+    destinationId: row.destination_id,
+    objectKey: row.object_key,
+    status: row.status as BackupLocationStatus,
+    uploadedAt: row.uploaded_at,
+    lastVerifiedAt: row.last_verified_at,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Record one copy of an artifact in one destination.
+ *
+ * Upserts on (artifact, destination, key) so a retried upload updates the copy
+ * it already knows about instead of inventing a second one.
+ */
+export function recordArtifactLocation(db: SqliteDatabase, input: unknown): BackupArtifactLocation {
+  if (!isRecord(input)) throw new AppDbValidationError("Location payload must be an object");
+
+  const now = new Date().toISOString();
+  const artifactId = text(input.artifactId, "artifactId", 64);
+  const destinationId = optionalText(input.destinationId, "destinationId", 64);
+  const objectKey = text(input.objectKey, "objectKey", 1024);
+  const status = oneOf(input.status, LOCATION_STATUSES, "status", "stored");
+
+  const existing = db
+    .prepare(
+      `SELECT * FROM backup_artifact_locations
+        WHERE artifact_id = ? AND object_key = ?
+          AND (destination_id IS ? OR destination_id = ?)`
+    )
+    .get<LocationRow>(artifactId, objectKey, destinationId, destinationId);
+
+  const id = existing?.id ?? (input.id === undefined ? generateId() : text(input.id, "id", 64));
+
+  if (existing) {
+    db.prepare(
+      `UPDATE backup_artifact_locations
+          SET status = ?, uploaded_at = ?, last_verified_at = ?, last_error = ?, updated_at = ?
+        WHERE id = ?`
+    ).run(
+      status,
+      optionalText(input.uploadedAt, "uploadedAt", 40) ?? existing.uploaded_at,
+      optionalText(input.lastVerifiedAt, "lastVerifiedAt", 40) ?? existing.last_verified_at,
+      optionalText(input.lastError, "lastError", 500),
+      now,
+      id
+    );
+  } else {
+    db.prepare(
+      `INSERT INTO backup_artifact_locations
+         (id, artifact_id, destination_id, object_key, status, uploaded_at, last_verified_at,
+          last_error, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      id,
+      artifactId,
+      destinationId,
+      objectKey,
+      status,
+      optionalText(input.uploadedAt, "uploadedAt", 40),
+      optionalText(input.lastVerifiedAt, "lastVerifiedAt", 40),
+      optionalText(input.lastError, "lastError", 500),
+      now,
+      now
+    );
+  }
+
+  const stored = db
+    .prepare("SELECT * FROM backup_artifact_locations WHERE id = ?")
+    .get<LocationRow>(id);
+  if (!stored) throw new AppDbValidationError("Failed to record artifact location");
+  return rowToLocation(stored);
+}
+
+export function listArtifactLocations(db: SqliteDatabase, artifactId: string): BackupArtifactLocation[] {
+  return db
+    .prepare("SELECT * FROM backup_artifact_locations WHERE artifact_id = ? ORDER BY created_at")
+    .all<LocationRow>(artifactId)
+    .map(rowToLocation);
+}
+
+export function listDestinationLocations(
+  db: SqliteDatabase,
+  destinationId: string,
+  options: { limit?: number } = {}
+): BackupArtifactLocation[] {
+  const limit = options.limit && options.limit > 0 ? Math.min(options.limit, 500) : 200;
+  return db
+    .prepare(
+      `SELECT * FROM backup_artifact_locations
+        WHERE destination_id = ? ORDER BY created_at DESC LIMIT ?`
+    )
+    .all<LocationRow>(destinationId, limit)
+    .map(rowToLocation);
+}

--- a/src/lib/app-db/backupRepository.ts
+++ b/src/lib/app-db/backupRepository.ts
@@ -71,10 +71,22 @@ export const DEFAULT_RETENTION: BackupRetention = {
 export type BackupPolicyContents = "budget" | "app-db" | "both";
 export type BackupEncryptionMode = "none" | "passphrase";
 
+/** How often a backup rule runs. Mirrors the automation engine's vocabulary. */
+export type BackupScheduleKind = "cron" | "interval";
+
 export type BackupPolicy = {
   id: string;
   name: string;
   enabled: boolean;
+  scheduleKind: BackupScheduleKind;
+  /** Set when `scheduleKind` is `cron`; five-field expression. */
+  cronExpression: string | null;
+  /** Set when `scheduleKind` is `interval`. */
+  intervalMinutes: number | null;
+  /** IANA timezone the cron expression is read in. */
+  timezone: string;
+  /** Whether stored copies are re-verified on a schedule. */
+  scrubEnabled: boolean;
   contents: BackupPolicyContents;
   sourceRef: JsonEnvelope;
   destinationIds: string[];
@@ -328,6 +340,11 @@ type PolicyRow = {
   encryption: string;
   encryption_credential_ref: string | null;
   retention_json: string;
+  schedule_kind: string | null;
+  cron_expression: string | null;
+  interval_minutes: number | null;
+  timezone: string | null;
+  scrub_enabled: number | null;
   created_at: string;
   updated_at: string;
 };
@@ -389,6 +406,13 @@ function rowToPolicy(row: PolicyRow): BackupPolicy {
     encryption: row.encryption as BackupEncryptionMode,
     encryptionCredentialRef: row.encryption_credential_ref,
     retention: parseRetention(row.retention_json),
+    scheduleKind: row.schedule_kind === "interval" ? "interval" : "cron",
+    cronExpression: row.cron_expression,
+    intervalMinutes: row.interval_minutes,
+    timezone: row.timezone || "UTC",
+    // Defaults on, because a backup nobody re-checks is the failure mode this
+    // feature exists to close.
+    scrubEnabled: row.scrub_enabled === null ? true : row.scrub_enabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -421,8 +445,9 @@ export function createBackupPolicy(db: SqliteDatabase, input: unknown): BackupPo
     `INSERT INTO backup_policies
        (id, name, enabled, contents, source_ref_json, destination_ids_json,
         verification_level, encryption, encryption_credential_ref, retention_json,
+        schedule_kind, cron_expression, interval_minutes, timezone, scrub_enabled,
         created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     id,
     text(input.name, "name", 120),
@@ -436,6 +461,16 @@ export function createBackupPolicy(db: SqliteDatabase, input: unknown): BackupPo
     encryption,
     optionalText(input.encryptionCredentialRef, "encryptionCredentialRef", 200),
     JSON.stringify(normalizeRetention(input.retention)),
+    oneOf(input.scheduleKind, ["cron", "interval"] as const, "scheduleKind", "cron"),
+    // A nightly backup in the small hours is the right default: late enough
+    // that the day's transactions are in, early enough to be done before anyone
+    // looks at the budget.
+    optionalText(input.cronExpression, "cronExpression", 120) ?? "0 2 * * *",
+    input.intervalMinutes === undefined || input.intervalMinutes === null
+      ? null
+      : count(input.intervalMinutes, "intervalMinutes", 1440),
+    optionalText(input.timezone, "timezone", 64) ?? "UTC",
+    input.scrubEnabled === false ? 0 : 1,
     now,
     now
   );
@@ -484,6 +519,20 @@ export function updateBackupPolicy(db: SqliteDatabase, id: string, input: unknow
   if (input.retention !== undefined) {
     set("retention_json", JSON.stringify(normalizeRetention(input.retention)));
   }
+  if (input.scheduleKind !== undefined) {
+    set("schedule_kind", oneOf(input.scheduleKind, ["cron", "interval"] as const, "scheduleKind", "cron"));
+  }
+  if (input.cronExpression !== undefined) {
+    set("cron_expression", optionalText(input.cronExpression, "cronExpression", 120));
+  }
+  if (input.intervalMinutes !== undefined) {
+    set(
+      "interval_minutes",
+      input.intervalMinutes === null ? null : count(input.intervalMinutes, "intervalMinutes", 1440)
+    );
+  }
+  if (input.timezone !== undefined) set("timezone", optionalText(input.timezone, "timezone", 64) ?? "UTC");
+  if (input.scrubEnabled !== undefined) set("scrub_enabled", input.scrubEnabled === false ? 0 : 1);
   if (assignments.length === 0) return existing;
 
   set("updated_at", new Date().toISOString());

--- a/src/lib/app-db/jsonEnvelope.ts
+++ b/src/lib/app-db/jsonEnvelope.ts
@@ -31,14 +31,26 @@ function normalizeKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+/**
+ * Names that mean "this is a secret", whatever the feature calls it.
+ *
+ * Widened when verified backups arrived with a vocabulary the original list did
+ * not cover — `secretAccessKey` and `passphrase` both walked straight through.
+ * The guard is only worth having if it knows the words people actually use, so
+ * it is kept deliberately broad: a false positive costs someone a rename, a
+ * false negative puts a live credential in a metadata column.
+ */
 function isSecretLikeKey(key: string): boolean {
   const normalized = normalizeKey(key);
   return (
-    normalized === "apikey" ||
-    normalized.endsWith("apikey") ||
     normalized.includes("password") ||
-    normalized.endsWith("token") ||
-    normalized.includes("credential")
+    normalized.includes("passphrase") ||
+    normalized.includes("credential") ||
+    normalized.includes("secret") ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("accesskey") ||
+    normalized.endsWith("privatekey") ||
+    normalized.endsWith("token")
   );
 }
 

--- a/src/lib/app-db/migrationUpgrade.test.ts
+++ b/src/lib/app-db/migrationUpgrade.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { getAppDb, resetAppDbForTests } from "./connection";
+import { getBackupCredential, upsertBackupCredential } from "./backupCredentialRepository";
 import { LATEST_SCHEMA_VERSION } from "./migrations";
 import {
   getReconciliationSession,
@@ -414,6 +415,32 @@ describe("upgrading an existing database", () => {
     } finally {
       resetAppDbForTests();
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("adds sealed backup credentials to an older database (v21)", () => {
+    const { root, path } = olderDatabase();
+    const previousKey = process.env.SYNC_VAULT_KEY;
+    process.env.SYNC_VAULT_KEY = "test-vault-key";
+    try {
+      const db = getAppDb(path);
+
+      upsertBackupCredential(db, {
+        ref: "dest-1",
+        kind: "s3",
+        secret: { accessKeyId: "AKIA", secretAccessKey: "shh" },
+      });
+
+      expect(getBackupCredential(db, "dest-1")).toEqual({
+        accessKeyId: "AKIA",
+        secretAccessKey: "shh",
+      });
+      expect(getReconciliationSession(db, "sess-old")).not.toBeNull();
+    } finally {
+      resetAppDbForTests();
+      rmSync(root, { recursive: true, force: true });
+      if (previousKey === undefined) delete process.env.SYNC_VAULT_KEY;
+      else process.env.SYNC_VAULT_KEY = previousKey;
     }
   });
 

--- a/src/lib/app-db/migrationUpgrade.test.ts
+++ b/src/lib/app-db/migrationUpgrade.test.ts
@@ -20,6 +20,13 @@ import {
   listAutomations,
 } from "./automationRepository";
 import { createAutomationRun, listAutomationRuns } from "./automationRunRepository";
+import {
+  createBackupArtifact,
+  createBackupDestination,
+  listArtifactLocations,
+  listBackupDestinations,
+  recordArtifactLocation,
+} from "./backupRepository";
 
 /**
  * Upgrading a database that already holds real work.
@@ -370,6 +377,40 @@ describe("upgrading an existing database", () => {
       expect(automation.runningSince).toBeNull();
       expect(claimAutomation(db, "auto-1", "2026-08-26T18:00:00.000Z")).toBe(true);
       expect(getAutomation(db, "auto-1")?.runningSince).toBe("2026-08-26T18:00:00.000Z");
+    } finally {
+      resetAppDbForTests();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("adds backup storage to an older database (v20)", () => {
+    // Additive, and nothing reads these tables yet, so an install carrying real
+    // work should gain them without losing any of it.
+    const { root, path } = olderDatabase();
+    try {
+      const db = getAppDb(path);
+
+      const destination = createBackupDestination(db, {
+        name: "NAS volume",
+        kind: "local",
+        config: { version: 1, data: { path: "/mnt/backups" } },
+      });
+      const artifact = createBackupArtifact(db, {
+        kind: "budget",
+        checksumSha256: "c".repeat(64),
+        sizeBytes: 1024,
+      });
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey: "/mnt/backups/a.zip",
+      });
+
+      expect(listBackupDestinations(db)).toHaveLength(1);
+      expect(listArtifactLocations(db, artifact.id)).toHaveLength(1);
+
+      // The pre-existing reconciliation work is untouched.
+      expect(getReconciliationSession(db, "sess-old")).not.toBeNull();
     } finally {
       resetAppDbForTests();
       rmSync(root, { recursive: true, force: true });

--- a/src/lib/app-db/migrations.ts
+++ b/src/lib/app-db/migrations.ts
@@ -3,6 +3,7 @@ import {
   APP_META_TABLE_SQL,
   BACKUP_ARTIFACT_LOCATION_TABLE_SQL,
   BACKUP_ARTIFACT_TABLE_SQL,
+  BACKUP_CREDENTIAL_TABLE_SQL,
   BACKUP_DESTINATION_TABLE_SQL,
   BACKUP_INDEX_SQL,
   BACKUP_POLICY_TABLE_SQL,
@@ -38,7 +39,7 @@ import {
 import { KDF_VERSION_META_KEY, SALT_META_KEY, VERIFIER_META_KEY } from "./vaultMetaKeys";
 import { AppDbUnavailableError } from "./errors";
 
-export const LATEST_SCHEMA_VERSION = 20;
+export const LATEST_SCHEMA_VERSION = 21;
 
 type Migration = {
   version: number;
@@ -266,6 +267,12 @@ const MIGRATIONS: readonly Migration[] = [
       BACKUP_ARTIFACT_LOCATION_TABLE_SQL,
       ...BACKUP_INDEX_SQL,
     ],
+  },
+  {
+    version: 21,
+    // Sealed credentials for backup destinations and backup encryption
+    // (RD-077 / PR-047b). Additive.
+    statements: [BACKUP_CREDENTIAL_TABLE_SQL],
   },
 ];
 

--- a/src/lib/app-db/migrations.ts
+++ b/src/lib/app-db/migrations.ts
@@ -39,7 +39,7 @@ import {
 import { KDF_VERSION_META_KEY, SALT_META_KEY, VERIFIER_META_KEY } from "./vaultMetaKeys";
 import { AppDbUnavailableError } from "./errors";
 
-export const LATEST_SCHEMA_VERSION = 21;
+export const LATEST_SCHEMA_VERSION = 22;
 
 type Migration = {
   version: number;
@@ -273,6 +273,19 @@ const MIGRATIONS: readonly Migration[] = [
     // Sealed credentials for backup destinations and backup encryption
     // (RD-077 / PR-047b). Additive.
     statements: [BACKUP_CREDENTIAL_TABLE_SQL],
+  },
+  {
+    version: 22,
+    // A backup rule owns its own schedule (RD-077 / PR-047d): people think
+    // "back up nightly at 2am" as part of the rule, not as a separate object.
+    // The automation engine mirrors these into automations. Additive.
+    apply(db) {
+      addColumnIfMissing(db, "backup_policies", "schedule_kind", "text NOT NULL DEFAULT 'cron'");
+      addColumnIfMissing(db, "backup_policies", "cron_expression", "text");
+      addColumnIfMissing(db, "backup_policies", "interval_minutes", "integer");
+      addColumnIfMissing(db, "backup_policies", "timezone", "text NOT NULL DEFAULT 'UTC'");
+      addColumnIfMissing(db, "backup_policies", "scrub_enabled", "integer NOT NULL DEFAULT 1");
+    },
   },
 ];
 

--- a/src/lib/app-db/migrations.ts
+++ b/src/lib/app-db/migrations.ts
@@ -1,6 +1,11 @@
 import type { SqliteDatabase } from "./types";
 import {
   APP_META_TABLE_SQL,
+  BACKUP_ARTIFACT_LOCATION_TABLE_SQL,
+  BACKUP_ARTIFACT_TABLE_SQL,
+  BACKUP_DESTINATION_TABLE_SQL,
+  BACKUP_INDEX_SQL,
+  BACKUP_POLICY_TABLE_SQL,
   AUTOMATION_DEFINITION_TABLE_SQL,
   AUTOMATION_INDEX_SQL,
   AUTOMATION_RUN_TABLE_SQL,
@@ -33,7 +38,7 @@ import {
 import { KDF_VERSION_META_KEY, SALT_META_KEY, VERIFIER_META_KEY } from "./vaultMetaKeys";
 import { AppDbUnavailableError } from "./errors";
 
-export const LATEST_SCHEMA_VERSION = 19;
+export const LATEST_SCHEMA_VERSION = 20;
 
 type Migration = {
   version: number;
@@ -248,6 +253,19 @@ const MIGRATIONS: readonly Migration[] = [
     // so the column is added on its own, guarded, and is a no-op on a database
     // that got the corrected v18.
     apply: applyAutomationClaimColumn,
+  },
+  {
+    version: 20,
+    // Verified backup storage (RD-077 / PR-047a). Additive: four new tables and
+    // their indexes, read by nothing yet, so the upgrade is reversible by
+    // dropping them.
+    statements: [
+      BACKUP_DESTINATION_TABLE_SQL,
+      BACKUP_POLICY_TABLE_SQL,
+      BACKUP_ARTIFACT_TABLE_SQL,
+      BACKUP_ARTIFACT_LOCATION_TABLE_SQL,
+      ...BACKUP_INDEX_SQL,
+    ],
   },
 ];
 

--- a/src/lib/app-db/schema.ts
+++ b/src/lib/app-db/schema.ts
@@ -647,3 +647,24 @@ export const BACKUP_INDEX_SQL = [
   // One row per copy: the same artifact cannot be recorded twice in one place.
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_backup_locations_unique ON backup_artifact_locations(artifact_id, destination_id, object_key)",
 ] as const;
+
+// ── Backup credentials (RD-077 / PR-047b) ────────────────────────────────────
+//
+// Sealed secrets for backup destinations and backup encryption, kept apart from
+// the sync vault because they answer to a different question: "what does Bench
+// need to write this copy", not "what does Bench need to reach your budget".
+// Same sealing (AES-256-GCM under SYNC_VAULT_KEY); the key is never stored.
+export const BACKUP_CREDENTIAL_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS backup_credentials (
+  ref text PRIMARY KEY,
+  -- 's3' | 'passphrase'
+  kind text NOT NULL,
+  label text NOT NULL DEFAULT '',
+  ciphertext text NOT NULL,
+  iv text NOT NULL,
+  auth_tag text NOT NULL,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+`;
+

--- a/src/lib/app-db/schema.ts
+++ b/src/lib/app-db/schema.ts
@@ -522,3 +522,128 @@ export const AUTOMATION_INDEX_SQL = [
   // The scheduler's selection query: enabled automations ordered by when they are due.
   "CREATE INDEX IF NOT EXISTS idx_automation_definitions_due ON automation_definitions(enabled, next_run_at)",
 ] as const;
+
+// ── Verified backup & recovery (RD-077 / PR-047a) ────────────────────────────
+//
+// Four tables, because the relationships are genuinely not one-to-one and
+// flattening them would lose the distinction the feature exists to make:
+//
+//   * a *destination* fails independently of any run that used it, so its
+//     health lives with it;
+//   * an *artifact* is one thing that was backed up — its identity, contents
+//     and verification belong to it, not to the place it landed;
+//   * a *location* is one copy of that artifact in one destination. An artifact
+//     in two destinations is one artifact in two places, and a failure in one
+//     of them must never read as a failure of both.
+//
+// No table holds a secret. S3 credentials and any backup passphrase are vault
+// references; the envelope guard rejects credential-shaped fields in config.
+export const BACKUP_DESTINATION_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS backup_destinations (
+  id text PRIMARY KEY,
+  name text NOT NULL,
+  -- 'local' | 's3'
+  kind text NOT NULL,
+  enabled integer NOT NULL DEFAULT 1,
+  -- Non-secret settings: an absolute path, or bucket/region/endpoint/prefix.
+  config_json text NOT NULL,
+  -- Vault fingerprint for the destination's credentials. Never a secret.
+  credential_ref text,
+  last_success_at text,
+  last_failure_at text,
+  last_failure_reason text,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+`;
+
+export const BACKUP_POLICY_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS backup_policies (
+  id text PRIMARY KEY,
+  name text NOT NULL,
+  enabled integer NOT NULL DEFAULT 1,
+  -- 'budget' | 'app-db' | 'both'
+  contents text NOT NULL DEFAULT 'both',
+  -- Which connection/budget this policy backs up: JSON envelope.
+  source_ref_json text NOT NULL,
+  -- Ordered destination ids; a policy fans out to all of them.
+  destination_ids_json text NOT NULL DEFAULT '[]',
+  -- 'archive' | 'data' | 'deep'
+  verification_level text NOT NULL DEFAULT 'data',
+  -- 'none' | 'passphrase'
+  encryption text NOT NULL DEFAULT 'none',
+  -- Vault fingerprint for a remembered backup passphrase, so unattended scrub
+  -- can re-verify encrypted artifacts. Absent means scrub reports that it
+  -- cannot read them rather than pretending it did.
+  encryption_credential_ref text,
+  -- Tiers, minimum age, and the automatic-safety-point protection window.
+  retention_json text NOT NULL,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+`;
+
+export const BACKUP_ARTIFACT_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS backup_artifacts (
+  id text PRIMARY KEY,
+  -- Null for an artifact discovered from a manifest whose policy is gone: the
+  -- file is still real and still restorable, which is the whole point.
+  policy_id text REFERENCES backup_policies(id) ON DELETE SET NULL,
+  -- 'budget' | 'app-db'
+  kind text NOT NULL,
+  created_at text NOT NULL,
+  source_budget_id text,
+  source_budget_name text,
+  size_bytes integer NOT NULL DEFAULT 0,
+  -- Of the bytes as stored. When encrypted, plaintext_checksum_sha256 is of
+  -- the archive before encryption, so a restore can be checked end to end.
+  checksum_sha256 text NOT NULL,
+  plaintext_checksum_sha256 text,
+  encrypted integer NOT NULL DEFAULT 0,
+  -- KDF, salt and IV. Never the key.
+  encryption_json text,
+  -- 'manual' | 'auto' | 'daily' | 'weekly' | 'monthly' | 'yearly'
+  tier text NOT NULL DEFAULT 'manual',
+  -- A user pin is permanent; protected_until is the automatic safety point's
+  -- window, after which it prunes like anything else.
+  pinned integer NOT NULL DEFAULT 0,
+  protected_until text,
+  -- "before payee cleanup apply" — what makes the inventory read as history.
+  taken_before text,
+  verification_level text,
+  -- 'unverified' | 'passed' | 'failed'
+  verification_status text NOT NULL DEFAULT 'unverified',
+  verified_at text,
+  -- Counts, date range, integrity result, anomaly findings.
+  verification_json text,
+  manifest_version integer NOT NULL DEFAULT 1,
+  bench_version text,
+  notes text
+);
+`;
+
+export const BACKUP_ARTIFACT_LOCATION_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS backup_artifact_locations (
+  id text PRIMARY KEY,
+  artifact_id text NOT NULL REFERENCES backup_artifacts(id) ON DELETE CASCADE,
+  destination_id text REFERENCES backup_destinations(id) ON DELETE SET NULL,
+  -- Absolute path, or object key within the destination's prefix.
+  object_key text NOT NULL,
+  -- 'stored' | 'failed' | 'missing' | 'deleted'
+  status text NOT NULL DEFAULT 'stored',
+  uploaded_at text,
+  last_verified_at text,
+  last_error text,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+`;
+
+export const BACKUP_INDEX_SQL = [
+  "CREATE INDEX IF NOT EXISTS idx_backup_artifacts_policy_created ON backup_artifacts(policy_id, created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_backup_artifacts_kind_created ON backup_artifacts(kind, created_at)",
+  "CREATE INDEX IF NOT EXISTS idx_backup_locations_artifact ON backup_artifact_locations(artifact_id)",
+  "CREATE INDEX IF NOT EXISTS idx_backup_locations_destination ON backup_artifact_locations(destination_id, status)",
+  // One row per copy: the same artifact cannot be recorded twice in one place.
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_backup_locations_unique ON backup_artifact_locations(artifact_id, destination_id, object_key)",
+] as const;

--- a/src/lib/automation/bootstrap.ts
+++ b/src/lib/automation/bootstrap.ts
@@ -1,4 +1,6 @@
 import { registerBankSyncJobType } from "./jobs/bankSync";
+import { registerBackupJobType } from "./jobs/backup";
+import { registerBackupScrubJobType } from "./jobs/backupScrub";
 import { registerBudgetFileSyncJobType } from "./jobs/budgetFileSync";
 
 /**
@@ -13,4 +15,6 @@ import { registerBudgetFileSyncJobType } from "./jobs/budgetFileSync";
 export function ensureAutomationJobTypesRegistered(): void {
   registerBudgetFileSyncJobType();
   registerBankSyncJobType();
+  registerBackupJobType();
+  registerBackupScrubJobType();
 }

--- a/src/lib/automation/jobs/backup.test.ts
+++ b/src/lib/automation/jobs/backup.test.ts
@@ -236,6 +236,7 @@ describe("how a scrub is reported", () => {
     passed: 3,
     failed: 0,
     missing: 0,
+    skipped: 0,
     artifacts: [],
     ...overrides,
   });

--- a/src/lib/automation/jobs/backup.test.ts
+++ b/src/lib/automation/jobs/backup.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @jest-environment node
+ */
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import { listAutomations } from "@/lib/app-db/automationRepository";
+import {
+  createBackupDestination,
+  createBackupPolicy,
+  updateBackupPolicy,
+  type BackupPolicy,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { backupJobType } from "./backup";
+import { reconcileBackupAutomations } from "./backupReconcile";
+import { BACKUP_JOB_TYPE, BACKUP_SCRUB_JOB_TYPE } from "./backupType";
+import { backupScrubJobType } from "./backupScrub";
+
+describe("backup rules become automations", () => {
+  let root: string;
+  let db: SqliteDatabase;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "actual-bench-backup-job-"));
+    db = getAppDb(join(root, "metadata.sqlite"));
+    mkdirSync(join(root, "volume"), { recursive: true });
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policy(overrides: Record<string, unknown> = {}): BackupPolicy {
+    const destination = createBackupDestination(db, {
+      name: "Volume",
+      kind: "local",
+      config: { version: 1, data: { path: join(root, "volume") } },
+    });
+    return createBackupPolicy(db, {
+      name: "Nightly",
+      destinationIds: [destination.id],
+      sourceRef: { version: 1, data: { connectionFingerprint: "conn-1" } },
+      ...overrides,
+    });
+  }
+
+  it("creates one automation per rule, with the rule's own schedule", () => {
+    const created = policy({ cronExpression: "0 3 * * *", timezone: "Asia/Dubai" });
+
+    reconcileBackupAutomations(db, [created]);
+
+    const [automation] = listAutomations(db, { type: BACKUP_JOB_TYPE });
+    expect(automation).toMatchObject({
+      name: "Nightly",
+      scheduleKind: "cron",
+      cronExpression: "0 3 * * *",
+      timezone: "Asia/Dubai",
+      enabled: true,
+      credentialRef: "conn-1",
+    });
+    expect(automation.config.data.policyId).toBe(created.id);
+  });
+
+  it("is idempotent, because it runs every tick", () => {
+    const created = policy();
+    reconcileBackupAutomations(db, [created]);
+    reconcileBackupAutomations(db, [created]);
+    reconcileBackupAutomations(db, [created]);
+
+    expect(listAutomations(db, { type: BACKUP_JOB_TYPE })).toHaveLength(1);
+  });
+
+  it("follows a schedule change made on the Backups page", () => {
+    const created = policy();
+    reconcileBackupAutomations(db, [created]);
+
+    const changed = updateBackupPolicy(db, created.id, { cronExpression: "30 4 * * *" })!;
+    reconcileBackupAutomations(db, [changed]);
+
+    expect(listAutomations(db, { type: BACKUP_JOB_TYPE })[0].cronExpression).toBe("30 4 * * *");
+  });
+
+  it("turns an automation off with its rule but never back on", () => {
+    // Someone who pressed Pause on the Automations page must not have it undone
+    // by the next reconcile.
+    const created = policy();
+    reconcileBackupAutomations(db, [created]);
+    const [automation] = listAutomations(db, { type: BACKUP_JOB_TYPE });
+
+    const disabled = updateBackupPolicy(db, created.id, { enabled: false })!;
+    reconcileBackupAutomations(db, [disabled]);
+    expect(listAutomations(db, { type: BACKUP_JOB_TYPE })[0].enabled).toBe(false);
+
+    const reEnabled = updateBackupPolicy(db, created.id, { enabled: true })!;
+    reconcileBackupAutomations(db, [reEnabled]);
+    const after = listAutomations(db, { type: BACKUP_JOB_TYPE }).find(
+      (entry) => entry.id === automation.id
+    );
+    expect(after?.enabled).toBe(false);
+  });
+
+  it("disables the automation of a rule that no longer exists rather than deleting its history", () => {
+    const created = policy();
+    reconcileBackupAutomations(db, [created]);
+
+    reconcileBackupAutomations(db, []);
+
+    const [automation] = listAutomations(db, { type: BACKUP_JOB_TYPE });
+    expect(automation.enabled).toBe(false);
+  });
+
+  it("creates one scrub automation for the whole install, not one per rule", () => {
+    // Rules usually share destinations; a scrub per rule would re-read the same
+    // objects several times a week, which on metered storage costs money for no
+    // extra confidence.
+    reconcileBackupAutomations(db, [policy(), policy({ name: "Weekly off-site" })]);
+
+    expect(listAutomations(db, { type: BACKUP_SCRUB_JOB_TYPE })).toHaveLength(1);
+    expect(listAutomations(db, { type: BACKUP_SCRUB_JOB_TYPE })[0].cronExpression).toBe("0 4 * * 0");
+  });
+
+  it("does not create a scrub automation when no rule wants one", () => {
+    reconcileBackupAutomations(db, [policy({ scrubEnabled: false })]);
+    expect(listAutomations(db, { type: BACKUP_SCRUB_JOB_TYPE })).toHaveLength(0);
+  });
+});
+
+describe("how a backup run is reported", () => {
+  const base = {
+    policyId: "pol-1",
+    startedAt: "2026-08-27T02:00:00.000Z",
+    finishedAt: "2026-08-27T02:01:00.000Z",
+    trigger: "scheduled" as const,
+  };
+
+  const artifact = (overrides: Record<string, unknown> = {}) => ({
+    kind: "budget" as const,
+    artifactId: "art-1",
+    status: "stored" as const,
+    sizeBytes: 1024,
+    verification: { level: "data" as const, status: "passed" as const, findings: [], content: {}, checksumSha256: "x" },
+    destinations: [
+      { destinationId: "d1", destinationName: "Volume", status: "stored" as const, objectKey: "k", sizeBytes: 1024 },
+    ],
+    ...overrides,
+  });
+
+  it("counts a run that stored nothing as a failure", () => {
+    const rollup = backupJobType.summarize({
+      policyId: "pol-1",
+      prune: null,
+      run: { ...base, artifacts: [artifact({ status: "failed", destinations: [] })], stored: false, verified: false, message: "Volume is full" },
+    });
+
+    expect(rollup.outcome).toBe("failed");
+    expect(rollup.message).toBe("Volume is full");
+  });
+
+  it("does not hold a failed destination against the automation's health", () => {
+    // Pausing a backup because one of two destinations is unreachable would
+    // stop the copies that were still working.
+    const rollup = backupJobType.summarize({
+      policyId: "pol-1",
+      prune: null,
+      run: {
+        ...base,
+        stored: true,
+        verified: true,
+        artifacts: [
+          artifact({
+            destinations: [
+              { destinationId: "d1", destinationName: "Volume", status: "stored", objectKey: "k", sizeBytes: 1 },
+              { destinationId: "d2", destinationName: "Off-site", status: "failed", objectKey: null, sizeBytes: null, error: "timeout" },
+            ],
+          }),
+        ],
+      },
+    });
+
+    expect(rollup.outcome).toBe("partial");
+    expect(rollup.countsAsFailure).toBe(false);
+  });
+
+  it("reports a stored-but-unverified copy as partial, not as success", () => {
+    const rollup = backupJobType.summarize({
+      policyId: "pol-1",
+      prune: null,
+      run: {
+        ...base,
+        stored: true,
+        verified: false,
+        message: "The archive does not contain db.sqlite.",
+        artifacts: [
+          artifact({
+            verification: {
+              level: "data" as const,
+              status: "failed" as const,
+              findings: ["The archive does not contain db.sqlite."],
+              content: {},
+              checksumSha256: "x",
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(rollup.outcome).toBe("partial");
+    expect(rollup.message).toMatch(/db\.sqlite/);
+  });
+
+  it("mentions retention only when it removed something", () => {
+    const clean = backupJobType.summarize({
+      policyId: "pol-1",
+      prune: null,
+      run: { ...base, stored: true, verified: true, artifacts: [artifact()] },
+    });
+    expect(clean.message).toBe("Verified 1 copy(ies).");
+
+    const pruned = backupJobType.summarize({
+      policyId: "pol-1",
+      prune: { dryRun: false, kept: 7, failed: 0, freedBytes: 2048, pruned: [{ artifactId: "old", reason: "r", createdAt: "", kind: "budget", sizeBytes: 2048, locations: [], removed: true }] },
+      run: { ...base, stored: true, verified: true, artifacts: [artifact()] },
+    });
+    expect(pruned.message).toMatch(/removed 1 older/);
+  });
+});
+
+describe("how a scrub is reported", () => {
+  const destination = (overrides: Record<string, unknown> = {}) => ({
+    destinationId: "d1",
+    destinationName: "Volume",
+    checked: 3,
+    passed: 3,
+    failed: 0,
+    missing: 0,
+    artifacts: [],
+    ...overrides,
+  });
+
+  it("fails outright when damage is found, and means it", () => {
+    // Unlike a failed backup, repeating the scrub will not improve matters —
+    // the copies that exist are bad. Health should go red and stay red.
+    const rollup = backupScrubJobType.summarize({
+      destinations: [destination({ failed: 1, passed: 2 })],
+    });
+
+    expect(rollup.outcome).toBe("failed");
+    expect(rollup.countsAsFailure).toBeUndefined();
+  });
+
+  it("treats an unreachable destination as partial, since it says nothing about the copies", () => {
+    const rollup = backupScrubJobType.summarize({
+      destinations: [destination({ checked: 0, passed: 0, error: "Could not reach minio.lan" })],
+    });
+
+    expect(rollup.outcome).toBe("partial");
+    expect(rollup.countsAsFailure).toBe(false);
+  });
+
+  it("says there is nothing to verify rather than claiming success", () => {
+    const rollup = backupScrubJobType.summarize({
+      destinations: [destination({ checked: 0, passed: 0 })],
+    });
+
+    expect(rollup.outcome).toBe("no_changes");
+  });
+});

--- a/src/lib/automation/jobs/backup.ts
+++ b/src/lib/automation/jobs/backup.ts
@@ -1,0 +1,221 @@
+import { getAppDb } from "@/lib/app-db/connection";
+import {
+  getBackupPolicy,
+  listBackupArtifacts,
+  listBackupPolicies,
+} from "@/lib/app-db/backupRepository";
+import { prune, type PruneResult } from "@/lib/backup/prune";
+import { runBackup, type BackupRunResult } from "@/lib/backup/runBackup";
+import { registerAutomationJobType } from "../registry";
+import { BACKUP_JOB_TYPE } from "./backupType";
+import { reconcileBackupAutomations } from "./backupReconcile";
+import type { AutomationJobType, AutomationRunContext } from "../registry";
+import type { AutomationRunRollup, JsonEnvelope } from "@/lib/app-db/types";
+
+/**
+ * Backup as an automation job type (RD-077 / PR-047d).
+ *
+ * The engine already knows how to run something on a schedule, hold a lock,
+ * back off after failures, keep history and report health. A backup needs every
+ * one of those and none of them are backup-specific, so this type is thin on
+ * purpose: take the backup, apply retention, and translate the outcome into the
+ * engine's vocabulary.
+ *
+ * The translation is where the judgement lives, and one decision matters more
+ * than the rest: **a partial backup does not count against the failure streak.**
+ * The engine auto-pauses an automation that keeps failing, which is right for a
+ * sync hammering a server that rejects it, and wrong here — pausing a backup
+ * because one of two destinations is unreachable would stop the copies that
+ * were still working. A run that stored *nothing* is a plain failure and does
+ * count; anything that got a copy somewhere is reported honestly as partial and
+ * left running.
+ */
+
+export { BACKUP_JOB_TYPE } from "./backupType";
+
+export type BackupJobConfig = {
+  policyId: string;
+};
+
+export type BackupJobResult = {
+  policyId: string;
+  run: BackupRunResult;
+  prune: PruneResult | null;
+};
+
+export const backupJobType: AutomationJobType<BackupJobConfig, BackupJobResult> = {
+  type: BACKUP_JOB_TYPE,
+  label: "Backup",
+
+  validateConfig(raw: JsonEnvelope): BackupJobConfig {
+    const policyId = raw.data.policyId;
+    if (typeof policyId !== "string" || !policyId.trim()) {
+      throw new Error("This automation has no backup rule to run (policyId is missing).");
+    }
+    return { policyId: policyId.trim() };
+  },
+
+  async run(ctx: AutomationRunContext<BackupJobConfig>): Promise<BackupJobResult> {
+    const db = getAppDb();
+    const policy = getBackupPolicy(db, ctx.config.policyId);
+    if (!policy) {
+      throw new Error("This backup rule no longer exists.");
+    }
+
+    ctx.logger.info(`Backing up "${policy.name}" to ${policy.destinationIds.length} destination(s)`);
+    const result = await runBackup(db, policy, { trigger: "scheduled" });
+
+    for (const artifact of result.artifacts) {
+      for (const destination of artifact.destinations) {
+        if (destination.status === "failed") {
+          ctx.logger.warn(`${destination.destinationName}: ${destination.error ?? "failed"}`);
+        }
+      }
+      if (artifact.verification && artifact.verification.status !== "passed") {
+        ctx.logger.warn(
+          `The ${artifact.kind} copy was stored but did not verify: ${
+            artifact.verification.findings[0] ?? "unknown reason"
+          }`
+        );
+      }
+    }
+
+    // Retention runs only when something was actually stored. Pruning after a
+    // failed backup would delete an old copy to make room for one that does not
+    // exist — precisely when the old copies matter most.
+    let pruneResult: PruneResult | null = null;
+    if (result.stored) {
+      pruneResult = await prune(db, {
+        artifacts: listBackupArtifacts(db, { policyId: policy.id, limit: 500 }),
+        retention: policy.retention,
+      });
+      if (pruneResult.pruned.length > 0) {
+        ctx.logger.info(`Retention removed ${pruneResult.pruned.length} older copy(ies).`);
+      }
+    }
+
+    return { policyId: policy.id, run: result, prune: pruneResult };
+  },
+
+  summarize(result: BackupJobResult): AutomationRunRollup {
+    const { run } = result;
+    const copies = run.artifacts.flatMap((artifact) => artifact.destinations).filter(
+      (destination) => destination.status === "stored"
+    ).length;
+
+    if (!run.stored) {
+      return {
+        outcome: "failed",
+        itemCount: 0,
+        message: run.message ?? "No copy could be stored.",
+      };
+    }
+
+    const failedDestinations = run.artifacts
+      .flatMap((artifact) => artifact.destinations)
+      .filter((destination) => destination.status === "failed");
+
+    if (!run.verified) {
+      return {
+        outcome: "partial",
+        itemCount: copies,
+        message: run.message ?? "Stored, but Bench could not confirm the copy is readable.",
+        // Deliberately not a failure for streak purposes: an unreadable source
+        // budget would otherwise pause the very automation that keeps trying to
+        // capture it, and the copy on disk is still better than nothing.
+        countsAsFailure: false,
+      };
+    }
+
+    if (failedDestinations.length > 0) {
+      return {
+        outcome: "partial",
+        itemCount: copies,
+        message: `Stored ${copies} copy(ies); ${failedDestinations.length} destination(s) failed.`,
+        countsAsFailure: false,
+      };
+    }
+
+    const pruned = result.prune?.pruned.length ?? 0;
+    return {
+      outcome: "ok",
+      itemCount: copies,
+      message:
+        pruned > 0
+          ? `Verified ${copies} copy(ies); removed ${pruned} older one(s).`
+          : `Verified ${copies} copy(ies).`,
+    };
+  },
+
+  serializeResult(result: BackupJobResult): JsonEnvelope {
+    return {
+      version: 1,
+      data: {
+        policyId: result.policyId,
+        stored: result.run.stored,
+        verified: result.run.verified,
+        message: result.run.message ?? null,
+        artifacts: result.run.artifacts.map((artifact) => ({
+          kind: artifact.kind,
+          artifactId: artifact.artifactId,
+          status: artifact.status,
+          sizeBytes: artifact.sizeBytes,
+          verification: artifact.verification
+            ? {
+                level: artifact.verification.level,
+                status: artifact.verification.status,
+                findings: artifact.verification.findings.slice(0, 5),
+              }
+            : null,
+          destinations: artifact.destinations.map((destination) => ({
+            destinationId: destination.destinationId,
+            destinationName: destination.destinationName,
+            status: destination.status,
+            objectKey: destination.objectKey,
+            sizeBytes: destination.sizeBytes,
+            error: destination.error ?? null,
+          })),
+        })),
+        prune: result.prune
+          ? {
+              removed: result.prune.pruned.filter((entry) => entry.removed).length,
+              failed: result.prune.failed,
+              freedBytes: result.prune.freedBytes,
+              entries: result.prune.pruned.slice(0, 20).map((entry) => ({
+                artifactId: entry.artifactId,
+                reason: entry.reason,
+                createdAt: entry.createdAt,
+                sizeBytes: entry.sizeBytes,
+              })),
+            }
+          : null,
+      },
+    };
+  },
+
+  /**
+   * Backup rules are created and edited on the Backups page while the server is
+   * up, so their automations are reconciled every tick rather than at boot —
+   * the lesson Budget File Sync learned when a flow enrolled after startup
+   * silently never ran.
+   */
+  reconcile(db) {
+    reconcileBackupAutomations(db, listBackupPolicies(db));
+  },
+
+  // A backup constructs nothing through Bench's write pipeline: it reads a
+  // budget and stores bytes. Nothing to review, so no classification.
+};
+
+let registered = false;
+
+export function registerBackupJobType(): void {
+  if (registered) return;
+  registerAutomationJobType(backupJobType);
+  registered = true;
+}
+
+/** Test-only: allow re-registration after the registry is reset. */
+export function __resetBackupRegistrationForTests(): void {
+  registered = false;
+}

--- a/src/lib/automation/jobs/backupReconcile.ts
+++ b/src/lib/automation/jobs/backupReconcile.ts
@@ -1,0 +1,173 @@
+import { createAutomation, listAutomations, updateAutomation } from "@/lib/app-db/automationRepository";
+import { logger } from "@/lib/logger";
+import type { BackupPolicy } from "@/lib/app-db/backupRepository";
+import type { AutomationDefinition, SqliteDatabase } from "@/lib/app-db/types";
+import { BACKUP_JOB_TYPE, BACKUP_SCRUB_JOB_TYPE } from "./backupType";
+
+/**
+ * Keeping backup automations in step with backup rules (RD-077 / PR-047d).
+ *
+ * A backup rule is edited on the Backups page; the thing that makes it happen
+ * on time is an automation. Rather than making the user maintain both, the rule
+ * is the source of truth and its automation is derived — created when the rule
+ * appears, rescheduled when its schedule changes, disabled when the rule is.
+ *
+ * Two rules carried over from Budget File Sync's migration, both learned the
+ * hard way:
+ *
+ *   * It runs **every tick**, not at boot, because a rule created while the
+ *     server is up would otherwise silently never run until the next restart.
+ *   * Enabling only ever follows the rule *off*, never back *on*. Someone who
+ *     pressed Pause on the Automations page must not have it undone by the next
+ *     reconcile, and an automation the engine health-paused must stay paused.
+ */
+
+export type BackupReconcileSummary = {
+  created: string[];
+  updated: string[];
+};
+
+function policyIdOf(automation: AutomationDefinition): string | null {
+  const policyId = automation.config.data.policyId;
+  return typeof policyId === "string" ? policyId : null;
+}
+
+function scheduleFor(policy: BackupPolicy) {
+  return policy.scheduleKind === "interval"
+    ? {
+        scheduleKind: "interval" as const,
+        intervalMinutes: policy.intervalMinutes ?? 1440,
+        cronExpression: null,
+        timezone: policy.timezone,
+      }
+    : {
+        scheduleKind: "cron" as const,
+        cronExpression: policy.cronExpression ?? "0 2 * * *",
+        intervalMinutes: null,
+        timezone: policy.timezone,
+      };
+}
+
+function scheduleChanged(automation: AutomationDefinition, policy: BackupPolicy): boolean {
+  const wanted = scheduleFor(policy);
+  return (
+    automation.scheduleKind !== wanted.scheduleKind ||
+    automation.cronExpression !== wanted.cronExpression ||
+    automation.intervalMinutes !== wanted.intervalMinutes ||
+    automation.timezone !== wanted.timezone ||
+    automation.name !== policy.name
+  );
+}
+
+export function reconcileBackupAutomations(
+  db: SqliteDatabase,
+  policies: BackupPolicy[]
+): BackupReconcileSummary {
+  return db.transaction(() => reconcileInTransaction(db, policies))() as BackupReconcileSummary;
+}
+
+function reconcileInTransaction(db: SqliteDatabase, policies: BackupPolicy[]): BackupReconcileSummary {
+  const summary: BackupReconcileSummary = { created: [], updated: [] };
+
+  const existingByPolicy = new Map<string, AutomationDefinition>();
+  for (const automation of listAutomations(db, { type: BACKUP_JOB_TYPE })) {
+    const policyId = policyIdOf(automation);
+    if (policyId) existingByPolicy.set(policyId, automation);
+  }
+
+  for (const policy of policies) {
+    const existing = existingByPolicy.get(policy.id);
+
+    if (!existing) {
+      const created = createAutomation(db, {
+        type: BACKUP_JOB_TYPE,
+        name: policy.name,
+        enabled: policy.enabled,
+        executionMode: "server",
+        ...scheduleFor(policy),
+        targetRef: { version: 1, data: { policyId: policy.id } },
+        // The source connection's credential is what a run needs first, so the
+        // engine's fail-closed check has something real to check against.
+        credentialRef:
+          typeof policy.sourceRef.data.connectionFingerprint === "string"
+            ? policy.sourceRef.data.connectionFingerprint
+            : null,
+        config: { version: 1, data: { policyId: policy.id } },
+      });
+      summary.created.push(created.id);
+      continue;
+    }
+
+    const changes: Record<string, unknown> = {};
+    if (scheduleChanged(existing, policy)) {
+      Object.assign(changes, scheduleFor(policy), { name: policy.name });
+    }
+    // Off follows the rule; on never does.
+    if (!policy.enabled && existing.enabled) changes.enabled = false;
+
+    if (Object.keys(changes).length > 0) {
+      updateAutomation(db, existing.id, changes);
+      summary.updated.push(existing.id);
+    }
+  }
+
+  // A rule that has been deleted leaves its automation behind, which would run
+  // forever against nothing. Disable rather than delete, so its history stays
+  // readable and the user can see what happened to it.
+  const liveIds = new Set(policies.map((policy) => policy.id));
+  for (const [policyId, automation] of existingByPolicy) {
+    if (!liveIds.has(policyId) && automation.enabled) {
+      updateAutomation(db, automation.id, { enabled: false });
+      summary.updated.push(automation.id);
+    }
+  }
+
+  reconcileScrubAutomation(db, policies, summary);
+
+  if (summary.created.length > 0) {
+    logger.info(`[automation] backup rules: ${summary.created.length} automation(s) created`);
+  }
+
+  return summary;
+}
+
+/**
+ * One scrub automation for the whole install, not one per rule.
+ *
+ * Scrubbing is about destinations, and several rules usually share the same
+ * ones. A scrub per rule would re-read the same objects several times a week
+ * for no additional confidence — and on metered object storage, re-reading is
+ * the part that costs money.
+ */
+function reconcileScrubAutomation(
+  db: SqliteDatabase,
+  policies: BackupPolicy[],
+  summary: BackupReconcileSummary
+): void {
+  const wanted = policies.some((policy) => policy.enabled && policy.scrubEnabled);
+  const [existing] = listAutomations(db, { type: BACKUP_SCRUB_JOB_TYPE });
+
+  if (!existing) {
+    if (!wanted) return;
+    const created = createAutomation(db, {
+      type: BACKUP_SCRUB_JOB_TYPE,
+      name: "Verify stored backups",
+      enabled: true,
+      executionMode: "server",
+      scheduleKind: "cron",
+      // Sunday early morning: a weekly check that lands before the week's work
+      // starts, and well away from the nightly backup window.
+      cronExpression: "0 4 * * 0",
+      timezone: policies[0]?.timezone ?? "UTC",
+      targetRef: { version: 1, data: {} },
+      config: { version: 1, data: {} },
+    });
+    summary.created.push(created.id);
+    return;
+  }
+
+  if (!wanted && existing.enabled) {
+    updateAutomation(db, existing.id, { enabled: false });
+    summary.updated.push(existing.id);
+  }
+}

--- a/src/lib/automation/jobs/backupScrub.ts
+++ b/src/lib/automation/jobs/backupScrub.ts
@@ -1,0 +1,145 @@
+import { getAppDb } from "@/lib/app-db/connection";
+import { listBackupDestinations } from "@/lib/app-db/backupRepository";
+import { scrubAll, type ScrubResult } from "@/lib/backup/scrub";
+import { registerAutomationJobType } from "../registry";
+import { BACKUP_SCRUB_JOB_TYPE } from "./backupType";
+import type { AutomationJobType, AutomationRunContext } from "../registry";
+import type { AutomationRunRollup, JsonEnvelope } from "@/lib/app-db/types";
+
+/**
+ * Scrub as an automation job type (RD-077 / PR-047d).
+ *
+ * Weekly re-verification of the newest copies in every destination. This is the
+ * job that turns "we took a backup" into "there is a backup there right now,
+ * and it opens" — storage rots quietly, and nothing announces a truncated
+ * object or a bucket someone tidied up.
+ *
+ * Damage found is a **failure**, and this one does count against the streak,
+ * unlike a partial backup. The reasoning is the mirror image: a backup run
+ * failing means today's copy is missing, which tomorrow's run may fix on its
+ * own, whereas a scrub failing means copies that already exist are bad, and
+ * nothing about repeating the scrub will improve them. That deserves the
+ * automation's health going red and staying red until someone looks.
+ */
+
+export { BACKUP_SCRUB_JOB_TYPE } from "./backupType";
+
+export type BackupScrubConfig = {
+  /** Empty means every enabled destination. */
+  destinationIds: string[];
+  newest: number;
+  deepest: number;
+};
+
+export type BackupScrubResult = {
+  destinations: ScrubResult[];
+};
+
+export const backupScrubJobType: AutomationJobType<BackupScrubConfig, BackupScrubResult> = {
+  type: BACKUP_SCRUB_JOB_TYPE,
+  label: "Verify backups",
+
+  validateConfig(raw: JsonEnvelope): BackupScrubConfig {
+    const ids = Array.isArray(raw.data.destinationIds)
+      ? raw.data.destinationIds.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const newest = typeof raw.data.newest === "number" ? raw.data.newest : 3;
+    const deepest = typeof raw.data.deepest === "number" ? raw.data.deepest : 1;
+    return { destinationIds: ids, newest, deepest };
+  },
+
+  async run(ctx: AutomationRunContext<BackupScrubConfig>): Promise<BackupScrubResult> {
+    const db = getAppDb();
+    const ids =
+      ctx.config.destinationIds.length > 0
+        ? ctx.config.destinationIds
+        : listBackupDestinations(db)
+            .filter((destination) => destination.enabled)
+            .map((destination) => destination.id);
+
+    ctx.logger.info(`Verifying the newest ${ctx.config.newest} copies in ${ids.length} destination(s)`);
+    const destinations = await scrubAll(db, ids, {
+      newest: ctx.config.newest,
+      deepest: ctx.config.deepest,
+    });
+
+    for (const result of destinations) {
+      if (result.failed > 0 || result.missing > 0) {
+        ctx.logger.error(
+          `${result.destinationName}: ${result.failed} damaged, ${result.missing} missing.`
+        );
+      }
+    }
+
+    return { destinations };
+  },
+
+  summarize(result: BackupScrubResult): AutomationRunRollup {
+    const checked = result.destinations.reduce((total, entry) => total + entry.checked, 0);
+    const failed = result.destinations.reduce((total, entry) => total + entry.failed, 0);
+    const missing = result.destinations.reduce((total, entry) => total + entry.missing, 0);
+    const unreachable = result.destinations.filter((entry) => entry.error);
+
+    if (failed > 0 || missing > 0) {
+      return {
+        outcome: "failed",
+        itemCount: checked,
+        message: `${failed} damaged and ${missing} missing copy(ies) found.`,
+      };
+    }
+    if (unreachable.length > 0) {
+      return {
+        outcome: "partial",
+        itemCount: checked,
+        message: `${unreachable.length} destination(s) could not be reached: ${unreachable[0].error}`,
+        // A destination being unreachable this week says nothing about the
+        // copies in it; the next scrub will find out.
+        countsAsFailure: false,
+      };
+    }
+    if (checked === 0) {
+      return { outcome: "no_changes", itemCount: 0, message: "There are no stored copies to verify yet." };
+    }
+    return { outcome: "ok", itemCount: checked, message: `${checked} copy(ies) verified.` };
+  },
+
+  serializeResult(result: BackupScrubResult): JsonEnvelope {
+    return {
+      version: 1,
+      data: {
+        destinations: result.destinations.map((entry) => ({
+          destinationId: entry.destinationId,
+          destinationName: entry.destinationName,
+          checked: entry.checked,
+          passed: entry.passed,
+          failed: entry.failed,
+          missing: entry.missing,
+          error: entry.error ?? null,
+          artifacts: entry.artifacts.map((artifact) => ({
+            artifactId: artifact.artifactId,
+            objectKey: artifact.objectKey,
+            status: artifact.status,
+            level: artifact.level,
+            detail: artifact.detail,
+          })),
+        })),
+      },
+    };
+  },
+
+  // No `reconcile`: the scrub automation is created and retired alongside the
+  // backup rules it protects, in `reconcileBackupAutomations`.
+};
+
+let registered = false;
+
+export function registerBackupScrubJobType(): void {
+  if (registered) return;
+  registerAutomationJobType(backupScrubJobType);
+  registered = true;
+}
+
+/** Test-only: allow re-registration after the registry is reset. */
+export function __resetBackupScrubRegistrationForTests(): void {
+  registered = false;
+}

--- a/src/lib/automation/jobs/backupScrub.ts
+++ b/src/lib/automation/jobs/backupScrub.ts
@@ -127,6 +127,10 @@ export const backupScrubJobType: AutomationJobType<BackupScrubConfig, BackupScru
           passed: entry.passed,
           failed: entry.failed,
           missing: entry.missing,
+          // Kept in the stored result: a run that could not open two copies
+          // reads very differently from one that verified them all, and the
+          // history is where anyone looks afterwards.
+          skipped: entry.skipped,
           error: entry.error ?? null,
           artifacts: entry.artifacts.map((artifact) => ({
             artifactId: artifact.artifactId,

--- a/src/lib/automation/jobs/backupScrub.ts
+++ b/src/lib/automation/jobs/backupScrub.ts
@@ -78,6 +78,7 @@ export const backupScrubJobType: AutomationJobType<BackupScrubConfig, BackupScru
     const checked = result.destinations.reduce((total, entry) => total + entry.checked, 0);
     const failed = result.destinations.reduce((total, entry) => total + entry.failed, 0);
     const missing = result.destinations.reduce((total, entry) => total + entry.missing, 0);
+    const skipped = result.destinations.reduce((total, entry) => total + entry.skipped, 0);
     const unreachable = result.destinations.filter((entry) => entry.error);
 
     if (failed > 0 || missing > 0) {
@@ -100,6 +101,18 @@ export const backupScrubJobType: AutomationJobType<BackupScrubConfig, BackupScru
     if (checked === 0) {
       return { outcome: "no_changes", itemCount: 0, message: "There are no stored copies to verify yet." };
     }
+
+    // A copy Bench could not open is not a verified copy, and the run should
+    // not read as though everything was checked.
+    if (skipped > 0) {
+      return {
+        outcome: "partial",
+        itemCount: checked - skipped,
+        message: `${checked - skipped} copy(ies) verified; ${skipped} could not be opened (no stored passphrase).`,
+        countsAsFailure: false,
+      };
+    }
+
     return { outcome: "ok", itemCount: checked, message: `${checked} copy(ies) verified.` };
   },
 

--- a/src/lib/automation/jobs/backupType.ts
+++ b/src/lib/automation/jobs/backupType.ts
@@ -1,0 +1,10 @@
+/**
+ * The backup job types' identifiers, alone in their own module.
+ *
+ * Same reason as `budgetFileSyncType` and `bankSyncType`: the job type and
+ * anything that needs to name it would otherwise import each other, and such
+ * cycles work under Jest's CommonJS while failing under a bundler's module
+ * initialization order.
+ */
+export const BACKUP_JOB_TYPE = "backup";
+export const BACKUP_SCRUB_JOB_TYPE = "backup-scrub";

--- a/src/lib/backup/destinations/index.test.ts
+++ b/src/lib/backup/destinations/index.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import { upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import { createBackupDestination } from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { createDestinationAdapter } from "./index";
+
+describe("choosing an adapter", () => {
+  let root: string;
+  let db: SqliteDatabase;
+  const previousKey = process.env.SYNC_VAULT_KEY;
+
+  beforeEach(() => {
+    process.env.SYNC_VAULT_KEY = "test-vault-key";
+    root = mkdtempSync(join(tmpdir(), "actual-bench-dest-factory-"));
+    db = getAppDb(join(root, "metadata.sqlite"));
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+    if (previousKey === undefined) delete process.env.SYNC_VAULT_KEY;
+    else process.env.SYNC_VAULT_KEY = previousKey;
+  });
+
+  it("builds a local adapter with no credentials at all", () => {
+    const destination = createBackupDestination(db, {
+      name: "Volume",
+      kind: "local",
+      config: { version: 1, data: { path: join(root, "backups") } },
+    });
+
+    expect(createDestinationAdapter(db, destination).kind).toBe("local");
+  });
+
+  it("builds an S3 adapter from the sealed credential", () => {
+    upsertBackupCredential(db, {
+      ref: "dest-s3",
+      kind: "s3",
+      secret: { accessKeyId: "AKIA", secretAccessKey: "shh" },
+    });
+    const destination = createBackupDestination(db, {
+      id: "dest-s3",
+      name: "Off-site",
+      kind: "s3",
+      credentialRef: "dest-s3",
+      config: { version: 1, data: { bucket: "bench", region: "eu-west-1" } },
+    });
+
+    expect(createDestinationAdapter(db, destination).kind).toBe("s3");
+  });
+
+  it("refuses to try unauthenticated when the credential is gone", () => {
+    // Fail closed. Attempting anyway would turn a vault problem into a pile of
+    // 403s that read like a broken bucket, and the user would go looking in the
+    // wrong place.
+    const destination = createBackupDestination(db, {
+      name: "Off-site",
+      kind: "s3",
+      credentialRef: "vanished",
+      config: { version: 1, data: { bucket: "bench" } },
+    });
+
+    expect(() => createDestinationAdapter(db, destination)).toThrow(/Re-enter its access key/);
+  });
+
+  it("says the vault key changed rather than blaming the bucket", () => {
+    upsertBackupCredential(db, {
+      ref: "dest-s3",
+      kind: "s3",
+      secret: { accessKeyId: "AKIA", secretAccessKey: "shh" },
+    });
+    const destination = createBackupDestination(db, {
+      id: "dest-s3",
+      name: "Off-site",
+      kind: "s3",
+      credentialRef: "dest-s3",
+      config: { version: 1, data: { bucket: "bench" } },
+    });
+
+    process.env.SYNC_VAULT_KEY = "rotated";
+    expect(() => createDestinationAdapter(db, destination)).toThrow(/SYNC_VAULT_KEY/);
+  });
+});

--- a/src/lib/backup/destinations/index.ts
+++ b/src/lib/backup/destinations/index.ts
@@ -1,0 +1,60 @@
+import { getBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import type { S3Credentials } from "@/lib/app-db/backupCredentialRepository";
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { LocalDestinationAdapter } from "./local";
+import { S3DestinationAdapter } from "./s3";
+import { DestinationError, type DestinationAdapter } from "./types";
+
+export * from "./types";
+export { inspectLocalPath, LocalDestinationAdapter } from "./local";
+export { S3DestinationAdapter, readS3Config } from "./s3";
+
+function isS3Credentials(value: unknown): value is S3Credentials {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as S3Credentials).accessKeyId === "string" &&
+    typeof (value as S3Credentials).secretAccessKey === "string"
+  );
+}
+
+/**
+ * Build the adapter for a destination, resolving its credentials (server-only).
+ *
+ * Fails closed, in the same shape as the automation engine's credential
+ * handling: a destination that says it needs keys and cannot produce them is an
+ * error, never an unauthenticated attempt. The alternative — trying anyway —
+ * turns a vault misconfiguration into a pile of 403s that look like a broken
+ * bucket.
+ */
+export function createDestinationAdapter(
+  db: SqliteDatabase,
+  destination: BackupDestination
+): DestinationAdapter {
+  if (destination.kind === "local") return new LocalDestinationAdapter(destination);
+
+  if (!destination.credentialRef) {
+    throw new DestinationError(
+      `Destination "${destination.name}" has no stored credentials. Re-enter its access key to use it.`
+    );
+  }
+
+  let secret: unknown;
+  try {
+    secret = getBackupCredential(db, destination.credentialRef);
+  } catch (error) {
+    throw new DestinationError(
+      `Could not unseal credentials for "${destination.name}". Check that SYNC_VAULT_KEY is set to the same value it was when they were saved.`,
+      { cause: error }
+    );
+  }
+
+  if (!isS3Credentials(secret)) {
+    throw new DestinationError(
+      `Stored credentials for "${destination.name}" are missing or unusable. Re-enter its access key.`
+    );
+  }
+
+  return new S3DestinationAdapter(destination, secret);
+}

--- a/src/lib/backup/destinations/local.test.ts
+++ b/src/lib/backup/destinations/local.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import { inspectLocalPath, LocalDestinationAdapter } from "./local";
+import { DestinationError } from "./types";
+
+function destination(path: string): BackupDestination {
+  return {
+    id: "dest-1",
+    name: "Volume",
+    kind: "local",
+    enabled: true,
+    config: { version: 1, data: { path } },
+    credentialRef: null,
+    lastSuccessAt: null,
+    lastFailureAt: null,
+    lastFailureReason: null,
+    createdAt: "2026-08-27T00:00:00.000Z",
+    updatedAt: "2026-08-27T00:00:00.000Z",
+  };
+}
+
+describe("local destination", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bench-backup-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("round-trips bytes exactly", async () => {
+    const adapter = new LocalDestinationAdapter(destination(root));
+    const payload = Buffer.from("budget archive bytes");
+
+    const stored = await adapter.put("2026/august.zip", payload);
+    expect(stored.sizeBytes).toBe(payload.byteLength);
+    expect(await adapter.get("2026/august.zip")).toEqual(payload);
+  });
+
+  it("leaves no partial file behind when a write fails", async () => {
+    const adapter = new LocalDestinationAdapter(destination(root));
+    // A directory where the file should go makes the rename fail.
+    await adapter.put("blocked/keep.txt", Buffer.from("x"));
+
+    await expect(adapter.put("blocked", Buffer.from("y"))).rejects.toThrow(DestinationError);
+
+    // The failed write must not leave a `.partial` masquerading as a backup.
+    const listed = await adapter.list("");
+    expect(listed.map((entry) => entry.key)).toEqual(["blocked/keep.txt"]);
+  });
+
+  it("refuses to escape the destination root", async () => {
+    const adapter = new LocalDestinationAdapter(destination(join(root, "inner")));
+    await expect(adapter.put("../escaped.zip", Buffer.from("x"))).rejects.toThrow(
+      /outside the destination/
+    );
+  });
+
+  it("reports a missing object as missing rather than throwing", async () => {
+    const adapter = new LocalDestinationAdapter(destination(root));
+    expect(await adapter.head("nope.zip")).toBeNull();
+    await expect(adapter.get("nope.zip")).rejects.toThrow(DestinationError);
+  });
+
+  it("lists keys relative to the root, recursively", async () => {
+    const adapter = new LocalDestinationAdapter(destination(root));
+    await adapter.put("a/one.zip", Buffer.from("1"));
+    await adapter.put("a/two.zip", Buffer.from("2"));
+    await adapter.put("b/three.zip", Buffer.from("3"));
+
+    expect((await adapter.list("a/")).map((entry) => entry.key)).toEqual(["a/one.zip", "a/two.zip"]);
+    expect((await adapter.list("")).length).toBe(3);
+  });
+
+  it("passes a real write-read-delete test and cleans up after itself", async () => {
+    const adapter = new LocalDestinationAdapter(destination(root));
+    const result = await adapter.test();
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((check) => check.name === "Round trip")?.status).toBe("pass");
+    expect(await adapter.list("")).toEqual([]);
+  });
+});
+
+describe("inspecting a candidate path", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bench-backup-inspect-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rejects a relative path, which would depend on where the server started", async () => {
+    const { checks } = await inspectLocalPath("backups");
+    expect(checks[0].status).toBe("fail");
+    expect(checks[0].detail).toMatch(/absolute/i);
+  });
+
+  it("rejects a path that is a file", async () => {
+    const file = join(root, "not-a-dir");
+    writeFileSync(file, "x");
+    const { checks } = await inspectLocalPath(file);
+    expect(checks.some((check) => check.status === "fail")).toBe(true);
+  });
+
+  it("refuses the directory holding Bench's own database", async () => {
+    const previous = process.env.ACTUAL_BENCH_DB_PATH;
+    process.env.ACTUAL_BENCH_DB_PATH = join(root, "actual-bench.sqlite");
+    try {
+      const { checks } = await inspectLocalPath(root);
+      expect(checks[0].status).toBe("fail");
+      expect(checks[0].detail).toMatch(/Bench's own database/);
+    } finally {
+      if (previous === undefined) delete process.env.ACTUAL_BENCH_DB_PATH;
+      else process.env.ACTUAL_BENCH_DB_PATH = previous;
+    }
+  });
+
+  it("creates a missing directory rather than making the user do it by hand", async () => {
+    const target = join(root, "nested", "backups");
+    const { checks } = await inspectLocalPath(target);
+    expect(checks[0].status).toBe("pass");
+    expect(checks[0].detail).toMatch(/Created/);
+  });
+
+  it("warns rather than refuses when the path shares a device with Bench's data", async () => {
+    const previous = process.env.ACTUAL_BENCH_DB_PATH;
+    process.env.ACTUAL_BENCH_DB_PATH = join(root, "actual-bench.sqlite");
+    try {
+      // A `/data/backups`-shaped setup: legitimate, but not off-site.
+      const { checks } = await inspectLocalPath(join(root, "backups"));
+      expect(checks.some((check) => check.status === "fail")).toBe(false);
+      expect(checks.find((check) => check.name === "Separation")?.status).toBe("warn");
+    } finally {
+      if (previous === undefined) delete process.env.ACTUAL_BENCH_DB_PATH;
+      else process.env.ACTUAL_BENCH_DB_PATH = previous;
+    }
+  });
+});

--- a/src/lib/backup/destinations/local.ts
+++ b/src/lib/backup/destinations/local.ts
@@ -1,0 +1,314 @@
+import { createHash, randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import { access, mkdir, readFile, readdir, rm, stat, statfs, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { resolveAppDbPath } from "@/lib/app-db/connection";
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import {
+  DestinationError,
+  type DestinationAdapter,
+  type DestinationCheck,
+  type DestinationFacts,
+  type DestinationTestResult,
+  type StoredObject,
+} from "./types";
+
+/**
+ * A local path destination (RD-077 / PR-047b).
+ *
+ * This is the destination most self-hosters will actually use: a directory
+ * inside a mounted volume. It is the simplest adapter and the one with the most
+ * ways to be quietly wrong, so most of the code here is about refusing to be
+ * quietly wrong — a backup written into a container's ephemeral layer, or into
+ * the same directory as the database it is meant to protect, is worse than no
+ * backup, because it looks like one.
+ *
+ * The rules are graded on purpose:
+ *
+ *   * **Refuse** what cannot work or would corrupt something: a relative path,
+ *     a path that is a file, a path Bench cannot write to, and the directory
+ *     holding Bench's own database.
+ *   * **Warn** about what is legal but weak: a backup sitting on the same
+ *     device as Bench's data, or a volume with very little room left. A warning
+ *     teaches; a refusal here would block the legitimate `/data/backups` mount
+ *     that most people want.
+ */
+
+export type LocalDestinationConfig = {
+  path: string;
+};
+
+/** Refuse traversal: a key must stay inside the destination root. */
+function resolveKey(root: string, key: string): string {
+  const target = resolve(root, key);
+  const rel = relative(root, target);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new DestinationError(`Refusing to use a path outside the destination: ${key}`);
+  }
+  return target;
+}
+
+export function readLocalConfig(destination: BackupDestination): LocalDestinationConfig {
+  const path = destination.config.data.path;
+  if (typeof path !== "string" || path.trim().length === 0) {
+    throw new DestinationError("This destination has no path configured.");
+  }
+  return { path: resolve(path.trim()) };
+}
+
+/**
+ * Static validation of a candidate path, usable before a destination exists —
+ * the "add destination" form calls this so the user learns about a bad path
+ * while they are still typing it rather than at 3am when the backup runs.
+ */
+export async function inspectLocalPath(rawPath: string): Promise<{
+  checks: DestinationCheck[];
+  facts: DestinationFacts;
+}> {
+  const checks: DestinationCheck[] = [];
+  const trimmed = rawPath.trim();
+  const facts: DestinationFacts = { location: trimmed };
+
+  if (!trimmed) {
+    checks.push({ name: "Path", status: "fail", detail: "A path is required." });
+    return { checks, facts };
+  }
+  if (!isAbsolute(trimmed)) {
+    checks.push({
+      name: "Path",
+      status: "fail",
+      detail: "Use an absolute path. A relative one depends on where the server happened to start.",
+    });
+    return { checks, facts };
+  }
+
+  const path = resolve(trimmed);
+  facts.location = path;
+
+  const appDbPath = resolveAppDbPath();
+  const appDbDir = dirname(appDbPath);
+  if (path === appDbDir) {
+    checks.push({
+      name: "Path",
+      status: "fail",
+      detail:
+        "This is the directory holding Bench's own database. Backups must not share it — use a subdirectory such as " +
+        `${join(appDbDir, "backups")}.`,
+    });
+    return { checks, facts };
+  }
+
+  // Create it if missing: asking someone to mkdir by hand inside a container is
+  // a good way to end up with a destination that is never actually configured.
+  let created = false;
+  try {
+    const info = await stat(path).catch(() => null);
+    if (info && !info.isDirectory()) {
+      checks.push({ name: "Path", status: "fail", detail: "That path exists and is a file, not a directory." });
+      return { checks, facts };
+    }
+    if (!info) {
+      await mkdir(path, { recursive: true });
+      created = true;
+    }
+    checks.push({
+      name: "Path",
+      status: "pass",
+      detail: created ? `Created ${path}.` : `${path} exists.`,
+    });
+  } catch (error) {
+    checks.push({
+      name: "Path",
+      status: "fail",
+      detail: `Cannot create ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return { checks, facts };
+  }
+
+  try {
+    await access(path, constants.W_OK);
+    checks.push({ name: "Writable", status: "pass", detail: "Bench can write here." });
+  } catch {
+    checks.push({
+      name: "Writable",
+      status: "fail",
+      detail: "Bench cannot write here. Check the volume's ownership and permissions.",
+    });
+    return { checks, facts };
+  }
+
+  try {
+    const fsStat = await statfs(path);
+    const freeBytes = Number(fsStat.bavail) * Number(fsStat.bsize);
+    const totalBytes = Number(fsStat.blocks) * Number(fsStat.bsize);
+    facts.freeBytes = freeBytes;
+    facts.totalBytes = totalBytes;
+    checks.push({
+      name: "Free space",
+      status: freeBytes < 512 * 1024 * 1024 ? "warn" : "pass",
+      detail: `${formatBytes(freeBytes)} free of ${formatBytes(totalBytes)}.`,
+    });
+  } catch {
+    facts.freeBytes = null;
+    checks.push({
+      name: "Free space",
+      status: "warn",
+      detail: "Bench could not read free space for this filesystem.",
+    });
+  }
+
+  try {
+    const [here, appDb] = await Promise.all([stat(path), stat(appDbDir).catch(() => null)]);
+    const sameDevice = appDb ? here.dev === appDb.dev : null;
+    facts.sameDeviceAsAppDb = sameDevice;
+    if (sameDevice) {
+      checks.push({
+        name: "Separation",
+        status: "warn",
+        detail:
+          "This is the same device as Bench's own data. It protects you from mistakes, but not from losing the disk — add a second destination for that.",
+      });
+    } else if (sameDevice === false) {
+      checks.push({ name: "Separation", status: "pass", detail: "A different device from Bench's data." });
+    }
+  } catch {
+    // Separation is advisory; failing to determine it is not a failure.
+  }
+
+  return { checks, facts };
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "unknown";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+export class LocalDestinationAdapter implements DestinationAdapter {
+  readonly kind = "local" as const;
+  readonly destinationId: string;
+  readonly name: string;
+  private readonly root: string;
+
+  constructor(destination: BackupDestination) {
+    this.destinationId = destination.id;
+    this.name = destination.name;
+    this.root = readLocalConfig(destination).path;
+  }
+
+  async put(key: string, bytes: Uint8Array): Promise<StoredObject> {
+    const target = resolveKey(this.root, key);
+    await mkdir(dirname(target), { recursive: true });
+    // Write to a sibling temp file and rename: a half-written backup that looks
+    // complete is the one failure mode this whole feature exists to prevent.
+    const temp = `${target}.${randomBytes(6).toString("hex")}.partial`;
+    try {
+      await writeFile(temp, bytes);
+      const { rename } = await import("node:fs/promises");
+      await rename(temp, target);
+    } catch (error) {
+      await rm(temp, { force: true }).catch(() => {});
+      throw new DestinationError(
+        `Could not write ${key}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error, retryable: true }
+      );
+    }
+    const info = await stat(target);
+    return { key, sizeBytes: info.size, lastModified: info.mtime.toISOString() };
+  }
+
+  async get(key: string): Promise<Buffer> {
+    try {
+      return await readFile(resolveKey(this.root, key));
+    } catch (error) {
+      throw new DestinationError(
+        `Could not read ${key}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
+    }
+  }
+
+  async head(key: string): Promise<StoredObject | null> {
+    try {
+      const info = await stat(resolveKey(this.root, key));
+      if (!info.isFile()) return null;
+      return { key, sizeBytes: info.size, lastModified: info.mtime.toISOString() };
+    } catch {
+      return null;
+    }
+  }
+
+  async list(prefix: string): Promise<StoredObject[]> {
+    const results: StoredObject[] = [];
+    const walk = async (dir: string): Promise<void> => {
+      const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+      for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(full);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        const key = relative(this.root, full).split(sep).join("/");
+        if (prefix && !key.startsWith(prefix)) continue;
+        const info = await stat(full).catch(() => null);
+        if (!info) continue;
+        results.push({ key, sizeBytes: info.size, lastModified: info.mtime.toISOString() });
+      }
+    };
+    await walk(this.root);
+    return results.sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  async remove(key: string): Promise<void> {
+    await rm(resolveKey(this.root, key), { force: true });
+  }
+
+  async facts(): Promise<DestinationFacts> {
+    const { facts } = await inspectLocalPath(this.root);
+    return facts;
+  }
+
+  async test(): Promise<DestinationTestResult> {
+    const { checks, facts } = await inspectLocalPath(this.root);
+    if (checks.some((check) => check.status === "fail")) {
+      return { ok: false, checks, facts };
+    }
+
+    // The only test that means anything: write real bytes, read them back and
+    // compare the checksum. Permissions can pass while the volume is read-only
+    // underneath, and a destination that cannot round-trip is not a destination.
+    const probeKey = `.bench-destination-test-${randomBytes(6).toString("hex")}`;
+    const payload = randomBytes(64);
+    try {
+      await this.put(probeKey, payload);
+      const readBack = await this.get(probeKey);
+      const same =
+        createHash("sha256").update(payload).digest("hex") ===
+        createHash("sha256").update(readBack).digest("hex");
+      checks.push({
+        name: "Round trip",
+        status: same ? "pass" : "fail",
+        detail: same
+          ? "Wrote a test file, read it back and the checksums matched."
+          : "The test file read back with different contents.",
+      });
+    } catch (error) {
+      checks.push({
+        name: "Round trip",
+        status: "fail",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      await this.remove(probeKey).catch(() => {});
+    }
+
+    return { ok: !checks.some((check) => check.status === "fail"), checks, facts };
+  }
+}

--- a/src/lib/backup/destinations/s3.test.ts
+++ b/src/lib/backup/destinations/s3.test.ts
@@ -94,6 +94,17 @@ describe("S3 destination behaviour", () => {
     expect(await adapter.head("gone.zip")).toBeNull();
   });
 
+  it("refuses to call an object gone when the bucket only refused to answer", async () => {
+    // A 403 is "you may not look", not "it is not there". Reading it as absence
+    // would have scrub reporting copies missing that are sitting safely in the
+    // bucket, and a refused delete recorded as done.
+    mockFetch(() => new Response("<Error><Code>AccessDenied</Code></Error>", { status: 403 }));
+    const adapter = new S3DestinationAdapter(destination({ bucket: "bench" }), credentials);
+
+    await expect(adapter.head("private.zip")).rejects.toThrow(/AccessDenied/);
+    await expect(adapter.remove("private.zip")).rejects.toThrow(/AccessDenied/);
+  });
+
   it("surfaces the provider's own error text, which is the only useful diagnostic", async () => {
     mockFetch(
       () =>

--- a/src/lib/backup/destinations/s3.test.ts
+++ b/src/lib/backup/destinations/s3.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment node
+ */
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import type { JsonObject } from "@/lib/app-db/types";
+import { S3DestinationAdapter } from "./s3";
+import { DestinationError } from "./types";
+
+function destination(config: JsonObject): BackupDestination {
+  return {
+    id: "dest-s3",
+    name: "Off-site",
+    kind: "s3",
+    enabled: true,
+    config: { version: 1, data: config },
+    credentialRef: "cred-1",
+    lastSuccessAt: null,
+    lastFailureAt: null,
+    lastFailureReason: null,
+    createdAt: "2026-08-27T00:00:00.000Z",
+    updatedAt: "2026-08-27T00:00:00.000Z",
+  };
+}
+
+const credentials = { accessKeyId: "AKIA", secretAccessKey: "secret" };
+
+type Call = { url: string; method: string; headers: Record<string, string>; body: unknown };
+
+function mockFetch(handler: (call: Call) => Response): { calls: Call[] } {
+  const calls: Call[] = [];
+  global.fetch = jest.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const call: Call = {
+      url: String(url),
+      method: init?.method ?? "GET",
+      headers: (init?.headers ?? {}) as Record<string, string>,
+      body: init?.body,
+    };
+    calls.push(call);
+    return handler(call);
+  }) as unknown as typeof fetch;
+  return { calls };
+}
+
+const originalFetch = global.fetch;
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("S3 destination addressing", () => {
+  it("uses path style against a custom endpoint, which is what self-hosted providers need", async () => {
+    const { calls } = mockFetch(() => new Response("", { status: 200 }));
+    const adapter = new S3DestinationAdapter(
+      destination({ bucket: "bench", endpoint: "https://minio.lan:9000", prefix: "budgets" }),
+      credentials
+    );
+
+    await adapter.put("2026/august.zip", Buffer.from("x"));
+
+    expect(calls[0].url).toBe("https://minio.lan:9000/bench/budgets/2026/august.zip");
+    expect(calls[0].headers.host).toBe("minio.lan:9000");
+  });
+
+  it("uses virtual-host style against AWS", async () => {
+    const { calls } = mockFetch(() => new Response("", { status: 200 }));
+    const adapter = new S3DestinationAdapter(
+      destination({ bucket: "bench", region: "eu-west-1" }),
+      credentials
+    );
+
+    await adapter.put("a.zip", Buffer.from("x"));
+
+    expect(calls[0].url).toBe("https://bench.s3.eu-west-1.amazonaws.com/a.zip");
+  });
+
+  it("signs every request", async () => {
+    const { calls } = mockFetch(() => new Response("", { status: 200 }));
+    const adapter = new S3DestinationAdapter(destination({ bucket: "bench" }), credentials);
+
+    await adapter.put("a.zip", Buffer.from("payload"));
+
+    expect(calls[0].headers.Authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIA\//);
+    // The content hash is of the real body, not the empty-payload constant.
+    expect(calls[0].headers["x-amz-content-sha256"]).not.toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+});
+
+describe("S3 destination behaviour", () => {
+  it("reports a missing object as missing instead of failing the run", async () => {
+    mockFetch(() => new Response("", { status: 404 }));
+    const adapter = new S3DestinationAdapter(destination({ bucket: "bench" }), credentials);
+
+    expect(await adapter.head("gone.zip")).toBeNull();
+  });
+
+  it("surfaces the provider's own error text, which is the only useful diagnostic", async () => {
+    mockFetch(
+      () =>
+        new Response(
+          "<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match</Message></Error>",
+          { status: 403 }
+        )
+    );
+    const adapter = new S3DestinationAdapter(destination({ bucket: "bench" }), credentials);
+
+    await expect(adapter.get("a.zip")).rejects.toThrow(/SignatureDoesNotMatch/);
+  });
+
+  it("marks server errors retryable and permission errors not", async () => {
+    mockFetch(() => new Response("<Error><Code>InternalError</Code></Error>", { status: 503 }));
+    const adapter = new S3DestinationAdapter(destination({ bucket: "bench" }), credentials);
+    await expect(adapter.get("a.zip")).rejects.toMatchObject({ retryable: true });
+
+    mockFetch(() => new Response("<Error><Code>AccessDenied</Code></Error>", { status: 403 }));
+    await expect(adapter.get("a.zip")).rejects.toMatchObject({ retryable: false });
+  });
+
+  it("pages through a truncated listing and strips the prefix from keys", async () => {
+    let page = 0;
+    mockFetch(() => {
+      page += 1;
+      return page === 1
+        ? new Response(
+            `<ListBucketResult><IsTruncated>true</IsTruncated><NextContinuationToken>tok</NextContinuationToken>
+             <Contents><Key>budgets/one.zip</Key><Size>10</Size><LastModified>2026-08-01T00:00:00.000Z</LastModified></Contents>
+             </ListBucketResult>`,
+            { status: 200 }
+          )
+        : new Response(
+            `<ListBucketResult><IsTruncated>false</IsTruncated>
+             <Contents><Key>budgets/two.zip</Key><Size>20</Size><LastModified>2026-08-02T00:00:00.000Z</LastModified></Contents>
+             </ListBucketResult>`,
+            { status: 200 }
+          );
+    });
+
+    const adapter = new S3DestinationAdapter(
+      destination({ bucket: "bench", prefix: "budgets" }),
+      credentials
+    );
+    const listed = await adapter.list("");
+
+    expect(listed.map((entry) => entry.key)).toEqual(["one.zip", "two.zip"]);
+    expect(listed[1].sizeBytes).toBe(20);
+  });
+
+  it("treats a bucket that will not delete as a warning, not a failure", async () => {
+    // Immutable / write-once buckets are a real configuration. Backups still
+    // work there; only retention cannot prune, and the user should be told that
+    // rather than being blocked from using the destination at all.
+    mockFetch((call) =>
+      call.method === "DELETE"
+        ? new Response("<Error><Code>AccessDenied</Code></Error>", { status: 405 })
+        : new Response(Buffer.from("probe"), { status: 200 })
+    );
+
+    const adapter = new S3DestinationAdapter(destination({ bucket: "bench" }), credentials);
+    // Read-back compares checksums, so a fixed body fails that check; assert on
+    // the delete check specifically.
+    const result = await adapter.test();
+
+    expect(result.checks.find((check) => check.name === "Delete")?.status).toBe("warn");
+    expect(result.checks.find((check) => check.name === "Delete")?.detail).toMatch(/retention/);
+  });
+
+  it("says which destination could not be reached when the network fails", async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND minio.lan");
+    }) as unknown as typeof fetch;
+
+    const adapter = new S3DestinationAdapter(
+      destination({ bucket: "bench", endpoint: "https://minio.lan:9000" }),
+      credentials
+    );
+
+    await expect(adapter.put("a.zip", Buffer.from("x"))).rejects.toThrow(DestinationError);
+    await expect(adapter.put("a.zip", Buffer.from("x"))).rejects.toThrow(/minio\.lan:9000/);
+  });
+});

--- a/src/lib/backup/destinations/s3.ts
+++ b/src/lib/backup/destinations/s3.ts
@@ -1,0 +1,308 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import type { S3Credentials } from "@/lib/app-db/backupCredentialRepository";
+import { EMPTY_PAYLOAD_SHA256, encodeS3Path, signS3Request } from "./sigv4";
+import {
+  DestinationError,
+  type DestinationAdapter,
+  type DestinationCheck,
+  type DestinationFacts,
+  type DestinationTestResult,
+  type StoredObject,
+} from "./types";
+
+/**
+ * An S3-compatible destination (RD-077 / PR-047b).
+ *
+ * "S3-compatible" rather than "AWS S3" throughout: the same four verbs reach
+ * MinIO on a NAS, Backblaze B2, Cloudflare R2, Wasabi and Garage, and for a
+ * self-hosted budget tool those are more likely than AWS itself. Nothing here
+ * assumes an amazonaws.com hostname, and path-style addressing is the default
+ * whenever a custom endpoint is given, because most of those providers need it.
+ */
+
+export type S3DestinationConfig = {
+  bucket: string;
+  region: string;
+  endpoint: string | null;
+  prefix: string;
+  forcePathStyle: boolean;
+  storageClass: string | null;
+};
+
+export function readS3Config(destination: BackupDestination): S3DestinationConfig {
+  const data = destination.config.data as Record<string, unknown>;
+  const bucket = typeof data.bucket === "string" ? data.bucket.trim() : "";
+  if (!bucket) throw new DestinationError("This destination has no bucket configured.");
+  const endpoint = typeof data.endpoint === "string" && data.endpoint.trim() ? data.endpoint.trim() : null;
+  return {
+    bucket,
+    region: typeof data.region === "string" && data.region.trim() ? data.region.trim() : "us-east-1",
+    endpoint,
+    prefix: normalizePrefix(typeof data.prefix === "string" ? data.prefix : ""),
+    // Custom endpoints are overwhelmingly path-style; virtual-host style against
+    // a self-hosted MinIO needs wildcard DNS that almost nobody sets up.
+    forcePathStyle: data.forcePathStyle === undefined ? endpoint !== null : data.forcePathStyle === true,
+    storageClass:
+      typeof data.storageClass === "string" && data.storageClass.trim() ? data.storageClass.trim() : null,
+  };
+}
+
+function normalizePrefix(prefix: string): string {
+  const trimmed = prefix.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  return trimmed ? `${trimmed}/` : "";
+}
+
+/** Read a single XML element's text, without pulling in a parser. */
+function tagValue(xml: string, tag: string): string | null {
+  const match = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml);
+  return match ? decodeXml(match[1]) : null;
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+export class S3DestinationAdapter implements DestinationAdapter {
+  readonly kind = "s3" as const;
+  readonly destinationId: string;
+  readonly name: string;
+  private readonly config: S3DestinationConfig;
+  private readonly credentials: S3Credentials;
+
+  constructor(destination: BackupDestination, credentials: S3Credentials) {
+    this.destinationId = destination.id;
+    this.name = destination.name;
+    this.config = readS3Config(destination);
+    this.credentials = credentials;
+  }
+
+  private get host(): string {
+    if (this.config.endpoint) {
+      const url = new URL(
+        this.config.endpoint.includes("://") ? this.config.endpoint : `https://${this.config.endpoint}`
+      );
+      return this.config.forcePathStyle ? url.host : `${this.config.bucket}.${url.host}`;
+    }
+    return this.config.forcePathStyle
+      ? `s3.${this.config.region}.amazonaws.com`
+      : `${this.config.bucket}.s3.${this.config.region}.amazonaws.com`;
+  }
+
+  private get scheme(): string {
+    if (!this.config.endpoint) return "https";
+    if (!this.config.endpoint.includes("://")) return "https";
+    return new URL(this.config.endpoint).protocol.replace(":", "");
+  }
+
+  /** Full object key including the configured prefix. */
+  private fullKey(key: string): string {
+    return `${this.config.prefix}${key.replace(/^\/+/, "")}`;
+  }
+
+  private async send(options: {
+    method: string;
+    key?: string;
+    query?: Record<string, string | undefined>;
+    body?: Uint8Array;
+    extraHeaders?: Record<string, string>;
+    expectMissing?: boolean;
+  }): Promise<Response> {
+    const objectPath = options.key === undefined ? "" : encodeS3Path(this.fullKey(options.key));
+    const path = this.config.forcePathStyle
+      ? `/${this.config.bucket}${objectPath}`
+      : objectPath || "/";
+
+    const body = options.body;
+    const payloadSha256 = body
+      ? createHash("sha256").update(body).digest("hex")
+      : EMPTY_PAYLOAD_SHA256;
+
+    const headers: Record<string, string> = { host: this.host, ...options.extraHeaders };
+    if (body) headers["content-length"] = String(body.byteLength);
+
+    const signed = signS3Request({
+      method: options.method,
+      path,
+      query: options.query,
+      headers,
+      payloadSha256,
+      region: this.config.region,
+      credentials: this.credentials,
+    });
+
+    const query = Object.entries(options.query ?? {}).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined
+    );
+    const search = query.length
+      ? `?${query.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&")}`
+      : "";
+    const url = `${this.scheme}://${this.host}${path}${search}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: options.method,
+        headers: signed.headers,
+        body: body ? Buffer.from(body) : undefined,
+      });
+    } catch (error) {
+      throw new DestinationError(
+        `Could not reach ${this.host}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error, retryable: true }
+      );
+    }
+
+    if (response.ok) return response;
+    if (options.expectMissing && (response.status === 404 || response.status === 403)) return response;
+
+    const text = await response.text().catch(() => "");
+    const code = tagValue(text, "Code");
+    const message = tagValue(text, "Message");
+    throw new DestinationError(
+      `${options.method} failed with ${response.status}${code ? ` (${code})` : ""}${
+        message ? `: ${message}` : ""
+      }`,
+      // 5xx and throttling are worth retrying; a 403 will be a 403 forever.
+      { retryable: response.status >= 500 || response.status === 429 }
+    );
+  }
+
+  async put(key: string, bytes: Uint8Array, contentType = "application/octet-stream"): Promise<StoredObject> {
+    const extraHeaders: Record<string, string> = { "content-type": contentType };
+    if (this.config.storageClass) extraHeaders["x-amz-storage-class"] = this.config.storageClass;
+    await this.send({ method: "PUT", key, body: bytes, extraHeaders });
+    return { key, sizeBytes: bytes.byteLength, lastModified: new Date().toISOString() };
+  }
+
+  async get(key: string): Promise<Buffer> {
+    const response = await this.send({ method: "GET", key });
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async head(key: string): Promise<StoredObject | null> {
+    const response = await this.send({ method: "HEAD", key, expectMissing: true });
+    if (!response.ok) return null;
+    const size = Number(response.headers.get("content-length") ?? "0");
+    const modified = response.headers.get("last-modified");
+    return {
+      key,
+      sizeBytes: Number.isFinite(size) ? size : 0,
+      lastModified: modified ? new Date(modified).toISOString() : null,
+    };
+  }
+
+  async list(prefix: string): Promise<StoredObject[]> {
+    const results: StoredObject[] = [];
+    let continuationToken: string | undefined;
+
+    do {
+      const response = await this.send({
+        method: "GET",
+        query: {
+          "list-type": "2",
+          prefix: `${this.config.prefix}${prefix}`,
+          "max-keys": "1000",
+          "continuation-token": continuationToken,
+        },
+      });
+      const xml = await response.text();
+
+      for (const match of xml.matchAll(/<Contents>([\s\S]*?)<\/Contents>/g)) {
+        const entry = match[1];
+        const key = tagValue(entry, "Key");
+        if (!key) continue;
+        results.push({
+          // Report keys relative to the prefix so callers never have to know
+          // about it — the prefix is where the destination lives, not part of
+          // an artifact's identity.
+          key: key.startsWith(this.config.prefix) ? key.slice(this.config.prefix.length) : key,
+          sizeBytes: Number(tagValue(entry, "Size") ?? "0"),
+          lastModified: tagValue(entry, "LastModified"),
+        });
+      }
+
+      continuationToken =
+        tagValue(xml, "IsTruncated") === "true"
+          ? tagValue(xml, "NextContinuationToken") ?? undefined
+          : undefined;
+    } while (continuationToken);
+
+    return results;
+  }
+
+  async remove(key: string): Promise<void> {
+    await this.send({ method: "DELETE", key, expectMissing: true });
+  }
+
+  async facts(): Promise<DestinationFacts> {
+    return {
+      location: `${this.config.bucket}/${this.config.prefix}`.replace(/\/$/, ""),
+      // Object storage has no meaningful free-space number, and inventing one
+      // would be worse than admitting there isn't one.
+      freeBytes: null,
+      totalBytes: null,
+    };
+  }
+
+  async test(): Promise<DestinationTestResult> {
+    const checks: DestinationCheck[] = [];
+    const facts = await this.facts();
+
+    const probeKey = `.bench-destination-test-${randomBytes(6).toString("hex")}`;
+    const payload = randomBytes(64);
+
+    try {
+      await this.put(probeKey, payload);
+      checks.push({ name: "Write", status: "pass", detail: `Wrote a test object to ${facts.location}.` });
+    } catch (error) {
+      checks.push({
+        name: "Write",
+        status: "fail",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      return { ok: false, checks, facts };
+    }
+
+    try {
+      const readBack = await this.get(probeKey);
+      const same =
+        createHash("sha256").update(payload).digest("hex") ===
+        createHash("sha256").update(readBack).digest("hex");
+      checks.push({
+        name: "Read back",
+        status: same ? "pass" : "fail",
+        detail: same ? "Read the test object back and the checksums matched." : "The test object read back with different contents.",
+      });
+    } catch (error) {
+      checks.push({
+        name: "Read back",
+        status: "fail",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    try {
+      await this.remove(probeKey);
+      checks.push({ name: "Delete", status: "pass", detail: "Removed the test object." });
+    } catch (error) {
+      // Write-without-delete is a real and sometimes deliberate configuration
+      // (immutable buckets). It is a warning because backups still work; only
+      // retention will not be able to prune.
+      checks.push({
+        name: "Delete",
+        status: "warn",
+        detail: `Bench could not delete its test object, so retention will not be able to prune here: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      });
+    }
+
+    return { ok: !checks.some((check) => check.status === "fail"), checks, facts };
+  }
+}

--- a/src/lib/backup/destinations/s3.ts
+++ b/src/lib/backup/destinations/s3.ts
@@ -159,7 +159,11 @@ export class S3DestinationAdapter implements DestinationAdapter {
     }
 
     if (response.ok) return response;
-    if (options.expectMissing && (response.status === 404 || response.status === 403)) return response;
+    // Only 404 counts as absent. A 403 means Bench was refused, and treating
+    // that as "gone" is the dangerous direction: scrub would report copies as
+    // missing that are sitting safely in the bucket, and a delete that was
+    // refused would be recorded as done.
+    if (options.expectMissing && response.status === 404) return response;
 
     const text = await response.text().catch(() => "");
     const code = tagValue(text, "Code");

--- a/src/lib/backup/destinations/sigv4.test.ts
+++ b/src/lib/backup/destinations/sigv4.test.ts
@@ -1,0 +1,87 @@
+import { EMPTY_PAYLOAD_SHA256, encodeS3Path, signS3Request, uriEncode } from "./sigv4";
+
+// AWS's published worked example for a signed GET Object request. Hand-written
+// signing is only defensible if it is checked against the authority, and this
+// vector is that check: if a future refactor changes a byte of the canonical
+// form, the signature stops matching and this fails.
+const AWS_EXAMPLE = {
+  accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+  secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  region: "us-east-1",
+  date: new Date("2013-05-24T00:00:00Z"),
+};
+
+describe("SigV4 signing", () => {
+  it("reproduces AWS's published GET Object signature", () => {
+    const signed = signS3Request({
+      method: "GET",
+      path: "/test.txt",
+      headers: { host: "examplebucket.s3.amazonaws.com", Range: "bytes=0-9" },
+      payloadSha256: EMPTY_PAYLOAD_SHA256,
+      region: AWS_EXAMPLE.region,
+      credentials: {
+        accessKeyId: AWS_EXAMPLE.accessKeyId,
+        secretAccessKey: AWS_EXAMPLE.secretAccessKey,
+      },
+      now: AWS_EXAMPLE.date,
+    });
+
+    expect(signed.signature).toBe(
+      "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
+    );
+    expect(signed.headers.Authorization).toContain(
+      "Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request"
+    );
+  });
+
+  it("signs a session token when one is present, so temporary credentials work", () => {
+    const signed = signS3Request({
+      method: "PUT",
+      path: "/backups/x.zip",
+      headers: { host: "bucket.example.com" },
+      payloadSha256: EMPTY_PAYLOAD_SHA256,
+      region: "us-east-1",
+      credentials: { accessKeyId: "a", secretAccessKey: "b", sessionToken: "session-token" },
+      now: AWS_EXAMPLE.date,
+    });
+
+    expect(signed.headers["x-amz-security-token"]).toBe("session-token");
+    expect(signed.headers.Authorization).toContain("x-amz-security-token");
+  });
+
+  it("changes when any part of the request changes", () => {
+    const base = {
+      method: "PUT",
+      headers: { host: "bucket.example.com" },
+      payloadSha256: EMPTY_PAYLOAD_SHA256,
+      region: "us-east-1",
+      credentials: { accessKeyId: "a", secretAccessKey: "b" },
+      now: AWS_EXAMPLE.date,
+    } as const;
+
+    const one = signS3Request({ ...base, path: "/a.zip" }).signature;
+    const two = signS3Request({ ...base, path: "/b.zip" }).signature;
+    const three = signS3Request({
+      ...base,
+      path: "/a.zip",
+      payloadSha256: "0".repeat(64),
+    }).signature;
+
+    expect(new Set([one, two, three]).size).toBe(3);
+  });
+});
+
+describe("key encoding", () => {
+  it("encodes each segment but keeps slashes as separators", () => {
+    expect(encodeS3Path("bench/Household budget/2026-08-27.zip")).toBe(
+      "/bench/Household%20budget/2026-08-27.zip"
+    );
+  });
+
+  it("leaves RFC 3986 unreserved characters alone and encodes everything else", () => {
+    expect(uriEncode("a-b_c.d~e")).toBe("a-b_c.d~e");
+    expect(uriEncode("a+b&c=d")).toBe("a%2Bb%26c%3Dd");
+    // Non-ASCII is encoded per UTF-8 byte, which is what S3 expects.
+    expect(uriEncode("é")).toBe("%C3%A9");
+  });
+});

--- a/src/lib/backup/destinations/sigv4.ts
+++ b/src/lib/backup/destinations/sigv4.ts
@@ -1,0 +1,146 @@
+import { createHash, createHmac } from "node:crypto";
+
+/**
+ * AWS Signature Version 4 for S3 (RD-077 / PR-047b).
+ *
+ * Written out rather than pulled in: the AWS SDK is tens of megabytes of
+ * dependency for four HTTP verbs, and Bench ships as a small self-hosted image.
+ * Signing is a hash chain over a canonical form of the request — mechanical,
+ * fully specified, and verified here against AWS's own published test vector,
+ * which is the only reason writing it by hand is defensible.
+ *
+ * Deliberately supports the whole S3-compatible family (MinIO, Backblaze B2,
+ * Cloudflare R2, Wasabi, Garage) by never assuming an AWS hostname.
+ */
+
+const ALGORITHM = "AWS4-HMAC-SHA256";
+
+export const EMPTY_PAYLOAD_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+export type SigV4Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+};
+
+export type SigV4Request = {
+  method: string;
+  /** Already-encoded path, beginning with `/`. */
+  path: string;
+  /** Query parameters, unencoded. */
+  query?: Record<string, string | undefined>;
+  headers: Record<string, string>;
+  /** Hex SHA-256 of the body. */
+  payloadSha256: string;
+  region: string;
+  service?: string;
+  credentials: SigV4Credentials;
+  /** Injectable so the test vector is reproducible. */
+  now?: Date;
+};
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return createHmac("sha256", key).update(data, "utf8").digest();
+}
+
+function hex(value: Buffer): string {
+  return value.toString("hex");
+}
+
+/**
+ * Percent-encode per RFC 3986. S3 requires object keys to be encoded in the
+ * canonical URI, but slashes stay as path separators.
+ */
+export function uriEncode(value: string, encodeSlash = true): string {
+  let out = "";
+  for (const char of Buffer.from(value, "utf8")) {
+    const c = String.fromCharCode(char);
+    if (/[A-Za-z0-9\-._~]/.test(c)) {
+      out += c;
+    } else if (c === "/") {
+      out += encodeSlash ? "%2F" : "/";
+    } else {
+      out += `%${char.toString(16).toUpperCase().padStart(2, "0")}`;
+    }
+  }
+  return out;
+}
+
+export function encodeS3Path(key: string): string {
+  return `/${key
+    .split("/")
+    .map((segment) => uriEncode(segment))
+    .join("/")}`;
+}
+
+function canonicalQuery(query: Record<string, string | undefined>): string {
+  return Object.entries(query)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([key, value]) => [uriEncode(key), uriEncode(value)] as const)
+    .sort((a, b) => (a[0] === b[0] ? a[1].localeCompare(b[1]) : a[0].localeCompare(b[0])))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}
+
+export type SignedRequest = {
+  headers: Record<string, string>;
+  amzDate: string;
+  canonicalRequest: string;
+  stringToSign: string;
+  signature: string;
+};
+
+/**
+ * Returns the headers to send, plus the intermediate forms — the canonical
+ * request and string to sign — because when a provider rejects a signature the
+ * only way to find out why is to compare those against what it echoes back.
+ */
+export function signS3Request(request: SigV4Request): SignedRequest {
+  const service = request.service ?? "s3";
+  const now = request.now ?? new Date();
+  const amzDate = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+  const dateStamp = amzDate.slice(0, 8);
+
+  const headers: Record<string, string> = { ...request.headers };
+  headers["x-amz-date"] = amzDate;
+  headers["x-amz-content-sha256"] = request.payloadSha256;
+  if (request.credentials.sessionToken) {
+    headers["x-amz-security-token"] = request.credentials.sessionToken;
+  }
+
+  const canonicalHeaderEntries = Object.entries(headers)
+    .map(([key, value]) => [key.toLowerCase(), value.trim().replace(/\s+/g, " ")] as const)
+    .sort((a, b) => a[0].localeCompare(b[0]));
+  const canonicalHeaders = canonicalHeaderEntries.map(([key, value]) => `${key}:${value}\n`).join("");
+  const signedHeaders = canonicalHeaderEntries.map(([key]) => key).join(";");
+
+  const canonicalRequest = [
+    request.method.toUpperCase(),
+    request.path,
+    canonicalQuery(request.query ?? {}),
+    canonicalHeaders,
+    signedHeaders,
+    request.payloadSha256,
+  ].join("\n");
+
+  const scope = `${dateStamp}/${request.region}/${service}/aws4_request`;
+  const stringToSign = [
+    ALGORITHM,
+    amzDate,
+    scope,
+    hex(createHash("sha256").update(canonicalRequest, "utf8").digest()),
+  ].join("\n");
+
+  const signingKey = hmac(
+    hmac(hmac(hmac(`AWS4${request.credentials.secretAccessKey}`, dateStamp), request.region), service),
+    "aws4_request"
+  );
+  const signature = hex(hmac(signingKey, stringToSign));
+
+  headers.Authorization =
+    `${ALGORITHM} Credential=${request.credentials.accessKeyId}/${scope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return { headers, amzDate, canonicalRequest, stringToSign, signature };
+}

--- a/src/lib/backup/destinations/types.ts
+++ b/src/lib/backup/destinations/types.ts
@@ -1,0 +1,76 @@
+import type { BackupDestinationKind } from "@/lib/app-db/backupRepository";
+
+/**
+ * The destination contract (RD-077 / PR-047b).
+ *
+ * Every place a backup can land — a mounted volume, a bucket — is reduced to
+ * the same seven operations, so the backup run in 047c never branches on where
+ * it is writing and retention never branches on where it is deleting.
+ *
+ * The interface is deliberately smaller than any storage API. It has no rename,
+ * no copy, no partial read: a backup system that needs those is a backup system
+ * doing something clever, and clever is the wrong instinct here.
+ */
+
+export type StoredObject = {
+  key: string;
+  sizeBytes: number;
+  /** ISO timestamp, when the destination reports one. */
+  lastModified: string | null;
+};
+
+/** What Bench can tell the user about a destination before trusting it. */
+export type DestinationFacts = {
+  /** Human-readable location — a path, or `bucket/prefix`. */
+  location: string;
+  /** Bytes free where the destination writes, when knowable. */
+  freeBytes?: number | null;
+  totalBytes?: number | null;
+  /** Filesystem type and device id, for local paths. */
+  filesystem?: string | null;
+  sameDeviceAsAppDb?: boolean | null;
+};
+
+export type DestinationCheckStatus = "pass" | "warn" | "fail";
+
+export type DestinationCheck = {
+  name: string;
+  status: DestinationCheckStatus;
+  detail: string;
+};
+
+export type DestinationTestResult = {
+  ok: boolean;
+  checks: DestinationCheck[];
+  facts: DestinationFacts;
+};
+
+/** Raised for any destination-level failure; carries something a user can act on. */
+export class DestinationError extends Error {
+  readonly retryable: boolean;
+
+  constructor(message: string, options: { retryable?: boolean; cause?: unknown } = {}) {
+    super(message);
+    this.name = "DestinationError";
+    this.retryable = options.retryable ?? false;
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+export interface DestinationAdapter {
+  readonly kind: BackupDestinationKind;
+  readonly destinationId: string;
+  readonly name: string;
+
+  /** Write bytes at `key`, overwriting. Returns what was actually stored. */
+  put(key: string, bytes: Uint8Array, contentType?: string): Promise<StoredObject>;
+  /** Read the whole object. Throws `DestinationError` when absent. */
+  get(key: string): Promise<Buffer>;
+  /** Metadata only, or null when the object is not there. */
+  head(key: string): Promise<StoredObject | null>;
+  list(prefix: string): Promise<StoredObject[]>;
+  remove(key: string): Promise<void>;
+  facts(): Promise<DestinationFacts>;
+  /** Write, read back, compare, delete — the only honest way to test a destination. */
+  test(): Promise<DestinationTestResult>;
+}

--- a/src/lib/backup/discover.ts
+++ b/src/lib/backup/discover.ts
@@ -1,0 +1,141 @@
+import {
+  createBackupArtifact,
+  getBackupArtifact,
+  recordArtifactLocation,
+  type BackupDestination,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { createDestinationAdapter } from "./destinations";
+import { MANIFEST_SUFFIX, parseManifest } from "./manifest";
+
+/**
+ * Rebuilding the inventory from a destination (RD-077 / PR-047e).
+ *
+ * This is the feature that makes the index honest about being a cache. Bench's
+ * database is a convenience — fast to query, good for the UI — but a backup
+ * system whose catalogue lives inside the thing being backed up has a circular
+ * dependency at exactly the wrong moment. Every artifact is therefore written
+ * with a manifest beside it, and this walks a destination reading them.
+ *
+ * The situation it is for: the server died, the volume was recreated, someone
+ * restored Bench onto a fresh machine — and the bucket is still full of
+ * backups. Point Bench at it and the inventory comes back, with verification
+ * status, retention tier and source budget intact, without a database to
+ * consult.
+ *
+ * It never overwrites what is already known, and never deletes: discovery adds.
+ * A manifest is evidence that a file exists, not authority over Bench's record
+ * of one it took itself.
+ */
+
+export type DiscoveryResult = {
+  destinationId: string;
+  destinationName: string;
+  scanned: number;
+  imported: number;
+  alreadyKnown: number;
+  unreadable: number;
+  notes: string[];
+};
+
+export async function discoverBackups(
+  db: SqliteDatabase,
+  destination: BackupDestination
+): Promise<DiscoveryResult> {
+  const result: DiscoveryResult = {
+    destinationId: destination.id,
+    destinationName: destination.name,
+    scanned: 0,
+    imported: 0,
+    alreadyKnown: 0,
+    unreadable: 0,
+    notes: [],
+  };
+
+  const adapter = createDestinationAdapter(db, destination);
+  const objects = await adapter.list("");
+  const manifests = objects.filter((object) => object.key.endsWith(MANIFEST_SUFFIX));
+
+  for (const object of manifests) {
+    result.scanned += 1;
+    const objectKey = object.key.slice(0, -MANIFEST_SUFFIX.length);
+
+    let manifest;
+    try {
+      manifest = parseManifest(await adapter.get(object.key));
+    } catch (error) {
+      result.unreadable += 1;
+      result.notes.push(
+        `${object.key}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      continue;
+    }
+
+    if (!manifest) {
+      result.unreadable += 1;
+      result.notes.push(`${object.key} could not be read as a manifest.`);
+      continue;
+    }
+
+    // The artifact must actually be there. A manifest whose file is gone
+    // describes a backup that no longer exists, and importing it would put a
+    // lie in the inventory.
+    const head = await adapter.head(objectKey);
+    if (!head) {
+      result.unreadable += 1;
+      result.notes.push(`${objectKey} is described by a manifest but is not present.`);
+      continue;
+    }
+
+    if (getBackupArtifact(db, manifest.artifactId)) {
+      result.alreadyKnown += 1;
+    } else {
+      createBackupArtifact(db, {
+        id: manifest.artifactId,
+        // Not attached to a policy: the rule that made it may not exist on this
+        // install, and inventing one would be worse than leaving it unowned.
+        policyId: null,
+        kind: manifest.kind,
+        createdAt: manifest.createdAt,
+        sourceBudgetId: manifest.source?.budgetId ?? null,
+        sourceBudgetName: manifest.source?.budgetName ?? null,
+        sizeBytes: manifest.sizeBytes || head.sizeBytes,
+        checksumSha256: manifest.checksumSha256,
+        plaintextChecksumSha256: manifest.plaintextChecksumSha256 ?? null,
+        encrypted: Boolean(manifest.encryption),
+        encryption: manifest.encryption
+          ? { version: 1, data: { ...manifest.encryption } }
+          : null,
+        tier: manifest.tier,
+        pinned: manifest.pinned,
+        protectedUntil: manifest.protectedUntil ?? null,
+        takenBefore: manifest.takenBefore ?? null,
+        // Carried across, but it describes a verification that happened
+        // elsewhere, possibly long ago. "Verify now" is what makes it current.
+        verificationLevel: manifest.verification?.level ?? null,
+        verificationStatus: manifest.verification?.status ?? "unverified",
+        verifiedAt: manifest.verification?.verifiedAt ?? null,
+        manifestVersion: manifest.manifestVersion,
+        benchVersion: manifest.benchVersion ?? null,
+        notes: "Discovered from its manifest.",
+      });
+      result.imported += 1;
+    }
+
+    recordArtifactLocation(db, {
+      artifactId: manifest.artifactId,
+      destinationId: destination.id,
+      objectKey,
+      status: "stored",
+      uploadedAt: manifest.createdAt,
+    });
+  }
+
+  if (manifests.length === 0 && objects.length > 0) {
+    result.notes.push(
+      `${objects.length} file(s) are here but none have a Bench manifest beside them, so Bench cannot tell what they are.`
+    );
+  }
+
+  return result;
+}

--- a/src/lib/backup/encryption.ts
+++ b/src/lib/backup/encryption.ts
@@ -1,0 +1,141 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import type { BackupEncryptionInfo } from "./manifest";
+
+/**
+ * Optional at-rest encryption for backup artifacts (RD-077 / PR-047c).
+ *
+ * Off by default and per policy, because for most self-hosters the backup lands
+ * on a volume they already control and encryption only adds a way to lose the
+ * data permanently. It matters the moment a copy goes somewhere they do not
+ * control — a bucket, a friend's NAS — and that is exactly when it must be
+ * airtight.
+ *
+ * The encrypted file is **self-describing**: an eight-byte magic, the KDF
+ * parameters, salt, IV and auth tag all precede the ciphertext. The manifest
+ * carries the same values, but a backup whose recovery depends on a second file
+ * being present is not a backup. Given the passphrase, `bench-restore` — or a
+ * dozen lines of Node — can decrypt an artifact with nothing else at hand.
+ *
+ * What is never written anywhere: the passphrase, and the key derived from it.
+ */
+
+const MAGIC = Buffer.from("BENCHBK1", "ascii");
+const FORMAT_VERSION = 1;
+const KEY_BYTES = 32;
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+
+/**
+ * scrypt cost. N=2^15 takes roughly a tenth of a second on a small VPS — slow
+ * enough to make a stolen artifact expensive to attack, fast enough that a
+ * nightly backup does not notice.
+ */
+const SCRYPT_PARAMS = { N: 32768, r: 8, p: 1, maxmem: 64 * 1024 * 1024 };
+
+export class BackupDecryptionError extends Error {
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message);
+    this.name = "BackupDecryptionError";
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+function deriveKey(passphrase: string, salt: Buffer): Buffer {
+  return scryptSync(passphrase.normalize("NFKC"), salt, KEY_BYTES, SCRYPT_PARAMS);
+}
+
+export type EncryptedArchive = {
+  bytes: Buffer;
+  info: BackupEncryptionInfo;
+};
+
+export function encryptArchive(plaintext: Uint8Array, passphrase: string): EncryptedArchive {
+  if (!passphrase.trim()) {
+    throw new Error("A passphrase is required to encrypt a backup.");
+  }
+
+  const salt = randomBytes(SALT_BYTES);
+  const iv = randomBytes(IV_BYTES);
+  const key = deriveKey(passphrase, salt);
+
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  const header = Buffer.concat([
+    MAGIC,
+    Buffer.from([FORMAT_VERSION, SALT_BYTES, IV_BYTES, authTag.length]),
+    salt,
+    iv,
+    authTag,
+  ]);
+
+  return {
+    bytes: Buffer.concat([header, ciphertext]),
+    info: {
+      algorithm: "aes-256-gcm",
+      kdf: "scrypt",
+      salt: salt.toString("base64"),
+      iv: iv.toString("base64"),
+      authTag: authTag.toString("base64"),
+    },
+  };
+}
+
+/** True when these bytes carry Bench's encrypted-artifact header. */
+export function isEncryptedArchive(bytes: Uint8Array): boolean {
+  if (bytes.byteLength < MAGIC.length) return false;
+  const head = Buffer.from(bytes.subarray(0, MAGIC.length));
+  return head.length === MAGIC.length && timingSafeEqual(head, MAGIC);
+}
+
+/**
+ * Decrypt an artifact using only the artifact itself.
+ *
+ * Failure messages distinguish "this is not one of ours" from "the passphrase
+ * is wrong", because a wrong passphrase is a thing the user can fix and a
+ * corrupt file is not, and telling them apart at 3am matters.
+ */
+export function decryptArchive(bytes: Uint8Array, passphrase: string): Buffer {
+  const buffer = Buffer.from(bytes);
+  if (!isEncryptedArchive(buffer)) {
+    throw new BackupDecryptionError("This file is not an encrypted Bench backup.");
+  }
+
+  let offset = MAGIC.length;
+  const version = buffer[offset];
+  const saltLength = buffer[offset + 1];
+  const ivLength = buffer[offset + 2];
+  const tagLength = buffer[offset + 3];
+  offset += 4;
+
+  if (version !== FORMAT_VERSION) {
+    throw new BackupDecryptionError(
+      `This backup was written in encryption format ${version}, which this version of Bench cannot read.`
+    );
+  }
+
+  const salt = buffer.subarray(offset, offset + saltLength);
+  offset += saltLength;
+  const iv = buffer.subarray(offset, offset + ivLength);
+  offset += ivLength;
+  const authTag = buffer.subarray(offset, offset + tagLength);
+  offset += tagLength;
+  const ciphertext = buffer.subarray(offset);
+
+  if (salt.length !== saltLength || iv.length !== ivLength || authTag.length !== tagLength) {
+    throw new BackupDecryptionError("This backup's encryption header is truncated or corrupt.");
+  }
+
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", deriveKey(passphrase, Buffer.from(salt)), iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch (error) {
+    // GCM cannot tell a wrong key from tampered bytes, so say both.
+    throw new BackupDecryptionError(
+      "Could not decrypt this backup. Either the passphrase is wrong or the file has been altered.",
+      { cause: error }
+    );
+  }
+}

--- a/src/lib/backup/inspect.ts
+++ b/src/lib/backup/inspect.ts
@@ -1,0 +1,146 @@
+import { getBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import {
+  getBackupArtifact,
+  getBackupDestination,
+  getBackupPolicy,
+  listArtifactLocations,
+  recordArtifactVerification,
+  type BackupArtifact,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { createDestinationAdapter } from "./destinations";
+import { decryptArchive } from "./encryption";
+import { sha256 } from "./manifest";
+import { verifyAppDbArchive, verifyBudgetArchive, type VerificationOutcome } from "./verify";
+
+/**
+ * Looking inside a backup without restoring it (RD-077 / PR-047e).
+ *
+ * The question people actually have in front of a list of backups is not "is
+ * this file intact" but "is *this* the one — does it still have the account I
+ * deleted, does it stop before the import that went wrong". Answering that by
+ * restoring means creating a budget, opening it, looking, and cleaning up.
+ *
+ * So Bench opens the archive server-side and reports what is in it: how many
+ * accounts, payees, categories and transactions, and the date range covered.
+ * Nothing is written anywhere and no budget is created — this is a read.
+ */
+
+export type InspectionResult = {
+  artifact: BackupArtifact;
+  objectKey: string;
+  destinationName: string;
+  checksumMatches: boolean;
+  encrypted: boolean;
+  /** False when it is encrypted and Bench has no stored passphrase for it. */
+  opened: boolean;
+  verification: VerificationOutcome | null;
+  message: string;
+};
+
+export async function inspectArtifact(
+  db: SqliteDatabase,
+  artifactId: string,
+  options: { passphrase?: string } = {}
+): Promise<InspectionResult> {
+  const artifact = getBackupArtifact(db, artifactId);
+  if (!artifact) throw new Error("That backup is not in the inventory.");
+
+  const location = listArtifactLocations(db, artifactId).find(
+    (entry) => entry.status === "stored" && entry.destinationId
+  );
+  if (!location?.destinationId) {
+    throw new Error("Bench has no stored copy of this backup to open.");
+  }
+
+  const destination = getBackupDestination(db, location.destinationId);
+  if (!destination) throw new Error("The destination holding this backup has been removed.");
+
+  const adapter = createDestinationAdapter(db, destination);
+  const bytes = await adapter.get(location.objectKey);
+  const checksumMatches = sha256(bytes) === artifact.checksumSha256;
+
+  const base = {
+    artifact,
+    objectKey: location.objectKey,
+    destinationName: destination.name,
+    checksumMatches,
+    encrypted: artifact.encrypted,
+  };
+
+  if (!checksumMatches) {
+    // Say it plainly and stop: opening bytes that are already known to be wrong
+    // tells the user nothing they can use.
+    return {
+      ...base,
+      opened: false,
+      verification: null,
+      message:
+        "The stored bytes no longer match the checksum recorded when this backup was written. Treat it as damaged.",
+    };
+  }
+
+  let plaintext: Uint8Array = bytes;
+  if (artifact.encrypted) {
+    const passphrase = options.passphrase ?? storedPassphrase(db, artifact);
+    if (!passphrase) {
+      return {
+        ...base,
+        opened: false,
+        verification: null,
+        message:
+          "This backup is encrypted and Bench has no stored passphrase for it. Enter the passphrase to look inside.",
+      };
+    }
+    plaintext = decryptArchive(bytes, passphrase);
+  }
+
+  const verification =
+    artifact.kind === "budget"
+      ? verifyBudgetArchive(plaintext, "deep")
+      : verifyAppDbArchive(plaintext, "data");
+
+  // An inspection is a verification, so it counts as one. Anything else would
+  // mean a user could open a backup, see it is fine, and still be told on the
+  // list that Bench has never checked it.
+  recordArtifactVerification(db, artifact.id, {
+    level: verification.level,
+    status: verification.status,
+    at: new Date().toISOString(),
+    findings: { version: 1, data: { findings: verification.findings } },
+  });
+
+  return {
+    ...base,
+    opened: true,
+    verification,
+    message:
+      verification.status === "passed"
+        ? describeContents(verification)
+        : verification.findings[0] ?? "Bench could not read this backup.",
+  };
+}
+
+function storedPassphrase(db: SqliteDatabase, artifact: BackupArtifact): string | null {
+  if (!artifact.policyId) return null;
+  const policy = getBackupPolicy(db, artifact.policyId);
+  if (!policy?.encryptionCredentialRef) return null;
+  try {
+    const secret = getBackupCredential(db, policy.encryptionCredentialRef);
+    return secret && "passphrase" in secret ? secret.passphrase : null;
+  } catch {
+    return null;
+  }
+}
+
+function describeContents(verification: VerificationOutcome): string {
+  const { content } = verification;
+  if (content.transactions === undefined) return "Opened and read; it is a valid database.";
+  const range =
+    content.earliestTransaction && content.latestTransaction
+      ? ` covering ${content.earliestTransaction} to ${content.latestTransaction}`
+      : "";
+  return `${content.transactions.toLocaleString()} transactions across ${
+    content.accounts ?? 0
+  } accounts${range}.`;
+}

--- a/src/lib/backup/manifest.test.ts
+++ b/src/lib/backup/manifest.test.ts
@@ -1,0 +1,130 @@
+import {
+  MANIFEST_VERSION,
+  manifestKeyFor,
+  parseManifest,
+  serializeManifest,
+  sha256,
+  type BackupManifest,
+} from "./manifest";
+
+function manifest(overrides: Partial<BackupManifest> = {}): BackupManifest {
+  return {
+    manifestVersion: MANIFEST_VERSION,
+    artifactId: "art-1",
+    kind: "budget",
+    createdAt: "2026-08-27T06:00:00.000Z",
+    sizeBytes: 4096,
+    checksumSha256: "a".repeat(64),
+    plaintextChecksumSha256: "b".repeat(64),
+    encryption: null,
+    source: { budgetId: "budget-1", budgetName: "Household", serverUrl: "https://budget.example.com" },
+    content: {
+      accounts: 14,
+      transactions: 8431,
+      earliestTransaction: "2021-01-04",
+      latestTransaction: "2026-08-26",
+      integrityCheck: "ok",
+    },
+    verification: { level: "data", status: "passed", verifiedAt: "2026-08-27T06:00:05.000Z" },
+    policy: { id: "pol-1", name: "Nightly" },
+    tier: "daily",
+    pinned: false,
+    protectedUntil: null,
+    takenBefore: null,
+    benchVersion: "1.3.0",
+    appDbSchemaVersion: 20,
+    ...overrides,
+  };
+}
+
+describe("checksums", () => {
+  it("matches a known vector, so a stored checksum means the same thing next year", () => {
+    expect(sha256(Buffer.from("abc", "utf8"))).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+  });
+
+  it("changes when a single byte changes", () => {
+    const a = sha256(Buffer.from("backup", "utf8"));
+    const b = sha256(Buffer.from("backuq", "utf8"));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("manifest round trip", () => {
+  it("survives serialization unchanged", () => {
+    const original = manifest();
+    const parsed = parseManifest(serializeManifest(original));
+    expect(parsed).toEqual(original);
+  });
+
+  it("sits beside its artifact", () => {
+    expect(manifestKeyFor("backups/household-2026-08-27.zip")).toBe(
+      "backups/household-2026-08-27.zip.manifest.json"
+    );
+  });
+
+  it("carries encryption parameters but never a key", () => {
+    const parsed = parseManifest(
+      serializeManifest(
+        manifest({
+          encryption: { algorithm: "aes-256-gcm", kdf: "scrypt", salt: "c2FsdA==", iv: "aXY=", authTag: "dGFn" },
+        })
+      )
+    );
+
+    expect(parsed?.encryption?.salt).toBe("c2FsdA==");
+    // Nothing in the serialized form may resemble key material.
+    const text = Buffer.from(serializeManifest(manifest())).toString("utf8");
+    expect(text).not.toMatch(/passphrase|"key"|secret/i);
+  });
+});
+
+describe("reading a manifest Bench did not write", () => {
+  it("keeps what a future version does carry rather than rejecting the file", () => {
+    // The case this exists for: someone points Bench at a directory written by
+    // a newer release. Refusing to list a real backup because of an unfamiliar
+    // field would be the exact failure the manifest is meant to prevent.
+    const parsed = parseManifest(
+      JSON.stringify({
+        manifestVersion: 99,
+        artifactId: "art-future",
+        kind: "budget",
+        createdAt: "2027-01-01T00:00:00.000Z",
+        sizeBytes: 10,
+        checksumSha256: "f".repeat(64),
+        tier: "fortnightly",
+        somethingNew: { nested: true },
+        verification: { level: "quantum", status: "passed" },
+      })
+    );
+
+    expect(parsed?.artifactId).toBe("art-future");
+    expect(parsed?.manifestVersion).toBe(99);
+    // An unknown tier is treated as manual: keeping a backup Bench does not
+    // understand is always safer than pruning it.
+    expect(parsed?.tier).toBe("manual");
+    // An unreadable verification level is not reported as a verified backup.
+    expect(parsed?.verification).toBeUndefined();
+  });
+
+  it("returns null only when there is no artifact to describe", () => {
+    expect(parseManifest("not json at all")).toBeNull();
+    expect(parseManifest(JSON.stringify({ artifactId: "x" }))).toBeNull();
+    expect(parseManifest(JSON.stringify({ checksumSha256: "y", kind: "budget" }))).toBeNull();
+    expect(parseManifest(JSON.stringify([1, 2, 3]))).toBeNull();
+  });
+
+  it("does not inherit a claim of verification from a malformed block", () => {
+    const parsed = parseManifest(
+      JSON.stringify({
+        artifactId: "art-2",
+        kind: "app-db",
+        checksumSha256: "d".repeat(64),
+        verification: "totally fine, trust me",
+      })
+    );
+
+    expect(parsed?.verification).toBeUndefined();
+  });
+});

--- a/src/lib/backup/manifest.ts
+++ b/src/lib/backup/manifest.ts
@@ -1,0 +1,221 @@
+import { createHash } from "node:crypto";
+
+/**
+ * The manifest written beside every backup artifact (RD-077 / PR-047a).
+ *
+ * Its job is to make a bare destination self-describing. Someone who has lost
+ * their Bench database entirely — the machine died, the volume was recreated —
+ * should be able to point Bench at a directory or a bucket and get their
+ * inventory back, because each file is accompanied by everything needed to
+ * understand it. That is also why the index in the app DB is a cache of these
+ * rather than the only record: an index living inside the database it indexes
+ * is not an index you can rely on.
+ *
+ * Two rules follow from that:
+ *
+ *   * **It is versioned, and read forgivingly.** A manifest written by a newer
+ *     Bench is a normal thing to meet, and the answer is to read what it does
+ *     carry rather than to reject the file — refusing to list a real backup
+ *     because its manifest has an unfamiliar field would be the exact failure
+ *     this feature exists to prevent.
+ *   * **It never contains a key.** Encryption parameters (KDF, salt, IV) travel
+ *     with the artifact because they are useless without the passphrase; the
+ *     passphrase and the derived key do not.
+ */
+
+export const MANIFEST_VERSION = 1;
+
+/** Suffix appended to an artifact's object key to locate its manifest. */
+export const MANIFEST_SUFFIX = ".manifest.json";
+
+export type BackupArtifactKind = "budget" | "app-db";
+
+export type BackupVerificationLevel = "archive" | "data" | "deep";
+
+export type BackupVerificationStatus = "unverified" | "passed" | "failed";
+
+export type BackupRetentionTier =
+  | "manual"
+  | "auto"
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "yearly";
+
+export type BackupEncryptionInfo = {
+  algorithm: "aes-256-gcm";
+  kdf: "scrypt";
+  /** Base64. Public by design — a salt is not a secret. */
+  salt: string;
+  iv: string;
+  authTag: string;
+};
+
+/** What an artifact was found to contain, recorded at verification time. */
+export type BackupContentSummary = {
+  accounts?: number;
+  transactions?: number;
+  payees?: number;
+  categories?: number;
+  /** Earliest and latest transaction dates, ISO `YYYY-MM-DD`. */
+  earliestTransaction?: string | null;
+  latestTransaction?: string | null;
+  integrityCheck?: string;
+};
+
+export type BackupManifest = {
+  manifestVersion: number;
+  artifactId: string;
+  kind: BackupArtifactKind;
+  createdAt: string;
+  /** Bytes as stored — encrypted size when the artifact is encrypted. */
+  sizeBytes: number;
+  checksumSha256: string;
+  /** Of the archive before encryption, so a restore is checkable end to end. */
+  plaintextChecksumSha256?: string | null;
+  encryption?: BackupEncryptionInfo | null;
+  source?: {
+    budgetId?: string | null;
+    budgetName?: string | null;
+    serverUrl?: string | null;
+  };
+  content?: BackupContentSummary;
+  verification?: {
+    level: BackupVerificationLevel;
+    status: BackupVerificationStatus;
+    verifiedAt?: string | null;
+    findings?: string[];
+  };
+  policy?: {
+    id?: string | null;
+    name?: string | null;
+  };
+  tier: BackupRetentionTier;
+  pinned: boolean;
+  protectedUntil?: string | null;
+  takenBefore?: string | null;
+  benchVersion?: string | null;
+  appDbSchemaVersion?: number | null;
+};
+
+export function sha256(bytes: Uint8Array | Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function manifestKeyFor(objectKey: string): string {
+  return `${objectKey}${MANIFEST_SUFFIX}`;
+}
+
+export function serializeManifest(manifest: BackupManifest): Uint8Array {
+  // Buffer rather than TextEncoder: this module already imports node:crypto, so
+  // it is server-only by construction, and Buffer is what the rest of the
+  // server-side code here speaks.
+  return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readEncryption(value: unknown): BackupEncryptionInfo | null {
+  if (!isRecord(value)) return null;
+  const salt = str(value.salt);
+  const iv = str(value.iv);
+  const authTag = str(value.authTag);
+  if (!salt || !iv || !authTag) return null;
+  return { algorithm: "aes-256-gcm", kdf: "scrypt", salt, iv, authTag };
+}
+
+function readContent(value: unknown): BackupContentSummary | undefined {
+  if (!isRecord(value)) return undefined;
+  const summary: BackupContentSummary = {};
+  for (const key of ["accounts", "transactions", "payees", "categories"] as const) {
+    const parsed = num(value[key]);
+    if (parsed !== undefined) summary[key] = parsed;
+  }
+  summary.earliestTransaction = str(value.earliestTransaction) ?? null;
+  summary.latestTransaction = str(value.latestTransaction) ?? null;
+  const integrity = str(value.integrityCheck);
+  if (integrity) summary.integrityCheck = integrity;
+  return summary;
+}
+
+const LEVELS: BackupVerificationLevel[] = ["archive", "data", "deep"];
+const STATUSES: BackupVerificationStatus[] = ["unverified", "passed", "failed"];
+const TIERS: BackupRetentionTier[] = ["manual", "auto", "daily", "weekly", "monthly", "yearly"];
+
+/**
+ * Read a manifest, keeping whatever is legible.
+ *
+ * Returns null only when the file cannot identify an artifact at all — no id,
+ * no checksum, no kind — because at that point there is nothing to list. Every
+ * other unfamiliar or missing field is tolerated: a manifest from a future
+ * version must still yield a usable inventory row today.
+ */
+export function parseManifest(input: string | Uint8Array): BackupManifest | null {
+  let raw: unknown;
+  try {
+    const text = typeof input === "string" ? input : Buffer.from(input).toString("utf8");
+    raw = JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isRecord(raw)) return null;
+
+  const artifactId = str(raw.artifactId);
+  const checksum = str(raw.checksumSha256);
+  const kind = raw.kind === "app-db" ? "app-db" : raw.kind === "budget" ? "budget" : undefined;
+  if (!artifactId || !checksum || !kind) return null;
+
+  const verificationRaw = isRecord(raw.verification) ? raw.verification : undefined;
+  const level = LEVELS.find((entry) => entry === verificationRaw?.level);
+  const status = STATUSES.find((entry) => entry === verificationRaw?.status);
+
+  return {
+    manifestVersion: num(raw.manifestVersion) ?? MANIFEST_VERSION,
+    artifactId,
+    kind,
+    createdAt: str(raw.createdAt) ?? new Date(0).toISOString(),
+    sizeBytes: num(raw.sizeBytes) ?? 0,
+    checksumSha256: checksum,
+    plaintextChecksumSha256: str(raw.plaintextChecksumSha256) ?? null,
+    encryption: readEncryption(raw.encryption),
+    source: isRecord(raw.source)
+      ? {
+          budgetId: str(raw.source.budgetId) ?? null,
+          budgetName: str(raw.source.budgetName) ?? null,
+          serverUrl: str(raw.source.serverUrl) ?? null,
+        }
+      : undefined,
+    content: readContent(raw.content),
+    verification: level
+      ? {
+          level,
+          status: status ?? "unverified",
+          verifiedAt: str(verificationRaw?.verifiedAt) ?? null,
+          findings: Array.isArray(verificationRaw?.findings)
+            ? verificationRaw.findings.filter((entry): entry is string => typeof entry === "string")
+            : undefined,
+        }
+      : undefined,
+    policy: isRecord(raw.policy)
+      ? { id: str(raw.policy.id) ?? null, name: str(raw.policy.name) ?? null }
+      : undefined,
+    // An unfamiliar tier from a newer version is treated as manual: keeping a
+    // backup Bench does not understand is always safer than pruning it.
+    tier: TIERS.find((entry) => entry === raw.tier) ?? "manual",
+    pinned: raw.pinned === true,
+    protectedUntil: str(raw.protectedUntil) ?? null,
+    takenBefore: str(raw.takenBefore) ?? null,
+    benchVersion: str(raw.benchVersion) ?? null,
+    appDbSchemaVersion: num(raw.appDbSchemaVersion) ?? null,
+  };
+}

--- a/src/lib/backup/prune.test.ts
+++ b/src/lib/backup/prune.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment node
+ */
+import { mkdtempSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import {
+  DEFAULT_RETENTION,
+  createBackupArtifact,
+  createBackupDestination,
+  createBackupPolicy,
+  getBackupArtifact,
+  listArtifactLocations,
+  recordArtifactLocation,
+  type BackupArtifact,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { prune, previewPrune } from "./prune";
+
+describe("carrying out a retention plan", () => {
+  let root: string;
+  let volume: string;
+  let db: SqliteDatabase;
+  let destinationId: string;
+  let policyId: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "actual-bench-prune-"));
+    volume = join(root, "volume");
+    mkdirSync(volume, { recursive: true });
+    db = getAppDb(join(root, "metadata.sqlite"));
+    destinationId = createBackupDestination(db, {
+      name: "Volume",
+      kind: "local",
+      config: { version: 1, data: { path: volume } },
+    }).id;
+    policyId = createBackupPolicy(db, {
+      name: "Nightly",
+      destinationIds: [destinationId],
+      sourceRef: { version: 1, data: { connectionFingerprint: "conn-1" } },
+    }).id;
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function storedArtifact(createdAt: string, overrides: Record<string, unknown> = {}): BackupArtifact {
+    const artifact = createBackupArtifact(db, {
+      policyId,
+      kind: "budget",
+      createdAt,
+      checksumSha256: "a".repeat(64),
+      sizeBytes: 10,
+      tier: "daily",
+      verificationStatus: "passed",
+      verificationLevel: "data",
+      ...overrides,
+    });
+    const key = `budget/household/${createdAt.slice(0, 10)}-${artifact.id.slice(0, 6)}.zip`;
+    mkdirSync(dirname(join(volume, key)), { recursive: true });
+    writeFileSync(join(volume, key), "backup bytes");
+    writeFileSync(join(volume, `${key}.manifest.json`), "{}");
+    recordArtifactLocation(db, {
+      artifactId: artifact.id,
+      destinationId,
+      objectKey: key,
+      status: "stored",
+      uploadedAt: createdAt,
+    });
+    return artifact;
+  }
+
+  const retention = { ...DEFAULT_RETENTION, daily: 1, weekly: 0, monthly: 0, yearly: 0, minimumAgeHours: 0 };
+  const now = new Date("2026-08-27T12:00:00.000Z");
+
+  it("deletes the artifact, its manifest and its row together", async () => {
+    const keep = storedArtifact("2026-08-27T02:00:00.000Z");
+    const drop = storedArtifact("2026-08-20T02:00:00.000Z");
+
+    const result = await prune(db, { artifacts: [keep, drop], retention, now });
+
+    expect(result.pruned.map((entry) => entry.artifactId)).toEqual([drop.id]);
+    expect(getBackupArtifact(db, drop.id)).toBeNull();
+    expect(getBackupArtifact(db, keep.id)).not.toBeNull();
+
+    const droppedKey = `budget/household/2026-08-20-${drop.id.slice(0, 6)}.zip`;
+    expect(existsSync(join(volume, droppedKey))).toBe(false);
+    expect(existsSync(join(volume, `${droppedKey}.manifest.json`))).toBe(false);
+  });
+
+  it("previews without touching anything", () => {
+    const keep = storedArtifact("2026-08-27T02:00:00.000Z");
+    const drop = storedArtifact("2026-08-20T02:00:00.000Z");
+
+    const preview = previewPrune(db, { artifacts: [keep, drop], retention, now });
+
+    expect(preview.dryRun).toBe(true);
+    expect(preview.pruned).toHaveLength(1);
+    expect(preview.freedBytes).toBe(10);
+    expect(preview.pruned[0].reason).toBeTruthy();
+    // Nothing removed.
+    expect(getBackupArtifact(db, drop.id)).not.toBeNull();
+    expect(listArtifactLocations(db, drop.id)[0].status).toBe("stored");
+  });
+
+  it("keeps the row when the copy could not be deleted", async () => {
+    // Removing Bench's record of a file that is still sitting in a destination
+    // would turn a transient error into an orphan nobody knows about.
+    const keep = storedArtifact("2026-08-27T02:00:00.000Z");
+    const drop = storedArtifact("2026-08-20T02:00:00.000Z");
+
+    const broken = createBackupDestination(db, {
+      name: "Unreachable",
+      kind: "s3",
+      credentialRef: "missing",
+      config: { version: 1, data: { bucket: "gone" } },
+    });
+    recordArtifactLocation(db, {
+      artifactId: drop.id,
+      destinationId: broken.id,
+      objectKey: "budget/household/copy.zip",
+      status: "stored",
+    });
+
+    const result = await prune(db, { artifacts: [keep, drop], retention, now });
+
+    expect(result.failed).toBe(1);
+    expect(result.pruned[0].removed).toBe(false);
+    expect(getBackupArtifact(db, drop.id)).not.toBeNull();
+    // The copy that could be deleted still was.
+    expect(
+      listArtifactLocations(db, drop.id).find((entry) => entry.destinationId === destinationId)?.status
+    ).toBe("deleted");
+  });
+
+  it("does nothing when the plan keeps everything", async () => {
+    const only = storedArtifact("2026-08-27T02:00:00.000Z");
+    const result = await prune(db, { artifacts: [only], retention, now });
+
+    expect(result.pruned).toEqual([]);
+    expect(result.freedBytes).toBe(0);
+    expect(getBackupArtifact(db, only.id)).not.toBeNull();
+  });
+});

--- a/src/lib/backup/prune.test.ts
+++ b/src/lib/backup/prune.test.ts
@@ -136,6 +136,31 @@ describe("carrying out a retention plan", () => {
     ).toBe("deleted");
   });
 
+  it("never lets a copy that was never stored protect one that was", async () => {
+    // Verification happens before the upload, so an artifact whose upload
+    // failed is still "verified". Left in the plan it could satisfy the
+    // last-good-copy rule while the real stored copy it stood in for was
+    // pruned.
+    const stored = storedArtifact("2026-08-20T02:00:00.000Z");
+    const neverStored = createBackupArtifact(db, {
+      policyId,
+      kind: "budget",
+      createdAt: "2026-08-27T02:00:00.000Z",
+      checksumSha256: "b".repeat(64),
+      sizeBytes: 10,
+      tier: "daily",
+      verificationStatus: "passed",
+      verificationLevel: "data",
+    });
+
+    const result = await prune(db, { artifacts: [neverStored, stored], retention, now });
+
+    // The stored copy survives as the newest verified one; the phantom is not
+    // considered at all.
+    expect(result.pruned).toEqual([]);
+    expect(getBackupArtifact(db, stored.id)).not.toBeNull();
+  });
+
   it("does nothing when the plan keeps everything", async () => {
     const only = storedArtifact("2026-08-27T02:00:00.000Z");
     const result = await prune(db, { artifacts: [only], retention, now });

--- a/src/lib/backup/prune.ts
+++ b/src/lib/backup/prune.ts
@@ -1,0 +1,174 @@
+import {
+  deleteBackupArtifact,
+  getBackupArtifact,
+  getBackupDestination,
+  listArtifactLocations,
+  recordArtifactLocation,
+  type BackupArtifact,
+  type BackupPolicy,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { createDestinationAdapter } from "./destinations";
+import { manifestKeyFor } from "./manifest";
+import { planRetention, type RetentionDecision } from "./retention";
+
+/**
+ * Carrying out a retention plan (RD-077 / PR-047d).
+ *
+ * Separate from `planRetention` on purpose: deciding and deleting are different
+ * acts, and keeping them apart means the preview a user approves is produced by
+ * exactly the code that then runs, not by a second implementation that agrees
+ * with it most of the time.
+ *
+ * The failure rule is the interesting one. If a copy cannot be deleted — the
+ * bucket is unreachable, the volume is read-only — the artifact **keeps its
+ * row**. Removing Bench's record of a file that is still sitting in a
+ * destination would turn a transient error into an orphan nobody knows about,
+ * and the whole point of the index is that it tells the truth about what exists.
+ */
+
+export type PruneEntry = {
+  artifactId: string;
+  reason: string;
+  createdAt: string;
+  kind: string;
+  sizeBytes: number;
+  /** Where copies of it live, and what happened to each. */
+  locations: { destinationName: string; objectKey: string; status: "deleted" | "failed" | "missing"; error?: string }[];
+  removed: boolean;
+};
+
+export type PruneResult = {
+  dryRun: boolean;
+  kept: number;
+  pruned: PruneEntry[];
+  failed: number;
+  freedBytes: number;
+};
+
+export type PrunePlanInput = {
+  artifacts: BackupArtifact[];
+  retention: BackupPolicy["retention"];
+  now?: Date;
+};
+
+/** Preview what a prune would do, without touching a destination. */
+export function previewPrune(db: SqliteDatabase, input: PrunePlanInput): PruneResult {
+  const plan = planRetention(input.artifacts, input.retention, input.now);
+  return {
+    dryRun: true,
+    kept: plan.keep.length,
+    failed: 0,
+    freedBytes: sumBytes(db, plan.prune),
+    pruned: plan.prune.map((decision) => describe(db, decision, true)),
+  };
+}
+
+function sumBytes(db: SqliteDatabase, decisions: RetentionDecision[]): number {
+  return decisions.reduce((total, decision) => {
+    const artifact = getBackupArtifact(db, decision.artifactId);
+    return total + (artifact?.sizeBytes ?? 0);
+  }, 0);
+}
+
+function describe(db: SqliteDatabase, decision: RetentionDecision, preview: boolean): PruneEntry {
+  const artifact = getBackupArtifact(db, decision.artifactId);
+  const locations = listArtifactLocations(db, decision.artifactId);
+  return {
+    artifactId: decision.artifactId,
+    reason: decision.reason,
+    createdAt: artifact?.createdAt ?? "",
+    kind: artifact?.kind ?? "budget",
+    sizeBytes: artifact?.sizeBytes ?? 0,
+    removed: false,
+    locations: locations.map((location) => ({
+      destinationName:
+        (location.destinationId && getBackupDestination(db, location.destinationId)?.name) ||
+        "Unknown destination",
+      objectKey: location.objectKey,
+      status: preview ? "deleted" : "missing",
+    })),
+  };
+}
+
+export async function prune(
+  db: SqliteDatabase,
+  input: PrunePlanInput & { dryRun?: boolean }
+): Promise<PruneResult> {
+  if (input.dryRun) return previewPrune(db, input);
+
+  const plan = planRetention(input.artifacts, input.retention, input.now);
+  const entries: PruneEntry[] = [];
+  let failed = 0;
+  let freedBytes = 0;
+
+  for (const decision of plan.prune) {
+    const artifact = getBackupArtifact(db, decision.artifactId);
+    if (!artifact) continue;
+
+    const locations = listArtifactLocations(db, artifact.id);
+    const results: PruneEntry["locations"] = [];
+    let allGone = true;
+
+    for (const location of locations) {
+      const destination = location.destinationId ? getBackupDestination(db, location.destinationId) : null;
+      if (!destination) {
+        // The destination was removed from Bench. There is nothing to delete
+        // through, so the record goes but no claim is made about the file.
+        results.push({ destinationName: "Removed destination", objectKey: location.objectKey, status: "missing" });
+        continue;
+      }
+      if (location.status === "deleted" || location.status === "failed") {
+        results.push({ destinationName: destination.name, objectKey: location.objectKey, status: "missing" });
+        continue;
+      }
+
+      try {
+        const adapter = createDestinationAdapter(db, destination);
+        await adapter.remove(location.objectKey);
+        await adapter.remove(manifestKeyFor(location.objectKey));
+        recordArtifactLocation(db, {
+          artifactId: artifact.id,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "deleted",
+        });
+        results.push({ destinationName: destination.name, objectKey: location.objectKey, status: "deleted" });
+      } catch (error) {
+        allGone = false;
+        failed += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        recordArtifactLocation(db, {
+          artifactId: artifact.id,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "stored",
+          lastError: message,
+        });
+        results.push({
+          destinationName: destination.name,
+          objectKey: location.objectKey,
+          status: "failed",
+          error: message,
+        });
+      }
+    }
+
+    if (allGone) {
+      deleteBackupArtifact(db, artifact.id);
+      freedBytes += artifact.sizeBytes;
+    }
+
+    entries.push({
+      artifactId: artifact.id,
+      reason: decision.reason,
+      createdAt: artifact.createdAt,
+      kind: artifact.kind,
+      sizeBytes: artifact.sizeBytes,
+      locations: results,
+      removed: allGone,
+    });
+  }
+
+  return { dryRun: false, kept: plan.keep.length, pruned: entries, failed, freedBytes };
+}

--- a/src/lib/backup/prune.ts
+++ b/src/lib/backup/prune.ts
@@ -46,6 +46,24 @@ export type PruneResult = {
   freedBytes: number;
 };
 
+/**
+ * The artifacts retention is allowed to reason about: the ones that exist.
+ *
+ * `listBackupArtifacts` includes rows whose upload failed, and those are
+ * verified - verification happens before the copy is written. Left in, such a
+ * row could become the newest verified copy and satisfy the rule that protects
+ * it, while the real stored copy it was standing in for got pruned. A backup
+ * that is not anywhere protects nothing.
+ */
+export function storedArtifacts(
+  db: SqliteDatabase,
+  artifacts: BackupArtifact[]
+): BackupArtifact[] {
+  return artifacts.filter((artifact) =>
+    listArtifactLocations(db, artifact.id).some((location) => location.status === "stored")
+  );
+}
+
 export type PrunePlanInput = {
   artifacts: BackupArtifact[];
   retention: BackupPolicy["retention"];
@@ -54,7 +72,7 @@ export type PrunePlanInput = {
 
 /** Preview what a prune would do, without touching a destination. */
 export function previewPrune(db: SqliteDatabase, input: PrunePlanInput): PruneResult {
-  const plan = planRetention(input.artifacts, input.retention, input.now);
+  const plan = planRetention(storedArtifacts(db, input.artifacts), input.retention, input.now);
   return {
     dryRun: true,
     kept: plan.keep.length,
@@ -97,7 +115,7 @@ export async function prune(
 ): Promise<PruneResult> {
   if (input.dryRun) return previewPrune(db, input);
 
-  const plan = planRetention(input.artifacts, input.retention, input.now);
+  const plan = planRetention(storedArtifacts(db, input.artifacts), input.retention, input.now);
   const entries: PruneEntry[] = [];
   let failed = 0;
   let freedBytes = 0;

--- a/src/lib/backup/readiness.ts
+++ b/src/lib/backup/readiness.ts
@@ -1,0 +1,176 @@
+import {
+  listBackupArtifacts,
+  listBackupDestinations,
+  listBackupPolicies,
+  listArtifactLocations,
+  type BackupArtifact,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+
+/**
+ * The readiness statement (RD-077 / PR-047e).
+ *
+ * One sentence at the top of the Recovery Center answering the only question
+ * that matters: *if this budget disappeared right now, what would I get back,
+ * and how old would it be?* Everything else on the page is evidence for this
+ * line.
+ *
+ * It is deliberately pessimistic. A backup system that reassures you is worse
+ * than no backup system, so anything Bench cannot presently prove — a copy it
+ * has never opened, a destination that failed last night, a single point of
+ * failure — pulls the statement down rather than being rounded up.
+ */
+
+export type ReadinessStatus = "protected" | "at-risk" | "unprotected";
+
+export type BackupReadiness = {
+  status: ReadinessStatus;
+  /** The headline sentence. Written to be read on its own. */
+  headline: string;
+  detail: string;
+  newestVerified: {
+    artifactId: string;
+    createdAt: string;
+    ageHours: number;
+    budgetName: string | null;
+  } | null;
+  totalCopies: number;
+  destinationCount: number;
+  /** More than one destination holding at least one copy. */
+  redundant: boolean;
+  issues: string[];
+};
+
+function hoursSince(iso: string, now: Date): number {
+  return (now.getTime() - new Date(iso).getTime()) / 3_600_000;
+}
+
+function describeAge(hours: number): string {
+  if (hours < 1) return "less than an hour ago";
+  if (hours < 24) return `${Math.round(hours)} hour${Math.round(hours) === 1 ? "" : "s"} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+export function buildBackupReadiness(db: SqliteDatabase, now: Date = new Date()): BackupReadiness {
+  const policies = listBackupPolicies(db);
+  const destinations = listBackupDestinations(db);
+  const artifacts = listBackupArtifacts(db, { limit: 500 });
+  const issues: string[] = [];
+
+  const stored = artifacts.filter((artifact) =>
+    listArtifactLocations(db, artifact.id).some((location) => location.status === "stored")
+  );
+  const verified = stored.filter((artifact) => artifact.verificationStatus === "passed");
+  const newest = verified[0] ?? null;
+
+  const destinationsHoldingCopies = new Set(
+    stored.flatMap((artifact) =>
+      listArtifactLocations(db, artifact.id)
+        .filter((location) => location.status === "stored" && location.destinationId)
+        .map((location) => location.destinationId as string)
+    )
+  );
+
+  const base = {
+    newestVerified: newest ? verifiedSummary(newest, now) : null,
+    totalCopies: stored.length,
+    destinationCount: destinationsHoldingCopies.size,
+    redundant: destinationsHoldingCopies.size > 1,
+  };
+
+  if (policies.length === 0 || destinations.length === 0) {
+    return {
+      ...base,
+      status: "unprotected",
+      headline: "Nothing is being backed up.",
+      detail:
+        destinations.length === 0
+          ? "Add a destination — a folder on this server, or an S3-compatible bucket — and Bench can start keeping verified copies."
+          : "Add a backup rule to start taking copies on a schedule.",
+      issues,
+    };
+  }
+
+  if (stored.length === 0) {
+    return {
+      ...base,
+      status: "unprotected",
+      headline: "No backup has been stored yet.",
+      detail: "A rule exists, but nothing has run successfully. Use “Back up now” to take the first copy.",
+      issues,
+    };
+  }
+
+  // Anything Bench cannot prove counts against readiness.
+  const failedVerification = stored.filter((artifact) => artifact.verificationStatus === "failed");
+  if (failedVerification.length > 0) {
+    issues.push(
+      `${failedVerification.length} stored ${
+        failedVerification.length === 1 ? "copy" : "copies"
+      } failed verification and should not be relied on.`
+    );
+  }
+
+  const brokenDestinations = destinations.filter(
+    (destination) =>
+      destination.enabled &&
+      destination.lastFailureAt &&
+      (!destination.lastSuccessAt || destination.lastFailureAt > destination.lastSuccessAt)
+  );
+  for (const destination of brokenDestinations) {
+    issues.push(`${destination.name} last failed: ${destination.lastFailureReason ?? "unknown error"}`);
+  }
+
+  if (!base.redundant) {
+    issues.push("Every copy is in one destination. Losing it loses all of them.");
+  }
+
+  const disabledPolicies = policies.filter((policy) => !policy.enabled);
+  if (disabledPolicies.length === policies.length) {
+    issues.push("Every backup rule is paused, so no new copies are being taken.");
+  }
+
+  if (!newest) {
+    return {
+      ...base,
+      status: "at-risk",
+      headline: "There are copies, but none Bench has been able to read.",
+      detail:
+        "A stored copy that has never verified might restore and might not. Run “Verify now” to find out which.",
+      issues,
+    };
+  }
+
+  const ageHours = hoursSince(newest.createdAt, now);
+  // Two days is the point at which a daily schedule has clearly missed one.
+  const stale = ageHours > 48;
+  if (stale) {
+    issues.push(`The newest verified copy is ${describeAge(ageHours)}.`);
+  }
+
+  const atRisk = stale || failedVerification.length > 0 || brokenDestinations.length > 0;
+
+  return {
+    ...base,
+    status: atRisk ? "at-risk" : "protected",
+    headline: atRisk
+      ? `Your last verified backup is from ${describeAge(ageHours)}, and something needs attention.`
+      : `You could restore a verified backup from ${describeAge(ageHours)}.`,
+    detail: `${base.totalCopies} stored ${base.totalCopies === 1 ? "copy" : "copies"} across ${
+      base.destinationCount
+    } destination${base.destinationCount === 1 ? "" : "s"}${
+      base.redundant ? ", so no single failure loses everything." : "."
+    }`,
+    issues,
+  };
+}
+
+function verifiedSummary(artifact: BackupArtifact, now: Date) {
+  return {
+    artifactId: artifact.id,
+    createdAt: artifact.createdAt,
+    ageHours: hoursSince(artifact.createdAt, now),
+    budgetName: artifact.sourceBudgetName,
+  };
+}

--- a/src/lib/backup/recoverySheet.ts
+++ b/src/lib/backup/recoverySheet.ts
@@ -1,0 +1,190 @@
+import {
+  listArtifactLocations,
+  listBackupArtifacts,
+  listBackupDestinations,
+  listBackupPolicies,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+
+/**
+ * The recovery sheet (RD-077 / PR-047e).
+ *
+ * A page of Markdown the user can print, keep in a password manager, or paste
+ * into a runbook — written for the situation that actually happens: Bench is
+ * gone, the server is gone, and someone is sitting in front of a laptop trying
+ * to get their budget back.
+ *
+ * That constraint decides everything about it. It names real paths and real
+ * object keys rather than describing them; it gives commands that work with
+ * `unzip`, `sqlite3` and `openssl` rather than through Bench; and it never
+ * assumes the reader can reach a running copy of this app, because if they
+ * could they would not need the sheet.
+ *
+ * It contains no secret. It says which passphrase is needed and where the user
+ * chose to keep it, never what it is — a recovery sheet ends up in a shared
+ * drive far more often than anyone plans for.
+ */
+
+export function buildRecoverySheet(db: SqliteDatabase, now: Date = new Date()): string {
+  const destinations = listBackupDestinations(db);
+  const policies = listBackupPolicies(db);
+  const artifacts = listBackupArtifacts(db, { limit: 20 });
+  const lines: string[] = [];
+
+  lines.push("# Actual Bench — Backup Recovery Sheet");
+  lines.push("");
+  lines.push(`Generated ${now.toISOString().replace("T", " ").slice(0, 16)} UTC.`);
+  lines.push("");
+  lines.push(
+    "Keep this with your passwords, not with your backups. It tells you how to get a budget back **without Bench**, which is the situation that matters."
+  );
+  lines.push("");
+
+  lines.push("## Where the copies are");
+  lines.push("");
+  if (destinations.length === 0) {
+    lines.push("_No destinations are configured._");
+  } else {
+    for (const destination of destinations) {
+      const config = destination.config.data as Record<string, unknown>;
+      if (destination.kind === "local") {
+        lines.push(`- **${destination.name}** — folder on the Bench server: \`${String(config.path ?? "")}\``);
+        lines.push(
+          "  - If the server is gone, this folder is gone too unless it was a mounted volume or a network share. Check where that volume actually lives."
+        );
+      } else {
+        const endpoint = config.endpoint ? String(config.endpoint) : "https://s3.amazonaws.com";
+        lines.push(
+          `- **${destination.name}** — S3-compatible bucket \`${String(config.bucket ?? "")}\`${
+            config.prefix ? ` under \`${String(config.prefix)}\`` : ""
+          }`
+        );
+        lines.push(`  - Endpoint: \`${endpoint}\` · Region: \`${String(config.region ?? "us-east-1")}\``);
+        lines.push(
+          "  - You need the access key for this bucket. Bench does not store it in readable form and it is not printed here."
+        );
+      }
+    }
+  }
+  lines.push("");
+
+  lines.push("## What is in them");
+  lines.push("");
+  lines.push(
+    "Every backup is stored beside a `.manifest.json` file describing it: what it is, when it was taken, its SHA-256 checksum, and whether it is encrypted. If this sheet is out of date, the manifests are not — read those."
+  );
+  lines.push("");
+  if (artifacts.length > 0) {
+    lines.push("Most recent copies Bench knew about:");
+    lines.push("");
+    lines.push("| Taken | What | Size | Verified | Where |");
+    lines.push("|---|---|---|---|---|");
+    for (const artifact of artifacts.slice(0, 10)) {
+      const locations = listArtifactLocations(db, artifact.id)
+        .filter((location) => location.status === "stored")
+        .map((location) => {
+          const destination = destinations.find((entry) => entry.id === location.destinationId);
+          return `${destination?.name ?? "unknown"}: \`${location.objectKey}\``;
+        });
+      lines.push(
+        `| ${artifact.createdAt.slice(0, 16).replace("T", " ")} | ${
+          artifact.kind === "budget" ? artifact.sourceBudgetName ?? "Budget" : "Bench settings"
+        } | ${formatBytes(artifact.sizeBytes)} | ${
+          artifact.verificationStatus === "passed" ? "yes" : "no"
+        } | ${locations.join("<br>") || "—"} |`
+      );
+    }
+    lines.push("");
+  }
+
+  const encrypted = policies.filter((policy) => policy.encryption === "passphrase");
+  if (encrypted.length > 0) {
+    lines.push("## Encryption");
+    lines.push("");
+    lines.push(
+      `These rules encrypt their backups: ${encrypted
+        .map((policy) => `**${policy.name}**`)
+        .join(", ")}. Their files end in \`.enc\` and begin with the ASCII marker \`BENCHBK1\`.`
+    );
+    lines.push("");
+    lines.push(
+      "Without the passphrase these files cannot be recovered by anyone, including you. Bench cannot reset it. If you do not know where that passphrase is written down, stop and fix that now — it is the single point of failure in this entire arrangement."
+    );
+    lines.push("");
+    lines.push("The file carries its own parameters, so it can be decrypted with nothing but itself:");
+    lines.push("");
+    lines.push("```");
+    lines.push("bytes  0..7    magic 'BENCHBK1'");
+    lines.push("byte   8       format version (1)");
+    lines.push("byte   9       salt length (16)");
+    lines.push("byte   10      IV length (12)");
+    lines.push("byte   11      auth tag length (16)");
+    lines.push("then           salt, IV, auth tag, then AES-256-GCM ciphertext");
+    lines.push("key            scrypt(passphrase, salt, N=32768, r=8, p=1) → 32 bytes");
+    lines.push("```");
+    lines.push("");
+    lines.push("Decrypting one with Node and nothing else installed:");
+    lines.push("");
+    lines.push("```js");
+    lines.push("const { readFileSync, writeFileSync } = require('node:fs');");
+    lines.push("const { scryptSync, createDecipheriv } = require('node:crypto');");
+    lines.push("const buf = readFileSync(process.argv[2]);");
+    lines.push("const [salt, iv, tag] = [buf.subarray(12, 28), buf.subarray(28, 40), buf.subarray(40, 56)];");
+    lines.push(
+      "const key = scryptSync(process.argv[3].normalize('NFKC'), salt, 32, { N: 32768, r: 8, p: 1, maxmem: 67108864 });"
+    );
+    lines.push("const d = createDecipheriv('aes-256-gcm', key, iv); d.setAuthTag(tag);");
+    lines.push(
+      "writeFileSync(process.argv[4], Buffer.concat([d.update(buf.subarray(56)), d.final()]));"
+    );
+    lines.push("```");
+    lines.push("");
+  }
+
+  lines.push("## Getting a budget back");
+  lines.push("");
+  lines.push("1. Copy the `.zip` you want off the destination (decrypt it first if it ends in `.enc`).");
+  lines.push(
+    "2. Check it is intact: `sha256sum yourfile.zip` should match `checksumSha256` in the manifest beside it — or `plaintextChecksumSha256` if it was encrypted."
+  );
+  lines.push(
+    "3. In Actual Budget, choose **Import file → Actual**, and pick the ZIP. Actual creates a *new* budget file from it; your existing budgets are untouched."
+  );
+  lines.push("");
+  lines.push(
+    "There is nothing Bench-specific about that ZIP — it is exactly what Actual's own export produces, so Actual can open it whether or not Bench still exists. That is the point."
+  );
+  lines.push("");
+  lines.push("If you only want to look inside one without importing it:");
+  lines.push("");
+  lines.push("```sh");
+  lines.push("unzip -o yourfile.zip -d restored/");
+  lines.push("sqlite3 restored/db.sqlite 'PRAGMA integrity_check;'");
+  lines.push("sqlite3 restored/db.sqlite 'SELECT COUNT(*) FROM transactions;'");
+  lines.push("```");
+  lines.push("");
+
+  lines.push("## Getting Bench's own settings back");
+  lines.push("");
+  lines.push(
+    "Copies marked *Bench settings* are the metadata database: sync rules, mappings, reconciliation sessions, automations and cleanup decisions. Restore it by stopping Bench, putting the file where `ACTUAL_BENCH_DB_PATH` points (default `/data/actual-bench.sqlite`), and starting it again."
+  );
+  lines.push("");
+  lines.push(
+    "It holds sealed credentials that only open with the same `SYNC_VAULT_KEY`. Restoring it onto a server with a different key gives you back every rule but no stored credentials, and you will be asked to enter them again."
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function formatBytes(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}

--- a/src/lib/backup/retention.test.ts
+++ b/src/lib/backup/retention.test.ts
@@ -1,0 +1,256 @@
+import type { BackupArtifact, BackupRetention } from "@/lib/app-db/backupRepository";
+import { DEFAULT_RETENTION } from "@/lib/app-db/backupRepository";
+import { planRetention } from "./retention";
+
+const NOW = new Date("2026-08-27T12:00:00.000Z");
+
+let counter = 0;
+function artifact(overrides: Partial<BackupArtifact> = {}): BackupArtifact {
+  counter += 1;
+  return {
+    id: `art-${counter}`,
+    policyId: "pol-1",
+    kind: "budget",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    sourceBudgetId: "budget-1",
+    sourceBudgetName: "Household",
+    sizeBytes: 1024,
+    checksumSha256: "a".repeat(64),
+    plaintextChecksumSha256: null,
+    encrypted: false,
+    encryption: null,
+    tier: "daily",
+    pinned: false,
+    protectedUntil: null,
+    takenBefore: null,
+    verificationLevel: "data",
+    verificationStatus: "passed",
+    verifiedAt: "2026-08-01T00:00:00.000Z",
+    verification: null,
+    manifestVersion: 1,
+    benchVersion: null,
+    notes: null,
+    ...overrides,
+  };
+}
+
+function daily(day: string, overrides: Partial<BackupArtifact> = {}): BackupArtifact {
+  return artifact({ createdAt: `${day}T02:00:00.000Z`, ...overrides });
+}
+
+function pruneIds(artifacts: BackupArtifact[], retention: BackupRetention = DEFAULT_RETENTION) {
+  return planRetention(artifacts, retention, NOW).prune.map((decision) => decision.artifactId);
+}
+
+describe("what retention refuses to delete", () => {
+  it("never prunes a pin, whatever the rules say", () => {
+    const pinned = daily("2020-01-01", { pinned: true });
+    const plan = planRetention([daily("2026-08-26"), pinned], { ...DEFAULT_RETENTION, daily: 1 }, NOW);
+
+    expect(plan.prune.map((entry) => entry.artifactId)).not.toContain(pinned.id);
+    expect(plan.keep.find((entry) => entry.artifactId === pinned.id)?.reason).toMatch(/Pinned/);
+  });
+
+  it("never prunes the newest verified copy, even with every tier set to zero", () => {
+    // The rule that makes everything else safe: no combination of settings can
+    // empty a destination.
+    const artifacts = [daily("2026-08-26"), daily("2026-08-20"), daily("2026-08-10")];
+    const empty: BackupRetention = {
+      daily: 0,
+      weekly: 0,
+      monthly: 0,
+      yearly: 0,
+      minimumAgeHours: 0,
+      autoProtectionDays: 0,
+      autoProtectionCount: 0,
+    };
+
+    const plan = planRetention(artifacts, empty, NOW);
+    expect(plan.keep).toHaveLength(1);
+    expect(plan.keep[0].artifactId).toBe(artifacts[0].id);
+    expect(plan.keep[0].reason).toMatch(/last good one/);
+  });
+
+  it("keeps the newest verified copy in preference to a newer unverified one", () => {
+    // A backup Bench could not read is not the copy to bet the last-good-copy
+    // guarantee on.
+    const broken = daily("2026-08-26", { verificationStatus: "failed" });
+    const good = daily("2026-08-25");
+    const plan = planRetention([broken, good], { ...DEFAULT_RETENTION, daily: 1, minimumAgeHours: 0 }, NOW);
+
+    expect(plan.keep.map((entry) => entry.artifactId)).toContain(good.id);
+    expect(plan.keep.find((entry) => entry.artifactId === good.id)?.reason).toMatch(/last good one/);
+  });
+
+  it("falls back to the newest copy when nothing has verified", () => {
+    const artifacts = [
+      daily("2026-08-26", { verificationStatus: "failed" }),
+      daily("2026-08-25", { verificationStatus: "failed" }),
+    ];
+    const plan = planRetention(
+      artifacts,
+      { ...DEFAULT_RETENTION, daily: 0, weekly: 0, monthly: 0, yearly: 0, minimumAgeHours: 0 },
+      NOW
+    );
+
+    expect(plan.keep).toHaveLength(1);
+    expect(plan.keep[0].reason).toMatch(/nothing verified/);
+  });
+
+  it("keeps anything younger than the minimum age", () => {
+    // A misconfigured schedule must not be able to cycle a day's worth of
+    // backups out of existence in an afternoon. The newest copy here failed
+    // verification, so it is not being kept by the last-good-copy rule.
+    const fresh = artifact({ createdAt: "2026-08-27T09:00:00.000Z", verificationStatus: "failed" });
+    const plan = planRetention(
+      [daily("2026-08-26"), fresh, daily("2026-08-20")],
+      { ...DEFAULT_RETENTION, daily: 1, weekly: 0, monthly: 0, yearly: 0 },
+      NOW
+    );
+
+    expect(plan.keep.find((entry) => entry.artifactId === fresh.id)?.reason).toMatch(/24h/);
+  });
+
+  it("never expires a backup somebody took by hand", () => {
+    const manual = daily("2024-01-01", { tier: "manual" });
+    expect(pruneIds([daily("2026-08-26"), manual])).not.toContain(manual.id);
+  });
+});
+
+describe("grandfather-father-son", () => {
+  it("keeps one copy per day, week, month and year", () => {
+    const artifacts = [
+      daily("2026-08-26"),
+      daily("2026-08-25"),
+      daily("2026-08-24"),
+      daily("2026-08-18"), // previous week
+      daily("2026-07-15"), // previous month
+      daily("2025-06-10"), // previous year
+    ];
+
+    const plan = planRetention(
+      artifacts,
+      { ...DEFAULT_RETENTION, daily: 3, weekly: 2, monthly: 2, yearly: 2, minimumAgeHours: 0 },
+      NOW
+    );
+
+    // Newest is the last-good-copy survivor; the rest fill the tiers, and
+    // nothing here is redundant enough to lose.
+    expect(plan.prune).toHaveLength(0);
+  });
+
+  it("prunes the extra copies once a day already has one", () => {
+    const kept = daily("2026-08-26");
+    const same = artifact({ createdAt: "2026-08-26T22:00:00.000Z" });
+    const older = artifact({ createdAt: "2026-08-26T06:00:00.000Z" });
+
+    const plan = planRetention(
+      [kept, same, older],
+      { ...DEFAULT_RETENTION, daily: 1, weekly: 0, monthly: 0, yearly: 0, minimumAgeHours: 0 },
+      NOW
+    );
+
+    // The newest survives as the last good copy and occupies the day's slot,
+    // so with daily:1 the other two are redundant.
+    expect(plan.prune).toHaveLength(2);
+    expect(plan.prune[0].reason).toMatch(/Superseded/);
+  });
+
+  it("counts budgets and Bench's own database separately", () => {
+    // Seven daily budget copies must not use up the allowance for the metadata
+    // database, or one of them would silently stop being kept.
+    const artifacts = [
+      daily("2026-08-26"),
+      daily("2026-08-25"),
+      daily("2026-08-26", { kind: "app-db" }),
+      daily("2026-08-25", { kind: "app-db" }),
+    ];
+
+    const plan = planRetention(
+      artifacts,
+      { ...DEFAULT_RETENTION, daily: 2, weekly: 0, monthly: 0, yearly: 0, minimumAgeHours: 0 },
+      NOW
+    );
+
+    expect(plan.prune).toHaveLength(0);
+    expect(plan.keep).toHaveLength(4);
+  });
+
+  it("keeps policies apart, so deleting one cannot thin another", () => {
+    const plan = planRetention(
+      [daily("2026-08-26"), daily("2026-08-26", { policyId: "pol-2" })],
+      { ...DEFAULT_RETENTION, daily: 1, minimumAgeHours: 0 },
+      NOW
+    );
+
+    expect(plan.prune).toHaveLength(0);
+  });
+});
+
+describe("automatic recovery points", () => {
+  it("protects them for the configured window rather than pinning them forever", () => {
+    const recent = artifact({ createdAt: "2026-08-20T10:00:00.000Z", tier: "auto" });
+    const old = artifact({ createdAt: "2026-06-01T10:00:00.000Z", tier: "auto" });
+
+    const plan = planRetention(
+      [daily("2026-08-26"), recent, old],
+      { ...DEFAULT_RETENTION, autoProtectionCount: 1 },
+      NOW
+    );
+
+    expect(plan.keep.find((entry) => entry.artifactId === recent.id)?.reason).toMatch(
+      /protection window/
+    );
+    expect(plan.prune.map((entry) => entry.artifactId)).toContain(old.id);
+  });
+
+  it("keeps the newest few even after the window closes", () => {
+    // Whichever protects more: the window or the count. Someone who does one
+    // risky operation a year should still find the recovery point from it.
+    const old = artifact({ createdAt: "2020-01-01T00:00:00.000Z", tier: "auto" });
+    const plan = planRetention(
+      [daily("2026-08-26"), old],
+      { ...DEFAULT_RETENTION, autoProtectionDays: 1, autoProtectionCount: 5 },
+      NOW
+    );
+
+    expect(plan.keep.map((entry) => entry.artifactId)).toContain(old.id);
+  });
+
+  it("lets them go once they are past both the window and the count", () => {
+    const points = Array.from({ length: 4 }, (_, index) =>
+      artifact({ createdAt: `2020-01-0${index + 1}T00:00:00.000Z`, tier: "auto" })
+    );
+
+    const plan = planRetention(
+      [daily("2026-08-26"), ...points],
+      { ...DEFAULT_RETENTION, autoProtectionDays: 1, autoProtectionCount: 2 },
+      NOW
+    );
+
+    // Newest two protected by count; the rest expire.
+    expect(plan.prune).toHaveLength(2);
+  });
+});
+
+describe("explaining itself", () => {
+  it("gives every artifact a reason, because a prune preview has to be readable", () => {
+    const artifacts = [
+      daily("2026-08-26"),
+      daily("2026-08-25"),
+      daily("2020-01-01"),
+      daily("2020-01-02", { pinned: true }),
+    ];
+
+    const plan = planRetention(artifacts, DEFAULT_RETENTION, NOW);
+
+    expect([...plan.keep, ...plan.prune]).toHaveLength(artifacts.length);
+    for (const decision of [...plan.keep, ...plan.prune]) {
+      expect(decision.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("decides nothing when there is nothing to decide", () => {
+    expect(planRetention([], DEFAULT_RETENTION, NOW)).toEqual({ keep: [], prune: [] });
+  });
+});

--- a/src/lib/backup/retention.ts
+++ b/src/lib/backup/retention.ts
@@ -1,0 +1,207 @@
+import type { BackupArtifact, BackupRetention } from "@/lib/app-db/backupRepository";
+import type { BackupArtifactKind } from "./manifest";
+
+/**
+ * Retention (RD-077 / PR-047d).
+ *
+ * Deleting backups is the most dangerous thing this feature does, so the rules
+ * are written as a set of *refusals* first and a schedule second. Pure and
+ * side-effect free by design: every decision can be shown to the user before
+ * anything is removed, and "preview" is the same code path as "prune" rather
+ * than a hopeful approximation of it.
+ *
+ * The refusals, in order of precedence:
+ *
+ *   1. **Pinned copies are never pruned.** A pin is a user saying "not this
+ *      one", and no policy outranks that.
+ *   2. **Protected copies are never pruned while protected.** Automatic safety
+ *      points take this: they were taken because something risky was about to
+ *      happen, and the window where you discover the damage is measured in days.
+ *   3. **Nothing younger than the minimum age is pruned**, whatever the rules
+ *      say. It stops a misconfigured schedule from cycling a day's worth of
+ *      backups out of existence in an afternoon.
+ *   4. **The newest verified copy of each thing survives**, always. If none is
+ *      verified, the newest copy survives instead. This is the rule that makes
+ *      the rest safe: there is no combination of settings that empties a
+ *      destination.
+ *   5. **Manual backups are never pruned automatically.** Somebody took that
+ *      one on purpose; Bench should not decide it has expired.
+ *
+ * Only then does grandfather-father-son apply: keep the newest copy of each of
+ * the last N days, weeks, months and years. A copy kept by any tier is kept.
+ */
+
+export type RetentionDecision = {
+  artifactId: string;
+  keep: boolean;
+  /** Plain language, shown verbatim in the prune preview. */
+  reason: string;
+};
+
+export type RetentionPlan = {
+  keep: RetentionDecision[];
+  prune: RetentionDecision[];
+};
+
+type Grouped = Map<string, BackupArtifact[]>;
+
+function groupKey(artifact: BackupArtifact): string {
+  // Grouped by policy *and* kind: a budget and a copy of Bench's own database
+  // are different things, and keeping seven of one must not count towards the
+  // other's seven.
+  return `${artifact.policyId ?? "orphan"}::${artifact.kind as BackupArtifactKind}`;
+}
+
+function group(artifacts: BackupArtifact[]): Grouped {
+  const grouped: Grouped = new Map();
+  for (const artifact of artifacts) {
+    const key = groupKey(artifact);
+    const list = grouped.get(key);
+    if (list) list.push(artifact);
+    else grouped.set(key, [artifact]);
+  }
+  for (const list of grouped.values()) {
+    list.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+  return grouped;
+}
+
+function dayBucket(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function weekBucket(iso: string): string {
+  const date = new Date(iso);
+  // ISO week: Thursday of the same week determines the year and week number.
+  const thursday = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  thursday.setUTCDate(thursday.getUTCDate() + 3 - ((thursday.getUTCDay() + 6) % 7));
+  const firstThursday = new Date(Date.UTC(thursday.getUTCFullYear(), 0, 4));
+  const week =
+    1 +
+    Math.round(
+      ((thursday.getTime() - firstThursday.getTime()) / 86_400_000 -
+        3 +
+        ((firstThursday.getUTCDay() + 6) % 7)) /
+        7
+    );
+  return `${thursday.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+function monthBucket(iso: string): string {
+  return iso.slice(0, 7);
+}
+
+function yearBucket(iso: string): string {
+  return iso.slice(0, 4);
+}
+
+const TIERS = [
+  { name: "daily", label: "day", bucket: dayBucket, limit: (r: BackupRetention) => r.daily },
+  { name: "weekly", label: "week", bucket: weekBucket, limit: (r: BackupRetention) => r.weekly },
+  { name: "monthly", label: "month", bucket: monthBucket, limit: (r: BackupRetention) => r.monthly },
+  { name: "yearly", label: "year", bucket: yearBucket, limit: (r: BackupRetention) => r.yearly },
+] as const;
+
+function hoursBetween(from: string, to: Date): number {
+  return (to.getTime() - new Date(from).getTime()) / 3_600_000;
+}
+
+/**
+ * Decide what to keep and what to prune. Never touches storage.
+ *
+ * @param artifacts every artifact under consideration, any order
+ * @param retention the policy's rules
+ * @param now injected so the plan is reproducible in tests and in a preview
+ */
+export function planRetention(
+  artifacts: BackupArtifact[],
+  retention: BackupRetention,
+  now: Date = new Date()
+): RetentionPlan {
+  const keep: RetentionDecision[] = [];
+  const prune: RetentionDecision[] = [];
+
+  for (const [, list] of group(artifacts)) {
+    const survivor =
+      list.find((artifact) => artifact.verificationStatus === "passed") ?? list[0] ?? null;
+
+    // Which buckets each tier has already filled, newest first.
+    const filled = new Map<string, Set<string>>(TIERS.map((tier) => [tier.name, new Set<string>()]));
+    // The copy that survives unconditionally still occupies its day, week,
+    // month and year. Without this, "keep 7 daily" would quietly keep eight,
+    // and every tier would be off by one in the direction of using more space
+    // than the user asked for.
+    if (survivor) {
+      for (const tier of TIERS) {
+        if (tier.limit(retention) > 0) filled.get(tier.name)!.add(tier.bucket(survivor.createdAt));
+      }
+    }
+    const autoProtectedIds = new Set(
+      list
+        .filter((artifact) => artifact.tier === "auto")
+        .slice(0, Math.max(0, retention.autoProtectionCount))
+        .map((artifact) => artifact.id)
+    );
+
+    for (const artifact of list) {
+      const decide = (reason: string, shouldKeep: boolean) => {
+        (shouldKeep ? keep : prune).push({ artifactId: artifact.id, keep: shouldKeep, reason });
+      };
+
+      if (artifact.pinned) {
+        decide("Pinned — kept until you unpin it.", true);
+        continue;
+      }
+      if (artifact.protectedUntil && new Date(artifact.protectedUntil) > now) {
+        decide(`Protected until ${artifact.protectedUntil.slice(0, 10)}.`, true);
+        continue;
+      }
+      if (artifact.id === survivor?.id) {
+        decide(
+          artifact.verificationStatus === "passed"
+            ? "Newest verified copy — Bench never prunes the last good one."
+            : "Newest copy — nothing verified is available to keep instead.",
+          true
+        );
+        continue;
+      }
+      if (hoursBetween(artifact.createdAt, now) < retention.minimumAgeHours) {
+        decide(`Less than ${retention.minimumAgeHours}h old.`, true);
+        continue;
+      }
+      if (artifact.tier === "manual") {
+        decide("Taken by hand — Bench does not expire manual backups.", true);
+        continue;
+      }
+      if (artifact.tier === "auto") {
+        const withinDays =
+          hoursBetween(artifact.createdAt, now) < retention.autoProtectionDays * 24;
+        if (withinDays || autoProtectedIds.has(artifact.id)) {
+          decide("Recovery point, still inside its protection window.", true);
+          continue;
+        }
+        decide("Recovery point past its protection window.", false);
+        continue;
+      }
+
+      const matched = TIERS.find((tier) => {
+        const limit = tier.limit(retention);
+        if (limit <= 0) return false;
+        const buckets = filled.get(tier.name)!;
+        const bucket = tier.bucket(artifact.createdAt);
+        if (buckets.has(bucket)) return false;
+        if (buckets.size >= limit) return false;
+        buckets.add(bucket);
+        return true;
+      });
+
+      if (matched) {
+        decide(`Kept as this ${matched.label}'s copy.`, true);
+      } else {
+        decide("Superseded by newer copies under the retention rules.", false);
+      }
+    }
+  }
+
+  return { keep, prune };
+}

--- a/src/lib/backup/runBackup.test.ts
+++ b/src/lib/backup/runBackup.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @jest-environment node
+ */
+import Database from "better-sqlite3";
+import { zipSync } from "fflate";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import { upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import {
+  createBackupDestination,
+  createBackupPolicy,
+  getBackupDestination,
+  listArtifactLocations,
+  listBackupArtifacts,
+} from "@/lib/app-db/backupRepository";
+import { upsertSyncCredential } from "@/lib/app-db/syncCredentialRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { decryptArchive } from "./encryption";
+import { parseManifest } from "./manifest";
+import { backupObjectKey, runBackup } from "./runBackup";
+
+function budgetDbBytes(): Uint8Array {
+  const root = mkdtempSync(join(tmpdir(), "bench-run-fixture-"));
+  const path = join(root, "db.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE payees (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE transactions (id TEXT PRIMARY KEY, acct TEXT, date INTEGER, amount INTEGER);
+    INSERT INTO accounts VALUES ('a1', 'Current');
+    INSERT INTO transactions VALUES ('t1', 'a1', 20260101, -500);
+  `);
+  db.close();
+  const bytes = readFileSync(path);
+  rmSync(root, { recursive: true, force: true });
+  return bytes;
+}
+
+const BUDGET_ZIP = zipSync({
+  "db.sqlite": budgetDbBytes(),
+  "metadata.json": Buffer.from(JSON.stringify({ budgetName: "Household", id: "budget-1" })),
+});
+
+function mockExport(bytes: Uint8Array = BUDGET_ZIP, status = 200) {
+  global.fetch = jest.fn(async () =>
+    status === 200
+      ? new Response(Buffer.from(bytes), { status: 200 })
+      : new Response(JSON.stringify({ message: "budget is locked" }), {
+          status,
+          headers: { "content-type": "application/json" },
+        })
+  ) as unknown as typeof fetch;
+}
+
+describe("running a backup", () => {
+  let root: string;
+  let db: SqliteDatabase;
+  let volume: string;
+  const previousKey = process.env.SYNC_VAULT_KEY;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.SYNC_VAULT_KEY = "test-vault-key";
+    root = mkdtempSync(join(tmpdir(), "actual-bench-run-backup-"));
+    volume = join(root, "volume");
+    db = getAppDb(join(root, "metadata.sqlite"));
+
+    upsertSyncCredential(db, {
+      connectionFingerprint: "conn-1",
+      mode: "http-api",
+      baseUrl: "https://actual.example.com",
+      budgetSyncId: "budget-1",
+      label: "Household",
+      secret: { apiKey: "key", encryptionPassword: "" },
+    });
+    mockExport();
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+    global.fetch = originalFetch;
+    if (previousKey === undefined) delete process.env.SYNC_VAULT_KEY;
+    else process.env.SYNC_VAULT_KEY = previousKey;
+  });
+
+  function localDestination(name = "Volume", path = volume) {
+    return createBackupDestination(db, {
+      name,
+      kind: "local",
+      config: { version: 1, data: { path } },
+    });
+  }
+
+  function policy(overrides: Record<string, unknown> = {}) {
+    return createBackupPolicy(db, {
+      name: "Nightly",
+      contents: "budget",
+      sourceRef: { version: 1, data: { connectionFingerprint: "conn-1" } },
+      destinationIds: [localDestination().id],
+      verificationLevel: "data",
+      ...overrides,
+    });
+  }
+
+  it("stores a verified copy and a manifest beside it", async () => {
+    const result = await runBackup(db, policy());
+
+    expect(result.stored).toBe(true);
+    expect(result.verified).toBe(true);
+
+    const [artifact] = listBackupArtifacts(db);
+    expect(artifact.verificationStatus).toBe("passed");
+    expect(artifact.kind).toBe("budget");
+
+    const [location] = listArtifactLocations(db, artifact.id);
+    expect(location.status).toBe("stored");
+
+    const stored = readFileSync(join(volume, location.objectKey));
+    expect(stored.byteLength).toBe(artifact.sizeBytes);
+
+    const manifest = parseManifest(readFileSync(join(volume, `${location.objectKey}.manifest.json`)));
+    expect(manifest?.artifactId).toBe(artifact.id);
+    expect(manifest?.content?.transactions).toBe(1);
+    expect(manifest?.source?.budgetName).toBe("Household");
+  });
+
+  it("keeps the copy that succeeded when another destination fails", async () => {
+    // The reason locations are their own table: one bad destination must not
+    // lose the copy that did land, or make the healthy one look broken.
+    const good = localDestination("Volume", join(root, "good"));
+    const bad = createBackupDestination(db, {
+      name: "Broken",
+      kind: "s3",
+      credentialRef: "missing",
+      config: { version: 1, data: { bucket: "nope" } },
+    });
+
+    const result = await runBackup(
+      db,
+      policy({ destinationIds: [good.id, bad.id] })
+    );
+
+    expect(result.stored).toBe(true);
+    const outcomes = result.artifacts[0].destinations;
+    expect(outcomes.find((entry) => entry.destinationId === good.id)?.status).toBe("stored");
+    expect(outcomes.find((entry) => entry.destinationId === bad.id)?.status).toBe("failed");
+
+    expect(getBackupDestination(db, good.id)?.lastSuccessAt).not.toBeNull();
+    expect(getBackupDestination(db, good.id)?.lastFailureReason).toBeNull();
+    expect(getBackupDestination(db, bad.id)?.lastFailureReason).toMatch(/access key/i);
+  });
+
+  it("verifies the plaintext, not the ciphertext", async () => {
+    upsertBackupCredential(db, {
+      ref: "pol-secret",
+      kind: "passphrase",
+      secret: { passphrase: "correct horse" },
+    });
+
+    const result = await runBackup(
+      db,
+      policy({ encryption: "passphrase", encryptionCredentialRef: "pol-secret" })
+    );
+
+    // Encrypted bytes are not a readable ZIP; the run still verifies, because
+    // verification happened before encryption.
+    expect(result.verified).toBe(true);
+
+    const [artifact] = listBackupArtifacts(db);
+    expect(artifact.encrypted).toBe(true);
+    expect(artifact.plaintextChecksumSha256).not.toBe(artifact.checksumSha256);
+
+    const [location] = listArtifactLocations(db, artifact.id);
+    expect(location.objectKey.endsWith(".zip.enc")).toBe(true);
+
+    const stored = readFileSync(join(volume, location.objectKey));
+    expect(decryptArchive(stored, "correct horse").byteLength).toBe(BUDGET_ZIP.byteLength);
+  });
+
+  it("records a stored-but-unverified copy rather than throwing it away", async () => {
+    // A backup Bench distrusts beats no backup, as long as nobody is allowed to
+    // believe it is fine.
+    mockExport(zipSync({ "readme.txt": Buffer.from("not a budget") }));
+
+    const result = await runBackup(db, policy());
+
+    expect(result.stored).toBe(true);
+    expect(result.verified).toBe(false);
+    expect(result.message).toMatch(/db\.sqlite/);
+    expect(listBackupArtifacts(db)[0].verificationStatus).toBe("failed");
+  });
+
+  it("says what went wrong when the export itself fails", async () => {
+    mockExport(BUDGET_ZIP, 423);
+
+    const result = await runBackup(db, policy());
+
+    expect(result.stored).toBe(false);
+    expect(result.message).toMatch(/budget is locked/);
+    expect(listBackupArtifacts(db)).toHaveLength(0);
+  });
+
+  it("refuses to run with nowhere to write instead of reporting success", async () => {
+    const result = await runBackup(db, policy({ destinationIds: [] }));
+
+    expect(result.stored).toBe(false);
+    expect(result.message).toMatch(/nowhere to write/);
+  });
+
+  it("backs up Bench's own database as a second artifact", async () => {
+    const result = await runBackup(db, policy({ contents: "both" }));
+
+    expect(result.artifacts.map((entry) => entry.kind)).toEqual(["budget", "app-db"]);
+    expect(result.stored).toBe(true);
+
+    const appDb = listBackupArtifacts(db).find((entry) => entry.kind === "app-db");
+    expect(appDb?.verificationStatus).toBe("passed");
+
+    const [location] = listArtifactLocations(db, appDb!.id);
+    // A consistent copy, openable on its own.
+    const copy = new Database(join(volume, location.objectKey), { readonly: true });
+    expect(copy.prepare("SELECT COUNT(*) AS n FROM backup_policies").get<{ n: number }>()?.n).toBe(1);
+    copy.close();
+  });
+
+  it("names objects so a human can find them without Bench", async () => {
+    const key = backupObjectKey({
+      kind: "budget",
+      label: "Household Budget",
+      createdAt: new Date("2026-08-27T04:05:06Z"),
+      artifactId: "abcdef123456",
+      encrypted: false,
+    });
+
+    expect(key).toBe("budget/household-budget/2026/2026-08-27T040506-abcdef12.zip");
+  });
+
+  it("leaves no manifest behind for an artifact that failed to upload", async () => {
+    // A manifest without its artifact would advertise a backup that is not there.
+    const readOnly = join(root, "read-only");
+    const destination = localDestination("Locked", readOnly);
+    // Replace the destination directory with a file, so every write fails.
+    rmSync(readOnly, { recursive: true, force: true });
+    writeFileSync(readOnly, "x");
+
+    const result = await runBackup(db, policy({ destinationIds: [destination.id] }));
+
+    expect(result.stored).toBe(false);
+    expect(statSync(readOnly).isFile()).toBe(true);
+  });
+
+  it("writes nothing outside the destination root", async () => {
+    await runBackup(db, policy());
+    // Everything under the volume, nothing beside it (bar SQLite's own WAL
+    // sidecars for the metadata database).
+    const strays = readdirSync(root).filter((entry) => !entry.startsWith("metadata.sqlite"));
+    expect(strays).toEqual(["volume"]);
+  });
+});

--- a/src/lib/backup/runBackup.ts
+++ b/src/lib/backup/runBackup.ts
@@ -1,0 +1,493 @@
+import { vaultEnabled } from "@/lib/sync/vault";
+import { getSyncCredential } from "@/lib/app-db/syncCredentialRepository";
+import { getBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import {
+  createBackupArtifact,
+  getBackupDestination,
+  recordArtifactLocation,
+  recordDestinationOutcome,
+  type BackupArtifact,
+  type BackupPolicy,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase, SyncCredential } from "@/lib/app-db/types";
+import { createDestinationAdapter, DestinationError } from "./destinations";
+import { encryptArchive } from "./encryption";
+import {
+  manifestKeyFor,
+  serializeManifest,
+  sha256,
+  MANIFEST_VERSION,
+  type BackupArtifactKind,
+  type BackupManifest,
+  type BackupRetentionTier,
+} from "./manifest";
+import { exportAppDbSnapshot } from "./sources/appDbExport";
+import { exportBudgetFromCredential } from "./sources/budgetExport";
+import { verifyAppDbArchive, verifyBudgetArchive, type VerificationOutcome } from "./verify";
+import { LATEST_SCHEMA_VERSION } from "@/lib/app-db/migrations";
+
+/**
+ * Taking a backup (RD-077 / PR-047c).
+ *
+ * The order of operations is the whole design, and it is not the obvious one:
+ *
+ *   1. **Export** from the source.
+ *   2. **Verify the plaintext**, before anything else touches it. Verifying
+ *      after encryption proves only that bytes survived a round trip, which is
+ *      the least interesting thing that can go wrong; verifying before it means
+ *      a passing artifact is one Bench has actually opened and read.
+ *   3. **Encrypt**, optionally, recording parameters but never the key.
+ *   4. **Fan out** to every destination independently, and record each result
+ *      on its own. One destination being down must not lose the copy that did
+ *      succeed elsewhere, and must not mark a healthy destination unhealthy.
+ *
+ * A run that verifies badly still writes its artifact and records the failure.
+ * That is deliberate: a backup Bench distrusts is more useful than no backup,
+ * as long as nobody is allowed to believe it is fine. Retention knows the
+ * difference — an unverified copy never counts as the last good one.
+ */
+
+export type BackupRunTrigger = "scheduled" | "manual" | "safety";
+
+export type DestinationOutcome = {
+  destinationId: string;
+  destinationName: string;
+  status: "stored" | "failed";
+  objectKey: string | null;
+  sizeBytes: number | null;
+  error?: string;
+};
+
+export type ArtifactOutcome = {
+  kind: BackupArtifactKind;
+  artifactId: string | null;
+  status: "stored" | "failed";
+  sizeBytes: number;
+  verification: VerificationOutcome | null;
+  destinations: DestinationOutcome[];
+  error?: string;
+};
+
+export type BackupRunResult = {
+  policyId: string | null;
+  trigger: BackupRunTrigger;
+  startedAt: string;
+  finishedAt: string;
+  artifacts: ArtifactOutcome[];
+  /** True when every requested artifact reached at least one destination. */
+  stored: boolean;
+  /** True when every stored artifact also verified. */
+  verified: boolean;
+  message?: string;
+};
+
+export type RunBackupOptions = {
+  trigger?: BackupRunTrigger;
+  tier?: BackupRetentionTier;
+  /** Recorded on the artifact: what the user was about to do. */
+  takenBefore?: string | null;
+  /** Protected from tier retention until this time. */
+  protectedUntil?: string | null;
+  notes?: string | null;
+  now?: Date;
+};
+
+function slug(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "budget"
+  );
+}
+
+/**
+ * Object keys are deliberately human-navigable: someone browsing the
+ * destination with `ls` or a bucket console should be able to find the copy
+ * they want without Bench's help, because the day they are looking is the day
+ * Bench is not available.
+ */
+export function backupObjectKey(input: {
+  kind: BackupArtifactKind;
+  label: string;
+  createdAt: Date;
+  artifactId: string;
+  encrypted: boolean;
+}): string {
+  const iso = input.createdAt.toISOString();
+  const day = iso.slice(0, 10);
+  const time = iso.slice(11, 19).replace(/:/g, "");
+  const extension = input.kind === "budget" ? "zip" : "sqlite";
+  const suffix = input.encrypted ? `${extension}.enc` : extension;
+  return `${input.kind}/${slug(input.label)}/${day.slice(0, 4)}/${day}T${time}-${input.artifactId.slice(0, 8)}.${suffix}`;
+}
+
+type PreparedArtifact = {
+  kind: BackupArtifactKind;
+  label: string;
+  plaintext: Buffer;
+  verification: VerificationOutcome;
+  sourceBudgetId: string | null;
+  sourceBudgetName: string | null;
+  serverUrl: string | null;
+};
+
+function readSourceCredential(db: SqliteDatabase, policy: BackupPolicy): SyncCredential {
+  const fingerprint = policy.sourceRef.data.connectionFingerprint;
+  if (typeof fingerprint !== "string" || !fingerprint.trim()) {
+    throw new Error("This backup has no source connection configured.");
+  }
+  if (!vaultEnabled()) {
+    throw new Error(
+      "The credential vault is disabled (SYNC_VAULT_KEY is unset), so Bench cannot reach the budget without you."
+    );
+  }
+
+  let credential: SyncCredential | null;
+  try {
+    credential = getSyncCredential(db, fingerprint);
+  } catch {
+    throw new Error("Bench could not decrypt the stored credentials; the vault key may have changed.");
+  }
+  if (!credential) {
+    throw new Error(
+      "The source connection is not enrolled for unattended use, so a scheduled backup cannot reach it."
+    );
+  }
+  return credential;
+}
+
+function readPassphrase(db: SqliteDatabase, policy: BackupPolicy): string {
+  if (!policy.encryptionCredentialRef) {
+    throw new Error("This backup is set to encrypt but has no stored passphrase.");
+  }
+  const secret = getBackupCredential(db, policy.encryptionCredentialRef);
+  const passphrase = secret && "passphrase" in secret ? secret.passphrase : "";
+  if (!passphrase) {
+    throw new Error("This backup's encryption passphrase is missing. Re-enter it to continue backing up.");
+  }
+  return passphrase;
+}
+
+/** Export and verify one artifact. Throws only when there is nothing to store. */
+async function prepareArtifact(
+  db: SqliteDatabase,
+  policy: BackupPolicy,
+  kind: BackupArtifactKind
+): Promise<PreparedArtifact> {
+  if (kind === "app-db") {
+    const bytes = exportAppDbSnapshot(db);
+    return {
+      kind,
+      label: "actual-bench",
+      plaintext: bytes,
+      verification: verifyAppDbArchive(bytes, policy.verificationLevel),
+      sourceBudgetId: null,
+      sourceBudgetName: null,
+      serverUrl: null,
+    };
+  }
+
+  const credential = readSourceCredential(db, policy);
+  const exported = await exportBudgetFromCredential(credential);
+  return {
+    kind,
+    label: credential.label || credential.budgetSyncId,
+    plaintext: exported.bytes,
+    verification: verifyBudgetArchive(exported.bytes, policy.verificationLevel),
+    sourceBudgetId: credential.budgetSyncId,
+    sourceBudgetName: credential.label || null,
+    serverUrl: exported.serverUrl,
+  };
+}
+
+function kindsFor(policy: BackupPolicy): BackupArtifactKind[] {
+  if (policy.contents === "budget") return ["budget"];
+  if (policy.contents === "app-db") return ["app-db"];
+  return ["budget", "app-db"];
+}
+
+export async function runBackup(
+  db: SqliteDatabase,
+  policy: BackupPolicy,
+  options: RunBackupOptions = {}
+): Promise<BackupRunResult> {
+  const now = options.now ?? new Date();
+  const startedAt = now.toISOString();
+  const trigger = options.trigger ?? "scheduled";
+  const tier = options.tier ?? (trigger === "manual" ? "manual" : trigger === "safety" ? "auto" : "daily");
+
+  const destinations = policy.destinationIds
+    .map((id) => getBackupDestination(db, id))
+    .filter((destination): destination is NonNullable<typeof destination> => destination !== null)
+    .filter((destination) => destination.enabled);
+
+  if (destinations.length === 0) {
+    return {
+      policyId: policy.id,
+      trigger,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      artifacts: [],
+      stored: false,
+      verified: false,
+      message:
+        "This backup has no enabled destination, so there is nowhere to write a copy. Add or re-enable one.",
+    };
+  }
+
+  const passphrase = policy.encryption === "passphrase" ? readPassphrase(db, policy) : null;
+  const artifacts: ArtifactOutcome[] = [];
+
+  for (const kind of kindsFor(policy)) {
+    let prepared: PreparedArtifact;
+    try {
+      prepared = await prepareArtifact(db, policy, kind);
+    } catch (error) {
+      artifacts.push({
+        kind,
+        artifactId: null,
+        status: "failed",
+        sizeBytes: 0,
+        verification: null,
+        destinations: [],
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const plaintextChecksum = prepared.verification.checksumSha256;
+    const encrypted = passphrase ? encryptArchive(prepared.plaintext, passphrase) : null;
+    const stored = encrypted ? encrypted.bytes : prepared.plaintext;
+
+    const artifact = createBackupArtifact(db, {
+      policyId: policy.id,
+      kind,
+      createdAt: startedAt,
+      sourceBudgetId: prepared.sourceBudgetId,
+      sourceBudgetName: prepared.sourceBudgetName,
+      sizeBytes: stored.byteLength,
+      // The checksum of the bytes as stored, which is what a later scrub can
+      // actually re-compute; the plaintext checksum is recorded beside it so a
+      // restore is checkable end to end.
+      checksumSha256: encrypted !== null ? sha256(stored) : plaintextChecksum,
+      plaintextChecksumSha256: plaintextChecksum,
+      encrypted: encrypted !== null,
+      encryption: encrypted ? { version: 1, data: { ...encrypted.info } } : null,
+      tier,
+      pinned: false,
+      protectedUntil: options.protectedUntil ?? null,
+      takenBefore: options.takenBefore ?? null,
+      verificationLevel: prepared.verification.level,
+      verificationStatus: prepared.verification.status,
+      verifiedAt: new Date().toISOString(),
+      verification: {
+        version: 1,
+        data: {
+          findings: prepared.verification.findings,
+          content: jsonSummary(prepared.verification.content),
+        },
+      },
+      manifestVersion: MANIFEST_VERSION,
+      notes: options.notes ?? null,
+    });
+
+    const objectKey = backupObjectKey({
+      kind,
+      label: prepared.label,
+      createdAt: now,
+      artifactId: artifact.id,
+      encrypted: encrypted !== null,
+    });
+
+    const manifest = buildManifest({
+      artifact,
+      policy,
+      prepared,
+      objectKey,
+      encrypted: encrypted !== null,
+    });
+
+    const results = await fanOut(db, destinations, objectKey, stored, manifest, artifact);
+
+    artifacts.push({
+      kind,
+      artifactId: artifact.id,
+      status: results.some((result) => result.status === "stored") ? "stored" : "failed",
+      sizeBytes: stored.byteLength,
+      verification: prepared.verification,
+      destinations: results,
+    });
+  }
+
+  const stored = artifacts.length > 0 && artifacts.every((entry) => entry.status === "stored");
+  const verified =
+    stored && artifacts.every((entry) => entry.verification?.status === "passed");
+
+  return {
+    policyId: policy.id,
+    trigger,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    artifacts,
+    stored,
+    verified,
+    message: summarize(artifacts, stored, verified),
+  };
+}
+
+/** Strip `undefined` so a content summary can be stored as JSON. */
+function jsonSummary(content: Record<string, unknown>): Record<string, string | number | null> {
+  const out: Record<string, string | number | null> = {};
+  for (const [key, value] of Object.entries(content)) {
+    if (value === undefined) continue;
+    if (typeof value === "string" || typeof value === "number" || value === null) out[key] = value;
+  }
+  return out;
+}
+
+function summarize(artifacts: ArtifactOutcome[], stored: boolean, verified: boolean): string | undefined {
+  const failedArtifact = artifacts.find((entry) => entry.status === "failed");
+  if (failedArtifact) {
+    return failedArtifact.error ?? `The ${failedArtifact.kind} backup could not be stored anywhere.`;
+  }
+  if (stored && !verified) {
+    const unverified = artifacts.find((entry) => entry.verification?.status !== "passed");
+    return (
+      unverified?.verification?.findings[0] ??
+      "The copy was stored, but Bench could not confirm it is readable."
+    );
+  }
+  const partial = artifacts.flatMap((entry) => entry.destinations).filter((entry) => entry.status === "failed");
+  if (partial.length > 0) {
+    return `Stored, but ${partial.length} destination${partial.length === 1 ? "" : "s"} failed: ${partial[0].error ?? "unknown error"}`;
+  }
+  return undefined;
+}
+
+function buildManifest(input: {
+  artifact: BackupArtifact;
+  policy: BackupPolicy;
+  prepared: PreparedArtifact;
+  objectKey: string;
+  encrypted: boolean;
+}): BackupManifest {
+  const { artifact, policy, prepared } = input;
+  return {
+    manifestVersion: MANIFEST_VERSION,
+    artifactId: artifact.id,
+    kind: artifact.kind,
+    createdAt: artifact.createdAt,
+    sizeBytes: artifact.sizeBytes,
+    checksumSha256: artifact.checksumSha256,
+    plaintextChecksumSha256: artifact.plaintextChecksumSha256,
+    encryption: input.encrypted
+      ? {
+          algorithm: "aes-256-gcm",
+          kdf: "scrypt",
+          salt: String(artifact.encryption?.data.salt ?? ""),
+          iv: String(artifact.encryption?.data.iv ?? ""),
+          authTag: String(artifact.encryption?.data.authTag ?? ""),
+        }
+      : null,
+    source: {
+      budgetId: prepared.sourceBudgetId,
+      budgetName: prepared.sourceBudgetName,
+      serverUrl: prepared.serverUrl,
+    },
+    content: prepared.verification.content,
+    verification: {
+      level: prepared.verification.level,
+      status: prepared.verification.status,
+      verifiedAt: artifact.verifiedAt,
+      findings: prepared.verification.findings,
+    },
+    policy: { id: policy.id, name: policy.name },
+    tier: artifact.tier,
+    pinned: artifact.pinned,
+    protectedUntil: artifact.protectedUntil,
+    takenBefore: artifact.takenBefore,
+    benchVersion: process.env.NEXT_PUBLIC_APP_VERSION ?? null,
+    appDbSchemaVersion: LATEST_SCHEMA_VERSION,
+  };
+}
+
+/**
+ * Write to every destination, independently.
+ *
+ * Each destination gets its own try/catch and its own recorded result, because
+ * "the S3 bucket was unreachable" and "the volume is full" are different
+ * problems with different fixes, and collapsing them into one run-level error
+ * hides which copies actually exist.
+ */
+async function fanOut(
+  db: SqliteDatabase,
+  destinations: ReturnType<typeof getBackupDestination>[],
+  objectKey: string,
+  bytes: Uint8Array,
+  manifest: BackupManifest,
+  artifact: BackupArtifact
+): Promise<DestinationOutcome[]> {
+  const results: DestinationOutcome[] = [];
+
+  for (const destination of destinations) {
+    if (!destination) continue;
+    const at = new Date().toISOString();
+    try {
+      const adapter = createDestinationAdapter(db, destination);
+      const written = await adapter.put(
+        objectKey,
+        bytes,
+        artifact.kind === "budget" && !artifact.encrypted ? "application/zip" : "application/octet-stream"
+      );
+      // The manifest goes second and only on success: a manifest without its
+      // artifact would advertise a backup that is not there.
+      await adapter.put(manifestKeyFor(objectKey), serializeManifest(manifest), "application/json");
+
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey,
+        status: "stored",
+        uploadedAt: at,
+        lastVerifiedAt: artifact.verificationStatus === "passed" ? at : null,
+      });
+      recordDestinationOutcome(db, destination.id, { success: true, at });
+
+      results.push({
+        destinationId: destination.id,
+        destinationName: destination.name,
+        status: "stored",
+        objectKey,
+        sizeBytes: written.sizeBytes,
+      });
+    } catch (error) {
+      const message =
+        error instanceof DestinationError || error instanceof Error
+          ? error.message
+          : String(error);
+
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey,
+        status: "failed",
+        lastError: message,
+      });
+      recordDestinationOutcome(db, destination.id, { success: false, at, reason: message });
+
+      results.push({
+        destinationId: destination.id,
+        destinationName: destination.name,
+        status: "failed",
+        objectKey: null,
+        sizeBytes: null,
+        error: message,
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/lib/backup/runBackup.ts
+++ b/src/lib/backup/runBackup.ts
@@ -90,6 +90,15 @@ export type RunBackupOptions = {
   protectedUntil?: string | null;
   notes?: string | null;
   now?: Date;
+  /**
+   * Narrow what this run copies, without changing the rule.
+   *
+   * Used by safety recovery points, which take the budget alone: they protect
+   * against a change about to be made to the budget, and copying Bench's own
+   * settings as well would double the wait for something the user did not ask
+   * for.
+   */
+  contentsOverride?: BackupPolicy["contents"];
 };
 
 function slug(value: string): string {
@@ -203,9 +212,9 @@ async function prepareArtifact(
   };
 }
 
-function kindsFor(policy: BackupPolicy): BackupArtifactKind[] {
-  if (policy.contents === "budget") return ["budget"];
-  if (policy.contents === "app-db") return ["app-db"];
+function kindsFor(contents: BackupPolicy["contents"]): BackupArtifactKind[] {
+  if (contents === "budget") return ["budget"];
+  if (contents === "app-db") return ["app-db"];
   return ["budget", "app-db"];
 }
 
@@ -241,7 +250,7 @@ export async function runBackup(
   const passphrase = policy.encryption === "passphrase" ? readPassphrase(db, policy) : null;
   const artifacts: ArtifactOutcome[] = [];
 
-  for (const kind of kindsFor(policy)) {
+  for (const kind of kindsFor(options.contentsOverride ?? policy.contents)) {
     let prepared: PreparedArtifact;
     try {
       prepared = await prepareArtifact(db, policy, kind);

--- a/src/lib/backup/safetyPoint.test.ts
+++ b/src/lib/backup/safetyPoint.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+import { zipSync } from "fflate";
+import Database from "better-sqlite3";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import {
+  createBackupDestination,
+  createBackupPolicy,
+  listBackupArtifacts,
+} from "@/lib/app-db/backupRepository";
+import { upsertSyncCredential } from "@/lib/app-db/syncCredentialRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { readSafetySettings, takeSafetyRecoveryPoint, writeSafetySettings } from "./safetyPoint";
+
+function budgetZip(): Uint8Array {
+  const root = mkdtempSync(join(tmpdir(), "bench-safety-fixture-"));
+  const path = join(root, "db.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE payees (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE transactions (id TEXT PRIMARY KEY, acct TEXT, date INTEGER, amount INTEGER);
+    INSERT INTO accounts VALUES ('a1', 'Current');
+  `);
+  db.close();
+  const bytes = readFileSync(path);
+  rmSync(root, { recursive: true, force: true });
+  return zipSync({ "db.sqlite": bytes, "metadata.json": Buffer.from("{}") });
+}
+
+describe("recovery points before risky changes", () => {
+  let root: string;
+  let db: SqliteDatabase;
+  const previousKey = process.env.SYNC_VAULT_KEY;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.SYNC_VAULT_KEY = "test-vault-key";
+    root = mkdtempSync(join(tmpdir(), "actual-bench-safety-"));
+    mkdirSync(join(root, "volume"), { recursive: true });
+    db = getAppDb(join(root, "metadata.sqlite"));
+    global.fetch = jest.fn(async () => new Response(Buffer.from(budgetZip()), { status: 200 })) as
+      unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+    global.fetch = originalFetch;
+    if (previousKey === undefined) delete process.env.SYNC_VAULT_KEY;
+    else process.env.SYNC_VAULT_KEY = previousKey;
+  });
+
+  function setUpPolicy() {
+    upsertSyncCredential(db, {
+      connectionFingerprint: "conn-1",
+      mode: "http-api",
+      baseUrl: "https://actual.example.com",
+      budgetSyncId: "budget-1",
+      label: "Household",
+      secret: { apiKey: "key", encryptionPassword: "" },
+    });
+    const destination = createBackupDestination(db, {
+      name: "Volume",
+      kind: "local",
+      config: { version: 1, data: { path: join(root, "volume") } },
+    });
+    return createBackupPolicy(db, {
+      name: "Nightly",
+      contents: "both",
+      destinationIds: [destination.id],
+      sourceRef: { version: 1, data: { connectionFingerprint: "conn-1" } },
+    });
+  }
+
+  it("takes a protected copy that expires rather than a permanent pin", async () => {
+    // A recovery point taken automatically must not accumulate forever — that
+    // is the failure mode of every "safety snapshot" that never cleans up.
+    setUpPolicy();
+
+    const outcome = await takeSafetyRecoveryPoint(db, { reason: "merging 40 payees" });
+
+    expect(outcome.status).toBe("taken");
+    const [artifact] = listBackupArtifacts(db);
+    expect(artifact.tier).toBe("auto");
+    expect(artifact.pinned).toBe(false);
+    expect(artifact.protectedUntil).not.toBeNull();
+    expect(artifact.takenBefore).toBe("merging 40 payees");
+  });
+
+  it("copies only the budget, so the user is not kept waiting for settings too", async () => {
+    setUpPolicy();
+    await takeSafetyRecoveryPoint(db, { reason: "a bulk edit" });
+
+    expect(listBackupArtifacts(db).map((artifact) => artifact.kind)).toEqual(["budget"]);
+  });
+
+  it("reuses a recent one instead of copying the same budget twice in a session", async () => {
+    setUpPolicy();
+    const first = await takeSafetyRecoveryPoint(db, { reason: "first change" });
+    const second = await takeSafetyRecoveryPoint(db, { reason: "second change" });
+
+    expect(second.status).toBe("reused");
+    expect(second.artifactId).toBe(first.artifactId);
+    expect(listBackupArtifacts(db)).toHaveLength(1);
+  });
+
+  it("takes a fresh one once the debounce window has passed", async () => {
+    setUpPolicy();
+    await takeSafetyRecoveryPoint(db, { reason: "first" });
+
+    const later = new Date(Date.now() + 61 * 60_000);
+    const outcome = await takeSafetyRecoveryPoint(db, { reason: "much later", now: later });
+
+    expect(outcome.status).toBe("taken");
+    expect(listBackupArtifacts(db)).toHaveLength(2);
+  });
+
+  it("does nothing when the user has turned it off", async () => {
+    setUpPolicy();
+    writeSafetySettings(db, { enabled: false });
+
+    const outcome = await takeSafetyRecoveryPoint(db, { reason: "a change" });
+
+    expect(outcome.status).toBe("disabled");
+    expect(listBackupArtifacts(db)).toHaveLength(0);
+  });
+
+  it("says plainly when there is no rule it can use", async () => {
+    const outcome = await takeSafetyRecoveryPoint(db, { reason: "a change" });
+
+    expect(outcome.status).toBe("unavailable");
+    expect(outcome.message).toMatch(/no backup rule/i);
+  });
+
+  it("reports a failure as a status rather than throwing at the user mid-action", async () => {
+    // The caller is in the middle of saving. An exception here would turn "the
+    // backup did not happen" into "your change did not happen".
+    setUpPolicy();
+    global.fetch = jest.fn(async () => {
+      throw new Error("connection refused");
+    }) as unknown as typeof fetch;
+
+    const outcome = await takeSafetyRecoveryPoint(db, { reason: "a change" });
+
+    expect(outcome.status).toBe("failed");
+    expect(outcome.message).toMatch(/connection refused/);
+  });
+
+  it("is on by default", () => {
+    expect(readSafetySettings(db).enabled).toBe(true);
+    expect(readSafetySettings(db).debounceMinutes).toBe(30);
+  });
+});

--- a/src/lib/backup/safetyPoint.ts
+++ b/src/lib/backup/safetyPoint.ts
@@ -1,0 +1,160 @@
+import { getAppMeta, setAppMeta } from "@/lib/app-db/appMetaRepository";
+import { listBackupArtifacts, listBackupPolicies } from "@/lib/app-db/backupRepository";
+import { logger } from "@/lib/logger";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { runBackup } from "./runBackup";
+
+/**
+ * Safety recovery points (RD-077 / PR-047f).
+ *
+ * A backup taken *because of what you are about to do*, rather than because of
+ * what time it is. Merging forty payees, applying a reconciliation, saving a
+ * month of budget edits — these are the moments people wish they had a backup
+ * from five minutes ago rather than from last night, and Bench is the thing
+ * about to make the change, so it is the thing that can take one first.
+ *
+ * Three rules keep it from being a nuisance:
+ *
+ *   * **Only for changes worth it.** Renaming one payee does not warrant a full
+ *     export; the caller decides what counts as risky and Bench trusts it.
+ *   * **Debounced.** Several risky operations in one working session share a
+ *     recovery point. Without this, an afternoon of cleanup would take a dozen
+ *     copies of the same budget minutes apart.
+ *   * **Protected, not pinned.** These expire — after the protection window, or
+ *     once enough newer ones exist. A pin is a decision a person makes; a
+ *     recovery point taken automatically should not silently accumulate
+ *     forever, which is the failure mode of every "safety snapshot" feature
+ *     that never cleans up after itself.
+ *
+ * It is on by default and can be turned off, because the people who most want
+ * it and the people who find it intrusive are both real.
+ */
+
+const ENABLED_KEY = "backup.safetyPoints.enabled";
+const DEBOUNCE_KEY = "backup.safetyPoints.debounceMinutes";
+
+export type SafetyPointSettings = {
+  enabled: boolean;
+  debounceMinutes: number;
+};
+
+export const DEFAULT_SAFETY_SETTINGS: SafetyPointSettings = {
+  enabled: true,
+  debounceMinutes: 30,
+};
+
+export function readSafetySettings(db: SqliteDatabase): SafetyPointSettings {
+  const enabled = getAppMeta(db, ENABLED_KEY);
+  const debounce = Number(getAppMeta(db, DEBOUNCE_KEY));
+  return {
+    enabled: enabled === null ? DEFAULT_SAFETY_SETTINGS.enabled : enabled !== "false",
+    debounceMinutes: Number.isFinite(debounce) && debounce > 0 ? debounce : DEFAULT_SAFETY_SETTINGS.debounceMinutes,
+  };
+}
+
+export function writeSafetySettings(
+  db: SqliteDatabase,
+  settings: Partial<SafetyPointSettings>
+): SafetyPointSettings {
+  if (settings.enabled !== undefined) setAppMeta(db, ENABLED_KEY, settings.enabled ? "true" : "false");
+  if (settings.debounceMinutes !== undefined) {
+    setAppMeta(db, DEBOUNCE_KEY, String(Math.max(1, Math.round(settings.debounceMinutes))));
+  }
+  return readSafetySettings(db);
+}
+
+export type SafetyPointOutcome = {
+  status: "taken" | "reused" | "disabled" | "unavailable" | "failed";
+  message: string;
+  artifactId?: string;
+  takenAt?: string;
+};
+
+/**
+ * Take a recovery point before something risky, unless there is a good reason
+ * not to.
+ *
+ * Never throws: the caller is in the middle of a user action, and an exception
+ * here would turn "the backup did not happen" into "your change did not happen".
+ * Every outcome is a status the caller can decide what to do about.
+ */
+export async function takeSafetyRecoveryPoint(
+  db: SqliteDatabase,
+  input: { reason: string; force?: boolean; now?: Date }
+): Promise<SafetyPointOutcome> {
+  const now = input.now ?? new Date();
+  const settings = readSafetySettings(db);
+
+  if (!settings.enabled && !input.force) {
+    return { status: "disabled", message: "Recovery points before risky changes are turned off." };
+  }
+
+  const policy = listBackupPolicies(db).find(
+    (entry) =>
+      entry.enabled &&
+      entry.destinationIds.length > 0 &&
+      typeof entry.sourceRef.data.connectionFingerprint === "string"
+  );
+  if (!policy) {
+    return {
+      status: "unavailable",
+      message:
+        "Bench has no backup rule it can use, so it cannot take a recovery point before this change.",
+    };
+  }
+
+  if (!input.force) {
+    const recent = listBackupArtifacts(db, { policyId: policy.id, limit: 20 }).find(
+      (artifact) =>
+        artifact.tier === "auto" &&
+        now.getTime() - new Date(artifact.createdAt).getTime() < settings.debounceMinutes * 60_000
+    );
+    if (recent) {
+      return {
+        status: "reused",
+        message: `Using the recovery point taken at ${recent.createdAt.slice(11, 16)} — it is recent enough.`,
+        artifactId: recent.id,
+        takenAt: recent.createdAt,
+      };
+    }
+  }
+
+  const protectedUntil = new Date(
+    now.getTime() + policy.retention.autoProtectionDays * 24 * 3_600_000
+  ).toISOString();
+
+  try {
+    const result = await runBackup(db, policy, {
+      trigger: "safety",
+      tier: "auto",
+      takenBefore: input.reason,
+      protectedUntil,
+      now,
+      // The budget alone: this protects against a change about to be made to
+      // the budget, and copying Bench's own settings too would double the time
+      // the user waits for something they did not ask for.
+      contentsOverride: "budget",
+    });
+
+    if (!result.stored) {
+      return {
+        status: "failed",
+        message: result.message ?? "Bench could not store a recovery point.",
+      };
+    }
+
+    const artifactId = result.artifacts.find((artifact) => artifact.artifactId)?.artifactId ?? undefined;
+    return {
+      status: "taken",
+      message: result.verified
+        ? "Recovery point taken and verified."
+        : "Recovery point stored, but Bench could not confirm it is readable.",
+      artifactId,
+      takenAt: result.startedAt,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`[backup] safety recovery point failed: ${message}`);
+    return { status: "failed", message };
+  }
+}

--- a/src/lib/backup/scrub.test.ts
+++ b/src/lib/backup/scrub.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment node
+ */
+import Database from "better-sqlite3";
+import { zipSync } from "fflate";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { getAppDb, resetAppDbForTests } from "@/lib/app-db/connection";
+import { upsertBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import {
+  createBackupArtifact,
+  createBackupDestination,
+  createBackupPolicy,
+  getBackupArtifact,
+  getBackupDestination,
+  listArtifactLocations,
+  recordArtifactLocation,
+} from "@/lib/app-db/backupRepository";
+import type { BackupDestination } from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { encryptArchive } from "./encryption";
+import { sha256 } from "./manifest";
+import { scrubDestination } from "./scrub";
+
+function budgetZip(): Uint8Array {
+  const root = mkdtempSync(join(tmpdir(), "bench-scrub-fixture-"));
+  const path = join(root, "db.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE payees (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE transactions (id TEXT PRIMARY KEY, acct TEXT, date INTEGER, amount INTEGER);
+    INSERT INTO accounts VALUES ('a1', 'Current');
+  `);
+  db.close();
+  const bytes = readFileSync(path);
+  rmSync(root, { recursive: true, force: true });
+  return zipSync({
+    "db.sqlite": bytes,
+    "metadata.json": Buffer.from(JSON.stringify({ budgetName: "Household", id: "budget-1" })),
+  });
+}
+
+describe("scrubbing a destination", () => {
+  let root: string;
+  let volume: string;
+  let db: SqliteDatabase;
+  let destination: BackupDestination;
+  let policyId: string;
+  const previousKey = process.env.SYNC_VAULT_KEY;
+
+  beforeEach(() => {
+    process.env.SYNC_VAULT_KEY = "test-vault-key";
+    root = mkdtempSync(join(tmpdir(), "actual-bench-scrub-"));
+    volume = join(root, "volume");
+    mkdirSync(volume, { recursive: true });
+    db = getAppDb(join(root, "metadata.sqlite"));
+    destination = createBackupDestination(db, {
+      name: "Volume",
+      kind: "local",
+      config: { version: 1, data: { path: volume } },
+    });
+    policyId = createBackupPolicy(db, { name: "Nightly", destinationIds: [destination.id] }).id;
+  });
+
+  afterEach(() => {
+    resetAppDbForTests();
+    rmSync(root, { recursive: true, force: true });
+    if (previousKey === undefined) delete process.env.SYNC_VAULT_KEY;
+    else process.env.SYNC_VAULT_KEY = previousKey;
+  });
+
+  function store(bytes: Uint8Array, overrides: Record<string, unknown> = {}) {
+    const artifact = createBackupArtifact(db, {
+      policyId,
+      kind: "budget",
+      sizeBytes: bytes.byteLength,
+      checksumSha256: sha256(bytes),
+      verificationStatus: "passed",
+      verificationLevel: "data",
+      ...overrides,
+    });
+    const key = `budget/household/${artifact.id.slice(0, 8)}.zip`;
+    mkdirSync(dirname(join(volume, key)), { recursive: true });
+    writeFileSync(join(volume, key), bytes);
+    recordArtifactLocation(db, {
+      artifactId: artifact.id,
+      destinationId: destination.id,
+      objectKey: key,
+      status: "stored",
+      uploadedAt: new Date().toISOString(),
+    });
+    return { artifact, key };
+  }
+
+  it("opens the newest copy and confirms it is readable", async () => {
+    const { artifact } = store(budgetZip());
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result).toMatchObject({ checked: 1, passed: 1, failed: 0, missing: 0 });
+    expect(result.artifacts[0].detail).toMatch(/Opened and read/);
+    expect(listArtifactLocations(db, artifact.id)[0].lastVerifiedAt).not.toBeNull();
+  });
+
+  it("catches bytes that changed under it", async () => {
+    // Bit rot does not change a file's size, so the checksum is what finds it.
+    const { artifact, key } = store(budgetZip());
+    const bytes = Buffer.from(readFileSync(join(volume, key)));
+    bytes[Math.floor(bytes.length / 2)] ^= 0xff;
+    writeFileSync(join(volume, key), bytes);
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result.failed).toBe(1);
+    expect(result.artifacts[0].detail).toMatch(/bytes have changed/);
+    expect(getBackupArtifact(db, artifact.id)?.verificationStatus).toBe("failed");
+  });
+
+  it("catches a truncated copy by its size before reading it", async () => {
+    const { key } = store(budgetZip());
+    writeFileSync(join(volume, key), readFileSync(join(volume, key)).subarray(0, 100));
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result.failed).toBe(1);
+    expect(result.artifacts[0].detail).toMatch(/Size changed/);
+  });
+
+  it("reports a copy someone deleted as missing, not as damaged", async () => {
+    // The distinction matters: it decides whether to suspect retention or a disk.
+    const { artifact, key } = store(budgetZip());
+    rmSync(join(volume, key));
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result).toMatchObject({ missing: 1, failed: 0 });
+    expect(listArtifactLocations(db, artifact.id)[0].status).toBe("missing");
+  });
+
+  it("proves an encrypted copy is decryptable, not merely present", async () => {
+    // An encrypted backup nobody can open is the most expensive kind of false
+    // confidence there is.
+    upsertBackupCredential(db, { ref: "pol-secret", kind: "passphrase", secret: { passphrase: "shh" } });
+    const encryptedPolicy = createBackupPolicy(db, {
+      name: "Off-site",
+      destinationIds: [destination.id],
+      encryption: "passphrase",
+      encryptionCredentialRef: "pol-secret",
+    });
+    const { bytes } = encryptArchive(budgetZip(), "shh");
+    store(bytes, { policyId: encryptedPolicy.id, encrypted: true });
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result.passed).toBe(1);
+    expect(result.artifacts[0].detail).toMatch(/Decrypted, opened and read/);
+  });
+
+  it("says so plainly when it has no passphrase to open a copy with", async () => {
+    const encryptedPolicy = createBackupPolicy(db, {
+      name: "Off-site",
+      destinationIds: [destination.id],
+      encryption: "passphrase",
+    });
+    const { bytes } = encryptArchive(budgetZip(), "shh");
+    store(bytes, { policyId: encryptedPolicy.id, encrypted: true });
+
+    const result = await scrubDestination(db, destination);
+
+    // Not a failure, and not a claim that it is fine either.
+    expect(result.passed).toBe(1);
+    expect(result.artifacts[0].detail).toMatch(/no stored passphrase/);
+  });
+
+  it("checksums the older copies rather than opening every one", async () => {
+    store(budgetZip());
+    store(budgetZip());
+    store(budgetZip());
+
+    const result = await scrubDestination(db, destination, { newest: 3, deepest: 1 });
+
+    expect(result.checked).toBe(3);
+    expect(result.artifacts.filter((entry) => entry.level === "checksum")).toHaveLength(2);
+    expect(result.artifacts.filter((entry) => entry.level === "deep")).toHaveLength(1);
+  });
+
+  it("records the destination's health, so a bad scrub is visible on it", async () => {
+    const { key } = store(budgetZip());
+    rmSync(join(volume, key));
+
+    await scrubDestination(db, destination);
+
+    expect(getBackupDestination(db, destination.id)?.lastFailureReason).toMatch(/missing/);
+  });
+
+  it("blames the credentials, not the copies, when it cannot reach the destination", async () => {
+    const broken = createBackupDestination(db, {
+      name: "Off-site",
+      kind: "s3",
+      credentialRef: "gone",
+      config: { version: 1, data: { bucket: "bench" } },
+    });
+
+    const result = await scrubDestination(db, broken);
+
+    expect(result.error).toMatch(/access key/i);
+    expect(result.checked).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+});

--- a/src/lib/backup/scrub.test.ts
+++ b/src/lib/backup/scrub.test.ts
@@ -224,6 +224,35 @@ describe("scrubbing a destination", () => {
     expect(result.artifacts.filter((entry) => entry.level === "deep")).toHaveLength(1);
   });
 
+  it("stops calling a copy verified when reading it threw", async () => {
+    // Decryption with the wrong stored passphrase throws rather than returning
+    // a verdict. Leaving the artifact verified would keep it counted as the
+    // newest verified copy - the one retention refuses to delete - while
+    // nobody can open it.
+    upsertBackupCredential(db, { ref: "pol-secret", kind: "passphrase", secret: { passphrase: "wrong" } });
+    const encryptedPolicy = createBackupPolicy(db, {
+      name: "Off-site",
+      destinationIds: [destination.id],
+      encryption: "passphrase",
+      encryptionCredentialRef: "pol-secret",
+    });
+    const { bytes } = encryptArchive(budgetZip(), "the actual passphrase");
+    const { artifact } = store(bytes, {
+      policyId: encryptedPolicy.id,
+      encrypted: true,
+      encryptionCredentialRef: "pol-secret",
+      verificationStatus: "passed",
+    });
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result.failed).toBe(1);
+    expect(getBackupArtifact(db, artifact.id)?.verificationStatus).toBe("failed");
+    // The file is still there; it is the reading of it that failed.
+    expect(listArtifactLocations(db, artifact.id)[0].status).toBe("stored");
+    expect(listArtifactLocations(db, artifact.id)[0].lastError).toMatch(/passphrase|altered/i);
+  });
+
   it("records the destination's health, so a bad scrub is visible on it", async () => {
     const { key } = store(budgetZip());
     rmSync(join(volume, key));

--- a/src/lib/backup/scrub.test.ts
+++ b/src/lib/backup/scrub.test.ts
@@ -159,7 +159,7 @@ describe("scrubbing a destination", () => {
     expect(result.artifacts[0].detail).toMatch(/Decrypted, opened and read/);
   });
 
-  it("says so plainly when it has no passphrase to open a copy with", async () => {
+  it("does not call a copy verified when it could not open it", async () => {
     const encryptedPolicy = createBackupPolicy(db, {
       name: "Off-site",
       destinationIds: [destination.id],
@@ -170,9 +170,46 @@ describe("scrubbing a destination", () => {
 
     const result = await scrubDestination(db, destination);
 
-    // Not a failure, and not a claim that it is fine either.
-    expect(result.passed).toBe(1);
+    // Not a failure, and emphatically not a pass: a lost passphrase would
+    // otherwise look like a healthy backup right up until someone needed it.
+    expect(result).toMatchObject({ passed: 0, failed: 0, skipped: 1 });
+    expect(result.artifacts[0].status).toBe("skipped");
     expect(result.artifacts[0].detail).toMatch(/no stored passphrase/);
+    // And nothing claims it was checked.
+    expect(listArtifactLocations(db, result.artifacts[0].artifactId)[0].lastVerifiedAt).toBeNull();
+  });
+
+  it("blames the copy, not the backup, when another destination still has it", async () => {
+    // Destinations fail independently. Marking the artifact failed here would
+    // strip the newest-verified-copy protection from a backup sitting intact in
+    // another bucket.
+    const { artifact, key } = store(budgetZip());
+    const elsewhere = createBackupDestination(db, {
+      name: "Off-site",
+      kind: "local",
+      config: { version: 1, data: { path: join(root, "elsewhere") } },
+    });
+    recordArtifactLocation(db, {
+      artifactId: artifact.id,
+      destinationId: elsewhere.id,
+      objectKey: key,
+      status: "stored",
+      uploadedAt: new Date().toISOString(),
+    });
+
+    const bytes = Buffer.from(readFileSync(join(volume, key)));
+    bytes[Math.floor(bytes.length / 2)] ^= 0xff;
+    writeFileSync(join(volume, key), bytes);
+
+    const result = await scrubDestination(db, destination);
+
+    expect(result.failed).toBe(1);
+    // The damaged copy is marked; the backup itself is still verified.
+    expect(getBackupArtifact(db, artifact.id)?.verificationStatus).toBe("passed");
+    const damaged = listArtifactLocations(db, artifact.id).find(
+      (entry) => entry.destinationId === destination.id
+    );
+    expect(damaged?.status).toBe("failed");
   });
 
   it("checksums the older copies rather than opening every one", async () => {

--- a/src/lib/backup/scrub.ts
+++ b/src/lib/backup/scrub.ts
@@ -3,6 +3,7 @@ import {
   getBackupArtifact,
   getBackupDestination,
   getBackupPolicy,
+  listArtifactLocations,
   listBackupArtifacts,
   listDestinationLocations,
   recordArtifactLocation,
@@ -44,7 +45,12 @@ import { verifyAppDbArchive, verifyBudgetArchive } from "./verify";
 export type ScrubArtifactResult = {
   artifactId: string;
   objectKey: string;
-  status: "passed" | "failed" | "missing";
+  /**
+   * `skipped` is not a lesser pass: it means Bench could not open the copy and
+   * therefore cannot say whether it is good. Reporting that as verified is how
+   * a lost passphrase stays invisible until the day it matters.
+   */
+  status: "passed" | "failed" | "missing" | "skipped";
   level: BackupVerificationLevel | "checksum";
   detail: string;
 };
@@ -56,6 +62,8 @@ export type ScrubResult = {
   passed: number;
   failed: number;
   missing: number;
+  /** Present and unchanged, but not opened - so not verified. */
+  skipped: number;
   artifacts: ScrubArtifactResult[];
   error?: string;
 };
@@ -67,6 +75,25 @@ export type ScrubOptions = {
   deepest?: number;
   now?: Date;
 };
+
+/**
+ * Is this artifact still good somewhere other than here?
+ *
+ * Verification status lives on the artifact, but a scrub only ever looks at one
+ * destination. Marking the artifact failed because this copy is damaged would
+ * contradict the rule the whole design rests on - destinations fail
+ * independently - and would strip the "newest verified copy" protection from an
+ * artifact that is sitting intact in another bucket.
+ */
+function intactElsewhere(
+  db: SqliteDatabase,
+  artifactId: string,
+  thisDestinationId: string
+): boolean {
+  return listArtifactLocations(db, artifactId).some(
+    (location) => location.destinationId !== thisDestinationId && location.status === "stored"
+  );
+}
 
 function passphraseFor(db: SqliteDatabase, artifact: BackupArtifact): string | null {
   if (!artifact.encrypted || !artifact.policyId) return null;
@@ -97,6 +124,7 @@ export async function scrubDestination(
     passed: 0,
     failed: 0,
     missing: 0,
+    skipped: 0,
     artifacts: [],
   };
 
@@ -141,7 +169,14 @@ export async function scrubDestination(
 
       if (head.sizeBytes !== artifact.sizeBytes) {
         result.failed += 1;
-        recordArtifactVerification(db, artifact.id, {
+        recordArtifactLocation(db, {
+          artifactId: artifact.id,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "failed",
+          lastError: `Stored size ${head.sizeBytes} does not match the recorded ${artifact.sizeBytes} bytes.`,
+        });
+        if (!intactElsewhere(db, artifact.id, destination.id)) recordArtifactVerification(db, artifact.id, {
           level: artifact.verificationLevel ?? "archive",
           status: "failed",
           at,
@@ -168,7 +203,14 @@ export async function scrubDestination(
       const checksum = sha256(bytes);
       if (checksum !== artifact.checksumSha256) {
         result.failed += 1;
-        recordArtifactVerification(db, artifact.id, {
+        recordArtifactLocation(db, {
+          artifactId: artifact.id,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "failed",
+          lastError: "The stored bytes no longer match the checksum recorded when written.",
+        });
+        if (!intactElsewhere(db, artifact.id, destination.id)) recordArtifactVerification(db, artifact.id, {
           level: artifact.verificationLevel ?? "archive",
           status: "failed",
           at,
@@ -212,23 +254,18 @@ export async function scrubDestination(
       if (artifact.encrypted) {
         const passphrase = passphraseFor(db, artifact);
         if (!passphrase) {
-          // Not a failure: Bench simply cannot open it unattended. Say so
-          // rather than implying the copy is bad or that it is proven good.
-          recordArtifactLocation(db, {
-            artifactId: artifact.id,
-            destinationId: destination.id,
-            objectKey: location.objectKey,
-            status: "stored",
-            lastVerifiedAt: at,
-          });
-          result.passed += 1;
+          // Not a failure, and emphatically not a pass: Bench cannot open it,
+          // so it cannot say whether it is good. Counting this as verified -
+          // and stamping lastVerifiedAt - would let a lost passphrase look like
+          // a healthy backup right up until someone needed it.
+          result.skipped += 1;
           result.artifacts.push({
             artifactId: artifact.id,
             objectKey: location.objectKey,
-            status: "passed",
+            status: "skipped",
             level: "checksum",
             detail:
-              "Present and unchanged. Bench has no stored passphrase for it, so its contents were not opened.",
+              "Present and unchanged, but Bench has no stored passphrase for it, so its contents were not checked.",
           });
           continue;
         }
@@ -240,12 +277,14 @@ export async function scrubDestination(
           ? verifyBudgetArchive(plaintext, "deep")
           : verifyAppDbArchive(plaintext, "data");
 
-      recordArtifactVerification(db, artifact.id, {
-        level: outcome.level,
-        status: outcome.status,
-        at,
-        findings: { version: 1, data: { findings: outcome.findings } },
-      });
+      if (outcome.status === "passed" || !intactElsewhere(db, artifact.id, destination.id)) {
+        recordArtifactVerification(db, artifact.id, {
+          level: outcome.level,
+          status: outcome.status,
+          at,
+          findings: { version: 1, data: { findings: outcome.findings } },
+        });
+      }
       recordArtifactLocation(db, {
         artifactId: artifact.id,
         destinationId: destination.id,

--- a/src/lib/backup/scrub.ts
+++ b/src/lib/backup/scrub.ts
@@ -1,0 +1,334 @@
+import { getBackupCredential } from "@/lib/app-db/backupCredentialRepository";
+import {
+  getBackupArtifact,
+  getBackupDestination,
+  getBackupPolicy,
+  listBackupArtifacts,
+  listDestinationLocations,
+  recordArtifactLocation,
+  recordArtifactVerification,
+  recordDestinationOutcome,
+  type BackupArtifact,
+  type BackupDestination,
+} from "@/lib/app-db/backupRepository";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+import { createDestinationAdapter } from "./destinations";
+import { decryptArchive } from "./encryption";
+import { sha256, type BackupVerificationLevel } from "./manifest";
+import { verifyAppDbArchive, verifyBudgetArchive } from "./verify";
+
+/**
+ * Scrub — re-verifying backups that already exist (RD-077 / PR-047d).
+ *
+ * Storage rots quietly. A copy that verified when it was written can be
+ * truncated by a full volume, silently corrupted by a failing disk, or removed
+ * by someone tidying up a bucket, and nothing announces any of it. Weekly
+ * re-verification of the newest few copies is what turns "we took a backup" into
+ * "there is a backup there right now, and it opens".
+ *
+ * What it does, per destination:
+ *
+ *   * **Presence and size.** The cheapest question, and the one that catches a
+ *     deleted or truncated object immediately.
+ *   * **Checksum.** Re-read the bytes and compare against what was recorded.
+ *     Bit rot does not change a file's size.
+ *   * **Contents.** Open the newest copy properly — decrypting first when the
+ *     policy's passphrase is stored, so an encrypted backup is proved to be
+ *     *decryptable*, not merely present. An encrypted backup nobody can open is
+ *     the most expensive kind of false confidence there is.
+ *
+ * A copy that has gone missing is marked missing rather than deleted: the
+ * distinction matters when deciding whether retention or a disk ate it.
+ */
+
+export type ScrubArtifactResult = {
+  artifactId: string;
+  objectKey: string;
+  status: "passed" | "failed" | "missing";
+  level: BackupVerificationLevel | "checksum";
+  detail: string;
+};
+
+export type ScrubResult = {
+  destinationId: string;
+  destinationName: string;
+  checked: number;
+  passed: number;
+  failed: number;
+  missing: number;
+  artifacts: ScrubArtifactResult[];
+  error?: string;
+};
+
+export type ScrubOptions = {
+  /** How many of the newest copies to check per destination. */
+  newest?: number;
+  /** How many of those to open fully rather than checksum. */
+  deepest?: number;
+  now?: Date;
+};
+
+function passphraseFor(db: SqliteDatabase, artifact: BackupArtifact): string | null {
+  if (!artifact.encrypted || !artifact.policyId) return null;
+  const policy = getBackupPolicy(db, artifact.policyId);
+  if (!policy?.encryptionCredentialRef) return null;
+  try {
+    const secret = getBackupCredential(db, policy.encryptionCredentialRef);
+    return secret && "passphrase" in secret ? secret.passphrase : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function scrubDestination(
+  db: SqliteDatabase,
+  destination: BackupDestination,
+  options: ScrubOptions = {}
+): Promise<ScrubResult> {
+  const now = options.now ?? new Date();
+  const at = now.toISOString();
+  const newest = Math.max(1, options.newest ?? 3);
+  const deepest = Math.max(0, options.deepest ?? 1);
+
+  const result: ScrubResult = {
+    destinationId: destination.id,
+    destinationName: destination.name,
+    checked: 0,
+    passed: 0,
+    failed: 0,
+    missing: 0,
+    artifacts: [],
+  };
+
+  let adapter;
+  try {
+    adapter = createDestinationAdapter(db, destination);
+  } catch (error) {
+    result.error = error instanceof Error ? error.message : String(error);
+    recordDestinationOutcome(db, destination.id, { success: false, at, reason: result.error });
+    return result;
+  }
+
+  const locations = listDestinationLocations(db, destination.id, { limit: 100 })
+    .filter((location) => location.status === "stored")
+    .slice(0, newest);
+
+  for (const [index, location] of locations.entries()) {
+    const artifact = getBackupArtifact(db, location.artifactId);
+    if (!artifact) continue;
+    result.checked += 1;
+
+    try {
+      const head = await adapter.head(location.objectKey);
+      if (!head) {
+        result.missing += 1;
+        recordArtifactLocation(db, {
+          artifactId: artifact.id,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "missing",
+          lastError: "The object is no longer in this destination.",
+        });
+        result.artifacts.push({
+          artifactId: artifact.id,
+          objectKey: location.objectKey,
+          status: "missing",
+          level: "checksum",
+          detail: "The copy is gone from this destination.",
+        });
+        continue;
+      }
+
+      if (head.sizeBytes !== artifact.sizeBytes) {
+        result.failed += 1;
+        recordArtifactVerification(db, artifact.id, {
+          level: artifact.verificationLevel ?? "archive",
+          status: "failed",
+          at,
+          findings: {
+            version: 1,
+            data: {
+              findings: [
+                `Stored size ${head.sizeBytes} does not match the recorded ${artifact.sizeBytes} bytes.`,
+              ],
+            },
+          },
+        });
+        result.artifacts.push({
+          artifactId: artifact.id,
+          objectKey: location.objectKey,
+          status: "failed",
+          level: "checksum",
+          detail: `Size changed: ${head.sizeBytes} bytes now, ${artifact.sizeBytes} when written.`,
+        });
+        continue;
+      }
+
+      const bytes = await adapter.get(location.objectKey);
+      const checksum = sha256(bytes);
+      if (checksum !== artifact.checksumSha256) {
+        result.failed += 1;
+        recordArtifactVerification(db, artifact.id, {
+          level: artifact.verificationLevel ?? "archive",
+          status: "failed",
+          at,
+          findings: {
+            version: 1,
+            data: { findings: ["The stored bytes no longer match the checksum recorded when written."] },
+          },
+        });
+        result.artifacts.push({
+          artifactId: artifact.id,
+          objectKey: location.objectKey,
+          status: "failed",
+          level: "checksum",
+          detail: "The bytes have changed since they were written.",
+        });
+        continue;
+      }
+
+      // Only the newest few are opened; the rest are proved intact by checksum,
+      // which is what actually detects rot.
+      if (index >= deepest) {
+        recordArtifactLocation(db, {
+          artifactId: artifact.id,
+          destinationId: destination.id,
+          objectKey: location.objectKey,
+          status: "stored",
+          lastVerifiedAt: at,
+        });
+        result.passed += 1;
+        result.artifacts.push({
+          artifactId: artifact.id,
+          objectKey: location.objectKey,
+          status: "passed",
+          level: "checksum",
+          detail: "Present, right size, checksum matches.",
+        });
+        continue;
+      }
+
+      let plaintext: Uint8Array = bytes;
+      if (artifact.encrypted) {
+        const passphrase = passphraseFor(db, artifact);
+        if (!passphrase) {
+          // Not a failure: Bench simply cannot open it unattended. Say so
+          // rather than implying the copy is bad or that it is proven good.
+          recordArtifactLocation(db, {
+            artifactId: artifact.id,
+            destinationId: destination.id,
+            objectKey: location.objectKey,
+            status: "stored",
+            lastVerifiedAt: at,
+          });
+          result.passed += 1;
+          result.artifacts.push({
+            artifactId: artifact.id,
+            objectKey: location.objectKey,
+            status: "passed",
+            level: "checksum",
+            detail:
+              "Present and unchanged. Bench has no stored passphrase for it, so its contents were not opened.",
+          });
+          continue;
+        }
+        plaintext = decryptArchive(bytes, passphrase);
+      }
+
+      const outcome =
+        artifact.kind === "budget"
+          ? verifyBudgetArchive(plaintext, "deep")
+          : verifyAppDbArchive(plaintext, "data");
+
+      recordArtifactVerification(db, artifact.id, {
+        level: outcome.level,
+        status: outcome.status,
+        at,
+        findings: { version: 1, data: { findings: outcome.findings } },
+      });
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey: location.objectKey,
+        status: "stored",
+        lastVerifiedAt: at,
+        lastError: outcome.status === "failed" ? outcome.findings[0] ?? "Verification failed." : null,
+      });
+
+      if (outcome.status === "passed") result.passed += 1;
+      else result.failed += 1;
+
+      result.artifacts.push({
+        artifactId: artifact.id,
+        objectKey: location.objectKey,
+        status: outcome.status,
+        level: outcome.level,
+        detail:
+          outcome.status === "passed"
+            ? artifact.encrypted
+              ? "Decrypted, opened and read."
+              : "Opened and read."
+            : outcome.findings[0] ?? "Verification failed.",
+      });
+    } catch (error) {
+      result.failed += 1;
+      const message = error instanceof Error ? error.message : String(error);
+      result.artifacts.push({
+        artifactId: artifact.id,
+        objectKey: location.objectKey,
+        status: "failed",
+        level: "checksum",
+        detail: message,
+      });
+    }
+  }
+
+  recordDestinationOutcome(db, destination.id, {
+    success: result.failed === 0 && result.missing === 0,
+    at,
+    reason:
+      result.failed > 0 || result.missing > 0
+        ? `Scrub found ${result.failed} damaged and ${result.missing} missing ${
+            result.failed + result.missing === 1 ? "copy" : "copies"
+          }.`
+        : undefined,
+  });
+
+  return result;
+}
+
+/** Scrub every enabled destination that holds at least one copy. */
+export async function scrubAll(
+  db: SqliteDatabase,
+  destinationIds: string[],
+  options: ScrubOptions = {}
+): Promise<ScrubResult[]> {
+  const results: ScrubResult[] = [];
+  for (const id of destinationIds) {
+    const destination = getBackupDestination(db, id);
+    if (!destination || !destination.enabled) continue;
+    results.push(await scrubDestination(db, destination, options));
+  }
+  return results;
+}
+
+/** Destinations worth scrubbing: enabled, and holding something. */
+export function scrubbableDestinationIds(db: SqliteDatabase, ids: string[]): string[] {
+  return ids.filter((id) => {
+    const destination = getBackupDestination(db, id);
+    if (!destination?.enabled) return false;
+    return listDestinationLocations(db, id, { limit: 1 }).length > 0;
+  });
+}
+
+/** Artifacts with no surviving copy anywhere — the inventory's bad news. */
+export function orphanedArtifacts(db: SqliteDatabase): BackupArtifact[] {
+  return listBackupArtifacts(db, { limit: 500 }).filter((artifact) => {
+    const locations = db
+      .prepare(
+        "SELECT COUNT(*) AS n FROM backup_artifact_locations WHERE artifact_id = ? AND status = 'stored'"
+      )
+      .get<{ n: number }>(artifact.id);
+    return Number(locations?.n ?? 0) === 0;
+  });
+}

--- a/src/lib/backup/scrub.ts
+++ b/src/lib/backup/scrub.ts
@@ -312,6 +312,28 @@ export async function scrubDestination(
     } catch (error) {
       result.failed += 1;
       const message = error instanceof Error ? error.message : String(error);
+
+      // A copy that threw on the way to being read is a copy Bench could not
+      // read. Leaving the artifact's verification alone would keep it counted
+      // as the newest verified copy - the one retention refuses to delete -
+      // while nobody can actually open it. The location stays `stored`: the
+      // file is still there, it is the reading of it that failed.
+      recordArtifactLocation(db, {
+        artifactId: artifact.id,
+        destinationId: destination.id,
+        objectKey: location.objectKey,
+        status: "stored",
+        lastError: message,
+      });
+      if (!intactElsewhere(db, artifact.id, destination.id)) {
+        recordArtifactVerification(db, artifact.id, {
+          level: artifact.verificationLevel ?? "archive",
+          status: "failed",
+          at,
+          findings: { version: 1, data: { findings: [message] } },
+        });
+      }
+
       result.artifacts.push({
         artifactId: artifact.id,
         objectKey: location.objectKey,

--- a/src/lib/backup/sources/appDbExport.ts
+++ b/src/lib/backup/sources/appDbExport.ts
@@ -1,0 +1,29 @@
+import { readFileSync, rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SqliteDatabase } from "@/lib/app-db/types";
+
+/**
+ * A consistent copy of Bench's own metadata database (RD-077 / PR-047c).
+ *
+ * Worth backing up separately from the budget, because it is the only place
+ * some things live: sync flows and their mappings, reconciliation sessions,
+ * automations and their history, saved queries, payee-cleanup decisions. Losing
+ * it does not lose money, but it loses every rule the user has taught Bench.
+ *
+ * `VACUUM INTO` rather than copying the file: it takes SQLite's own read lock,
+ * so the copy is transactionally consistent even if a sync is writing at the
+ * time, and it produces a compact database with no WAL to reunite later.
+ * Copying the file by hand while WAL is active is how people end up with
+ * backups that open but are missing the last hour of work.
+ */
+export function exportAppDbSnapshot(db: SqliteDatabase): Buffer {
+  const scratch = mkdtempSync(join(tmpdir(), "bench-appdb-backup-"));
+  const target = join(scratch, "actual-bench.sqlite");
+  try {
+    db.prepare("VACUUM INTO ?").run(target);
+    return readFileSync(target);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/src/lib/backup/sources/budgetExport.ts
+++ b/src/lib/backup/sources/budgetExport.ts
@@ -1,0 +1,108 @@
+import { queueServerRequest } from "@/app/api/proxy/serverQueue";
+import type { SyncCredential } from "@/lib/app-db/types";
+
+/**
+ * Exporting a budget from the server, unattended (RD-077 / PR-047c).
+ *
+ * A scheduled backup has no browser to borrow, so it goes to the Actual server
+ * itself with credentials from the vault — the same arrangement unattended sync
+ * already uses, and the reason a policy's source is an *enrolled connection*
+ * rather than an arbitrary URL: enrolment is where the operator already decided
+ * Bench may act on this budget without them present.
+ *
+ * The request goes through the shared per-server queue. That is not politeness:
+ * Actual opens a budget file to serve an export, and a sync applying changes to
+ * the same budget at the same moment is how you get "budget is already open"
+ * errors and, worse, a backup taken mid-write.
+ */
+
+export class BudgetExportError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "BudgetExportError";
+    this.status = status;
+  }
+}
+
+export type ExportedBudget = {
+  bytes: Buffer;
+  filename: string | null;
+  budgetSyncId: string;
+  serverUrl: string;
+};
+
+function filenameFromDisposition(disposition: string | null): string | null {
+  if (!disposition) return null;
+  const quoted = /filename\s*=\s*"([^"]*)"/i.exec(disposition);
+  if (quoted?.[1]) return quoted[1].trim();
+  const plain = /filename\s*=\s*([^;]+)/i.exec(disposition);
+  return plain?.[1]?.trim() ?? null;
+}
+
+export async function exportBudgetFromCredential(
+  credential: SyncCredential,
+  options: { timeoutMs?: number } = {}
+): Promise<ExportedBudget> {
+  const base = credential.baseUrl.replace(/\/$/, "");
+  const url = `${base}/v1/budgets/${encodeURIComponent(credential.budgetSyncId)}/export`;
+
+  const result = await queueServerRequest<{ status: number; body?: ExportedBudget; error?: string }>(
+    { baseUrl: credential.baseUrl, budgetSyncId: credential.budgetSyncId, apiKey: credential.secret.apiKey },
+    `backup-${Math.random().toString(36).slice(2, 9)}`,
+    async () => {
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: "GET",
+          headers: {
+            "x-api-key": credential.secret.apiKey,
+            Accept: "application/zip, application/octet-stream, */*",
+            "budget-encryption-password": credential.secret.encryptionPassword ?? "",
+          },
+          // Exports of a large budget are slow, and a backup that gives up at
+          // 60s on a big file is a backup that never runs for the people who
+          // need it most.
+          signal: AbortSignal.timeout(options.timeoutMs ?? 300_000),
+        });
+      } catch (error) {
+        return {
+          status: 502,
+          error: `Could not reach ${base}: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      if (!response.ok) {
+        let message = `HTTP ${response.status}`;
+        try {
+          const json = (await response.json()) as { message?: string; error?: string };
+          message = json.message ?? json.error ?? message;
+        } catch {
+          // Non-JSON error body; the status is what we have.
+        }
+        return { status: response.status, error: message };
+      }
+
+      const bytes = Buffer.from(await response.arrayBuffer());
+      return {
+        status: 200,
+        body: {
+          bytes,
+          filename: filenameFromDisposition(response.headers.get("content-disposition")),
+          budgetSyncId: credential.budgetSyncId,
+          serverUrl: base,
+        },
+      };
+    }
+  );
+
+  if (!result.body) {
+    throw new BudgetExportError(result.error ?? `Export failed with HTTP ${result.status}`, result.status);
+  }
+  // A server that answers 200 with nothing is a failure, not an empty backup.
+  if (result.body.bytes.byteLength === 0) {
+    throw new BudgetExportError("The server returned an empty export.", 200);
+  }
+  return result.body;
+}

--- a/src/lib/backup/verify.test.ts
+++ b/src/lib/backup/verify.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment node
+ */
+import Database from "better-sqlite3";
+import { zipSync } from "fflate";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decryptArchive, encryptArchive } from "./encryption";
+import { verifyAppDbArchive, verifyBudgetArchive } from "./verify";
+
+/** A miniature but real Actual-shaped budget database. */
+function budgetDbBytes(options: { transactions?: number } = {}): Uint8Array {
+  const root = mkdtempSync(join(tmpdir(), "bench-verify-fixture-"));
+  const path = join(root, "db.sqlite");
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT, tombstone INTEGER DEFAULT 0);
+    CREATE TABLE payees (id TEXT PRIMARY KEY, name TEXT, tombstone INTEGER DEFAULT 0);
+    CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT, tombstone INTEGER DEFAULT 0);
+    CREATE TABLE transactions (id TEXT PRIMARY KEY, acct TEXT, date INTEGER, amount INTEGER);
+    INSERT INTO accounts VALUES ('a1', 'Current', 0), ('a2', 'Savings', 0);
+    INSERT INTO payees VALUES ('p1', 'Grocer', 0);
+    INSERT INTO categories VALUES ('c1', 'Food', 0);
+  `);
+  const insert = db.prepare("INSERT INTO transactions VALUES (?, 'a1', ?, -1000)");
+  const count = options.transactions ?? 3;
+  for (let index = 0; index < count; index += 1) {
+    insert.run(`t${index}`, 20260101 + index);
+  }
+  db.close();
+  const bytes = readFileSync(path);
+  rmSync(root, { recursive: true, force: true });
+  return bytes;
+}
+
+function budgetZip(overrides: Record<string, Uint8Array> = {}): Uint8Array {
+  return zipSync({
+    "db.sqlite": budgetDbBytes(),
+    "metadata.json": Buffer.from(JSON.stringify({ budgetName: "Household", id: "budget-1" })),
+    ...overrides,
+  });
+}
+
+describe("verifying a budget archive", () => {
+  it("passes a real export and reports what is inside it", () => {
+    const result = verifyBudgetArchive(budgetZip(), "data");
+
+    expect(result.status).toBe("passed");
+    expect(result.findings).toEqual([]);
+    expect(result.content).toMatchObject({
+      accounts: 2,
+      payees: 1,
+      categories: 1,
+      transactions: 3,
+      integrityCheck: "ok",
+      earliestTransaction: "2026-01-01",
+      latestTransaction: "2026-01-03",
+    });
+  });
+
+  it("fails a truncated upload, which is the failure this feature exists for", () => {
+    // Half a ZIP is the classic silent backup failure: the file is there, it is
+    // roughly the right size, and it is worthless.
+    const full = budgetZip();
+    const result = verifyBudgetArchive(full.subarray(0, Math.floor(full.length / 2)), "data");
+
+    expect(result.status).toBe("failed");
+    expect(result.findings.join(" ")).toMatch(/ZIP|db\.sqlite/);
+  });
+
+  it("fails an archive whose database is corrupt rather than merely unreadable", () => {
+    const dbBytes = Buffer.from(budgetDbBytes({ transactions: 200 }));
+    // Keep a valid SQLite header and scribble over a later page, so nothing
+    // short of actually opening the database would notice.
+    dbBytes.fill(0x7a, 4096, 8192);
+    const result = verifyBudgetArchive(budgetZip({ "db.sqlite": dbBytes }), "data");
+
+    expect(result.status).toBe("failed");
+    expect(result.content.integrityCheck).not.toBe("ok");
+  });
+
+  it("fails an archive that is not an Actual export at all", () => {
+    const result = verifyBudgetArchive(zipSync({ "notes.txt": Buffer.from("hello") }), "data");
+
+    expect(result.status).toBe("failed");
+    expect(result.findings[0]).toMatch(/db\.sqlite/);
+  });
+
+  it("notes a missing metadata.json without condemning the backup", () => {
+    const result = verifyBudgetArchive(zipSync({ "db.sqlite": budgetDbBytes() }), "archive");
+
+    // Still usable — Actual can import it — so this is a finding, not a failure.
+    expect(result.status).toBe("passed");
+    expect(result.findings[0]).toMatch(/metadata\.json/);
+  });
+
+  it("does the cheap check at archive level and the real one at data level", () => {
+    const dbBytes = Buffer.from(budgetDbBytes({ transactions: 200 }));
+    dbBytes.fill(0x7a, 4096, 8192);
+    const archive = budgetZip({ "db.sqlite": dbBytes });
+
+    // Structurally fine, contents rotten: exactly the difference between the levels.
+    expect(verifyBudgetArchive(archive, "archive").status).toBe("passed");
+    expect(verifyBudgetArchive(archive, "data").status).toBe("failed");
+  });
+
+  it("reports the checksum of the bytes it was given", () => {
+    const archive = budgetZip();
+    const first = verifyBudgetArchive(archive, "archive");
+    const second = verifyBudgetArchive(archive, "data");
+
+    expect(first.checksumSha256).toBe(second.checksumSha256);
+    expect(first.checksumSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("verifying a copy of Bench's own database", () => {
+  it("passes a healthy copy", () => {
+    const result = verifyAppDbArchive(budgetDbBytes(), "data");
+    expect(result.status).toBe("passed");
+    expect(result.content.integrityCheck).toBe("ok");
+  });
+
+  it("fails something that is not a SQLite file", () => {
+    const result = verifyAppDbArchive(Buffer.from("this is not a database"), "archive");
+    expect(result.status).toBe("failed");
+    expect(result.findings[0]).toMatch(/SQLite header/);
+  });
+});
+
+describe("encryption", () => {
+  it("round-trips an archive and verification still passes afterwards", () => {
+    const archive = budgetZip();
+    const { bytes } = encryptArchive(archive, "correct horse battery staple");
+
+    expect(Buffer.from(bytes).includes(Buffer.from("db.sqlite"))).toBe(false);
+    const decrypted = decryptArchive(bytes, "correct horse battery staple");
+    expect(verifyBudgetArchive(decrypted, "data").status).toBe("passed");
+  });
+
+  it("tells a wrong passphrase apart from a file that is not ours", () => {
+    const { bytes } = encryptArchive(budgetZip(), "right");
+
+    expect(() => decryptArchive(bytes, "wrong")).toThrow(/passphrase is wrong or the file has been altered/);
+    expect(() => decryptArchive(budgetZip(), "right")).toThrow(/not an encrypted Bench backup/);
+  });
+
+  it("detects tampering, because an auth tag is the point of GCM", () => {
+    const { bytes } = encryptArchive(budgetZip(), "right");
+    const tampered = Buffer.from(bytes);
+    tampered[tampered.length - 1] ^= 0xff;
+
+    expect(() => decryptArchive(tampered, "right")).toThrow(/altered/);
+  });
+
+  it("is self-describing, so an artifact can be decrypted without its manifest", () => {
+    const { bytes, info } = encryptArchive(budgetZip(), "right");
+
+    // The header carries the same parameters the manifest records.
+    expect(Buffer.from(bytes.subarray(0, 8)).toString("ascii")).toBe("BENCHBK1");
+    expect(info.salt).toBeTruthy();
+    expect(decryptArchive(bytes, "right").length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/backup/verify.ts
+++ b/src/lib/backup/verify.ts
@@ -175,20 +175,26 @@ export function verifyBudgetArchive(
     };
   }
 
+  // Advisory findings are worth reporting and must not condemn the copy. A
+  // missing metadata.json costs you the budget's name, not its data: the
+  // archive still imports. Letting it fail verification would exclude a
+  // perfectly restorable copy from being the newest verified one, which is the
+  // copy retention refuses to delete.
+  const advisories: string[] = [];
   let metadata: MetadataJson | null = null;
   const metadataBytes = normalized.get("metadata.json");
   if (!metadataBytes) {
-    findings.push("The archive has no metadata.json, so its budget name and id are unknown.");
+    advisories.push("The archive has no metadata.json, so its budget name and id are unknown.");
   } else {
     try {
       metadata = JSON.parse(strFromU8(metadataBytes)) as MetadataJson;
     } catch {
-      findings.push("The archive's metadata.json is not valid JSON.");
+      advisories.push("The archive's metadata.json is not valid JSON.");
     }
   }
 
   if (level === "archive") {
-    return { level, status: "passed", findings, content: {}, checksumSha256 };
+    return { level, status: "passed", findings: advisories, content: {}, checksumSha256 };
   }
 
   // better-sqlite3 needs a file. A temp copy is cheap next to the confidence of
@@ -222,8 +228,9 @@ export function verifyBudgetArchive(
 
     return {
       level,
+      // Only a fatal finding fails a copy; advisories travel with it.
       status: findings.length === 0 ? "passed" : "failed",
-      findings,
+      findings: [...findings, ...advisories],
       content,
       checksumSha256,
     };
@@ -236,6 +243,7 @@ export function verifyBudgetArchive(
         `The archive's database could not be opened: ${
           error instanceof Error ? error.message : String(error)
         }`,
+        ...advisories,
       ],
       content: {},
       checksumSha256,

--- a/src/lib/backup/verify.ts
+++ b/src/lib/backup/verify.ts
@@ -1,0 +1,302 @@
+import Database from "better-sqlite3";
+
+type SqliteHandle = InstanceType<typeof Database>;
+import { unzipSync, strFromU8 } from "fflate";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  runDiagnosticChecks,
+  runIntegrityCheck,
+  type DiagnosticDb,
+} from "@/features/budget-diagnostics/lib/diagnosticChecks";
+import type { BudgetDiagnostic, MetadataJson } from "@/features/budget-diagnostics/types";
+import { sha256, type BackupContentSummary, type BackupVerificationLevel } from "./manifest";
+
+/**
+ * Verification (RD-077 / PR-047c) — the reason this feature is called
+ * *verified* backup.
+ *
+ * A backup nobody has opened is a hypothesis. Bench can do better than most
+ * tools here for a specific reason: Budget Diagnostics already unzips an Actual
+ * export, opens `db.sqlite` and reasons about its contents, so verification is
+ * that machinery pointed at an artifact instead of at a live budget. The checks
+ * below are literally the same functions — a backup is held to exactly the
+ * standard Bench holds a working budget to.
+ *
+ * Three levels, because thoroughness has a cost and the right amount of it
+ * depends on when you are asking:
+ *
+ *   * **archive** — it is a real ZIP, it contains what an Actual export
+ *     contains, and its bytes match the checksum. Cheap; run on every artifact.
+ *   * **data** — open the database, run `PRAGMA integrity_check`, and count
+ *     what is inside. This is the level that catches truncated uploads and
+ *     silently corrupted storage, and it is the default.
+ *   * **deep** — the full diagnostic suite, including relationship checks. Slow
+ *     enough to be worth reserving for the newest copy during a scrub.
+ *
+ * Verification always runs on the **plaintext** archive, before encryption:
+ * verifying ciphertext proves only that bytes survived, which is the least
+ * interesting thing that can go wrong.
+ */
+
+export type VerificationOutcome = {
+  level: BackupVerificationLevel;
+  status: "passed" | "failed";
+  /** Human-readable, ordered worst first; safe to show verbatim. */
+  findings: string[];
+  content: BackupContentSummary;
+  checksumSha256: string;
+};
+
+function describe(finding: BudgetDiagnostic): string {
+  return finding.details?.length
+    ? `${finding.title}: ${finding.message} (${finding.details.slice(0, 3).join("; ")})`
+    : `${finding.title}: ${finding.message}`;
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function sqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+/** The Budget Diagnostics database interface, backed by better-sqlite3. */
+function createDiagnosticDb(database: SqliteHandle): DiagnosticDb {
+  return {
+    exec: (sql) => {
+      database.exec(sql);
+    },
+    selectValue: (sql) => {
+      // The single-column shape every diagnostic query uses; taking the first
+      // value keeps this working for `PRAGMA integrity_check` too, whose column
+      // is named after the pragma rather than aliased.
+      const row = database.prepare(sql).get<Record<string, unknown>>();
+      return row ? Object.values(row)[0] : undefined;
+    },
+    selectRows: <T extends Record<string, unknown>>(sql: string) =>
+      database.prepare(sql).all() as T[],
+    objectExists: (name, type) => {
+      const typeClause = type ? ` AND type = ${sqlLiteral(type)}` : "";
+      const row = database
+        .prepare(`SELECT COUNT(*) AS n FROM sqlite_schema WHERE name = ${sqlLiteral(name)}${typeClause}`)
+        .get() as { n: number } | undefined;
+      return Number(row?.n ?? 0) > 0;
+    },
+    getColumns: (name) =>
+      (database.prepare(`PRAGMA table_info(${quoteIdentifier(name)})`).all() as { name: string }[]).map(
+        (row) => String(row.name)
+      ),
+  };
+}
+
+function count(database: SqliteHandle, table: string): number | undefined {
+  try {
+    const row = database.prepare(`SELECT COUNT(*) AS n FROM ${quoteIdentifier(table)}`).get() as
+      | { n: number }
+      | undefined;
+    return Number(row?.n ?? 0);
+  } catch {
+    return undefined;
+  }
+}
+
+function summarize(database: SqliteHandle): BackupContentSummary {
+  const summary: BackupContentSummary = {
+    accounts: count(database, "accounts"),
+    transactions: count(database, "transactions"),
+    payees: count(database, "payees"),
+    categories: count(database, "categories"),
+  };
+
+  try {
+    // Actual stores dates as YYYYMMDD integers.
+    const row = database
+      .prepare(
+        "SELECT MIN(date) AS earliest, MAX(date) AS latest FROM transactions WHERE date IS NOT NULL"
+      )
+      .get() as { earliest: number | null; latest: number | null } | undefined;
+    summary.earliestTransaction = formatActualDate(row?.earliest ?? null);
+    summary.latestTransaction = formatActualDate(row?.latest ?? null);
+  } catch {
+    summary.earliestTransaction = null;
+    summary.latestTransaction = null;
+  }
+
+  return summary;
+}
+
+function formatActualDate(value: number | null): string | null {
+  if (value === null || !Number.isFinite(value)) return null;
+  const text = String(value);
+  if (text.length !== 8) return null;
+  return `${text.slice(0, 4)}-${text.slice(4, 6)}-${text.slice(6, 8)}`;
+}
+
+/**
+ * Verify a plaintext budget export.
+ *
+ * Never throws for a bad artifact: an unreadable backup is a *result*, not an
+ * exception, and the whole point is to record it and tell someone.
+ */
+export function verifyBudgetArchive(
+  bytes: Uint8Array,
+  level: BackupVerificationLevel
+): VerificationOutcome {
+  const checksumSha256 = sha256(bytes);
+  const findings: string[] = [];
+
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(bytes);
+  } catch (error) {
+    return {
+      level,
+      status: "failed",
+      findings: [`Not a readable ZIP archive: ${error instanceof Error ? error.message : String(error)}`],
+      content: {},
+      checksumSha256,
+    };
+  }
+
+  const normalized = new Map(
+    Object.entries(files).map(([path, content]) => [path.replace(/^\.?\//, ""), content])
+  );
+  const dbBytes = normalized.get("db.sqlite");
+  if (!dbBytes) {
+    return {
+      level,
+      status: "failed",
+      findings: ["The archive does not contain db.sqlite, so it is not an Actual export."],
+      content: {},
+      checksumSha256,
+    };
+  }
+
+  let metadata: MetadataJson | null = null;
+  const metadataBytes = normalized.get("metadata.json");
+  if (!metadataBytes) {
+    findings.push("The archive has no metadata.json, so its budget name and id are unknown.");
+  } else {
+    try {
+      metadata = JSON.parse(strFromU8(metadataBytes)) as MetadataJson;
+    } catch {
+      findings.push("The archive's metadata.json is not valid JSON.");
+    }
+  }
+
+  if (level === "archive") {
+    return { level, status: "passed", findings, content: {}, checksumSha256 };
+  }
+
+  // better-sqlite3 needs a file. A temp copy is cheap next to the confidence of
+  // actually opening the database rather than trusting its header.
+  const scratch = mkdtempSync(join(tmpdir(), "bench-verify-"));
+  const dbPath = join(scratch, "db.sqlite");
+  let database: SqliteHandle | null = null;
+
+  try {
+    writeFileSync(dbPath, dbBytes);
+    database = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const diagnosticDb = createDiagnosticDb(database);
+
+    const integrity = runIntegrityCheck(diagnosticDb);
+    const failedIntegrity = integrity.filter((finding) => finding.severity === "error");
+    findings.push(...failedIntegrity.map(describe));
+
+    const content = summarize(database);
+    content.integrityCheck = failedIntegrity.length === 0 ? "ok" : "failed";
+
+    if (level === "deep") {
+      const diagnostics = runDiagnosticChecks(diagnosticDb, metadata);
+      findings.push(
+        ...diagnostics.filter((finding) => finding.severity === "error").map(describe)
+      );
+    }
+
+    if (content.transactions === undefined || content.accounts === undefined) {
+      findings.push("The database opened but does not have Actual's tables.");
+    }
+
+    return {
+      level,
+      status: findings.length === 0 ? "passed" : "failed",
+      findings,
+      content,
+      checksumSha256,
+    };
+  } catch (error) {
+    return {
+      level,
+      status: "failed",
+      findings: [
+        ...findings,
+        `The archive's database could not be opened: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ],
+      content: {},
+      checksumSha256,
+    };
+  } finally {
+    database?.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Verify a copy of Bench's own metadata database.
+ *
+ * Simpler than a budget: there is no archive around it and no Actual schema to
+ * hold it to, so "does it open and does SQLite believe it" is the whole test.
+ */
+export function verifyAppDbArchive(
+  bytes: Uint8Array,
+  level: BackupVerificationLevel
+): VerificationOutcome {
+  const checksumSha256 = sha256(bytes);
+  if (level === "archive") {
+    const looksLikeSqlite = Buffer.from(bytes.subarray(0, 15)).toString("ascii") === "SQLite format 3";
+    return {
+      level,
+      status: looksLikeSqlite ? "passed" : "failed",
+      findings: looksLikeSqlite ? [] : ["This file does not have a SQLite header."],
+      content: {},
+      checksumSha256,
+    };
+  }
+
+  const scratch = mkdtempSync(join(tmpdir(), "bench-verify-appdb-"));
+  const dbPath = join(scratch, "app.sqlite");
+  let database: SqliteHandle | null = null;
+
+  try {
+    writeFileSync(dbPath, bytes);
+    database = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const row = database.prepare("PRAGMA integrity_check").get<Record<string, unknown>>();
+    const result = String(row ? Object.values(row)[0] ?? "" : "");
+    const ok = result.toLowerCase() === "ok";
+    return {
+      level,
+      status: ok ? "passed" : "failed",
+      findings: ok ? [] : [`PRAGMA integrity_check returned: ${result}`],
+      content: { integrityCheck: ok ? "ok" : "failed" },
+      checksumSha256,
+    };
+  } catch (error) {
+    return {
+      level,
+      status: "failed",
+      findings: [
+        `The copy could not be opened: ${error instanceof Error ? error.message : String(error)}`,
+      ],
+      content: {},
+      checksumSha256,
+    };
+  } finally {
+    database?.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Why

A zip someone exported once is not a backup. You do not know whether it still opens, whether it is complete, or how old it is — and you find out on the day it matters.

This is the first half of **verified backups**: copies taken on a schedule, **opened and read** to prove they work, written to as many places as you like, kept to rules that cannot delete the last good one.

Bench can do this credibly because it already reads Actual exports — Budget File Health unzips one, opens `db.sqlite` and runs `PRAGMA integrity_check`. Verification is that machinery pointed at a backup, so a copy is held to the standard a working budget is held to.

> Split from a larger branch purely so it can be reviewed: the full change is 134 files, over the automated reviewer's limit. The follow-up sits on top of this branch and covers the Recovery Center's later revisions, the run history view, unattended access, and the automation-engine defects this work uncovered.

## What is here

- **Storage and identity** — destinations, rules, artifacts and their locations, plus a versioned manifest written beside every copy so a bare destination is self-describing. An artifact stored in two places is one artifact in two places, and a failure in one must not read as a failure of both.
- **Destinations** — a folder on the server (with graded refusals: a relative path, a file, an unwritable directory, or Bench's own data directory) and S3-compatible buckets, with SigV4 written out rather than pulling in the SDK, verified against AWS's published test vector. Testing a destination writes real bytes, reads them back and compares checksums.
- **The run** — export, verify the plaintext, *then* encrypt, then fan out to every destination independently. Verifying ciphertext proves only that bytes survived, which is the least interesting thing that can go wrong.
- **Retention** — written as refusals first: never a pin, never a protected copy, never anything under the minimum age, never a manual copy, and never the newest verified one. No combination of settings can empty a destination, and the prune preview is produced by the code that prunes.
- **Scrub** — weekly re-verification of the newest copies per destination, decrypting first where the passphrase is stored, so an encrypted backup is proved *decryptable* rather than merely present.
- **Recovery Center** — inventory with what is inside each copy, inspect-without-restoring, discovery that rebuilds the index from manifests alone, and a recovery sheet documenting how to restore with `unzip`, `sqlite3` and `node` if Bench is gone.
- **Recovery points** before risky changes, debounced, protected rather than pinned so they expire on their own.

## Notes for review

- **App DB schema v20–v22**, all additive.
- **Deleting a rule keeps its backups and its passphrase.** Deleting the secret with the rule would quietly make every encrypted copy unopenable; Bench collects it once the last copy needing it is gone.
- Restore is deliberately download plus Actual's own **Import file → Actual**, which creates a *new* budget. Actual's HTTP API has no import endpoint, and the UI says so rather than hiding it.
- **Not verified by the suite:** the S3 adapter is exercised against a mocked endpoint and AWS's signing vector — nobody has yet watched a backup land in a real bucket.

`npm run lint`, `npx tsc --noEmit`, `npm test` and `npm run build` all pass.
