### PR TITLE
Filter and sort the automations and backups tables, and document scheduled work

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -52,6 +52,12 @@ export default defineConfig({
 						{ label: 'Build & audit rules', link: '/user-guide/rules/' },
 						{ label: 'Reconcile a bank statement', link: '/user-guide/bank-reconciliation/' },
 						{ label: 'Sync budget files', link: '/user-guide/budget-sync/' },
+						// Work that happens when nobody is watching is neither a
+						// one-off task nor a reference entry, which is why it had
+						// no home before and went undocumented.
+						{ label: 'Run work on a schedule', link: '/user-guide/automations/' },
+						{ label: 'Pull transactions from your bank', link: '/user-guide/bank-sync/' },
+						{ label: 'Keep verified backups', link: '/user-guide/backups/' },
 						{ label: 'Explore & diagnose data', link: '/user-guide/budget-file-tools/' },
 					],
 				},
@@ -70,7 +76,6 @@ export default defineConfig({
 						{ label: 'ActualQL', link: '/user-guide/actualql/' },
 						{ label: 'FX Rates', link: '/user-guide/fx-rates/' },
 						{ label: 'Bundle Export / Import', link: '/user-guide/bundle-export-import/' },
-						{ label: 'Backups', link: '/user-guide/backups/' },
 					],
 				},
 				{

--- a/docs-site/src/content/docs/administration/upgrading-and-backups.mdx
+++ b/docs-site/src/content/docs/administration/upgrading-and-backups.mdx
@@ -14,7 +14,7 @@ metadata database.
 
 | Data | Where | Back up? |
 |---|---|---|
-| Actual budget data | Your Actual Server | Yes — but backed up by **Actual Budget**, not Actual Bench |
+| Actual budget data | Your Actual Server | Yes — by Actual, or by Actual Bench's own [Backups](../../user-guide/backups/) |
 | Actual Bench metadata | `/data` volume (SQLite) | **Yes** |
 | Configuration | Your Compose file / environment | Yes |
 | `SYNC_VAULT_KEY` | Your secret manager | Yes — **store it separately and safely** |
@@ -89,13 +89,24 @@ container. Keep the same `/data` volume so your metadata carries over.
 
 ## Back up the metadata database
 
-Back up the `/data` volume (or at least the SQLite file at `ACTUAL_BENCH_DB_PATH`, default
-`/data/actual-bench.sqlite`).
+The easiest route is to let Bench do it: a [backup rule](../../user-guide/backups/) set to copy
+**Bench settings** takes a consistent snapshot of this database on a schedule, verifies it opens, and
+writes it wherever you point it. It uses SQLite's own `VACUUM INTO`, so the copy is safe to take
+while Bench is running and arrives with no `-wal` file to reunite.
+
+To do it by hand instead, back up the `/data` volume (or at least the SQLite file at
+`ACTUAL_BENCH_DB_PATH`, default `/data/actual-bench.sqlite`).
 
 :::caution[Back up SQLite safely]
 For a consistent copy, stop the container first, or use a SQLite-safe backup method. Copying a live
 database file mid-write can produce a corrupt backup. Include any SQLite sidecar files (for example
 `-wal` / `-shm`) if present.
+:::
+
+:::note[The vault key travels separately]
+Restoring this database onto a host with a different `SYNC_VAULT_KEY` gives you back every rule,
+flow and automation but none of the stored credentials — Bench will ask for them again. That is true
+however the copy was taken.
 :::
 
 Also back up your Compose/environment configuration, and store `SYNC_VAULT_KEY` **separately** in your

--- a/docs-site/src/content/docs/getting-started/introduction.mdx
+++ b/docs-site/src/content/docs/getting-started/introduction.mdx
@@ -32,6 +32,9 @@ that in Actual Budget. Actual Bench is the occasional workbench for larger jobs.
 | Seed a new budget or clean up an established one | [Set up and clean up data](../../user-guide/managing-your-data/) |
 | Create complex automation or audit existing rules | [Rules](../../user-guide/rules/) |
 | Compare a downloaded statement with an account | [Bank Reconciliation](../../user-guide/bank-reconciliation/) |
+| Pull transactions from your bank on a schedule | [Bank Sync](../../user-guide/bank-sync/) |
+| Keep verified backups of a budget | [Backups](../../user-guide/backups/) |
+| Run any of it while Bench is closed | [Automations](../../user-guide/automations/) |
 | Copy selected data between budget files | [Budget Sync](../../user-guide/budget-sync/) |
 | Investigate the contents or health of a budget | [Budget File Tools](../../user-guide/budget-file-tools/) |
 | Ask a custom question of saved budget data | [ActualQL](../../user-guide/actualql/) |
@@ -42,8 +45,10 @@ Actual Bench is not intended to replace:
 
 - Everyday transaction entry and mobile budgeting in Actual.
 - Actual's normal budget views and reports.
-- Actual's own bank-sync and day-to-day reconciliation experience. Actual Bench adds a separate,
-  statement-driven workbench for cases where you want to import and audit a complete statement.
+- Actual's bank connections themselves. Actual owns the link to your bank; Bench can schedule the
+  sync and report what each account returned, but the connection is Actual's.
+- Actual's day-to-day reconciliation experience. Actual Bench adds a separate, statement-driven
+  workbench for cases where you want to import and audit a complete statement.
 - The official Actual Budget documentation.
 
 ## Why the workflows feel different

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Actual Bench documentation
-description: Explore the main tools Actual Bench adds for advanced budgeting, administration, reconciliation, synchronization, and analysis.
+description: Explore the main tools Actual Bench adds for advanced budgeting, administration, reconciliation, synchronization, scheduled work, verified backups, and analysis.
 template: splash
 hero:
-  tagline: Advanced tools for Actual Budget. See the full year clearly, manage budget data in bulk, audit rules, reconcile statements, sync budget files, and investigate the details.
+  tagline: Advanced tools for Actual Budget. See the full year clearly, manage budget data in bulk, audit rules, reconcile statements, sync budget files, keep verified backups, and run it all on a schedule.
   image:
     file: ../../assets/actual-bench-icon.png
     alt: Actual Bench
@@ -21,7 +21,8 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 Actual Budget remains the place for everyday budgeting and transaction entry. **Actual Bench** is the
 independent companion you open when a larger job becomes slow, repetitive, difficult to inspect, or
-risky to do one item at a time.
+risky to do one item at a time—and the one that keeps working when you close it, on a schedule you
+chose.
 
 :::note[Independent companion app]
 Actual Bench is not the official Actual Budget application or documentation. It connects to an
@@ -51,6 +52,14 @@ existing Actual Server and adds focused administration, planning, audit, and dat
 		Create saved, preview-first flows for transactions, payees, and categories, including controlled conversion between budgets kept in different currencies.
 		[Explore Budget File Sync →](/actual-bench/user-guide/budget-sync/)
 	</Card>
+	<Card title="Scheduled Work" icon="seti:clock">
+		Run bank syncs, backups and sync flows on a schedule with the app closed—one engine, with run history, health, backoff, and credentials the server can use on its own.
+		[Explore Automations →](/actual-bench/user-guide/automations/)
+	</Card>
+	<Card title="Verified Backups" icon="seti:shell">
+		Scheduled copies of your budget that Bench **opens and reads** to prove they work, kept in a folder or an S3-compatible bucket, on rules that never delete the last good one.
+		[Explore Backups →](/actual-bench/user-guide/backups/)
+	</Card>
 	<Card title="ActualQL and Budget File Tools" icon="magnifier">
 		Query saved budget data, inspect an exported file, run structural health checks, or browse its SQLite tables without writing anything back.
 		[Explore analysis and diagnostics →](/actual-bench/user-guide/budget-file-tools/)
@@ -64,12 +73,16 @@ existing Actual Server and adds focused administration, planning, audit, and dat
 | Budgeting | A compact working view with Budget, Spent, and Balance together for up to six months | A focused 12-month Budget, Actuals, or Balance view, annual context, and spreadsheet-style editing |
 | Budget structure | Everyday creation and maintenance inside the budgeting experience | Bulk actions, CSV, duplicate handling, dependency visibility, and staged review |
 | Rules | Executes automation as transactions arrive | Richer authoring plus a whole-rule-set diagnostics pass |
-| Reconciliation | Everyday importing, bank sync, and normal reconciliation | A persistent, statement-driven comparison and correction workflow |
+| Reconciliation | Everyday importing and normal reconciliation | A persistent, statement-driven comparison and correction workflow |
+| Bank connections | Owns the connection to your bank and performs the sync | Decides *when* it runs, on a schedule with nothing open, and shows what each account returned |
+| Unattended work | Runs while you have Actual open | A scheduling engine with run history, health, backoff, and credentials the server can use on its own |
+| Backups | Manual export of a budget file | Scheduled copies that are opened and read to prove they work, kept in more than one place, on rules that never delete the last good one |
 | Multiple budget files | Keeps each budget independent | Controlled one-way synchronization, mappings, history, review queues, and FX conversion |
 | Investigation | Reports and normal data views | ActualQL, exported-file diagnostics, and read-only SQLite inspection |
 
 Actual Bench remains a companion, not a replacement. Continue using Actual Budget for everyday
-transaction entry, normal budgeting, reports, bank sync, and mobile use.
+transaction entry, normal budgeting, reports, and mobile use. Bench does not connect to your bank -
+Actual does that - but it can decide when that sync runs and tell you what came back.
 
 ## How changes reach your budget
 
@@ -79,6 +92,8 @@ Actual Bench uses different safety models for different jobs:
 - **Preview → select → Apply** for Budget File Sync and Bank Reconciliation.
 - **Read-only** for ActualQL, Rule Diagnostics, Budget File Health, and the Data Browser.
 - **Immediate explicit actions** for notes and carryover toggles.
+- **Scheduled, with a record** for automations: they run unattended, and every run is kept with its
+  result, duration, and log. See [Automations](/actual-bench/user-guide/automations/).
 
 The relevant guide states its write model before its instructions. Read [Work safely](/actual-bench/getting-started/core-concepts/)
 for the complete model.
@@ -90,6 +105,7 @@ for the complete model.
 	<LinkCard title="Try the demo" href="https://actual-bench-demo.vercel.app" description="Explore realistic Envelope and Tracking household budgets without connecting your own data." />
 	<LinkCard title="Install Actual Bench" href="/actual-bench/getting-started/installation/" description="Run the container and keep its metadata persistent." />
 	<LinkCard title="Connect a budget" href="/actual-bench/getting-started/connecting/" description="Choose the connection mode your installation supports and open a budget." />
+	<LinkCard title="Protect a budget" href="/actual-bench/user-guide/backups/" description="Take verified backups on a schedule, and know what you would get back if you needed it." />
 </CardGrid>
 
 ## Project and support

--- a/docs-site/src/content/docs/user-guide/automations.mdx
+++ b/docs-site/src/content/docs/user-guide/automations.mdx
@@ -88,9 +88,6 @@ twice on a fall-back day runs **once**.
 in one click — then by automation and kind, and searchable by the line a run reported. Each run
 expands to its result, its duration, any retries, and a redacted log.
 
-Runs of a deleted automation are kept and labelled as such: the record of what happened is not undone
-by removing the thing that did it.
-
 An automation's own drawer keeps the newest ten runs, which is enough to answer "is this healthy".
 
 ## When something fails
@@ -112,8 +109,14 @@ streak: pausing it would stop the copies that were still working. A scrub that f
 
 ## Pausing and deleting
 
-**Pause** stops an automation running and keeps everything else. **Delete** removes it along with its
-run history; what it produced — backups, synced transactions — stays where it is.
+**Pause** stops an automation running and keeps everything else — its schedule, its history, its
+credentials.
 
-Deleting a backup rule removes its automation for you, unless that automation has history worth
-keeping, in which case it is paused with an explanation instead.
+**Delete** removes the automation *and its run history*. What the automation produced is untouched:
+backups stay in their destinations, synced transactions stay in the budget. Only the record of the
+runs goes.
+
+That is why deleting a **backup rule** does not always delete its automation. If the automation has
+never run, it is removed with the rule. If it has history, it is paused with an explanation instead,
+so the record of backups that actually happened survives the rule that made them. Delete it yourself
+from this page when you no longer want that record.

--- a/docs-site/src/content/docs/user-guide/automations.mdx
+++ b/docs-site/src/content/docs/user-guide/automations.mdx
@@ -1,0 +1,119 @@
+---
+title: Automations
+description: Run work on a schedule in Actual Bench — bank syncs, backups and budget file syncs that run with the app closed, with run history, health, and credentials the server can use unattended.
+sidebar:
+  order: 13
+---
+
+Some jobs are worth doing on a timetable rather than when you remember: pulling this week's
+transactions, taking a backup, moving data between budget files. **Automations** is the one place
+Actual Bench runs that work, and the one place you find out what happened.
+
+Open it from **Automations** under the **Tools** sidebar section (`/automations`).
+
+:::note[Not Actual's Budget Automations]
+Actual Budget has an experimental feature of its own called Budget Automations. This is a different
+thing: Bench's own scheduled jobs, which Bench runs. It does not drive Actual's feature.
+:::
+
+## What can run on a schedule
+
+| Kind | What it does | Set up in |
+|---|---|---|
+| **Bank sync** | Asks Actual to pull new transactions from the banks you connected to it | [Bank Sync](../bank-sync/) |
+| **Backup** | Takes a verified copy of your budget and of Bench's own settings | [Backups](../backups/) |
+| **Budget file sync** | Runs a saved sync flow, safe items only | [Budget Sync](../budget-sync/) |
+| **Verify backups** | Re-reads stored copies to check they are still readable | created with your first backup rule |
+
+**New automation** on the Automations page lists all of them and takes you to where each is
+configured. A backup and a sync flow are set up in their own screens because that is where the
+decisions live; what they share is the engine that runs them.
+
+## The one thing worth knowing first
+
+Every automation says **where it runs**, on its own row:
+
+| | |
+|---|---|
+| **Runs on the server** | Runs on schedule even with Actual Bench closed. Needs HTTP API mode and a budget enrolled for unattended access. |
+| **Runs in your browser** | Runs only while Bench is open in a tab. Close it and nothing happens. This is a convenience, not automation. |
+
+Direct (browser) mode can never run unattended: Actual's engine runs in your browser there, so there
+is nothing on the server to run. Bench says so rather than implying otherwise.
+
+**One instance only.** The engine runs inside the Bench server process. Running two containers
+against one database would run your automations twice; Bench does not coordinate across instances.
+
+## Unattended access
+
+Anything that runs with the browser closed needs credentials the server can use, which means two
+things: `SYNC_VAULT_KEY` set on the server, and the budget itself **enrolled**.
+
+The **Connections** tab lists the budgets Bench may act on, when each was enrolled, and — the column
+worth the tab — **what depends on it**. Withdrawing a credential stops those automations, so the
+confirmation names them before it happens.
+
+Two things to expect:
+
+- Enrolment is **per budget, not per server**. Three budgets on one server are three entries.
+- Bench can only enrol the budget you are **currently connected to**, because that is the only API
+  key your browser holds. Any other budget says so and asks you to switch to it first.
+
+You can enrol from Connections, from the bank sync or backup dialogs, or from a Budget File Sync
+flow — all four write the same list.
+
+:::caution[What gets stored]
+That budget's API key, and its encryption password if it has one, encrypted with the server's
+`SYNC_VAULT_KEY`. The key itself is never stored beside them. Nothing else is kept: no budget data,
+and no other budget on the same server.
+:::
+
+## Schedules
+
+Choose the shape that matches how you think about it — every few hours, every day at a time, on
+chosen days of the week, once a month — or write a cron expression if you want something the simple
+modes cannot say, like weekday mornings only.
+
+Whatever you pick, the picker says back **what it understood** and **when the next runs land**. That
+second line is the one that catches mistakes: `0 0 * * *` reads like a fair guess at midnight until
+the preview shows the next run is fourteen hours away.
+
+Clock-based schedules carry an explicit **time zone**. Daylight saving is handled deliberately: a
+time that does not exist on a spring-forward day runs as the gap closes, and a time that happens
+twice on a fall-back day runs **once**.
+
+## Run history
+
+**Run history** shows every run across every automation, filtered by outcome first — *what failed?*
+in one click — then by automation and kind, and searchable by the line a run reported. Each run
+expands to its result, its duration, any retries, and a redacted log.
+
+Runs of a deleted automation are kept and labelled as such: the record of what happened is not undone
+by removing the thing that did it.
+
+An automation's own drawer keeps the newest ten runs, which is enough to answer "is this healthy".
+
+## When something fails
+
+Bench treats a failure as information, not an emergency:
+
+- **Backoff.** Attempts space out after a failure, up to a ceiling, so a broken job stops hammering
+  whatever it cannot reach.
+- **Auto-pause.** After a run of consecutive failures the automation pauses itself and says why.
+  **Resume** clears both the pause and the streak. Editing a schedule does not clear a pause.
+- **Overdue is a warning.** An automation well past its next run is flagged even when nothing failed.
+- **Fail closed on credentials.** An automation that names a credential it cannot resolve — vault off,
+  key rotated, enrolment withdrawn — does not run at all, and pauses with that reason.
+
+What counts as a failure is the job's own judgement, and the two answers differ on purpose. A backup
+that reached one of two destinations is reported as partial but does **not** count against the
+streak: pausing it would stop the copies that were still working. A scrub that finds a damaged copy
+**does** count — repeating it will not improve matters, and someone should look.
+
+## Pausing and deleting
+
+**Pause** stops an automation running and keeps everything else. **Delete** removes it along with its
+run history; what it produced — backups, synced transactions — stays where it is.
+
+Deleting a backup rule removes its automation for you, unless that automation has history worth
+keeping, in which case it is paused with an explanation instead.

--- a/docs-site/src/content/docs/user-guide/backups.mdx
+++ b/docs-site/src/content/docs/user-guide/backups.mdx
@@ -140,6 +140,16 @@ unsaved, the reason is shown, and you can save anyway.
 
 Turn it off from the checkbox under the rules if you would rather it did not.
 
+## Backing up Bench itself
+
+A rule set to copy **Bench settings** snapshots Bench's own metadata database — your sync flows and
+mappings, reconciliation sessions, automations, saved queries and payee-cleanup decisions. It needs
+no budget connection at all, because it is a local database copy.
+
+Restoring it is an operator job rather than an in-app one: see
+[Upgrades & backups](../../administration/upgrading-and-backups/), which covers where the file goes
+and why the `SYNC_VAULT_KEY` has to travel with it.
+
 ## Getting a backup back
 
 **Look inside** opens a copy and tells you what is in it — accounts, payees, transactions and the

--- a/docs-site/src/content/docs/user-guide/bank-sync.mdx
+++ b/docs-site/src/content/docs/user-guide/bank-sync.mdx
@@ -1,0 +1,72 @@
+---
+title: Bank Sync
+description: Schedule Actual's own bank sync from Actual Bench — pull new transactions with nothing open, per-account results, and honest reporting of what each bank returned.
+sidebar:
+  order: 14
+---
+
+Actual connects to your bank. **Actual Bench decides when that sync runs** — on a schedule, with
+nothing open — and tells you what each account came back with.
+
+That division matters, and it is the whole feature: Bench never talks to your bank, holds no bank
+credentials, and adds no provider. It asks Actual to do the thing Actual already does, at a time you
+chose, and then reports honestly.
+
+Set one up from **Automations → New automation → Bank sync** (`/automations`).
+
+## What you need
+
+- Accounts **linked to a bank in Actual** (SimpleFIN or GoCardless). Bench cannot create those links.
+- **HTTP API Server mode**, and the budget [enrolled for unattended access](../automations/#unattended-access) —
+  a scheduled sync runs with your browser closed, so the server needs credentials of its own.
+
+A Direct (browser) connection can pull on demand while Bench is open, but it can never run
+unattended: Actual's engine lives in your browser there, so with the tab closed there is nothing to
+run.
+
+## Setting one up
+
+The dialog shows **which accounts will actually sync** before you commit to anything:
+
+- Accounts linked to a bank are listed with when each last synced.
+- Accounts with no bank link are listed too, marked **not connected to a bank — skipped**.
+
+That list is the point. Without it, scheduling can only assert "every linked account is synced" and
+hope — and someone whose accounts are all unlinked would create an automation that does nothing,
+forever, without a hint as to why. If none are linked, Bench refuses to schedule the run rather than
+letting you create it.
+
+Then choose how often. Every few hours suits most people; the minimum interval is 15 minutes,
+because below that a run spends its time reopening the budget rather than syncing.
+
+## What a run reports
+
+Each account is synced **separately**, so one bank being down does not stop the others:
+
+| Result | Meaning |
+|---|---|
+| **Synced** | Actual accepted the pull for this account |
+| **Failed** | This account's provider or link failed — the reason is on the run |
+| **Skipped** | The account is closed, or not linked to a bank |
+
+A run where some accounts failed is reported as **partial**. It does not count against the
+automation's failure streak: one unreachable bank out of twelve is a normal Tuesday, and pausing the
+whole automation over it would be wrong. A run where *every* account failed does count.
+
+:::note[Transaction counts]
+Bench reports a number of imported transactions only where it could measure one. In Direct mode the
+pull finishes before the call returns, so a count is real. Over the HTTP API, the server answers that
+the sync has *started* — so Bench records the run as accepted and does not invent a figure it cannot
+observe.
+:::
+
+Full results, including per-account reasons and the redacted log, are in
+[Run history](../automations/#run-history).
+
+## What this does not do
+
+- It does not connect to your bank, or store bank credentials. Actual owns that.
+- It does not re-import a statement or reconcile anything. For a downloaded statement, use
+  [Bank Reconciliation](../bank-reconciliation/).
+- It does not fix a broken bank link. If a provider needs re-authorising, that is done in Actual;
+  Bench will keep reporting the failure until it is.

--- a/src/app/api/automations/runs/route.ts
+++ b/src/app/api/automations/runs/route.ts
@@ -55,8 +55,9 @@ export async function GET(request: Request) {
     return NextResponse.json({
       runs: runs.map((run) => ({
         ...run,
-        // A deleted automation leaves its runs behind on purpose: the history of
-        // what happened is not undone by removing the thing that did it.
+        // Deleting an automation cascades to its runs, so this is a fallback
+        // rather than the deletion story: a run whose automation cannot be
+        // resolved still belongs in the history, named as best we can.
         automationName: (run.automationId && names.get(run.automationId)) || "Deleted automation",
         typeLabel: typeLabels.get(run.type) ?? run.type,
       })),

--- a/src/components/ui/sortable-header.tsx
+++ b/src/components/ui/sortable-header.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A column header you can sort by.
+ *
+ * The entity tables each grew their own copy of this - the same tri-state
+ * button, the same three icons, the same `aria-sort` on the cell. This is that
+ * pattern extracted rather than reinvented, so a sortable column behaves and
+ * announces itself the same way wherever it appears.
+ *
+ * Tri-state on purpose: ascending, descending, and back to the table's own
+ * order. A sort you cannot undo forces a reload to see the default again.
+ */
+
+export type SortDirection = "asc" | "desc" | null;
+
+export function nextSortDirection(current: SortDirection): SortDirection {
+  return current === null ? "asc" : current === "asc" ? "desc" : null;
+}
+
+/**
+ * Sort state for a table with one active column at a time.
+ *
+ * Returns the direction for `key` if it is the active column, and null
+ * otherwise - so a header can render itself without knowing about its siblings.
+ */
+export function directionFor<K extends string>(
+  sort: { key: K; direction: SortDirection } | null,
+  key: K
+): SortDirection {
+  return sort && sort.key === key ? sort.direction : null;
+}
+
+export function SortableHeader<K extends string>({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  className,
+  align = "left",
+}: {
+  label: string;
+  sortKey: K;
+  sort: { key: K; direction: SortDirection } | null;
+  onSort: (key: K, direction: SortDirection) => void;
+  className?: string;
+  align?: "left" | "right";
+}) {
+  const direction = directionFor(sort, sortKey);
+
+  return (
+    <th
+      scope="col"
+      className={cn("px-4 py-2 font-medium", align === "right" && "text-right", className)}
+      aria-sort={
+        direction === "asc" ? "ascending" : direction === "desc" ? "descending" : "none"
+      }
+    >
+      <button
+        type="button"
+        className={cn(
+          "flex select-none items-center gap-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          align === "right" && "ml-auto",
+          direction && "text-foreground"
+        )}
+        onClick={() => onSort(sortKey, nextSortDirection(direction))}
+        aria-label={`Sort by ${label}${
+          direction === "asc" ? ", ascending" : direction === "desc" ? ", descending" : ""
+        }`}
+      >
+        {label}
+        {direction === null ? (
+          <ArrowUpDown className="size-3 opacity-30" aria-hidden />
+        ) : direction === "asc" ? (
+          <ArrowUp className="size-3" aria-hidden />
+        ) : (
+          <ArrowDown className="size-3" aria-hidden />
+        )}
+      </button>
+    </th>
+  );
+}
+
+/**
+ * Compare two rows by a value that may be missing.
+ *
+ * Missing values sort last in both directions rather than being treated as
+ * empty strings or zeros: a backup that has never run is not "older than
+ * everything", it is unknown, and burying it under real data in one direction
+ * while floating it to the top in the other is how sorted tables mislead.
+ */
+export function compareValues(
+  a: string | number | null | undefined,
+  b: string | number | null | undefined,
+  direction: Exclude<SortDirection, null>
+): number {
+  const aMissing = a === null || a === undefined || a === "";
+  const bMissing = b === null || b === undefined || b === "";
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+
+  const result = typeof a === "number" && typeof b === "number" ? a - b : String(a).localeCompare(String(b));
+  return direction === "asc" ? result : -result;
+}

--- a/src/features/automations/components/AutomationsFilterBar.tsx
+++ b/src/features/automations/components/AutomationsFilterBar.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { PillGroup } from "@/components/ui/pill-group";
+import type { AutomationJobTypeSummary, AutomationListItem } from "../lib/automationsApi";
+
+/**
+ * Narrowing the list of automations (RD-079).
+ *
+ * Same shape as the filter bars on the entity pages - search, pills, a count -
+ * because this is the same task: find the row you mean among rows that all look
+ * alike. Status leads, because the question people arrive with is "what is
+ * broken", and it is the one filter worth a single click.
+ */
+
+export type AutomationStatusFilter = "all" | "ok" | "warning" | "failing" | "paused";
+
+const STATUS_OPTIONS: { value: AutomationStatusFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "failing", label: "Failing" },
+  { value: "warning", label: "Attention" },
+  { value: "paused", label: "Paused" },
+  { value: "ok", label: "Healthy" },
+];
+
+export function AutomationsFilterBar({
+  search,
+  onSearchChange,
+  status,
+  onStatusChange,
+  type,
+  onTypeChange,
+  jobTypes,
+  filteredCount,
+  totalCount,
+}: {
+  search: string;
+  onSearchChange: (value: string) => void;
+  status: AutomationStatusFilter;
+  onStatusChange: (value: AutomationStatusFilter) => void;
+  type: string;
+  onTypeChange: (value: string) => void;
+  jobTypes: AutomationJobTypeSummary[];
+  filteredCount: number;
+  totalCount: number;
+}) {
+  const filtering = search.trim() !== "" || status !== "all" || type !== "";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border/40 bg-muted/10 px-4 py-1.5">
+      <div className="relative flex items-center">
+        <Search className="absolute left-1.5 size-3.5 text-muted-foreground" aria-hidden />
+        <input
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="Search automations…"
+          aria-label="Search automations"
+          className="h-6 w-52 rounded border border-border bg-background pl-6 pr-6 text-xs outline-none focus:ring-1 focus:ring-ring"
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => onSearchChange("")}
+            aria-label="Clear search"
+            className="absolute right-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3" aria-hidden />
+          </button>
+        )}
+      </div>
+
+      <PillGroup options={STATUS_OPTIONS} value={status} onChange={onStatusChange} />
+
+      {jobTypes.length > 1 && (
+        <select
+          className="h-6 rounded border border-border bg-background px-1.5 text-xs"
+          value={type}
+          onChange={(event) => onTypeChange(event.target.value)}
+          aria-label="Filter by kind"
+        >
+          <option value="">Any kind</option>
+          {jobTypes.map((jobType) => (
+            <option key={jobType.type} value={jobType.type}>
+              {jobType.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <span className="text-xs text-muted-foreground">
+        {filtering ? `${filteredCount} of ${totalCount}` : `${totalCount}`}
+      </span>
+
+      {filtering && (
+        <button
+          type="button"
+          className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+          onClick={() => {
+            onSearchChange("");
+            onStatusChange("all");
+            onTypeChange("");
+          }}
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Rows matching the current filters, in the order they were given. */
+export function filterAutomations(
+  automations: AutomationListItem[],
+  filters: { search: string; status: AutomationStatusFilter; type: string }
+): AutomationListItem[] {
+  const needle = filters.search.trim().toLowerCase();
+
+  return automations.filter((automation) => {
+    if (filters.status !== "all" && automation.status !== filters.status) return false;
+    if (filters.type && automation.type !== filters.type) return false;
+    if (!needle) return true;
+
+    // Searched over what is on the row: someone types what they can see.
+    return [automation.name, automation.typeLabel, automation.scheduleLabel, automation.statusSummary]
+      .filter((value): value is string => typeof value === "string")
+      .some((value) => value.toLowerCase().includes(needle));
+  });
+}

--- a/src/features/automations/components/AutomationsTable.tsx
+++ b/src/features/automations/components/AutomationsTable.tsx
@@ -9,9 +9,14 @@ import {
   Loader2,
   Pause,
   Play,
+  Trash2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/ui/sortable-header";
 import { cn } from "@/lib/utils";
 import { executionModeCopy, formatDateTime, jobTypeIcon, relativeTime } from "../lib/presentation";
 import type { AutomationListItem } from "../lib/automationsApi";
@@ -73,34 +78,48 @@ const STATUS_STYLE: Record<
   idle: { icon: CircleDot, tone: "text-muted-foreground", label: "Idle" },
 };
 
+export type AutomationSortKey =
+  | "status"
+  | "name"
+  | "type"
+  | "schedule"
+  | "lastRun"
+  | "nextRun";
+
 type AutomationsTableProps = {
   automations: AutomationListItem[];
   runningId: string | null;
+  sort: { key: AutomationSortKey; direction: SortDirection } | null;
+  onSort: (key: AutomationSortKey, direction: SortDirection) => void;
   onOpen: (automationId: string) => void;
   onRunNow: (automationId: string) => void;
   onToggleEnabled: (automation: AutomationListItem) => void;
   onResume: (automationId: string) => void;
+  onDelete: (automation: AutomationListItem) => void;
 };
 
 export function AutomationsTable({
   automations,
   runningId,
+  sort,
+  onSort,
   onOpen,
   onRunNow,
   onToggleEnabled,
   onResume,
+  onDelete,
 }: AutomationsTableProps) {
   return (
     <div className="min-h-0 flex-1 overflow-auto">
       <table className="w-full text-xs">
         <thead className="sticky top-0 z-10 bg-muted text-left text-[11px] uppercase text-muted-foreground">
           <tr>
-            <th className="px-3 py-2">Status</th>
-            <th className="px-3 py-2">Automation</th>
-            <th className="px-3 py-2">Type</th>
-            <th className="px-3 py-2">Schedule</th>
-            <th className="px-3 py-2">Last run</th>
-            <th className="px-3 py-2">Next run</th>
+            <SortableHeader label="Status" sortKey="status" sort={sort} onSort={onSort} className="px-3 py-2" />
+            <SortableHeader label="Automation" sortKey="name" sort={sort} onSort={onSort} className="px-3 py-2" />
+            <SortableHeader label="Type" sortKey="type" sort={sort} onSort={onSort} className="px-3 py-2" />
+            <SortableHeader label="Schedule" sortKey="schedule" sort={sort} onSort={onSort} className="px-3 py-2" />
+            <SortableHeader label="Last run" sortKey="lastRun" sort={sort} onSort={onSort} className="px-3 py-2" />
+            <SortableHeader label="Next run" sortKey="nextRun" sort={sort} onSort={onSort} className="px-3 py-2" />
             <th className="w-px px-3 py-2 text-right">
               <span className="sr-only">Actions</span>
             </th>
@@ -236,6 +255,21 @@ export function AutomationsTable({
                         {automation.enabled ? <Pause aria-hidden /> : <Play aria-hidden />}
                       </Button>
                     )}
+
+                    {/* Deleting is how an automation actually goes away. Pause
+                        is not: a backup rule that has been deleted leaves its
+                        automation behind, paused with a reason, and without
+                        this there was no way to clear it. */}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => onDelete(automation)}
+                      aria-label={`Delete ${automation.name}`}
+                      title="Delete this automation. Its run history goes with it."
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
                   </div>
                 </td>
               </tr>

--- a/src/features/automations/components/AutomationsView.test.tsx
+++ b/src/features/automations/components/AutomationsView.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { AutomationsView } from "./AutomationsView";
 import * as api from "../lib/automationsApi";
 import type { AutomationListItem } from "../lib/automationsApi";
@@ -85,6 +85,9 @@ function renderView() {
 describe("AutomationsView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Filters and sort persist to sessionStorage, so one test's filter would
+    // otherwise decide what the next one can see.
+    sessionStorage.clear();
     mockedApi.listAutomations.mockResolvedValue({ automations: [automation()], jobTypes: [] });
     mockedApi.listAutomationRuns.mockResolvedValue([run()]);
     mockedApi.runAutomationNow.mockResolvedValue({
@@ -236,6 +239,89 @@ describe("AutomationsView", () => {
     // people get wrong about this page.
     expect(screen.getByText(/Auto-sync on a server schedule/i)).toBeInTheDocument();
     expect(screen.getByText(/stays out of here on purpose/i)).toBeInTheDocument();
+  });
+
+  it("keeps the filters reachable when a filter matches nothing", async () => {
+    // Keyed on the filtered list, an empty result replaced the whole page -
+    // filter bar included - with "nothing is scheduled yet": untrue, and no way
+    // back.
+    renderView();
+    await screen.findByText("Household → Joint");
+
+    fireEvent.change(screen.getByLabelText("Search automations"), {
+      target: { value: "nothing matches this" },
+    });
+
+    expect(await screen.findByText(/No automation matches those filters/)).toBeInTheDocument();
+    expect(screen.queryByText(/Nothing is scheduled yet/)).not.toBeInTheDocument();
+
+    // And the way back is right there.
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(await screen.findByText("Household → Joint")).toBeInTheDocument();
+  });
+
+  it("can delete an automation, and says what goes with it", async () => {
+    // Pause is not removal: a backup rule that has been deleted leaves its
+    // automation behind, paused with a reason, and there was no way to clear
+    // it.
+    renderView();
+    await screen.findByText("Household → Joint");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete household/i }));
+
+    expect(await screen.findByText('Delete "Household → Joint"?')).toBeInTheDocument();
+    expect(screen.getByText(/run history goes with it/)).toBeInTheDocument();
+    expect(mockedApi.deleteAutomation).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    // React Query passes its own context as a second argument.
+    await waitFor(() =>
+      expect(mockedApi.deleteAutomation).toHaveBeenCalledWith("auto-1", expect.anything())
+    );
+  });
+
+  it("filters to what is broken in one click", async () => {
+    // The question people arrive with is "what is failing", so it is the filter
+    // worth a single click rather than a search term.
+    mockedApi.listAutomations.mockResolvedValue({
+      automations: [
+        automation({ id: "ok", name: "Working one" }),
+        automation({ id: "bad", name: "Broken one", status: "failing" }),
+      ],
+      jobTypes: [],
+    });
+
+    renderView();
+    await screen.findByText("Working one");
+
+    fireEvent.click(screen.getByRole("button", { name: "Failing" }));
+
+    await waitFor(() => expect(screen.queryByText("Working one")).not.toBeInTheDocument());
+    expect(screen.getByText("Broken one")).toBeInTheDocument();
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+  });
+
+  it("sorts by a column, and back to its own order", async () => {
+    mockedApi.listAutomations.mockResolvedValue({
+      automations: [
+        automation({ id: "b", name: "Beta" }),
+        automation({ id: "a", name: "Alpha" }),
+      ],
+      jobTypes: [],
+    });
+
+    renderView();
+    const header = await screen.findByRole("button", { name: /sort by automation/i });
+
+    fireEvent.click(header);
+    expect(header.closest("th")).toHaveAttribute("aria-sort", "ascending");
+    expect(within(screen.getAllByRole("row")[1]).getByText("Alpha")).toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(within(screen.getAllByRole("row")[1]).getByText("Beta")).toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(header.closest("th")).toHaveAttribute("aria-sort", "none");
   });
 
   it("offers every kind of automation from one place", async () => {
@@ -391,9 +477,11 @@ describe("AutomationsView", () => {
     renderView();
 
     // Anyone who cannot distinguish the hues — or who pastes a screenshot into
-    // a bug report — still learns which row is in trouble.
-    expect(await screen.findByText("Healthy")).toBeInTheDocument();
-    expect(screen.getByText("Failing")).toBeInTheDocument();
+    // a bug report — still learns which row is in trouble. Scoped to the table:
+    // the filter pills carry the same words.
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("Healthy")).toBeInTheDocument();
+    expect(within(table).getByText("Failing")).toBeInTheDocument();
     expect(screen.getByText(/provider unreachable/)).toBeInTheDocument();
   });
 });

--- a/src/features/automations/components/AutomationsView.test.tsx
+++ b/src/features/automations/components/AutomationsView.test.tsx
@@ -7,8 +7,10 @@ import { toast } from "sonner";
 import type { AutomationRun } from "@/lib/app-db/types";
 
 jest.mock("../lib/automationsApi");
+// Mutable so one test can arrive by a link that names an automation.
+let searchParams = new URLSearchParams();
 jest.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParams,
   usePathname: () => "/automations",
 }));
 jest.mock("sonner", () => ({
@@ -88,6 +90,7 @@ describe("AutomationsView", () => {
     // Filters and sort persist to sessionStorage, so one test's filter would
     // otherwise decide what the next one can see.
     sessionStorage.clear();
+    searchParams = new URLSearchParams();
     mockedApi.listAutomations.mockResolvedValue({ automations: [automation()], jobTypes: [] });
     mockedApi.listAutomationRuns.mockResolvedValue([run()]);
     mockedApi.runAutomationNow.mockResolvedValue({
@@ -258,6 +261,22 @@ describe("AutomationsView", () => {
     // And the way back is right there.
     fireEvent.click(screen.getByRole("button", { name: "Clear" }));
     expect(await screen.findByText("Household → Joint")).toBeInTheDocument();
+  });
+
+  it("opens the automation a link names, whatever filter was left set", async () => {
+    // Connections links to /automations?open=<id>. Resolved from the filtered
+    // rows, a leftover filter made that link open nothing - and an open drawer
+    // closed when its row was filtered out from behind it.
+    sessionStorage.setItem(
+      "filters:automations",
+      JSON.stringify({ search: "matches nothing", status: "all", type: "" })
+    );
+    searchParams = new URLSearchParams("open=auto-1");
+
+    renderView();
+
+    expect(await screen.findByText(/No automation matches those filters/)).toBeInTheDocument();
+    expect(await screen.findByText("Every 30 minutes")).toBeInTheDocument();
   });
 
   it("can delete an automation, and says what goes with it", async () => {

--- a/src/features/automations/components/AutomationsView.tsx
+++ b/src/features/automations/components/AutomationsView.tsx
@@ -170,7 +170,11 @@ export function AutomationsView() {
   });
   const automations = sortAutomations(filtered, sort);
   const reviewQueue = reviewQueueQuery.data ?? [];
-  const selected = automations.find((automation) => automation.id === selectedId) ?? null;
+  // Resolved from every automation, not the filtered rows: a link that names
+  // one - /automations?open=<id>, which Connections uses - has to open it
+  // whatever filter was left set, and an open drawer should not close because
+  // its row was filtered out from behind it.
+  const selected = allAutomations.find((automation) => automation.id === selectedId) ?? null;
 
   return (
     <PageLayout

--- a/src/features/automations/components/AutomationsView.tsx
+++ b/src/features/automations/components/AutomationsView.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { ConfirmDialog, type ConfirmState } from "@/components/ui/confirm-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,17 +17,25 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import {
+  deleteAutomation,
   listAutomations,
   listReviewQueue,
   patchAutomation,
   runAutomationNow,
 } from "../lib/automationsApi";
 
+import { usePersistedFilters } from "@/hooks/usePersistedFilters";
+import type { SortDirection } from "@/components/ui/sortable-header";
 import { AutomationDetail } from "./AutomationDetail";
+import {
+  AutomationsFilterBar,
+  filterAutomations,
+  type AutomationStatusFilter,
+} from "./AutomationsFilterBar";
 import { AutomationsTabs } from "./AutomationsTabs";
-import { AutomationsTable } from "./AutomationsTable";
+import { AutomationsTable, type AutomationSortKey } from "./AutomationsTable";
 import { NewBankSyncDialog } from "./NewBankSyncDialog";
-import { describeAutomationsSummary, jobTypeIcon } from "../lib/presentation";
+import { describeAutomationsSummary, jobTypeIcon, sortAutomations } from "../lib/presentation";
 
 /**
  * The Automations workspace (RD-079 / PR-043d).
@@ -48,6 +57,7 @@ export function AutomationsView() {
   // someone to find the row themselves on a page they were sent to for it.
   const [selectedId, setSelectedId] = useState<string | null>(params.get("open"));
   const [creating, setCreating] = useState(false);
+  const [confirm, setConfirm] = useState<ConfirmState | null>(null);
 
   const automationsQuery = useQuery({
     queryKey: ["automations"],
@@ -99,6 +109,15 @@ export function AutomationsView() {
     onError: (error: Error) => toast.error(error.message),
   });
 
+  const remove = useMutation({
+    mutationFn: deleteAutomation,
+    onSuccess: () => {
+      toast.success("Automation deleted");
+      invalidate();
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
   const reviewQueueQuery = useQuery({
     queryKey: ["automation-review-queue"],
     queryFn: listReviewQueue,
@@ -123,7 +142,33 @@ export function AutomationsView() {
     }
   }
 
-  const automations = automationsQuery.data?.automations ?? [];
+  const allAutomations = automationsQuery.data?.automations ?? [];
+
+  // Filters and sort persist the way the entity pages persist theirs, so
+  // switching to a run and back does not lose the view you set up.
+  const [view, setView] = usePersistedFilters<{
+    search: string;
+    status: AutomationStatusFilter;
+    type: string;
+    sortKey: AutomationSortKey | null;
+    sortDirection: SortDirection;
+  }>("filters:automations", {
+    search: "",
+    status: "all",
+    type: "",
+    sortKey: null,
+    sortDirection: null,
+  });
+
+  const sort =
+    view.sortKey && view.sortDirection ? { key: view.sortKey, direction: view.sortDirection } : null;
+
+  const filtered = filterAutomations(allAutomations, {
+    search: view.search,
+    status: view.status,
+    type: view.type,
+  });
+  const automations = sortAutomations(filtered, sort);
   const reviewQueue = reviewQueueQuery.data ?? [];
   const selected = automations.find((automation) => automation.id === selectedId) ?? null;
 
@@ -138,7 +183,11 @@ export function AutomationsView() {
       error={automationsQuery.error}
       onRetry={() => void automationsQuery.refetch()}
       emptyState={
-        automations.length === 0 ? (
+        // Keyed on the unfiltered list. Keyed on the filtered one, a filter
+        // matching nothing replaced the whole page - filter bar included - with
+        // "nothing is scheduled yet", stranding you in a view you could not
+        // undo and telling you something untrue on the way.
+        allAutomations.length === 0 ? (
           <div className="mx-auto max-w-xl px-6 py-14">
             <h2 className="text-sm font-semibold">Nothing is scheduled yet</h2>
             <p className="mt-2 text-sm text-muted-foreground">
@@ -289,19 +338,66 @@ export function AutomationsView() {
           </section>
         )}
 
+        <AutomationsFilterBar
+          search={view.search}
+          onSearchChange={(search) => setView((current) => ({ ...current, search }))}
+          status={view.status}
+          onStatusChange={(status) => setView((current) => ({ ...current, status }))}
+          type={view.type}
+          onTypeChange={(type) => setView((current) => ({ ...current, type }))}
+          jobTypes={automationsQuery.data?.jobTypes ?? []}
+          filteredCount={automations.length}
+          totalCount={allAutomations.length}
+        />
+
+        {automations.length === 0 && allAutomations.length > 0 ? (
+          <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+            No automation matches those filters.
+          </p>
+        ) : (
         <AutomationsTable
           automations={automations}
           runningId={runNow.isPending ? (runNow.variables ?? null) : null}
+          sort={sort}
+          onSort={(sortKey, sortDirection) =>
+            setView((current) => ({
+              ...current,
+              sortKey: sortDirection ? sortKey : null,
+              sortDirection,
+            }))
+          }
           onOpen={setSelectedId}
           onRunNow={(id) => runNow.mutate(id)}
           onToggleEnabled={(automation) =>
             setEnabled.mutate({ id: automation.id, enabled: !automation.enabled })
           }
           onResume={(id) => resume.mutate(id)}
+          onDelete={(automation) =>
+            setConfirm({
+              title: `Delete "${automation.name}"?`,
+              message:
+                automation.type === "budget-file-sync"
+                  ? "It stops running and its run history goes with it. The sync flow itself is untouched - set its review policy back to unattended and the automation returns."
+                  : automation.type === "backup"
+                    ? "It stops running and its run history goes with it. The backups it took are kept."
+                    : "It stops running and its run history goes with it.",
+              destructiveLabel: "Delete",
+              onConfirm: () => remove.mutate(automation.id),
+            })
+          }
         />
+        )}
       </div>
 
       <NewBankSyncDialog open={creating} onOpenChange={setCreating} onCreated={invalidate} />
+
+      <ConfirmDialog
+        open={confirm !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        state={confirm}
+      />
 
       {selected && <AutomationDetail automation={selected} onClose={() => setSelectedId(null)} />}
     </PageLayout>

--- a/src/features/automations/components/ConnectionsView.tsx
+++ b/src/features/automations/components/ConnectionsView.tsx
@@ -94,7 +94,10 @@ export function ConnectionsView() {
                   {connections.length} {connections.length === 1 ? "budget" : "budgets"}
                 </span>
               </h2>
-              <p className="mt-0.5 max-w-3xl text-xs text-muted-foreground">
+              {/* No reading-column cap: the sentence is one thought and fits on
+                  one line at desk width. Capped at 3xl it wrapped for no
+                  reason, since nothing sits beside it but the Refresh button. */}
+              <p className="mt-0.5 text-xs text-muted-foreground">
                 Bench can act on these budgets while your browser is closed - that is what a
                 scheduled sync, bank pull or backup needs. Each budget is enrolled separately, so
                 three budgets means three entries here.
@@ -217,10 +220,6 @@ export function ConnectionsView() {
             </div>
           )}
 
-          <p className="mt-3 text-xs text-muted-foreground">
-            Budget File Sync also enrols connections from its own flow editor - it is the same list,
-            reached from where you happen to be.
-          </p>
         </div>
       </div>
 

--- a/src/features/automations/components/RunHistoryFilterBar.tsx
+++ b/src/features/automations/components/RunHistoryFilterBar.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { MultiPillGroup } from "@/components/ui/pill-group";
+import { runStatusLabel } from "../lib/presentation";
+import type { RunHistory } from "../lib/automationsApi";
+import type { AutomationRunStatus } from "@/lib/app-db/types";
+
+/**
+ * Narrowing the run history (RD-079).
+ *
+ * Deliberately the same bar as the automations list: search, pills, selects,
+ * a count, a way out. Two screens in one feature asking the same question -
+ * which of these rows do I mean - should not answer it with two different
+ * controls.
+ *
+ * Outcome allows more than one at a time, because "failed or partial" is one
+ * thought, not two searches.
+ */
+
+const STATUS_OPTIONS: { value: AutomationRunStatus; label: string }[] = [
+  { value: "failed", label: runStatusLabel("failed") },
+  { value: "partial", label: runStatusLabel("partial") },
+  { value: "succeeded", label: runStatusLabel("succeeded") },
+  { value: "no_changes", label: runStatusLabel("no_changes") },
+  { value: "running", label: runStatusLabel("running") },
+  { value: "cancelled", label: runStatusLabel("cancelled") },
+];
+
+export function RunHistoryFilterBar({
+  search,
+  onSearchChange,
+  statuses,
+  onStatusesChange,
+  automationId,
+  onAutomationChange,
+  type,
+  onTypeChange,
+  options,
+  filteredCount,
+  totalCount,
+  capped,
+  actions,
+}: {
+  search: string;
+  onSearchChange: (value: string) => void;
+  statuses: AutomationRunStatus[];
+  onStatusesChange: (value: AutomationRunStatus[]) => void;
+  automationId: string;
+  onAutomationChange: (value: string) => void;
+  type: string;
+  onTypeChange: (value: string) => void;
+  options: Pick<RunHistory, "automations" | "jobTypes"> | undefined;
+  filteredCount: number;
+  totalCount: number;
+  /** The server returned as many runs as it will: say so once, in the count. */
+  capped: boolean;
+  /** Page-level controls, right-aligned - rather than a row of their own. */
+  actions?: React.ReactNode;
+}) {
+  const filtering =
+    search.trim() !== "" || statuses.length > 0 || automationId !== "" || type !== "";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border/40 bg-muted/10 px-4 py-1.5">
+      <div className="relative flex items-center">
+        <Search className="absolute left-1.5 size-3.5 text-muted-foreground" aria-hidden />
+        <input
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="Search runs…"
+          aria-label="Search runs"
+          className="h-6 w-52 rounded border border-border bg-background pl-6 pr-6 text-xs outline-none focus:ring-1 focus:ring-ring"
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => onSearchChange("")}
+            aria-label="Clear search"
+            className="absolute right-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3" aria-hidden />
+          </button>
+        )}
+      </div>
+
+      <MultiPillGroup options={STATUS_OPTIONS} values={statuses} onChange={onStatusesChange} />
+
+      {(options?.automations.length ?? 0) > 1 && (
+        <select
+          className="h-6 rounded border border-border bg-background px-1.5 text-xs"
+          value={automationId}
+          onChange={(event) => onAutomationChange(event.target.value)}
+          aria-label="Filter by automation"
+        >
+          <option value="">Any automation</option>
+          {options?.automations.map((automation) => (
+            <option key={automation.id} value={automation.id}>
+              {automation.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {(options?.jobTypes.length ?? 0) > 1 && (
+        <select
+          className="h-6 rounded border border-border bg-background px-1.5 text-xs"
+          value={type}
+          onChange={(event) => onTypeChange(event.target.value)}
+          aria-label="Filter by kind"
+        >
+          <option value="">Any kind</option>
+          {options?.jobTypes.map((jobType) => (
+            <option key={jobType.type} value={jobType.type}>
+              {jobType.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {/* One statement about how many, including the cap. Saying "200" and then
+          "newest 200 shown" beside it is the same fact twice. */}
+      <span className="text-xs text-muted-foreground">
+        {search.trim() ? `${filteredCount} of ` : ""}
+        {capped ? `newest ${totalCount}` : totalCount} {totalCount === 1 ? "run" : "runs"}
+      </span>
+
+      {filtering && (
+        <button
+          type="button"
+          className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+          onClick={() => {
+            onSearchChange("");
+            onStatusesChange([]);
+            onAutomationChange("");
+            onTypeChange("");
+          }}
+        >
+          Clear
+        </button>
+      )}
+
+      {actions && (
+        <>
+          <span className="flex-1" />
+          {actions}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/automations/components/RunHistoryView.test.tsx
+++ b/src/features/automations/components/RunHistoryView.test.tsx
@@ -77,6 +77,17 @@ describe("run history", () => {
   });
 
   it("filters to one automation, for chasing a single thing", async () => {
+    // The picker appears only when there is more than one to choose between: a
+    // question with one answer is not a question.
+    mockedApi.fetchRunHistory.mockResolvedValue(
+      history({
+        automations: [
+          { id: "auto-1", name: "Nightly backup", type: "backup" },
+          { id: "auto-2", name: "Bank sync", type: "bank-sync" },
+        ],
+      })
+    );
+
     renderView();
     await screen.findByText("No copy could be stored.");
 
@@ -103,9 +114,12 @@ describe("run history", () => {
     expect(screen.getByText("No copy could be stored.")).toBeInTheDocument();
   });
 
-  it("says how many of the listed runs did not finish cleanly", async () => {
+  it("counts the runs it is showing, once", async () => {
+    // The outcome pills already answer "how many failed" in a click, and every
+    // row carries its own status - a tally beside them was a third telling of
+    // the same thing.
     renderView();
-    expect(await screen.findByText(/1 of these run did not finish cleanly/)).toBeInTheDocument();
+    expect(await screen.findByText("2 runs")).toBeInTheDocument();
   });
 
   it("tells an empty result apart from an empty history", async () => {

--- a/src/features/automations/components/RunHistoryView.test.tsx
+++ b/src/features/automations/components/RunHistoryView.test.tsx
@@ -91,6 +91,18 @@ describe("run history", () => {
     );
   });
 
+  it("finds a run by the line it reported", async () => {
+    // "What failed" is usually remembered as a phrase from the error rather
+    // than as a status.
+    renderView();
+    await screen.findByText("No copy could be stored.");
+
+    fireEvent.change(screen.getByLabelText("Search runs"), { target: { value: "no copy" } });
+
+    expect(await screen.findByText(/1 of 2/)).toBeInTheDocument();
+    expect(screen.getByText("No copy could be stored.")).toBeInTheDocument();
+  });
+
   it("says how many of the listed runs did not finish cleanly", async () => {
     renderView();
     expect(await screen.findByText(/1 of these run did not finish cleanly/)).toBeInTheDocument();

--- a/src/features/automations/components/RunHistoryView.tsx
+++ b/src/features/automations/components/RunHistoryView.tsx
@@ -159,6 +159,15 @@ export function RunHistoryView() {
           )}
 
           <span className="flex-1" />
+          {runs.length >= 200 && (
+            <span
+              className="text-muted-foreground"
+              title="Older runs are still recorded; narrow the filters to reach them."
+            >
+              newest 200 shown
+            </span>
+          )}
+
           {failing > 0 && (
             <span className="text-destructive">
               {failing} of these {failing === 1 ? "run" : "runs"} did not finish cleanly

--- a/src/features/automations/components/RunHistoryView.tsx
+++ b/src/features/automations/components/RunHistoryView.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { cn } from "@/lib/utils";
@@ -40,6 +40,7 @@ export function RunHistoryView() {
   const params = useSearchParams();
   const automationFromUrl = params.get("automation") ?? "";
 
+  const [search, setSearch] = useState("");
   const [statuses, setStatuses] = useState<AutomationRunStatus[]>([]);
   const [automationId, setAutomationId] = useState(automationFromUrl);
   const [type, setType] = useState("");
@@ -72,7 +73,18 @@ export function RunHistoryView() {
     );
   }
 
-  const runs = query.data?.runs ?? [];
+  // Searched client-side over what the row shows: the automation's name and the
+  // line it reported. "What failed" is often remembered as a phrase from the
+  // error, not as a status.
+  const needle = search.trim().toLowerCase();
+  const runs = (query.data?.runs ?? []).filter((run) =>
+    needle
+      ? [run.automationName, run.typeLabel, run.rollup?.message, run.error?.data.message]
+          .filter((value): value is string => typeof value === "string")
+          .some((value) => value.toLowerCase().includes(needle))
+      : true
+  );
+  const total = query.data?.runs.length ?? 0;
   const failing = runs.filter((run) => run.status === "failed" || run.status === "partial").length;
 
   return (
@@ -86,8 +98,30 @@ export function RunHistoryView() {
     >
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2 text-xs">
+          <div className="relative flex items-center">
+            <Search className="absolute left-1.5 size-3.5 text-muted-foreground" aria-hidden />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search runs…"
+              aria-label="Search runs"
+              className="h-6 w-44 rounded border border-border bg-background pl-6 pr-6 text-xs outline-none focus:ring-1 focus:ring-ring"
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                aria-label="Clear search"
+                className="absolute right-1.5 text-muted-foreground hover:text-foreground"
+              >
+                <X className="size-3" aria-hidden />
+              </button>
+            )}
+          </div>
+
           <span className="font-medium">
-            {runs.length} {runs.length === 1 ? "run" : "runs"}
+            {needle ? `${runs.length} of ${total}` : `${runs.length}`}{" "}
+            {total === 1 ? "run" : "runs"}
           </span>
           <span className="text-muted-foreground">|</span>
 
@@ -144,7 +178,7 @@ export function RunHistoryView() {
             ))}
           </select>
 
-          {(statuses.length > 0 || automationId || type) && (
+          {(statuses.length > 0 || automationId || type || search) && (
             <button
               type="button"
               className="text-muted-foreground underline-offset-4 hover:underline"
@@ -152,6 +186,7 @@ export function RunHistoryView() {
                 setStatuses([]);
                 setAutomationId("");
                 setType("");
+                setSearch("");
               }}
             >
               Clear
@@ -191,12 +226,12 @@ export function RunHistoryView() {
         {runs.length === 0 ? (
           <div className="mx-auto max-w-lg px-6 py-16 text-center">
             <h2 className="text-sm font-semibold">
-              {statuses.length > 0 || automationId || type
+              {statuses.length > 0 || automationId || type || search
                 ? "Nothing matches those filters"
                 : "Nothing has run yet"}
             </h2>
             <p className="mt-2 text-sm text-muted-foreground">
-              {statuses.length > 0 || automationId || type
+              {statuses.length > 0 || automationId || type || search
                 ? "Clear a filter to widen the search."
                 : "Runs appear here as automations fire - scheduled or on demand."}
             </p>

--- a/src/features/automations/components/RunHistoryView.tsx
+++ b/src/features/automations/components/RunHistoryView.tsx
@@ -3,13 +3,13 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
-import { RefreshCw, Search, X } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { cn } from "@/lib/utils";
 import { fetchRunHistory } from "../lib/automationsApi";
-import { runStatusLabel } from "../lib/presentation";
 import { AutomationsTabs } from "./AutomationsTabs";
+import { RunHistoryFilterBar } from "./RunHistoryFilterBar";
 import { RunRow } from "./RunRow";
 import type { AutomationRunStatus } from "@/lib/app-db/types";
 
@@ -26,15 +26,6 @@ import type { AutomationRunStatus } from "@/lib/app-db/types";
  * chasing one thing in particular. Runs of a deleted automation stay listed:
  * the history of what happened is not undone by removing the thing that did it.
  */
-
-const STATUS_FILTERS: AutomationRunStatus[] = [
-  "failed",
-  "partial",
-  "succeeded",
-  "no_changes",
-  "running",
-  "cancelled",
-];
 
 export function RunHistoryView() {
   const params = useSearchParams();
@@ -67,12 +58,6 @@ export function RunHistoryView() {
     }
   }
 
-  function toggleStatus(status: AutomationRunStatus) {
-    setStatuses((current) =>
-      current.includes(status) ? current.filter((entry) => entry !== status) : [...current, status]
-    );
-  }
-
   // Searched client-side over what the row shows: the automation's name and the
   // line it reported. "What failed" is often remembered as a phrase from the
   // error, not as a status.
@@ -85,7 +70,7 @@ export function RunHistoryView() {
       : true
   );
   const total = query.data?.runs.length ?? 0;
-  const failing = runs.filter((run) => run.status === "failed" || run.status === "partial").length;
+
 
   return (
     <PageLayout
@@ -97,131 +82,34 @@ export function RunHistoryView() {
       onRetry={() => void query.refetch()}
     >
       <div className="flex min-h-0 flex-1 flex-col">
-        <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2 text-xs">
-          <div className="relative flex items-center">
-            <Search className="absolute left-1.5 size-3.5 text-muted-foreground" aria-hidden />
-            <input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search runs…"
-              aria-label="Search runs"
-              className="h-6 w-44 rounded border border-border bg-background pl-6 pr-6 text-xs outline-none focus:ring-1 focus:ring-ring"
-            />
-            {search && (
-              <button
-                type="button"
-                onClick={() => setSearch("")}
-                aria-label="Clear search"
-                className="absolute right-1.5 text-muted-foreground hover:text-foreground"
-              >
-                <X className="size-3" aria-hidden />
-              </button>
-            )}
-          </div>
-
-          <span className="font-medium">
-            {needle ? `${runs.length} of ${total}` : `${runs.length}`}{" "}
-            {total === 1 ? "run" : "runs"}
-          </span>
-          <span className="text-muted-foreground">|</span>
-
-          {/* Outcome first: "what failed" is the question this page exists for,
-              and it should take one click to ask. */}
-          <span className="text-muted-foreground">Outcome</span>
-          {STATUS_FILTERS.map((status) => {
-            const active = statuses.includes(status);
-            return (
-              <button
-                key={status}
-                type="button"
-                aria-pressed={active}
-                onClick={() => toggleStatus(status)}
-                className={cn(
-                  "rounded-md border px-2 py-0.5 transition-colors",
-                  active
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-input text-muted-foreground hover:bg-accent"
-                )}
-              >
-                {runStatusLabel(status)}
-              </button>
-            );
-          })}
-
-          <span className="ml-2 text-muted-foreground">Automation</span>
-          <select
-            className="h-6 rounded-md border border-input bg-background px-1.5 text-xs"
-            value={automationId}
-            onChange={(event) => setAutomationId(event.target.value)}
-            aria-label="Filter by automation"
-          >
-            <option value="">Any</option>
-            {query.data?.automations.map((automation) => (
-              <option key={automation.id} value={automation.id}>
-                {automation.name}
-              </option>
-            ))}
-          </select>
-
-          <span className="text-muted-foreground">Kind</span>
-          <select
-            className="h-6 rounded-md border border-input bg-background px-1.5 text-xs"
-            value={type}
-            onChange={(event) => setType(event.target.value)}
-            aria-label="Filter by job type"
-          >
-            <option value="">Any</option>
-            {query.data?.jobTypes.map((jobType) => (
-              <option key={jobType.type} value={jobType.type}>
-                {jobType.label}
-              </option>
-            ))}
-          </select>
-
-          {(statuses.length > 0 || automationId || type || search) && (
-            <button
-              type="button"
-              className="text-muted-foreground underline-offset-4 hover:underline"
-              onClick={() => {
-                setStatuses([]);
-                setAutomationId("");
-                setType("");
-                setSearch("");
-              }}
+        <RunHistoryFilterBar
+          search={search}
+          onSearchChange={setSearch}
+          statuses={statuses}
+          onStatusesChange={setStatuses}
+          automationId={automationId}
+          onAutomationChange={setAutomationId}
+          type={type}
+          onTypeChange={setType}
+          options={query.data}
+          filteredCount={runs.length}
+          totalCount={total}
+          capped={total >= 200}
+          actions={
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 text-xs"
+              onClick={() => void handleRefresh()}
+              disabled={refreshing}
+              aria-label="Refresh run history"
+              title="Re-read the run history"
             >
-              Clear
-            </button>
-          )}
-
-          <span className="flex-1" />
-          {runs.length >= 200 && (
-            <span
-              className="text-muted-foreground"
-              title="Older runs are still recorded; narrow the filters to reach them."
-            >
-              newest 200 shown
-            </span>
-          )}
-
-          {failing > 0 && (
-            <span className="text-destructive">
-              {failing} of these {failing === 1 ? "run" : "runs"} did not finish cleanly
-            </span>
-          )}
-
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-6 text-xs"
-            onClick={() => void handleRefresh()}
-            disabled={refreshing}
-            aria-label="Refresh run history"
-            title="Re-read the run history"
-          >
-            <RefreshCw className={cn(refreshing && "animate-spin")} aria-hidden />
-            Refresh
-          </Button>
-        </div>
+              <RefreshCw className={cn(refreshing && "animate-spin")} aria-hidden />
+              Refresh
+            </Button>
+          }
+        />
 
         {runs.length === 0 ? (
           <div className="mx-auto max-w-lg px-6 py-16 text-center">

--- a/src/features/automations/lib/presentation.ts
+++ b/src/features/automations/lib/presentation.ts
@@ -6,6 +6,9 @@ import {
   Timer,
   type LucideIcon,
 } from "lucide-react";
+import { compareValues, type SortDirection } from "@/components/ui/sortable-header";
+import type { AutomationSortKey } from "../components/AutomationsTable";
+import type { AutomationListItem } from "./automationsApi";
 import type { AutomationExecutionMode, AutomationRun, AutomationRunStatus } from "@/lib/app-db/types";
 
 /**
@@ -196,4 +199,41 @@ export function jobTypeIcon(type: string): LucideIcon {
     default:
       return Timer;
   }
+}
+
+/** Where a status sits when sorting: worst first, because that is why you sort. */
+const STATUS_ORDER: Record<AutomationListItem["status"], number> = {
+  failing: 0,
+  paused: 1,
+  warning: 2,
+  idle: 3,
+  ok: 4,
+};
+
+export function sortAutomations(
+  automations: AutomationListItem[],
+  sort: { key: AutomationSortKey; direction: SortDirection } | null
+): AutomationListItem[] {
+  if (!sort || !sort.direction) return automations;
+  const { key, direction } = sort;
+
+  const value = (automation: AutomationListItem): string | number | null => {
+    switch (key) {
+      case "status":
+        return STATUS_ORDER[automation.status];
+      case "name":
+        return automation.name;
+      case "type":
+        return automation.typeLabel;
+      case "schedule":
+        return automation.scheduleLabel;
+      case "lastRun":
+        return automation.lastRunAt;
+      case "nextRun":
+        // A paused automation has no next run, whatever the stored value says.
+        return automation.enabled && !automation.autoPausedAt ? automation.nextRunAt : null;
+    }
+  };
+
+  return [...automations].sort((a, b) => compareValues(value(a), value(b), direction));
 }

--- a/src/features/backups/components/BackupsTable.tsx
+++ b/src/features/backups/components/BackupsTable.tsx
@@ -2,6 +2,7 @@
 
 import { CircleCheck, CircleHelp, CircleX, Lock, Pin, Server } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { SortableHeader, type SortDirection } from "@/components/ui/sortable-header";
 import { cn } from "@/lib/utils";
 import {
   artifactContents,
@@ -37,15 +38,26 @@ const STATE_STYLE: Record<CopyState, { icon: LucideIcon; tone: string; row?: str
   gone: { icon: CircleX, tone: "text-destructive", row: "bg-destructive/5" },
 };
 
+export type BackupSortKey =
+  | "taken"
+  | "contents"
+  | "inside"
+  | "covers"
+  | "state"
+  | "rule"
+  | "size";
+
 type Props = {
   artifacts: ArtifactWithLocations[];
   /** Names for the rules that made these copies. */
   policies: { id: string; name: string }[];
   selectedId: string | null;
+  sort: { key: BackupSortKey; direction: SortDirection } | null;
+  onSort: (key: BackupSortKey, direction: SortDirection) => void;
   onOpen: (artifactId: string) => void;
 };
 
-export function BackupsTable({ artifacts, policies, selectedId, onOpen }: Props) {
+export function BackupsTable({ artifacts, policies, selectedId, sort, onSort, onOpen }: Props) {
   const policyNames = new Map(policies.map((policy) => [policy.id, policy.name]));
 
   return (
@@ -53,16 +65,16 @@ export function BackupsTable({ artifacts, policies, selectedId, onOpen }: Props)
       <table className="w-full border-collapse text-xs">
         <thead className="sticky top-0 z-10 bg-background">
           <tr className="border-b border-border text-left text-xs text-muted-foreground">
-            <th scope="col" className="px-4 py-2 font-medium">Taken</th>
-            <th scope="col" className="px-4 py-2 font-medium">Contents</th>
+            <SortableHeader label="Taken" sortKey="taken" sort={sort} onSort={onSort} />
+            <SortableHeader label="Contents" sortKey="contents" sort={sort} onSort={onSort} />
             {/* Two columns verification already knows the answer to, and
                 which decide "is this the copy I want": how much budget it
                 holds, and which period it covers. */}
-            <th scope="col" className="px-4 py-2 font-medium">Inside</th>
-            <th scope="col" className="px-4 py-2 font-medium">Covers</th>
-            <th scope="col" className="px-4 py-2 font-medium">State</th>
-            <th scope="col" className="px-4 py-2 font-medium">Rule</th>
-            <th scope="col" className="px-4 py-2 font-medium">Size</th>
+            <SortableHeader label="Inside" sortKey="inside" sort={sort} onSort={onSort} />
+            <SortableHeader label="Covers" sortKey="covers" sort={sort} onSort={onSort} />
+            <SortableHeader label="State" sortKey="state" sort={sort} onSort={onSort} />
+            <SortableHeader label="Rule" sortKey="rule" sort={sort} onSort={onSort} />
+            <SortableHeader label="Size" sortKey="size" sort={sort} onSort={onSort} />
             <th scope="col" className="px-4 py-2 font-medium">Stored in</th>
             <th scope="col" className="px-4 py-2 font-medium">Keep</th>
           </tr>

--- a/src/features/backups/components/BackupsView.test.tsx
+++ b/src/features/backups/components/BackupsView.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { toast } from "sonner";
 import { BackupsView } from "./BackupsView";
 import * as api from "../lib/backupsApi";
@@ -211,6 +211,71 @@ describe("the Recovery Center", () => {
     expect(await screen.findByText("Nightly")).toBeInTheDocument();
     expect(screen.getByText("discovered")).toBeInTheDocument();
     expect(screen.getByText("rule deleted")).toBeInTheDocument();
+  });
+
+  it("finds a copy by what you remember about it", async () => {
+    mockedApi.fetchRecoveryCenter.mockResolvedValue(
+      data({
+        artifacts: [
+          artifact({ sourceBudgetName: "Household" }),
+          artifact({ id: "art-2", sourceBudgetName: "Joint account" }),
+        ],
+      })
+    );
+
+    renderView();
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("Joint account")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search backups"), { target: { value: "joint" } });
+
+    await waitFor(() => expect(within(table).queryByText("Household")).not.toBeInTheDocument());
+    expect(within(table).getByText("Joint account")).toBeInTheDocument();
+    expect(screen.getByText(/1 of 2/)).toBeInTheDocument();
+  });
+
+  it("keeps the filters reachable when nothing matches", async () => {
+    renderView();
+    await screen.findByText("Household");
+
+    fireEvent.change(screen.getByLabelText("Search backups"), {
+      target: { value: "nothing matches this" },
+    });
+
+    expect(await screen.findByText("No copy matches those filters.")).toBeInTheDocument();
+    // Not the guided "no copies yet" state, which would strand you.
+    expect(screen.queryByText("No copies yet")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(await screen.findByText("Household")).toBeInTheDocument();
+  });
+
+  it("sorts by a column, and back to its own order", async () => {
+    mockedApi.fetchRecoveryCenter.mockResolvedValue(
+      data({
+        artifacts: [
+          artifact({ id: "big", sizeBytes: 9_000_000 }),
+          artifact({ id: "small", sizeBytes: 1_000 }),
+        ],
+      })
+    );
+
+    renderView();
+    const sizeHeader = await screen.findByRole("button", { name: /sort by size/i });
+
+    fireEvent.click(sizeHeader);
+    expect(sizeHeader.closest("th")).toHaveAttribute("aria-sort", "ascending");
+    let rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("1000 B")).toBeInTheDocument();
+
+    fireEvent.click(sizeHeader);
+    expect(sizeHeader.closest("th")).toHaveAttribute("aria-sort", "descending");
+    rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("8.6 MB")).toBeInTheDocument();
+
+    // A sort you cannot undo forces a reload to see the default again.
+    fireEvent.click(sizeHeader);
+    expect(sizeHeader.closest("th")).toHaveAttribute("aria-sort", "none");
   });
 
   it("shows each copy's state in words, not only in colour", async () => {

--- a/src/features/backups/components/BackupsView.tsx
+++ b/src/features/backups/components/BackupsView.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { SortDirection } from "@/components/ui/sortable-header";
 import {
   backUpNow,
   deleteDestination,
@@ -21,10 +22,15 @@ import {
   scrubNow,
   testDestination,
 } from "../lib/backupsApi";
-import { copyState, sortArtifacts } from "../lib/presentation";
+import {
+  byNewestFirst,
+  filterArtifacts,
+  sortArtifacts,
+} from "../lib/presentation";
 import { fetchSafetySettings, patchSafetySettings } from "../lib/safetyPoint";
 import { BackupDetail } from "./BackupDetail";
 import { InventoryTab, type KindFilter, type StateFilter } from "./InventoryTab";
+import type { BackupSortKey } from "./BackupsTable";
 import { SetupTab } from "./SetupTab";
 import { BackupRuleDialog } from "./BackupRuleDialog";
 import { DestinationDialog } from "./DestinationDialog";
@@ -87,9 +93,22 @@ export function BackupsView() {
   // page should land on the copies when there are copies - having once opened
   // Setup should not mean every later visit starts on the settings.
   const [view, setView] = usePersistedFilters<{
+    search: string;
     stateFilter: StateFilter;
     kindFilter: KindFilter;
-  }>("filters:backups", { stateFilter: "all", kindFilter: "all" });
+    budget: string;
+    policyId: string;
+    sortKey: BackupSortKey | null;
+    sortDirection: SortDirection;
+  }>("filters:backups", {
+    search: "",
+    stateFilter: "all",
+    kindFilter: "all",
+    budget: "",
+    policyId: "",
+    sortKey: null,
+    sortDirection: null,
+  });
   const [chosenTab, setChosenTab] = useState<"setup" | "backups" | null>(
     wantsNewRule ? "setup" : null
   );
@@ -231,16 +250,23 @@ export function BackupsView() {
   }
 
   const data = query.data;
-  const artifacts = sortArtifacts(data?.artifacts ?? []);
+  const artifacts = byNewestFirst(data?.artifacts ?? []);
   const selected = artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
 
-  const filtered = artifacts.filter((artifact) => {
-    if (view.kindFilter !== "all" && artifact.kind !== view.kindFilter) return false;
-    if (view.stateFilter === "all") return true;
-    const state = copyState(artifact);
-    if (view.stateFilter === "problem") return state === "damaged" || state === "gone";
-    return state === view.stateFilter;
-  });
+  const sort =
+    view.sortKey && view.sortDirection ? { key: view.sortKey, direction: view.sortDirection } : null;
+
+  const filtered = sortArtifacts(
+    filterArtifacts(artifacts, data?.policies ?? [], {
+      search: view.search,
+      state: view.stateFilter,
+      kind: view.kindFilter,
+      budget: view.budget,
+      policyId: view.policyId,
+    }),
+    data?.policies ?? [],
+    sort
+  );
 
   // The two things that have to happen before anything can be backed up, in
   // the order they have to happen in.
@@ -383,13 +409,37 @@ export function BackupsView() {
               data={data}
               artifacts={artifacts}
               filtered={filtered}
+              search={view.search}
               stateFilter={view.stateFilter}
               kindFilter={view.kindFilter}
+              budget={view.budget}
+              policyId={view.policyId}
+              sort={sort}
               selectedArtifactId={selectedArtifactId}
               needsDestination={needsDestination}
               needsRule={needsRule}
+              onSearch={(value) => setView((current) => ({ ...current, search: value }))}
               onStateFilter={(value) => setView((current) => ({ ...current, stateFilter: value }))}
               onKindFilter={(value) => setView((current) => ({ ...current, kindFilter: value }))}
+              onBudget={(value) => setView((current) => ({ ...current, budget: value }))}
+              onPolicy={(value) => setView((current) => ({ ...current, policyId: value }))}
+              onSort={(sortKey, sortDirection) =>
+                setView((current) => ({
+                  ...current,
+                  sortKey: sortDirection ? sortKey : null,
+                  sortDirection,
+                }))
+              }
+              onClearFilters={() =>
+                setView((current) => ({
+                  ...current,
+                  search: "",
+                  stateFilter: "all",
+                  kindFilter: "all",
+                  budget: "",
+                  policyId: "",
+                }))
+              }
               onOpenArtifact={setSelectedArtifactId}
               onGoToSetup={() => setTab("setup")}
             />

--- a/src/features/backups/components/InventoryTab.tsx
+++ b/src/features/backups/components/InventoryTab.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { FileText, Loader2, ShieldCheck } from "lucide-react";
+import { FileText, Loader2, Search, ShieldCheck, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { BackupsTable } from "./BackupsTable";
+import { BackupsTable, type BackupSortKey } from "./BackupsTable";
 import { ReadinessBanner } from "./ReadinessBanner";
-import { formatBytes } from "../lib/presentation";
+import { budgetsInArtifacts, formatBytes } from "../lib/presentation";
+import type { SortDirection } from "@/components/ui/sortable-header";
 import type { ArtifactWithLocations, RecoveryCenterData } from "../lib/backupsApi";
 
 /**
@@ -30,13 +31,22 @@ type Props = {
   onVerify: () => void;
   artifacts: ArtifactWithLocations[];
   filtered: ArtifactWithLocations[];
+  search: string;
   stateFilter: StateFilter;
   kindFilter: KindFilter;
+  budget: string;
+  policyId: string;
+  sort: { key: BackupSortKey; direction: SortDirection } | null;
   selectedArtifactId: string | null;
   needsDestination: boolean;
   needsRule: boolean;
+  onSearch: (value: string) => void;
   onStateFilter: (value: StateFilter) => void;
   onKindFilter: (value: KindFilter) => void;
+  onBudget: (value: string) => void;
+  onPolicy: (value: string) => void;
+  onSort: (key: BackupSortKey, direction: SortDirection) => void;
+  onClearFilters: () => void;
   onOpenArtifact: (artifactId: string) => void;
   onGoToSetup: () => void;
 };
@@ -47,16 +57,33 @@ export function InventoryTab({
   onVerify,
   artifacts,
   filtered,
+  search,
   stateFilter,
   kindFilter,
+  budget,
+  policyId,
+  sort,
   selectedArtifactId,
   needsDestination,
   needsRule,
+  onSearch,
   onStateFilter,
   onKindFilter,
+  onBudget,
+  onPolicy,
+  onSort,
+  onClearFilters,
   onOpenArtifact,
   onGoToSetup,
 }: Props) {
+  const budgets = budgetsInArtifacts(artifacts);
+  const filtering =
+    search.trim() !== "" ||
+    stateFilter !== "all" ||
+    kindFilter !== "all" ||
+    budget !== "" ||
+    policyId !== "";
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <ReadinessBanner readiness={data.readiness} />
@@ -130,17 +157,29 @@ export function InventoryTab({
       ) : (
         <>
           <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-xs">
-            {/* The count that used to sit in the page header, now beside the
-                filters that change it. */}
-            <span className="font-medium">
-              {filtered.length === artifacts.length
-                ? `${artifacts.length} ${artifacts.length === 1 ? "copy" : "copies"}`
-                : `${filtered.length} of ${artifacts.length}`}
-              <span className="font-normal text-muted-foreground">
-                , {formatBytes(filtered.reduce((total, entry) => total + entry.sizeBytes, 0))}
-              </span>
-            </span>
-            <span className="text-muted-foreground">|</span>
+            {/* Search first, because with a few hundred copies the fastest way
+                to the one you mean is to type part of what you remember - a
+                budget name, a rule, or the destination it went to. */}
+            <div className="relative flex items-center">
+              <Search className="absolute left-1.5 size-3.5 text-muted-foreground" aria-hidden />
+              <input
+                value={search}
+                onChange={(event) => onSearch(event.target.value)}
+                placeholder="Search copies…"
+                aria-label="Search backups"
+                className="h-6 w-48 rounded border border-border bg-background pl-6 pr-6 outline-none focus:ring-1 focus:ring-ring"
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => onSearch("")}
+                  aria-label="Clear search"
+                  className="absolute right-1.5 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="size-3" aria-hidden />
+                </button>
+              )}
+            </div>
 
             <select
               className="h-6 rounded-md border border-input bg-background px-1.5 text-xs"
@@ -165,6 +204,69 @@ export function InventoryTab({
               <option value="app-db">Bench settings</option>
             </select>
 
+            {/* Only offered when there is more than one: a picker with one
+                option is a question with one answer. */}
+            {budgets.length > 1 && (
+              <select
+                className="h-6 rounded-md border border-input bg-background px-1.5 text-xs"
+                value={budget}
+                onChange={(event) => onBudget(event.target.value)}
+                aria-label="Filter by budget"
+              >
+                <option value="">Any budget</option>
+                {budgets.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+            )}
+
+            {data.policies.length > 1 && (
+              <select
+                className="h-6 rounded-md border border-input bg-background px-1.5 text-xs"
+                value={policyId}
+                onChange={(event) => onPolicy(event.target.value)}
+                aria-label="Filter by rule"
+              >
+                <option value="">Any rule</option>
+                {data.policies.map((policy) => (
+                  <option key={policy.id} value={policy.id}>
+                    {policy.name}
+                  </option>
+                ))}
+              </select>
+            )}
+
+            <span className="font-medium">
+              {filtering ? `${filtered.length} of ${artifacts.length}` : `${artifacts.length}`}
+              <span className="font-normal text-muted-foreground">
+                {" "}
+                {artifacts.length === 1 ? "copy" : "copies"},{" "}
+                {formatBytes(filtered.reduce((total, entry) => total + entry.sizeBytes, 0))}
+              </span>
+            </span>
+
+            {filtering && (
+              <button
+                type="button"
+                className="text-muted-foreground underline-offset-4 hover:underline"
+                onClick={onClearFilters}
+              >
+                Clear
+              </button>
+            )}
+
+            {/* The list stops at 200. Saying so is the difference between
+                "these are your copies" and "these are the newest 200 of them",
+                and only one of those is true. */}
+            {artifacts.length >= 200 && (
+              <span className="text-muted-foreground" title="Older copies are still stored and still restorable; this view shows the newest 200.">
+                newest 200 shown
+              </span>
+            )}
+
+            <span className="flex-1" />
             <span
               className="text-muted-foreground"
               title="Retention never removes a pinned copy, anything under the minimum age, or the newest verified copy. Backups you take by hand are kept until you delete them."
@@ -172,10 +274,6 @@ export function InventoryTab({
               Pinned and newest-verified copies are never deleted
             </span>
 
-            <span className="flex-1" />
-
-            {/* The actions that act on this inventory, beside it rather than in
-                a page header shared with Setup. */}
             <Button
               variant="outline"
               size="sm"
@@ -203,12 +301,20 @@ export function InventoryTab({
             </Button>
           </div>
 
+          {filtered.length === 0 ? (
+            <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+              No copy matches those filters.
+            </p>
+          ) : (
           <BackupsTable
             artifacts={filtered}
             policies={data.policies}
             selectedId={selectedArtifactId}
+            sort={sort}
+            onSort={onSort}
             onOpen={onOpenArtifact}
           />
+          )}
         </>
       )}
     </div>

--- a/src/features/backups/components/InventoryTab.tsx
+++ b/src/features/backups/components/InventoryTab.tsx
@@ -238,8 +238,11 @@ export function InventoryTab({
               </select>
             )}
 
+            {/* One statement about how many, the cap included. Saying "200"
+                and then "newest 200 shown" beside it is the same fact twice. */}
             <span className="font-medium">
-              {filtering ? `${filtered.length} of ${artifacts.length}` : `${artifacts.length}`}
+              {filtering ? `${filtered.length} of ` : ""}
+              {artifacts.length >= 200 ? `newest ${artifacts.length}` : artifacts.length}
               <span className="font-normal text-muted-foreground">
                 {" "}
                 {artifacts.length === 1 ? "copy" : "copies"},{" "}
@@ -255,15 +258,6 @@ export function InventoryTab({
               >
                 Clear
               </button>
-            )}
-
-            {/* The list stops at 200. Saying so is the difference between
-                "these are your copies" and "these are the newest 200 of them",
-                and only one of those is true. */}
-            {artifacts.length >= 200 && (
-              <span className="text-muted-foreground" title="Older copies are still stored and still restorable; this view shows the newest 200.">
-                newest 200 shown
-              </span>
             )}
 
             <span className="flex-1" />

--- a/src/features/backups/lib/presentation.ts
+++ b/src/features/backups/lib/presentation.ts
@@ -1,4 +1,6 @@
+import { compareValues, type SortDirection } from "@/components/ui/sortable-header";
 import { describeCronExpression } from "@/lib/automation/cron";
+import type { BackupSortKey } from "../components/BackupsTable";
 import type { ArtifactWithLocations } from "./backupsApi";
 import type { BackupPolicy } from "@/lib/app-db/backupRepository";
 
@@ -129,8 +131,8 @@ export function describeContents(policy: BackupPolicy): string {
   return "Budget + Bench settings";
 }
 
-/** Which copies are worth showing first: trouble, then recency. */
-export function sortArtifacts(artifacts: ArtifactWithLocations[]): ArtifactWithLocations[] {
+/** Newest first - the default order, before anyone sorts a column. */
+export function byNewestFirst(artifacts: ArtifactWithLocations[]): ArtifactWithLocations[] {
   return [...artifacts].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 }
 
@@ -176,4 +178,92 @@ export function describeContentsSize(contents: ArtifactContents): string {
 export function describeCoverage(contents: ArtifactContents): string {
   if (!contents.earliest || !contents.latest) return "-";
   return `${contents.earliest} → ${contents.latest}`;
+}
+
+/** Where a copy's state sits when sorting: worst first, because that is why you sort. */
+const COPY_STATE_ORDER: Record<CopyState, number> = {
+  gone: 0,
+  damaged: 1,
+  unverified: 2,
+  verified: 3,
+};
+
+export function sortArtifacts(
+  artifacts: ArtifactWithLocations[],
+  policies: { id: string; name: string }[],
+  sort: { key: BackupSortKey; direction: SortDirection } | null
+): ArtifactWithLocations[] {
+  if (!sort || !sort.direction) return artifacts;
+  const { key, direction } = sort;
+  const policyNames = new Map(policies.map((policy) => [policy.id, policy.name]));
+
+  const value = (artifact: ArtifactWithLocations): string | number | null => {
+    switch (key) {
+      case "taken":
+        return artifact.createdAt;
+      case "contents":
+        return artifact.kind === "budget" ? artifact.sourceBudgetName ?? "Budget" : "Bench settings";
+      case "inside":
+        return artifactContents(artifact).transactions;
+      case "covers":
+        return artifactContents(artifact).latest;
+      case "state":
+        return COPY_STATE_ORDER[copyState(artifact)];
+      case "rule":
+        return (artifact.policyId && policyNames.get(artifact.policyId)) ?? null;
+      case "size":
+        return artifact.sizeBytes;
+    }
+  };
+
+  return [...artifacts].sort((a, b) => compareValues(value(a), value(b), direction));
+}
+
+/** Rows matching the current filters, in the order they were given. */
+export function filterArtifacts(
+  artifacts: ArtifactWithLocations[],
+  policies: { id: string; name: string }[],
+  filters: { search: string; state: string; kind: string; budget: string; policyId: string }
+): ArtifactWithLocations[] {
+  const needle = filters.search.trim().toLowerCase();
+  const policyNames = new Map(policies.map((policy) => [policy.id, policy.name]));
+
+  return artifacts.filter((artifact) => {
+    if (filters.kind !== "all" && artifact.kind !== filters.kind) return false;
+    if (filters.budget && artifact.sourceBudgetName !== filters.budget) return false;
+    if (filters.policyId && artifact.policyId !== filters.policyId) return false;
+
+    if (filters.state !== "all") {
+      const state = copyState(artifact);
+      const matches =
+        filters.state === "problem" ? state === "damaged" || state === "gone" : state === filters.state;
+      if (!matches) return false;
+    }
+
+    if (!needle) return true;
+
+    // Searched over what is on the row, plus where the copy lives - someone
+    // hunting for "the one on the NAS" is searching for the destination.
+    return [
+      artifact.sourceBudgetName,
+      artifact.kind === "app-db" ? "Bench settings" : "budget",
+      artifact.policyId ? policyNames.get(artifact.policyId) : null,
+      artifact.takenBefore,
+      ...artifact.locations.map((location) => location.destinationName),
+      ...artifact.locations.map((location) => location.objectKey),
+    ]
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+      .some((value) => value.toLowerCase().includes(needle));
+  });
+}
+
+/** The budgets these copies came from, for the filter that names them. */
+export function budgetsInArtifacts(artifacts: ArtifactWithLocations[]): string[] {
+  return [
+    ...new Set(
+      artifacts
+        .map((artifact) => artifact.sourceBudgetName)
+        .filter((name): name is string => typeof name === "string" && name.length > 0)
+    ),
+  ].sort((a, b) => a.localeCompare(b));
 }


### PR DESCRIPTION
Two tables had grown past the size where reading them top to bottom is a strategy, and the documentation site still described the product as it was several features ago.

## Tables

**Automations** gains search over what is on the row, status pills, and a kind filter once more than one job type exists. Status leads because "what is broken" is the question people arrive with, and it is the one filter worth a single click.

**Backups** gains search over the budget, rule, destination and object key — someone hunting for "the one on the NAS" is searching by destination — plus filters for budget and rule beside the existing state and contents.

**Every column on both sorts**, tri-state: ascending, descending, back to the table's own order, because a sort you cannot undo forces a reload to see the default again. Two decisions inside that:

- Missing values sort last in **both** directions. An automation that has never run is not "older than everything", it is unknown, and floating it to the top one way while burying it the other is how sorted tables mislead.
- Status and copy state sort worst-first, since that is why you sorted them.

The header is one shared component now; the entity tables had each grown their own copy of the same tri-state button and `aria-sort` cell.

**Run history** gets the same filter bar as the automations list — two screens in one feature were asking "which of these rows do I mean" with two different controls — plus search over the line a run reported, because a failure is usually remembered as a phrase from the message rather than as a status.

## Three defects found while doing it

- **A filter matching nothing replaced the whole Automations page**, filter bar included, with "Nothing is scheduled yet". Untrue, and no way back. The empty state is keyed on the unfiltered list now.
- **An automation could not be deleted from the UI.** Pause is not removal, and a deleted backup rule leaves its automation behind, paused with a reason and previously unclearable. Delete exists now, and the confirmation says what goes with it: the run history does, the backups do not.
- **Both lists silently stopped at 200.** They say so, in the count rather than beside it — "these are your copies" and "these are the newest 200 of them" are different claims.

## Documentation site

The site still told readers to "continue using Actual Budget for … bank sync", and listed Actual's bank sync under what Bench does not replace. Bench schedules bank syncs. Both now draw the line where it falls: **Actual owns the connection to your bank; Bench decides when it runs and reports what came back.**

- **Automations gets a page**, written as a task — the engine, unattended access, schedules and DST, run history, backoff and auto-pause had no user-facing documentation anywhere.
- **Bank sync gets its own page**, since people search for "bank sync" rather than for the engine underneath it. It is explicit about what it is not, and about why an imported-transaction count appears in Direct mode but not over HTTP.
- **Both, plus Backups, move into Common Workflows.** Work that happens when nobody is watching is neither a one-off task nor a reference entry, which is exactly why it had no home and went undocumented.
- **The homepage** gains cards for scheduled work and verified backups, three rows in the complements table, and a fourth safety model: scheduled, with a record.
- **The two backup pages stop contradicting each other** — the operator guide was still telling self-hosters to stop the container and hand-copy the database the app now backs up on a schedule.

`npm run lint`, `npx tsc --noEmit`, `npm test` (273 suites) and both builds pass.
